### PR TITLE
Update to v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Modified TMA dearraying script command to abort if dearraying for the first time by default - this encourages good practice of checking dearrayed result prior to running full analysis (although means that any generated script would need to be run twice - once to dearray, and again to do everything else)
 * 'Relabel TMA Grid' now a scriptable command
 * Fixed reassigning child objects with 'Make inverse annotation' command
+* Fixed bug that prevented plugins cancelling more than once
 * Set default logging level to INFO
 * Added sample script to change logging level
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Set default logging level to INFO
 * Added sample script to change logging level
 * Improved display of licenses & third-party dependencies
+* Updated location of user preferences
  
 
 ## Version 0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
   * Separation of paths in 'Help -> System info'
   * Cached image paths (still experimental)
 * Fixed reassigning child objects with 'Make inverse annotation' command
-* Set default logging level to INFO (and added sample script to change level)
+* Set default logging level to INFO
+* Added sample script to change logging level
  
 
 ## Version 0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Added sample script to change logging level
 * Improved display of licenses & third-party dependencies
 * Updated location of user preferences
+* Added menu entry to reset preferences
  
 
 ## Version 0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Version 0.0.3
+
+* Fixed several formatting issues for Windows, including:
+  * Import of tab-delimited data (e.g. TMA grids)
+  * Separation of paths in 'Help -> System info'
+  * Cached image paths (still experimental)
+* Fixed reassigning child objects with 'Make inverse annotation' command
+* Set default logging level to INFO (and added sample script to change level)
+ 
+
 ## Version 0.0.2
 
 * New Help menu links to online resources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 * Fixed several formatting issues for Windows, including:
   * Import of tab-delimited data (e.g. TMA grids)
+  * Escaping of paths when exporting TMA data
   * Separation of paths in 'Help -> System info'
   * Cached image paths (still experimental)
+* TMA data export now records directory (rather than name) in script, for more generality
+* Updated TMA dearraying command to support fluorescence TMAs
+* Modified TMA dearraying script command to abort if dearraying for the first time by default - this encourages good practice of checking dearrayed result prior to running full analysis (although means that any generated script would need to be run twice - once to dearray, and again to do everything else)
 * Fixed reassigning child objects with 'Make inverse annotation' command
 * Set default logging level to INFO
 * Added sample script to change logging level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@
   * Escaping of paths when exporting TMA data
   * Separation of paths in 'Help -> System info'
   * Cached image paths (still experimental)
-* TMA data export now records directory (rather than name) in script, for more generality
+* TMA data export now records directory (rather than name) in script, so that it can be reused across a project without editing
+* Added use of OpenSlide's background color - this fixes previously-buggy appearance when scans where part of the image is omitted (e.g. some mrxs images)
 * Updated TMA dearraying command to support fluorescence TMAs
-* Modified TMA dearraying script command to abort if dearraying for the first time by default - this encourages good practice of checking dearrayed result prior to running full analysis (although means that any generated script would need to be run twice - once to dearray, and again to do everything else)
+* Modified TMA dearraying script command to abort if dearraying for the first time by default - this encourages good practice of checking dearrayed result prior to running full analysis (although means that any generated script would need to be run twice - once to dearray, and then again to do everything else)
 * 'Relabel TMA Grid' now a scriptable command
 * Fixed reassigning child objects with 'Make inverse annotation' command
 * Fixed bug that prevented plugins cancelling more than once
+* Minor improvements to Brightness/Contrast panel
 * Set default logging level to INFO
 * Added sample script to change logging level
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 * New Help menu links to online resources
 * Source code now included for dependencies (from Maven)
-* 'Objects -> Create full image annotation' command now scriptable
+* 'Objects -> Create full image annotation' command is now scriptable
 * Error notification now displayed if an image can't be opened
-* Extension ClassLoader changes to help add dependencies
+* Extension ClassLoader changes to help add dependencies (without copying or symbolic linking)
+* Fixed some weird behavior when multiple images are contained in the same file
 
 
 ## Version 0.0.1-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Minor improvements to Brightness/Contrast panel
 * Set default logging level to INFO
 * Added sample script to change logging level
+* Improved display of licenses & third-party dependencies
  
 
 ## Version 0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * TMA data export now records directory (rather than name) in script, for more generality
 * Updated TMA dearraying command to support fluorescence TMAs
 * Modified TMA dearraying script command to abort if dearraying for the first time by default - this encourages good practice of checking dearrayed result prior to running full analysis (although means that any generated script would need to be run twice - once to dearray, and again to do everything else)
+* 'Relabel TMA Grid' now a scriptable command
 * Fixed reassigning child objects with 'Make inverse annotation' command
 * Set default logging level to INFO
 * Added sample script to change logging level

--- a/build.xml
+++ b/build.xml
@@ -77,6 +77,11 @@
 				<include name="THIRD-PARTY.txt"/>
 			</fileset>
 		</copy>
+		<copy todir="${basedir}/licenses/QuPath/">
+			<fileset dir="${basedir}/..">
+				<include name="LICENSE.txt"/>
+			</fileset>
+		</copy>
 		
 		<fx:resources id="appRes">
 			<!-- <fx:fileset dir="${basedir}/classes" includes="**/*" /> -->

--- a/build.xml
+++ b/build.xml
@@ -83,6 +83,7 @@
 			<fx:fileset dir="${basedir}" includes="qupath/*"/>
 			<fx:fileset dir="${basedir}" includes="qupath/sources/*"/>
 			<fx:fileset dir="${basedir}" includes="jars/*" excludes="jars/*-natives-*"/>
+			<fx:fileset dir="${basedir}" includes="jars/sources/*"/>
 			<fx:fileset dir="${basedir}/dist/" includes="QuPathApp.jar"/>
 			
 			<!-- See http://docs.oracle.com/javafx/2/deployment/self-contained-packaging.htm -->

--- a/build.xml
+++ b/build.xml
@@ -99,7 +99,7 @@
 			<fx:fileset dir="${basedir}" includes="licenses/*" />
 			<fx:fileset dir="${basedir}" includes="licenses/**" />
 		</fx:resources>
-		<fx:application id="QuPathAppID" name="QuPath" mainClass="qupath.QuPath" version="0.0.2" />
+		<fx:application id="QuPathAppID" name="QuPath" mainClass="qupath.QuPath" version="0.0.3" />
 		
 		<!-- Set time for Manifest -->
 		<tstamp>
@@ -116,7 +116,7 @@
 			<manifest>
 				<attribute name="Implementation-Vendor" value="QUB"/>
 				<attribute name="Implementation-Title" value="QuPath"/>
-				<attribute name="Implementation-Version" value="0.0.2"/>
+				<attribute name="Implementation-Version" value="0.0.3"/>
 				<attribute name="QuPath-build-time" value="${BUILD_TIME}"/>
 				<attribute name="JavaFX-Feature-Proxy" value="None"/>
 			</manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>qupath</groupId>
 	<artifactId>qupath</artifactId>
-	<version>0.0.2</version>
+	<version>0.0.3</version>
 	<description>Main QuPath project</description>
 
 	<developers>
@@ -393,22 +393,22 @@ Contact: IP Management (ipmanagement@qub.ac.uk)</copyrightOwners>
 			<dependency>
 				<groupId>qupath</groupId>
 				<artifactId>qupath-core</artifactId>
-				<version>0.0.2</version>
+				<version>0.0.3</version>
 			</dependency>
 			<dependency>
 				<groupId>qupath</groupId>
 				<artifactId>qupath-core-awt</artifactId>
-				<version>0.0.2</version>
+				<version>0.0.3</version>
 			</dependency>
 			<dependency>
 				<groupId>qupath</groupId>
 				<artifactId>qupath-core-processing</artifactId>
-				<version>0.0.2</version>
+				<version>0.0.3</version>
 			</dependency>
 			<dependency>
 				<groupId>qupath</groupId>
 				<artifactId>qupath-core-processing-awt</artifactId>
-				<version>0.0.2</version>
+				<version>0.0.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.opencv</groupId>
@@ -418,17 +418,17 @@ Contact: IP Management (ipmanagement@qub.ac.uk)</copyrightOwners>
 			<dependency>
 				<groupId>qupath</groupId>
 				<artifactId>qupath-gui-fx</artifactId>
-				<version>0.0.2</version>
+				<version>0.0.3</version>
 			</dependency>
 			<dependency>
 				<groupId>qupath</groupId>
 				<artifactId>qupath-processing-ij</artifactId>
-				<version>0.0.2</version>
+				<version>0.0.3</version>
 			</dependency>
 			<dependency>
 				<groupId>qupath</groupId>
 				<artifactId>qupath-processing-opencv</artifactId>
-				<version>0.0.2</version>
+				<version>0.0.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>

--- a/qupath-core-awt/pom.xml
+++ b/qupath-core-awt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>qupath</groupId>
     <artifactId>qupath</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
   </parent>
   <artifactId>qupath-core-awt</artifactId>
   <name>qupath-core-awt</name>

--- a/qupath-core-awt/pom.xml.versionsBackup
+++ b/qupath-core-awt/pom.xml.versionsBackup
@@ -5,35 +5,18 @@
   <parent>
     <groupId>qupath</groupId>
     <artifactId>qupath</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.2</version>
   </parent>
-  <artifactId>qupath-processing-opencv</artifactId>
-  <name>qupath-processing-opencv</name>
+  <artifactId>qupath-core-awt</artifactId>
+  <name>qupath-core-awt</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-	
   <dependencies>
     <dependency>
-			<groupId>qupath</groupId>
-			<artifactId>qupath-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>qupath</groupId>
-			<artifactId>qupath-core-awt</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>qupath</groupId>
-			<artifactId>qupath-core-processing</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>qupath</groupId>
-			<artifactId>qupath-core-processing-awt</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.opencv</groupId>
-			<artifactId>opencv</artifactId>
-		</dependency>
+    	<groupId>qupath</groupId>
+    	<artifactId>qupath-core</artifactId>
+    </dependency>
   </dependencies>
   
   <build>
@@ -48,5 +31,5 @@
 			</plugin>
 		</plugins>
 	</build>
-  <description>Processing library for QuPath, using OpenCV's Java bindings.</description>
+  <description>Core QuPath code that makes use of Java AWT.</description>
 </project>

--- a/qupath-core-awt/src/main/java/qupath/lib/www/URLHelpers.java
+++ b/qupath-core-awt/src/main/java/qupath/lib/www/URLHelpers.java
@@ -44,6 +44,8 @@ import javax.imageio.ImageIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import qupath.lib.common.GeneralTools;
+
 /**
  * Collection of static methods that help with reading images using HTTP requests.
  * 
@@ -122,7 +124,8 @@ public class URLHelpers {
 			return null;
 		
 //		File file = new File(dirCache, url.replace("/", "_"));
-		Path cachePath = fileSystem.getPath(cacheRootPath, url.replace("://", File.separator).replace(":/", File.separator).replace("?", "?"+File.separator));
+		String questionChar = GeneralTools.isWindows() ? "" : "?";
+		Path cachePath = fileSystem.getPath(cacheRootPath, url.replace("://", File.separator).replace(":/", File.separator).replace("?", questionChar+File.separator));
 //		File file = new File(dirCache, url.replace("://", File.separator).replace(":/", File.separator).replace("?", "?"+File.separator));
 		// First, try reading from existing cached file
 		if (Files.exists(cachePath)) {

--- a/qupath-core-processing-awt/pom.xml.versionsBackup
+++ b/qupath-core-processing-awt/pom.xml.versionsBackup
@@ -5,7 +5,7 @@
   <parent>
     <groupId>qupath</groupId>
     <artifactId>qupath</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.2</version>
   </parent>
   <artifactId>qupath-core-processing-awt</artifactId>
   <name>qupath-core-processing-awt</name>

--- a/qupath-core-processing-awt/src/main/java/qupath/lib/display/ChannelDisplayInfo.java
+++ b/qupath-core-processing-awt/src/main/java/qupath/lib/display/ChannelDisplayInfo.java
@@ -212,6 +212,7 @@ public interface ChannelDisplayInfo {
 
 		protected float minAllowed, maxAllowed;
 		protected float minDisplay, maxDisplay;
+		protected boolean clipToAllowed = false;
 
 		// The 'channel' corresponds to the 'band' in Java parlance
 		public AbstractChannelInfo(int nBits) {
@@ -221,6 +222,31 @@ public interface ChannelDisplayInfo {
 			this.maxDisplay = maxAllowed;
 		}
 
+		/**
+		 * Returns true if the min and max display are forced into the allowed range, false otherwise.
+		 * 
+		 * This makes it possible to either be strict about contrast settings or more flexible.
+		 * 
+		 * @return
+		 */
+		public boolean doClipToAllowed() {
+			return clipToAllowed;
+		}
+		
+		/**
+		 * Specify whether min/max display values should be clipped to fall within the allowed range.
+		 * 
+		 * This makes it possible to either be strict about contrast settings or more flexible.
+		 * 
+		 * @param clipToAllowed
+		 */
+		public void setClipToAllowed(final boolean clipToAllowed) {
+			this.clipToAllowed = clipToAllowed;
+			if (clipToAllowed) {
+				this.minDisplay = Math.min(Math.max(minDisplay, minAllowed), maxAllowed);
+				this.maxDisplay = Math.min(Math.max(maxDisplay, minAllowed), maxAllowed);
+			}
+		}
 		
 		@Override
 		public void setMinMaxAllowed(float minAllowed, float maxAllowed) {
@@ -241,12 +267,12 @@ public interface ChannelDisplayInfo {
 
 		@Override
 		public void setMinDisplay(float minDisplay) {
-			this.minDisplay = Math.max(minAllowed, minDisplay);
+			this.minDisplay = clipToAllowed ? Math.max(minAllowed, minDisplay) : minDisplay;
 		}
 
 		@Override
 		public void setMaxDisplay(float maxDisplay) {
-			this.maxDisplay = Math.min(maxAllowed, maxDisplay);
+			this.maxDisplay = clipToAllowed ? Math.min(maxAllowed, maxDisplay) : maxDisplay;
 		}
 		
 		@Override

--- a/qupath-core-processing/pom.xml
+++ b/qupath-core-processing/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.2</version>
+		<version>0.0.3</version>
 	</parent>
 	<artifactId>qupath-core-processing</artifactId>
 	<name>qupath-core-processing</name>

--- a/qupath-core-processing/pom.xml.versionsBackup
+++ b/qupath-core-processing/pom.xml.versionsBackup
@@ -6,30 +6,24 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.3</version>
+		<version>0.0.2</version>
 	</parent>
-	<artifactId>qupath-extension-openslide</artifactId>
-	<name>qupath-extension-openslide</name>
+	<artifactId>qupath-core-processing</artifactId>
+	<name>qupath-core-processing</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
-
 	<dependencies>
 		<dependency>
-			<groupId>org.openslide</groupId>
-			<artifactId>openslide</artifactId>
-			<version>3.4.1</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-math3</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>qupath</groupId>
 			<artifactId>qupath-core</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>qupath</groupId>
-			<artifactId>qupath-core-awt</artifactId>
-		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<plugins>
 			<plugin>
@@ -40,11 +34,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.googlecode.mavennatives</groupId>
-				<artifactId>maven-nativedependencies-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
-	<description>QuPath ImageServer implementation using OpenSlide.</description>
+	<description>Core processing code without external dependencies (apart from logging/testing).</description>
 </project>

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/AbstractPluginRunner.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/AbstractPluginRunner.java
@@ -179,6 +179,9 @@ public abstract class AbstractPluginRunner<T> implements PluginRunner<T> {
 		if (tasks.isEmpty())
 			return;
 		
+		// Reset cancelled status
+		tasksCancelled = false;
+		
 		// Ensure we have a pool
 		if (pool == null || pool.isShutdown()) {
 			int n = getNumThreads();

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/workflow/RunSavedClassifierWorkflowStep.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/workflow/RunSavedClassifierWorkflowStep.java
@@ -26,6 +26,7 @@ package qupath.lib.plugins.workflow;
 import java.util.Collections;
 import java.util.Map;
 
+import qupath.lib.common.GeneralTools;
 import qupath.lib.plugins.workflow.ScriptableWorkflowStep;
 
 /**
@@ -49,7 +50,7 @@ public class RunSavedClassifierWorkflowStep implements ScriptableWorkflowStep {
 	 */
 	public RunSavedClassifierWorkflowStep(final String name, final String classifierPath) {
 		this.name = name;
-		this.classifierPath = classifierPath.replace("\\", "\\\\");
+		this.classifierPath = GeneralTools.escapeFilePath(classifierPath);
 	}
 	
 	public RunSavedClassifierWorkflowStep(final String classifierPath) {

--- a/qupath-core/pom.xml.versionsBackup
+++ b/qupath-core/pom.xml.versionsBackup
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.3</version>
+		<version>0.0.2</version>
 	</parent>
 	<artifactId>qupath-core</artifactId>
 

--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -67,6 +67,16 @@ public class GeneralTools {
 	}
 	
 	/**
+	 * Escape backslashes in an absolute file path - useful when scripting.
+	 * 
+	 * @param path
+	 * @return
+	 */
+	public static String escapeFilePath(final String path) {
+		return path.replace("\\", "\\\\");
+	}
+	
+	/**
 	 * Clip a value to be within a specific range.
 	 * 
 	 * @param value

--- a/qupath-extension-ij/pom.xml
+++ b/qupath-extension-ij/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.2</version>
+		<version>0.0.3</version>
 	</parent>
 	<artifactId>qupath-extension-ij</artifactId>
 	<name>qupath-extension-ij</name>

--- a/qupath-extension-ij/pom.xml.versionsBackup
+++ b/qupath-extension-ij/pom.xml.versionsBackup
@@ -6,30 +6,29 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.3</version>
+		<version>0.0.2</version>
 	</parent>
-	<artifactId>qupath-extension-openslide</artifactId>
-	<name>qupath-extension-openslide</name>
+	<artifactId>qupath-extension-ij</artifactId>
+	<name>qupath-extension-ij</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
-
 	<dependencies>
 		<dependency>
-			<groupId>org.openslide</groupId>
-			<artifactId>openslide</artifactId>
-			<version>3.4.1</version>
+			<groupId>qupath</groupId>
+			<artifactId>qupath-gui-fx</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>qupath</groupId>
-			<artifactId>qupath-core</artifactId>
+			<artifactId>qupath-processing-ij</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>qupath</groupId>
-			<artifactId>qupath-core-awt</artifactId>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
 		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<plugins>
 			<plugin>
@@ -40,11 +39,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.googlecode.mavennatives</groupId>
-				<artifactId>maven-nativedependencies-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
-	<description>QuPath ImageServer implementation using OpenSlide.</description>
+	<description>Integration of ImageJ commands &amp; GUI functions with QuPath.</description>
 </project>

--- a/qupath-extension-input/pom.xml
+++ b/qupath-extension-input/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.2</version>
+		<version>0.0.3</version>
 	</parent>
 	<artifactId>qupath-extension-input</artifactId>
 	<name>qupath-extension-input</name>

--- a/qupath-extension-input/pom.xml.versionsBackup
+++ b/qupath-extension-input/pom.xml.versionsBackup
@@ -6,27 +6,24 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.3</version>
+		<version>0.0.2</version>
 	</parent>
-	<artifactId>qupath-extension-openslide</artifactId>
-	<name>qupath-extension-openslide</name>
+	<artifactId>qupath-extension-input</artifactId>
+	<name>qupath-extension-input</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<dependencies>
 		<dependency>
-			<groupId>org.openslide</groupId>
-			<artifactId>openslide</artifactId>
-			<version>3.4.1</version>
+			<groupId>net.java.jinput</groupId>
+			<artifactId>jinput</artifactId>
+			<version>2.0.6</version>
 		</dependency>
 		<dependency>
 			<groupId>qupath</groupId>
-			<artifactId>qupath-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>qupath</groupId>
-			<artifactId>qupath-core-awt</artifactId>
+			<artifactId>qupath-gui-fx</artifactId>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 	
@@ -46,5 +43,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	<description>QuPath ImageServer implementation using OpenSlide.</description>
+	<description>Support for special input devices - in this case, a 3D mouse.</description>
 </project>

--- a/qupath-extension-opencv/pom.xml
+++ b/qupath-extension-opencv/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.2</version>
+		<version>0.0.3</version>
 	</parent>
 	<artifactId>qupath-extension-opencv</artifactId>
 	<name>qupath-extension-opencv</name>

--- a/qupath-extension-opencv/pom.xml.versionsBackup
+++ b/qupath-extension-opencv/pom.xml.versionsBackup
@@ -6,30 +6,26 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.3</version>
+		<version>0.0.2</version>
 	</parent>
-	<artifactId>qupath-extension-openslide</artifactId>
-	<name>qupath-extension-openslide</name>
+	<artifactId>qupath-extension-opencv</artifactId>
+	<name>qupath-extension-opencv</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<dependencies>
 		<dependency>
-			<groupId>org.openslide</groupId>
-			<artifactId>openslide</artifactId>
-			<version>3.4.1</version>
+			<groupId>qupath</groupId>
+			<artifactId>qupath-gui-fx</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>qupath</groupId>
-			<artifactId>qupath-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>qupath</groupId>
-			<artifactId>qupath-core-awt</artifactId>
+			<artifactId>qupath-processing-opencv</artifactId>
 		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<plugins>
 			<plugin>
@@ -46,5 +42,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	<description>QuPath ImageServer implementation using OpenSlide.</description>
+	<description>OpenCV-dependent code for QuPath.</description>
 </project>

--- a/qupath-extension-openslide/pom.xml.versionsBackup
+++ b/qupath-extension-openslide/pom.xml.versionsBackup
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.3</version>
+		<version>0.0.2</version>
 	</parent>
 	<artifactId>qupath-extension-openslide</artifactId>
 	<name>qupath-extension-openslide</name>

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/OpenslideImageServer.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/OpenslideImageServer.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import qupath.lib.awt.common.AwtTools;
 import qupath.lib.awt.images.PathBufferedImage;
-import qupath.lib.common.GeneralTools;
 import qupath.lib.images.PathImage;
 import qupath.lib.regions.RegionRequest;
 
@@ -202,9 +201,11 @@ public class OpenslideImageServer extends AbstractImageServer<BufferedImage> {
         try {
 			// Create a thumbnail for the region
 			osr.paintRegionARGB(data, region.x, region.y, level, levelWidth, levelHeight);
-			// If we don't have a background color & don't need to resize, we can be done
-			if (backgroundColor == null && GeneralTools.almostTheSame(downsample, downsampleFactor, 0.001))
-				return img;
+			
+			// Previously tried to take shortcut and only repaint if needed - 
+			// but transparent pixels happened too often, and it's really needed to repaint every time
+//			if (backgroundColor == null && GeneralTools.almostTheSame(downsample, downsampleFactor, 0.001))
+//				return img;
 			
 			// Rescale if we have to
 			int width = (int)(region.width / downsampleFactor + .5);

--- a/qupath-extension-openslide/src/main/resources/licenses/OpenSlide/README.md
+++ b/qupath-extension-openslide/src/main/resources/licenses/OpenSlide/README.md
@@ -1,5 +1,25 @@
 OpenSlide source for 3.4.1 is available at https://github.com/openslide/openslide/releases/tag/v3.4.1
 
-Pre-built binaries from http://openslide.org/download/ were used for Windows distribution.
-
 Source for Java is available at https://github.com/openslide/openslide-java/releases/tag/v0.12.1
+
+Pre-built binaries from http://openslide.org/download/ were used for Windows distribution, and subsequently added to a Jar file for easier import from the local Maven repository.
+
+Source for the Windows distribution (including dependencies) is available at https://github.com/openslide/openslide-winbuild/releases/tag/v20150527
+
+Listed versions for OpenSlide dependencies are:
+	zlib                           1.2.8
+	libpng                         1.6.17
+	libjpeg-turbo                  1.4.0
+	libtiff                        4.0.4beta
+	OpenJPEG                       2.1.0
+	win-iconv                      0.0.6
+	gettext                        0.19.4
+	libffi                         3.2.1
+	glib                           2.44.1
+	gdk-pixbuf                     2.31.1
+	pixman                         0.32.6
+	cairo                          1.14.2
+	libxml2                        2.9.2
+	SQLite                         3.8.10.1
+	OpenSlide                      3.4.1
+	OpenSlide Java                 0.12.1

--- a/qupath-extension-pen/pom.xml
+++ b/qupath-extension-pen/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.2</version>
+		<version>0.0.3</version>
 	</parent>
 	<artifactId>qupath-extension-pen</artifactId>
 	<name>qupath-extension-pen</name>

--- a/qupath-extension-pen/pom.xml.versionsBackup
+++ b/qupath-extension-pen/pom.xml.versionsBackup
@@ -6,27 +6,24 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.3</version>
+		<version>0.0.2</version>
 	</parent>
-	<artifactId>qupath-extension-openslide</artifactId>
-	<name>qupath-extension-openslide</name>
+	<artifactId>qupath-extension-pen</artifactId>
+	<name>qupath-extension-pen</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<dependencies>
 		<dependency>
-			<groupId>org.openslide</groupId>
-			<artifactId>openslide</artifactId>
-			<version>3.4.1</version>
+			<groupId>qupath</groupId>
+			<artifactId>qupath-gui-fx</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>qupath</groupId>
-			<artifactId>qupath-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>qupath</groupId>
-			<artifactId>qupath-core-awt</artifactId>
+			<groupId>net.sourceforge.jpen</groupId>
+			<artifactId>jpen</artifactId>
+			<version>2-150301</version>
 		</dependency>
 	</dependencies>
 	
@@ -46,5 +43,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	<description>QuPath ImageServer implementation using OpenSlide.</description>
+	<description>Support for pressure-sensitive graphics tablets as input devices.</description>
 </project>

--- a/qupath-extension-script-editor/pom.xml
+++ b/qupath-extension-script-editor/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.2</version>
+		<version>0.0.3</version>
 	</parent>
 	<artifactId>qupath-extension-script-editor</artifactId>
 	<properties>

--- a/qupath-extension-script-editor/pom.xml.versionsBackup
+++ b/qupath-extension-script-editor/pom.xml.versionsBackup
@@ -6,27 +6,38 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.3</version>
+		<version>0.0.2</version>
 	</parent>
-	<artifactId>qupath-extension-openslide</artifactId>
-	<name>qupath-extension-openslide</name>
+	<artifactId>qupath-extension-script-editor</artifactId>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
+	<!-- <repositories>
+		<repository>
+			<id>bintray</id>
+			<name>Hephaestus</name>
+			<url>https://dl.bintray.com/giancosta86/Hephaestus/</url>
+		</repository>
+	</repositories> -->
 	<dependencies>
 		<dependency>
-			<groupId>org.openslide</groupId>
-			<artifactId>openslide</artifactId>
-			<version>3.4.1</version>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy-jsr223</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>qupath</groupId>
-			<artifactId>qupath-core</artifactId>
+			<artifactId>qupath-gui-fx</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>qupath</groupId>
-			<artifactId>qupath-core-awt</artifactId>
+			<groupId>org.fxmisc.richtext</groupId>
+			<artifactId>richtextfx</artifactId>
+			<version>0.6.10</version>
 		</dependency>
 	</dependencies>
 	
@@ -40,11 +51,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.googlecode.mavennatives</groupId>
-				<artifactId>maven-nativedependencies-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
-	<description>QuPath ImageServer implementation using OpenSlide.</description>
+	<name>qupath-extension-script-editor</name>
+	<description>An improved script editor for QuPath, using RichTextFX.</description>
 </project>

--- a/qupath-gui-fx/pom.xml
+++ b/qupath-gui-fx/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.2</version>
+		<version>0.0.3</version>
 	</parent>
 	<artifactId>qupath-gui-fx</artifactId>
 	<name>qupath-gui-fx</name>

--- a/qupath-gui-fx/pom.xml.versionsBackup
+++ b/qupath-gui-fx/pom.xml.versionsBackup
@@ -6,20 +6,14 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.3</version>
+		<version>0.0.2</version>
 	</parent>
-	<artifactId>qupath-extension-openslide</artifactId>
-	<name>qupath-extension-openslide</name>
+	<artifactId>qupath-gui-fx</artifactId>
+	<name>qupath-gui-fx</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
-
 	<dependencies>
-		<dependency>
-			<groupId>org.openslide</groupId>
-			<artifactId>openslide</artifactId>
-			<version>3.4.1</version>
-		</dependency>
 		<dependency>
 			<groupId>qupath</groupId>
 			<artifactId>qupath-core</artifactId>
@@ -28,8 +22,34 @@
 			<groupId>qupath</groupId>
 			<artifactId>qupath-core-awt</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>qupath</groupId>
+			<artifactId>qupath-core-processing</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>qupath</groupId>
+			<artifactId>qupath-core-processing-awt</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.controlsfx</groupId>
+			<artifactId>controlsfx</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jfxtras</groupId>
+			<artifactId>jfxtras-menu</artifactId>
+		</dependency>
 	</dependencies>
-	
+
+
+	<!-- <build> <plugins> <plugin> <groupId>org.apache.maven.plugins</groupId> 
+		<artifactId>maven-jar-plugin</artifactId> <configuration> <archive> <manifest> 
+		<mainClass>qupath.QuPath</mainClass> </manifest> </archive> </configuration> 
+		</plugin> </plugins> </build> -->
+
 	<build>
 		<plugins>
 			<plugin>
@@ -40,11 +60,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.googlecode.mavennatives</groupId>
-				<artifactId>maven-nativedependencies-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
-	<description>QuPath ImageServer implementation using OpenSlide.</description>
+	<description>Primary JavaFX GUI for QuPath.</description>
 </project>

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -759,31 +759,6 @@ public class QuPathGUI implements ModeWrapper, ImageDataWrapper<BufferedImage>, 
 //	}
 	
 	
-	private static void updateLibraryPath(final File dirExtensions) {
-		if (dirExtensions == null)
-			return;
-		// Ensure that the extensions directory is on the Java library path - in case native libraries are required
-		String libraryPath = System.getProperty("java.library.path");
-		if (libraryPath != null && dirExtensions != null && dirExtensions.isDirectory() && !libraryPath.contains(dirExtensions.getAbsolutePath())) {
-			libraryPath = libraryPath + ":" + dirExtensions;
-			for (File dir : dirExtensions.listFiles()) {
-				if (!dir.isHidden() && dir.isDirectory()) {
-					try {
-						Path dirPath = dir.toPath();
-						if (Files.isSymbolicLink(dirPath))
-							dirPath = Files.readSymbolicLink(dirPath);
-						libraryPath = libraryPath + ":" + dirPath.toFile().getAbsolutePath();
-					} catch (Exception e) {
-						logger.error("Error adding extension path", e);
-					}
-				}
-			}
-			System.setProperty("java.library.path", libraryPath);
-
-		}
-	}
-	
-	
 	/**
 	 * Directory containing extensions.
 	 * 
@@ -796,7 +771,6 @@ public class QuPathGUI implements ModeWrapper, ImageDataWrapper<BufferedImage>, 
 		if (path != null) {
 			File dir = new File(path);
 			if (dir.isDirectory()) {
-				updateLibraryPath(dir);
 				return dir;
 			}
 		}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -173,6 +173,7 @@ import qupath.lib.gui.commands.ProjectImportImagesCommand;
 import qupath.lib.gui.commands.ProjectMetadataEditorCommand;
 import qupath.lib.gui.commands.ProjectOpenCommand;
 import qupath.lib.gui.commands.ProjectSaveCommand;
+import qupath.lib.gui.commands.ResetPreferencesCommand;
 import qupath.lib.gui.commands.RigidObjectEditorCommand;
 import qupath.lib.gui.commands.RotateImageCommand;
 import qupath.lib.gui.commands.SampleScriptLoader;
@@ -945,51 +946,63 @@ public class QuPathGUI implements ModeWrapper, ImageDataWrapper<BufferedImage>, 
 			logger.info("No extension directory found!");
 			// Prompt to create an extensions directory
 			File dirDefault = getDefaultExtensionDirectory();
-			if (dirDefault.exists())
-				dir = dirDefault;
-			else {
-				Dialog<ButtonType> dialog = new Dialog<>();
-				dialog.initOwner(getStage());
-				
-				ButtonType btUseDefault = new ButtonType("Use default", ButtonData.YES);
-				ButtonType btChooseDirectory = new ButtonType("Choose directory", ButtonData.NO);
-				ButtonType btCancel = new ButtonType("Cancel", ButtonData.CANCEL_CLOSE);
-				dialog.getDialogPane().getButtonTypes().setAll(btUseDefault, btChooseDirectory, btCancel);
-				
-				dialog.setHeaderText(null);
-				dialog.setTitle("Choose extensions directory");
-				dialog.setContentText("No extensions directory is set.\n\nQuPath can automatically create one at\n" + dirDefault.getAbsolutePath() + 
-						"\n\nDo you want to use this default, or specify another directory?");
-				Optional<ButtonType> result = dialog.showAndWait();
-				if (!result.isPresent() || result.get() == btCancel) {
-					logger.info("No extension directory set - extensions not installed");
+			String msg;
+			if (dirDefault.exists()) {
+				msg = "An directory already exists at " + dirDefault.getAbsolutePath() + 
+						"\n\nDo you want to use this default, or specify another directory?";
+			} else {
+				msg = "QuPath can automatically create one at\n" + dirDefault.getAbsolutePath() + 
+						"\n\nDo you want to use this default, or specify another directory?";
+			}
+			
+			Dialog<ButtonType> dialog = new Dialog<>();
+			dialog.initOwner(getStage());
+
+			ButtonType btUseDefault = new ButtonType("Use default", ButtonData.YES);
+			ButtonType btChooseDirectory = new ButtonType("Choose directory", ButtonData.NO);
+			ButtonType btCancel = new ButtonType("Cancel", ButtonData.CANCEL_CLOSE);
+			dialog.getDialogPane().getButtonTypes().setAll(btUseDefault, btChooseDirectory, btCancel);
+
+			dialog.setHeaderText(null);
+			dialog.setTitle("Choose extensions directory");
+			dialog.setContentText("No extensions directory is set.\n\n" + msg);
+			Optional<ButtonType> result = dialog.showAndWait();
+			if (!result.isPresent() || result.get() == btCancel) {
+				logger.info("No extension directory set - extensions not installed");
+				return;
+			}
+			if (result.get() == btUseDefault) {
+				if (!dirDefault.exists() && !dirDefault.mkdirs()) {
+					DisplayHelpers.showErrorMessage("Extension error", "Unable to create directory at \n" + dirDefault.getAbsolutePath());
 					return;
 				}
-				if (result.get() == btUseDefault) {
-					if (!dirDefault.mkdirs()) {
-						DisplayHelpers.showErrorMessage("Extension error", "Unable to create directory at \n" + dirDefault.getAbsolutePath());
-						return;
-					}
-					dir = dirDefault;
-					PathPrefs.setExtensionsPath(dir.getAbsolutePath());
-				} else {
-					dir = getDialogHelper().promptForDirectory(dirDefault);
-					if (dir == null) {
-						logger.info("No extension directory set - extensions not installed");
-						return;
-					}
+				dir = dirDefault;
+				PathPrefs.setExtensionsPath(dir.getAbsolutePath());
+			} else {
+				dir = getDialogHelper().promptForDirectory(dirDefault);
+				if (dir == null) {
+					logger.info("No extension directory set - extensions not installed");
+					return;
 				}
 			}
 		}
 		// Create directory if we need it
 		if (!dir.exists())
 			dir.mkdir();
+		
 		// Copy all files into extensions directory
 		Path dest = dir.toPath();
 		for (File file : files) {
 			Path source = file.toPath();
+			Path destination = dest.resolve(source.getFileName());
+			if (destination.toFile().exists()) {
+				// It would be better to check how many files will be overwritten in one go,
+				// but this should be a pretty rare occurrence
+				if (!DisplayHelpers.showConfirmDialog("Install extension", "Overwrite " + destination.toFile().getName() + "?\n\nYou will have to restart QuPath to see the updates."))
+					return;
+			}
 			try {
-				Files.copy(source, dest.resolve(source.getFileName()), StandardCopyOption.REPLACE_EXISTING);
+				Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
 			} catch (IOException e) {
 				DisplayHelpers.showErrorMessage("Extension error", file + "\ncould not be copied, sorry");
 				logger.error("Could not copy file {}", file, e);
@@ -2312,7 +2325,8 @@ public class QuPathGUI implements ModeWrapper, ImageDataWrapper<BufferedImage>, 
 				getActionMenuItem(GUIActions.COPY_VIEW),
 				getActionMenuItem(GUIActions.COPY_WINDOW),
 				null,
-				getActionMenuItem(GUIActions.PREFERENCES)
+				getActionMenuItem(GUIActions.PREFERENCES),
+				createCommandAction(new ResetPreferencesCommand(), "Reset preferences")
 				);
 
 		// Create Tools menu

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -193,7 +193,6 @@ import qupath.lib.gui.commands.TMAAddNote;
 import qupath.lib.gui.commands.TMAExportViewerCommand;
 import qupath.lib.gui.commands.TMAGridAdd;
 import qupath.lib.gui.commands.TMAGridAdd.TMAAddType;
-import qupath.lib.gui.commands.TMAGridRelabel;
 import qupath.lib.gui.commands.TMAGridRemove.TMARemoveType;
 import qupath.lib.gui.commands.TMAGridReset;
 import qupath.lib.gui.commands.TMAGridRemove;
@@ -218,6 +217,7 @@ import qupath.lib.gui.commands.scriptable.SelectObjectsByClassCommand;
 import qupath.lib.gui.commands.scriptable.SelectObjectsByMeasurementCommand;
 import qupath.lib.gui.commands.scriptable.ShapeSimplifierCommand;
 import qupath.lib.gui.commands.scriptable.SpecifyAnnotationCommand;
+import qupath.lib.gui.commands.scriptable.TMAGridRelabel;
 import qupath.lib.gui.commands.selectable.CellDisplaySelectable;
 import qupath.lib.gui.commands.selectable.ToolSelectable;
 import qupath.lib.gui.extensions.QuPathExtension;
@@ -2469,7 +2469,7 @@ public class QuPathGUI implements ModeWrapper, ImageDataWrapper<BufferedImage>, 
 						createCommandAction(new TMAGridRemove(this, TMARemoveType.ROW), "Remove TMA row"),
 						createCommandAction(new TMAGridRemove(this, TMARemoveType.COLUMN), "Remove TMA column")
 						),
-				createCommandAction(new TMAGridRelabel(this), "Relabel TMA cores"),
+				createCommandAction(new TMAGridRelabel(this), "Relabel TMA grid"),
 				createCommandAction(new TMAGridReset(this), "Reset TMA metadata"),
 				getActionMenuItem(GUIActions.CLEAR_TMA_CORES),
 				createCommandAction(new TMAGridView(this), "TMA grid summary view (experimental)"),

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ResetPreferencesCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ResetPreferencesCommand.java
@@ -1,0 +1,52 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
+ * Contact: IP Management (ipmanagement@qub.ac.uk)
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package qupath.lib.gui.commands;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import qupath.lib.gui.commands.interfaces.PathCommand;
+import qupath.lib.gui.helpers.DisplayHelpers;
+import qupath.lib.gui.prefs.PathPrefs;
+
+/**
+ * Command to reset all preferences in PathPrefs to their default states.
+ * 
+ * @author Pete Bankhead
+ *
+ */
+public class ResetPreferencesCommand implements PathCommand {
+	
+	private static Logger logger = LoggerFactory.getLogger(ResetPreferencesCommand.class);
+
+	@Override
+	public void run() {
+		if (DisplayHelpers.showConfirmDialog("Reset Preferences", "Do you want to reset all custom preferences?\n\nYou may have to restart QuPath to see all changes.")) {
+			PathPrefs.resetPreferences();
+		}
+		else
+			logger.info("Reset preferences command skipped!");
+	}
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowSystemInfoCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowSystemInfoCommand.java
@@ -148,11 +148,11 @@ public class ShowSystemInfoCommand implements PathCommand {
 	    // Show paths (at the end, since they may be rather long)
 		sb.append("\n");
 		sb.append("Library path:");
-		for (String p : System.getProperty("java.library.path").split(":"))
+		for (String p : System.getProperty("java.library.path").split(File.pathSeparator))
 			sb.append("\n      ").append(p);
 		sb.append("\n\n");
 		sb.append("Class path:");
-		for (String p : System.getProperty("java.class.path").split(":"))
+		for (String p : System.getProperty("java.class.path").split(File.pathSeparator))
 			sb.append("\n      ").append(p);
 		
 		return sb.toString();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMAExporterCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMAExporterCommand.java
@@ -27,6 +27,7 @@ import java.awt.image.BufferedImage;
 
 import java.io.File;
 
+import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.ViewerManager;
 import qupath.lib.gui.commands.interfaces.PathCommand;
@@ -77,7 +78,7 @@ public class TMAExporterCommand implements PathCommand {
 		if (file != null) {
 			double downsample = PathPrefs.getTMAExportDownsample();
 			PathAwtIO.writeTMAData(file, imageData, viewer.getOverlayOptions(), downsample);
-			WorkflowStep step = new DefaultScriptableWorkflowStep("Export TMA data", "exportTMAData(\"" + file.getAbsolutePath() + "\", " + downsample + ")");
+			WorkflowStep step = new DefaultScriptableWorkflowStep("Export TMA data", "exportTMAData(\"" + GeneralTools.escapeFilePath(file.getParentFile().getAbsolutePath()) + "\", " + downsample + ")");
 			imageData.getHistoryWorkflow().addStep(step);
 //			PathAwtIO.writeTMAData(file, imageData, viewer.getOverlayOptions(), Double.NaN);
 			dirPrevious = file.getParentFile();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMAScoreImportCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMAScoreImportCommand.java
@@ -261,7 +261,7 @@ public class TMAScoreImportCommand implements PathCommand {
 		// Try to create a string grid
 		List<String[]> rows = new ArrayList<>();
 		int nCols = -1;
-		for (String row : text.split("\n|\r")) {
+		for (String row : text.split("\\r?\\n")) {
 			String[] cols;
 			if (row.contains("\t"))
 				cols = row.split("\t");

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/scriptable/InverseObjectCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/scriptable/InverseObjectCommand.java
@@ -24,6 +24,8 @@
 package qupath.lib.gui.commands.scriptable;
 
 import java.awt.geom.Area;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,6 +90,12 @@ public class InverseObjectCommand implements PathCommand {
 		// Create the new ROI
 		PathShape shapeNew = PathROIToolsAwt.combineROIs(shape, shapeSelected, PathROIToolsAwt.CombineOp.SUBTRACT);
 		PathObject pathObjectNew = new PathAnnotationObject(shapeNew);
+		
+		// Reassign all other children to the new parent
+		List<PathObject> children = new ArrayList<>(parent.getChildObjects());
+		children.remove(pathObject);
+		pathObjectNew.addPathObjects(children);
+		
 		parent.addPathObject(pathObjectNew);
 		hierarchy.fireHierarchyChangedEvent(parent);
 		hierarchy.getSelectionModel().setSelectedObject(pathObjectNew);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/helpers/DisplayHelpers.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/helpers/DisplayHelpers.java
@@ -366,6 +366,34 @@ public class DisplayHelpers {
 	}
 	
 	
+	/**
+	 * Show an input dialog requesting a numeric value.
+	 * 
+	 * @param title
+	 * @param message
+	 * @param initialInput
+	 * @return Number input by the user, or NaN if no valid number was entered, or null if cancel was pressed.
+	 */
+	public static Double showInputDialog(final String title, final String message, final Double initialInput) {
+		String result = showInputDialog(title, message, initialInput == null ? "" : initialInput.toString());
+		if (result == null)
+			return null;
+		try {
+			return Double.parseDouble(result);
+		} catch (Exception e) {
+			logger.error("Unable to parse numeric value from {}", result);
+			return Double.NaN;
+		}
+	}
+	
+	/**
+	 * Show an input dialog requesting a String input.
+	 * 
+	 * @param title
+	 * @param message
+	 * @param initialInput
+	 * @return
+	 */
 	public static String showInputDialog(final String title, final String message, final String initialInput) {
 		if (Platform.isFxApplicationThread()) {
 			TextInputDialog dialog = new TextInputDialog(initialInput);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/PreferencePanel.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/PreferencePanel.java
@@ -457,6 +457,19 @@ public class PreferencePanel {
 
 		private Property<String> prop;
 		private ObservableValue<File> fileValue;
+		
+//		private ObjectProperty<File> fileValue;
+//
+//		DirectoryPropertyItem(final Property<String> prop) {
+//			this.prop = prop;
+//			fileValue = new SimpleObjectProperty<>();
+//			updateFileProperty();
+//			prop.addListener((v, o, n) -> updateFileProperty());
+//		}
+//		
+//		private void updateFileProperty() {
+//			fileValue.set(prop.getValue() == null ? null : new File(prop.getValue()));
+//		}
 
 		DirectoryPropertyItem(final Property<String> prop) {
 			this.prop = prop;
@@ -567,6 +580,12 @@ public class PreferencePanel {
 			});
 			if (property.getDescription() != null)
 				control.setTooltip(new Tooltip(property.getDescription()));
+			
+			// Bind to the text property
+			if (property instanceof DirectoryPropertyItem) {
+				control.textProperty().bindBidirectional(((DirectoryPropertyItem)property).prop);
+			}
+			value = Bindings.createObjectBinding(() -> new File(control.getText()), control.textProperty());
 		}
 
 		@Override
@@ -576,10 +595,6 @@ public class PreferencePanel {
 
 		@Override
 		protected ObservableValue<File> getObservableValue() {
-			if (value == null) {
-				TextField control = getEditor();
-				value = Bindings.createObjectBinding(() -> new File(control.getText()), control.textProperty());
-			}
 			return value;
 		}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -65,12 +65,9 @@ import qupath.lib.projects.ProjectIO;
  */
 public class PathPrefs {
 	
-	final private static String NODE_NAME = "uk.ac.qupath.prefs";
-	
-//	final private static String NODE_NAME = "QuPathAppID";
+	final private static String NODE_NAME = "io.github.qupath";
 	
 	private static Logger logger = LoggerFactory.getLogger(PathPrefs.class);
-
 	
 	public static BooleanProperty useProjectImageCache = createPersistentPreference("useProjectImageCache", Boolean.FALSE);
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -69,6 +69,11 @@ public class PathPrefs {
 	
 	private static Logger logger = LoggerFactory.getLogger(PathPrefs.class);
 	
+	/**
+	 * Flag used to trigger when properties should be reset to their default values.
+	 */
+	private static BooleanProperty resetProperty = new SimpleBooleanProperty(Boolean.FALSE);
+
 	public static BooleanProperty useProjectImageCache = createPersistentPreference("useProjectImageCache", Boolean.FALSE);
 	
 	/**
@@ -212,6 +217,7 @@ public class PathPrefs {
 			Preferences prefs = getUserPreferences();
 			prefs.removeNode();
 			prefs.flush();
+			resetProperty.set(!resetProperty.get());
 			logger.info("Preferences have been reset");
 		} catch (BackingStoreException e) {
 			logger.error("Failed to reset preferences", e);
@@ -952,6 +958,8 @@ public class PathPrefs {
 		BooleanProperty property = createTransientPreference(name, defaultValue);
 		property.set(getUserPreferences().getBoolean(name, defaultValue));
 		property.addListener((v, o, n) -> getUserPreferences().putBoolean(name, n));
+		// Triggered when reset is called
+		resetProperty.addListener((c, o, v) -> property.setValue(defaultValue));
 		return property;
 	}
 	
@@ -979,6 +987,8 @@ public class PathPrefs {
 		IntegerProperty property = createTransientPreference(name, defaultValue);
 		property.set(getUserPreferences().getInt(name, defaultValue));
 		property.addListener((v, o, n) -> getUserPreferences().putInt(name, n.intValue()));
+		// Triggered when reset is called
+		resetProperty.addListener((c, o, v) -> property.setValue(defaultValue));
 		return property;
 	}
 	
@@ -1006,6 +1016,8 @@ public class PathPrefs {
 		DoubleProperty property = createTransientPreference(name, defaultValue);
 		property.set(getUserPreferences().getDouble(name, defaultValue));
 		property.addListener((v, o, n) -> getUserPreferences().putDouble(name, n.doubleValue()));
+		// Triggered when reset is called
+		resetProperty.addListener((c, o, v) -> property.setValue(defaultValue));
 		return property;
 	}
 	
@@ -1032,7 +1044,14 @@ public class PathPrefs {
 	public static StringProperty createPersistentPreference(final String name, final String defaultValue) {
 		StringProperty property = createTransientPreference(name, defaultValue);
 		property.set(getUserPreferences().get(name, defaultValue));
-		property.addListener((v, o, n) -> getUserPreferences().put(name, n));
+		property.addListener((v, o, n) -> {
+			if (n == null)
+				getUserPreferences().remove(name);
+			else
+				getUserPreferences().put(name, n);
+		});
+		// Triggered when reset is called
+		resetProperty.addListener((c, o, v) -> property.setValue(defaultValue));
 		return property;
 	}
 	
@@ -1070,6 +1089,8 @@ public class PathPrefs {
 		FloatProperty property = new PositiveFloatThicknessProperty(name, defaultValue);
 		property.set(getUserPreferences().getFloat(name, defaultValue));
 		property.addListener((v, o, n) -> getUserPreferences().putFloat(name, n.floatValue()));
+		// Triggered when reset is called
+		resetProperty.addListener((c, o, v) -> property.setValue(defaultValue));
 		return property;
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -42,7 +42,6 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;

--- a/qupath-gui-fx/src/main/resources/logback.xml
+++ b/qupath-gui-fx/src/main/resources/logback.xml
@@ -10,7 +10,7 @@
 
 
 
-  <root level="debug">
+  <root level="info">
     <appender-ref ref="STDOUT" />
   </root>
   

--- a/qupath-gui-fx/src/main/resources/scripts/Set_logging_level.groovy
+++ b/qupath-gui-fx/src/main/resources/scripts/Set_logging_level.groovy
@@ -1,0 +1,25 @@
+/*
+ * Set the logging level to 'debug'.
+ *
+ * This will result in more information being logged - which could be useful for
+ * debugging... or might just get in the way.
+ *
+ * Note #1: other logging levels are possible. In order of increasing verbosity, these are:
+ *   - Level.ERROR
+ *   - Level.WARN
+ *   - Level.INFO
+ *   - Level.DEBUG
+ *   - Level.TRACE
+ *
+ * Note #2: This assumes that Logback is being used (it is by default with QuPath).
+ */
+
+
+import ch.qos.logback.classic.Level
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+
+def root = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+root.setLevel(Level.DEBUG)
+println("Logger level: " + root.getLevel())

--- a/qupath-processing-ij/pom.xml
+++ b/qupath-processing-ij/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.2</version>
+		<version>0.0.3</version>
 	</parent>
 	<artifactId>qupath-processing-ij</artifactId>
 	<name>qupath-processing-ij</name>

--- a/qupath-processing-ij/pom.xml.versionsBackup
+++ b/qupath-processing-ij/pom.xml.versionsBackup
@@ -6,19 +6,17 @@
 	<parent>
 		<groupId>qupath</groupId>
 		<artifactId>qupath</artifactId>
-		<version>0.0.3</version>
+		<version>0.0.2</version>
 	</parent>
-	<artifactId>qupath-extension-openslide</artifactId>
-	<name>qupath-extension-openslide</name>
+	<artifactId>qupath-processing-ij</artifactId>
+	<name>qupath-processing-ij</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
-
 	<dependencies>
 		<dependency>
-			<groupId>org.openslide</groupId>
-			<artifactId>openslide</artifactId>
-			<version>3.4.1</version>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>qupath</groupId>
@@ -28,8 +26,16 @@
 			<groupId>qupath</groupId>
 			<artifactId>qupath-core-awt</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>qupath</groupId>
+			<artifactId>qupath-core-processing</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>qupath</groupId>
+			<artifactId>qupath-core-processing-awt</artifactId>
+		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<plugins>
 			<plugin>
@@ -40,11 +46,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.googlecode.mavennatives</groupId>
-				<artifactId>maven-nativedependencies-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
-	<description>QuPath ImageServer implementation using OpenSlide.</description>
+	<description>Processing commands for QuPath that depend on ImageJ.</description>
 </project>

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/dearray/TMADearrayerPluginIJ.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/dearray/TMADearrayerPluginIJ.java
@@ -365,7 +365,7 @@ public class TMADearrayerPluginIJ extends AbstractInteractivePlugin<BufferedImag
 	
 	@Override
 	protected void addWorkflowStep(final ImageData<BufferedImage> imageData, final String arg) {
-		WorkflowStep step = new SimplePluginWorkflowStep(getName(), (Class<? extends PathPlugin<?>>)getClass(), arg, "if (!isTMADearrayed())\n\t", null);
+		WorkflowStep step = new SimplePluginWorkflowStep(getName(), (Class<? extends PathPlugin<?>>)getClass(), arg, "if (!isTMADearrayed()) {\n\t", "\n\treturn;\n}");
 		imageData.getHistoryWorkflow().addStep(step);
 		logger.info("{}", step);
 	}

--- a/qupath-processing-opencv/pom.xml.versionsBackup
+++ b/qupath-processing-opencv/pom.xml.versionsBackup
@@ -5,7 +5,7 @@
   <parent>
     <groupId>qupath</groupId>
     <artifactId>qupath</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.2</version>
   </parent>
   <artifactId>qupath-processing-opencv</artifactId>
   <name>qupath-processing-opencv</name>

--- a/src/main/resources/eclipse/README.md
+++ b/src/main/resources/eclipse/README.md
@@ -1,0 +1,19 @@
+## Setting up QuPath in Eclipse
+
+Warning!  The instructions below are rather unrefined, but hopefully give enough of a starting point.
+
+To run QuPath within Eclipse, a few steps are needed:
+- Install e(fx)clipse - http://www.eclipse.org/efxclipse/
+- Check out the QuPath repository/fork
+- File -> Import... the project to Eclipse using Maven -> Existing Maven Projects
+- Set build path etc. appropriately
+
+Since the last step is rather vague, a rather hackish way to approach it is:
+- Copy the 'classpath' and 'project' files in this resource directory into your primary 'qupath' project directory, and rename as '.classpath' and '.project'
+- Right-click on your 'qupath' project and choose 'Maven -> Update project...' (may not be essential, but generally a good first option when things go wrong)
+- Right-click again and choose 'Run As -> Maven install' (this will get native libraries etc. in basically the right place)
+- Right-click and select 'Build Path -> Configure Build Path...'; under the 'Libraries -> Maven Dependencies' option set the native library location to be qupath/deploy/natives
+
+If all goes well, you should be able to run qupath.QuPath as an application now.
+
+Note: For Windows, it seems to be necessary to adjust the Run Configuration to have qupath/deploy/natives as the working directory as well to get native libraries to work acceptably.

--- a/src/main/resources/eclipse/classpath
+++ b/src/main/resources/eclipse/classpath
@@ -1,55 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-        <classpathentry kind="src" output="target/classes" path="src/main/java">
-                <attributes>
-                        <attribute name="optional" value="true"/>
-                        <attribute name="maven.pomderived" value="true"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
-                <attributes>
-                        <attribute name="maven.pomderived" value="true"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry kind="src" output="target/test-classes" path="src/test/java">
-                <attributes>
-                        <attribute name="optional" value="true"/>
-                        <attribute name="maven.pomderived" value="true"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-                <attributes>
-                        <attribute name="maven.pomderived" value="true"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
-                <attributes>
-                        <attribute name="maven.pomderived" value="true"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
-                <attributes>
-                        <attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="qupath-main/deploy/natives"/>
-                        <attribute name="maven.pomderived" value="true"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-core"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-core-awt"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-core-processing"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-ij"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-openslide"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-input"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-pen">
-                <attributes>
-                        <attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="qupath-pen/target/natives/jpen-2-150301"/>
-                </attributes>
-        </classpathentry>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-opencv"/>
-        <classpathentry kind="con" path="org.eclipse.fx.ide.jdt.core.JAVAFX_CONTAINER"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-scripting"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-core-processing-awt"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-gui-fx"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-ij-processing"/>
-        <classpathentry combineaccessrules="false" kind="src" path="/qupath-opencv-processing"/>
-        <classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="qupath/deploy/natives"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="src" path="src/test/java"/>
+	<classpathentry kind="src" path="src/test/resources"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-core"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-core-awt"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-core-processing"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-core-processing-awt"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-extension-ij"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-extension-input"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-extension-opencv"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-extension-openslide"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-extension-pen"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-extension-script-editor"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-gui-fx"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-processing-ij"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/qupath-processing-opencv"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/main/resources/eclipse/eclipse_classpath_explanation
+++ b/src/main/resources/eclipse/eclipse_classpath_explanation
@@ -1,4 +1,0 @@
-Eclipse's .classpath files aren't included in git any more (although .project files remain).
-If yours gets lost, you can try taking the classpath file from this directory and put it into qupath-main, remaining it to .classpath
-
-Maven -> Update Project should take care of the other class paths, only qupath-main is more awkward.

--- a/src/main/resources/eclipse/project
+++ b/src/main/resources/eclipse/project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>qupath</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
* Fixed several formatting issues for Windows, including:
  * Import of tab-delimited data (e.g. TMA grids)
  * Escaping of paths when exporting TMA data
  * Separation of paths in 'Help -> System info'
  * Cached image paths (still experimental)
* TMA data export now records directory (rather than name) in script, so that it can be reused across a project without editing
* Added use of OpenSlide's background color - this fixes previously-buggy appearance when scans where part of the image is omitted (e.g. some mrxs images)
* Updated TMA dearraying command to support fluorescence TMAs
* Modified TMA dearraying script command to abort if dearraying for the first time by default - this encourages good practice of checking dearrayed result prior to running full analysis (although means that any generated script would need to be run twice - once to dearray, and then again to do everything else)
* 'Relabel TMA Grid' now a scriptable command
* Fixed reassigning child objects with 'Make inverse annotation' command
* Fixed bug that prevented plugins cancelling more than once
* Minor improvements to Brightness/Contrast panel
* Set default logging level to INFO
* Added sample script to change logging level
* Improved display of licenses & third-party dependencies
* Updated location of user preferences
* Added menu entry to reset preferences