### PR TITLE
Fix setThickStrokeThickness in PathPrefs to set the correct value

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -1702,7 +1702,7 @@ public class PathPrefs {
     }
     
     public static void setThickStrokeThickness(float thickness) {
-    	strokeThinThickness.set(thickness);
+    	strokeThickThickness.set(thickness);
     }
 
     public static float getThickStrokeThickness() {


### PR DESCRIPTION
Discovered this while attempting to set the stroke thickness on an Annotation.