### PR TITLE
Search by URIs + minor fixes

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/classify/PathClassifierPanel.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/classify/PathClassifierPanel.java
@@ -26,7 +26,10 @@ package qupath.lib.gui.panels.classify;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +47,8 @@ import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.tools.PaneTools;
 import qupath.lib.gui.viewer.QuPathViewer;
 import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathDetectionObject;
+import qupath.lib.objects.PathObject;
 import qupath.lib.plugins.workflow.RunSavedClassifierWorkflowStep;
 
 
@@ -121,7 +126,15 @@ public class PathClassifierPanel {
 		if (classifier == null || imageData == null || !classifier.isValid())
 			return;
 
-
+		Collection<PathObject> pathObjects = imageData.getHierarchy().getDetectionObjects();
+		var availableFeatures = PathClassifierTools.getAvailableFeatures(pathObjects);
+		var requiredFeatures = classifier.getRequiredMeasurements();
+		String missingFeatures = requiredFeatures.stream()
+										.filter(p -> !availableFeatures.contains(p))
+										.collect(Collectors.joining("\n\t"));
+		if (!missingFeatures.isEmpty())
+			logger.warn("Detection objects are missing the following feature(s):\n\t" + missingFeatures +  "\nWill proceed with classification anyway..");
+		
 		// TODO: Set cursor
 
 		//		QuPathGUI qupath = manager instanceof QuPathGUI ? (QuPathGUI)manager : null;


### PR DESCRIPTION
- Added the possibility to sort project entries by additional keys (more than just entry metadata values, see below).
- Added URI key to sort project entries by URIs (e.g. different images coming from the same file will be grouped together).
- A warning now appears when applying detection classifier with missing features (https://github.com/qupath/qupath/issues/411)