### PR TITLE
Helper method to format spinners input

### DIFF
--- a/qupath-experimental/src/main/java/qupath/experimental/commands/SimpleThresholdCommand.java
+++ b/qupath-experimental/src/main/java/qupath/experimental/commands/SimpleThresholdCommand.java
@@ -31,6 +31,7 @@ import qupath.lib.gui.ml.PixelClassificationOverlay;
 import qupath.lib.gui.ml.PixelClassifierPane;
 import qupath.lib.gui.ml.PixelClassifierTools;
 import qupath.lib.gui.ml.PixelClassifierPane.ClassificationResolution;
+import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.gui.tools.PaneTools;
 import qupath.lib.gui.viewer.QuPathViewer;
 import qupath.lib.gui.viewer.overlays.PathOverlay;
@@ -142,6 +143,7 @@ public class SimpleThresholdCommand implements Runnable {
 		labelSigma.textProperty().bind(
 				Bindings.createStringBinding(() -> GeneralTools.formatNumber(sigma.get(), 2), sigma)
 				);
+		GuiTools.restrictSpinnerInputToNumber(sigmaSpinner, true);
 		PaneTools.addGridRow(pane, row++, 0, "Select smoothing sigma value (higher values give a smoother result)", label, sigmaSpinner, labelSigma);
 
 		label = new Label("Threshold");
@@ -150,6 +152,7 @@ public class SimpleThresholdCommand implements Runnable {
 		labelThreshold.textProperty().bind(
 				Bindings.createStringBinding(() -> GeneralTools.formatNumber(threshold.get(), 2), threshold)
 				);
+		GuiTools.restrictSpinnerInputToNumber(spinner, true);
 		PaneTools.addGridRow(pane, row++, 0, "Select threshold value", label, spinner, labelThreshold);
 
 		Label labelAbove = new Label("Above threshold");

--- a/qupath-experimental/src/main/java/qupath/lib/gui/ml/FeatureCalculatorBuilder.java
+++ b/qupath-experimental/src/main/java/qupath/lib/gui/ml/FeatureCalculatorBuilder.java
@@ -1,13 +1,10 @@
 package qupath.lib.gui.ml;
 
 import java.awt.image.BufferedImage;
-import java.text.NumberFormat;
-import java.text.ParsePosition;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.function.UnaryOperator;
 
 import org.controlsfx.control.CheckComboBox;
 import org.slf4j.Logger;
@@ -23,7 +20,6 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Spinner;
-import javafx.scene.control.TextFormatter;
 import javafx.scene.layout.GridPane;
 import qupath.lib.gui.dialogs.Dialogs;
 import qupath.lib.gui.tools.GuiTools;
@@ -306,26 +302,12 @@ abstract class FeatureCalculatorBuilder {
 			var spinnerNormalize = new Spinner<Double>(0.0, 32.0, 8.0, 1.0);
 			normalizationSigma = spinnerNormalize.valueProperty();
 			spinnerNormalize.setEditable(true);
-			
-			NumberFormat format = NumberFormat.getNumberInstance();
-			UnaryOperator<TextFormatter.Change> filter = c -> {
-			    if (c.isContentChange()) {
-			    	String newText = c.getControlNewText();
-			        ParsePosition parsePosition = new ParsePosition(0);
-			        format.parse(newText, parsePosition);
-			        if (parsePosition.getIndex() < c.getControlNewText().length()) {
-			            return null;
-			        }
-			    }
-			    return c;
-			};
-			TextFormatter<Integer> normalizeFormatter = new TextFormatter<Integer>(filter);
-			spinnerNormalize.getEditor().setTextFormatter(normalizeFormatter);
+			GuiTools.restrictSpinnerInputToNumber(spinnerNormalize, true);
 			spinnerNormalize.focusedProperty().addListener((v, o, n) -> {
-					if (spinnerNormalize.getEditor().getText().equals(""))
-						spinnerNormalize.getValueFactory().valueProperty().set(0.0);
+				if (spinnerNormalize.getEditor().getText().equals(""))
+					spinnerNormalize.getValueFactory().valueProperty().set(0.0);
 			});
-
+			
 			var cb3D = new CheckBox("Use 3D filters");
 			do3D = cb3D.selectedProperty();
 

--- a/qupath-experimental/src/main/java/qupath/lib/gui/ml/PixelClassifierPane.java
+++ b/qupath-experimental/src/main/java/qupath/lib/gui/ml/PixelClassifierPane.java
@@ -463,8 +463,10 @@ public class PixelClassifierPane {
 		btnFeatureAuto.setMaxHeight(Double.MAX_VALUE);
 		spinFeatureMin.disableProperty().bind(featureDisableBinding);
 		spinFeatureMin.setEditable(true);
+		GuiTools.restrictSpinnerInputToNumber(spinFeatureMin, true);
 		spinFeatureMax.disableProperty().bind(featureDisableBinding);
 		spinFeatureMax.setEditable(true);
+		GuiTools.restrictSpinnerInputToNumber(spinFeatureMax, true);
 		var paneFeatures = new GridPane();
 		comboDisplayFeatures.setTooltip(new Tooltip("Choose classification result or feature overlay to display (Warning: This requires a lot of memory & computation!)"));
 		spinFeatureMin.setTooltip(new Tooltip("Min display value for feature overlay"));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -5,6 +5,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.net.URI;
 import java.text.NumberFormat;
+import java.text.ParsePosition;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.controlsfx.control.CheckComboBox;
@@ -41,8 +43,10 @@ import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.Slider;
+import javafx.scene.control.Spinner;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.WritableImage;
@@ -653,6 +657,35 @@ public class GuiTools {
 		} else
 			Platform.runLater(() -> refreshList(listView));
 	}
+	
+	
+	/**
+	 * Restrict the possible spinner input to integer (or double) format.
+	 * @param spinner
+	 * @param allowDecimals
+	 */
+	public static void restrictSpinnerInputToNumber(Spinner<? extends Number> spinner, boolean allowDecimals) {
+		NumberFormat format;
+		if (allowDecimals)
+			format = NumberFormat.getNumberInstance();
+		else
+			format = NumberFormat.getIntegerInstance();
+		
+		UnaryOperator<TextFormatter.Change> filter = c -> {
+		    if (c.isContentChange()) {
+		    	String newText = c.getControlNewText();
+		        ParsePosition parsePosition = new ParsePosition(0);
+		        format.parse(newText, parsePosition);
+		        if (parsePosition.getIndex() < c.getControlNewText().length()) {
+		            return null;
+		        }
+		    }
+		    return c;
+		};
+		TextFormatter<Integer> normalizeFormatter = new TextFormatter<Integer>(filter);
+		spinner.getEditor().setTextFormatter(normalizeFormatter);		
+	}
+	
 
 	/**
 	 * Prompt the user to set properties for the currently-selected annotation(s).


### PR DESCRIPTION
- Created helper method in GuiTools class to restrict input of spinners to either Integer format or Double format.
- Restricted spinners from the Pixel Classifier pane (and its feature pane) and the Simple Thresholder pane.