### PR TITLE
Fixed CompressionType display

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriter.java
@@ -177,37 +177,24 @@ public class OMEPyramidWriter {
 			case ZLIB:
 				return "ZLIB (lossless)";
 			default:
-				throw new IllegalArgumentException("Unknown compression type " + this);
-			}
-		}
-
-		/**
-		 * Get the CompressionType corresponding to the given input
-		 * @param compression
-		 * @return
-		 */
-		public static CompressionType fromFriendlyString(String compression) {
-			switch(compression) {
-			case "Default (lossless or lossy)":
-				return DEFAULT;
-			case "JPEG-2000 (lossless)":
-				return J2K;
-			case "JPEG-2000 (lossy)":
-				return J2K_LOSSY;
-			case "JPEG (lossy)":
-				return JPEG;
-			case "Uncompressed":
-				return UNCOMPRESSED;
-			case "LZW (lossless)":
-				return LZW;
-			case "ZLIB (lossless)":
-				return ZLIB;
-			default:
-				throw new IllegalArgumentException("Unknown compression type " + compression);
+				throw new IllegalArgumentException("Unknown compression type: " + this);
 			}
 		}
 		
+		/**
+		 * Get the CompressionType corresponding to the given input
+		 * @param friendlyCompression
+		 * @return
+		 */
+		public static CompressionType fromFriendlyString(String friendlyCompression) {
+			for (var compression: CompressionType.values()) {
+				if (friendlyCompression.equals(compression.toFriendlyString()))
+					return compression;
+			}
+			throw new IllegalArgumentException("Unknown compression type: " + friendlyCompression);
+		}
 	}
+
 	
 	
 	private static int DEFAULT_TILE_SIZE = 512;

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriter.java
@@ -180,6 +180,32 @@ public class OMEPyramidWriter {
 				throw new IllegalArgumentException("Unknown compression type " + this);
 			}
 		}
+
+		/**
+		 * Get the CompressionType corresponding to the given input
+		 * @param compression
+		 * @return
+		 */
+		public static CompressionType fromFriendlyString(String compression) {
+			switch(compression) {
+			case "Default (lossless or lossy)":
+				return DEFAULT;
+			case "JPEG-2000 (lossless)":
+				return J2K;
+			case "JPEG-2000 (lossy)":
+				return J2K_LOSSY;
+			case "JPEG (lossy)":
+				return JPEG;
+			case "Uncompressed":
+				return UNCOMPRESSED;
+			case "LZW (lossless)":
+				return LZW;
+			case "ZLIB (lossless)":
+				return ZLIB;
+			default:
+				throw new IllegalArgumentException("Unknown compression type " + compression);
+			}
+		}
 		
 	}
 	

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriterCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriterCommand.java
@@ -142,13 +142,13 @@ public class OMEPyramidWriterCommand implements Runnable {
 		
 		// Set compression - with a sanity check for validity, defaulting to another comparable method if necessary
 		CompressionType compression = getDefaultPyramidCompression();
-		List<CompressionType> compatibleCompression = Arrays.stream(CompressionType.values()).filter(c -> c.supportsImage(server)).collect(Collectors.toList());
-		if (!compatibleCompression.contains(compression))
+		List<String> compatibleCompression = Arrays.stream(CompressionType.values()).filter(c -> c.supportsImage(server)).map(c -> c.toFriendlyString()).collect(Collectors.toList());
+		if (!compatibleCompression.contains(compression.toFriendlyString()))
 			compression = CompressionType.DEFAULT;
 		
 		
 		var params = new ParameterList()
-				.addChoiceParameter("compression", "Compression type", compression, compatibleCompression)
+				.addChoiceParameter("compression", "Compression type", compression.toFriendlyString(), compatibleCompression)
 				.addIntParameter("scaledDownsample", "Pyramidal downsample", scaledDownsample.get(), "", 1, 8,
 						"Amount to downsample each consecutive pyramidal level; use 1 to indicate the image should not be pyramidal")
 				.addIntParameter("tileSize", "Tile size", getDefaultTileSize(), "px", "Tile size for export (should be between 128 and 8192)")
@@ -167,7 +167,7 @@ public class OMEPyramidWriterCommand implements Runnable {
 		if (!Dialogs.showParameterDialog("Export OME-TIFF", params))
 			return;
 		
-		compression = (CompressionType)params.getChoiceParameterValue("compression");
+		compression = CompressionType.fromFriendlyString((String)params.getChoiceParameterValue("compression"));
 		defaultPyramidCompression.set(compression);
 		
 		int downsampleScale = params.getIntParameterValue("scaledDownsample");


### PR DESCRIPTION
Fixed display of CompressionType in QuPath while keeping the original 'simple' display in the CLI.