### PR TITLE
Fixed max memory bug

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -269,6 +269,7 @@ public class PathPrefs {
 					List<String> lines = Files.readAllLines(config);
 					int jvmOptions = -1;
 					int argOptions = -1;
+					int lineXx = -1;
 					int lineXmx = -1;
 					int i = 0;
 					for (String line : lines) {
@@ -276,11 +277,15 @@ public class PathPrefs {
 					        jvmOptions = i;
 					    if (line.startsWith("[ArgOptions]"))
 					        argOptions = i;
+					    if (line.toLowerCase().contains("-xx"))
+					    	lineXx = i;
 					    if (line.toLowerCase().contains("-xmx"))
 					        lineXmx = i;
 					    i++;
 					}
-					if (lineXmx >= 0)
+					if (lineXx >= 0)
+						lines.set(lineXx, memory);
+					else if (lineXmx >= 0)
 					    lines.set(lineXmx, memory);
 					else if (argOptions > jvmOptions && jvmOptions >= 0) {
 					    lines.add(jvmOptions+1, memory);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -277,7 +277,7 @@ public class PathPrefs {
 					        jvmOptions = i;
 					    if (line.startsWith("[ArgOptions]"))
 					        argOptions = i;
-					    if (line.toLowerCase().contains("-xx"))
+					    if (line.toLowerCase().contains("-xx:maxrampercentage"))
 					    	lineXx = i;
 					    if (line.toLowerCase().contains("-xmx"))
 					        lineXmx = i;


### PR DESCRIPTION
- Fixed bug where the max memory remained unchanged after manually setting it (in the setup option), even after restarting QuPath. 

Github issue: https://github.com/qupath/qupath/issues/490