### PR TITLE
Improve registration of type adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is a *minor release* that fixes the following bugs:
 * Create thresholder' dialog grows in size and forgets recent options when reopening (https://github.com/qupath/qupath/issues/517)
 * Brightness/Contrast & color transforms reset when training a pixel classifier/creating a thresholder for an RGB image (https://github.com/qupath/qupath/issues/509)
 * Null pointer exception when opening an incompatible image when training a pixel classifier (e.g. RGB to multichannel)
+* Occasional "Width (-1) and height (-1) cannot be <= 0" error when opening an image
 
 
 ## Version 0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a *minor release* that fixes the following bugs:
 * Brightness/Contrast & color transforms reset when training a pixel classifier/creating a thresholder for an RGB image (https://github.com/qupath/qupath/issues/509)
 * Null pointer exception when opening an incompatible image when training a pixel classifier (e.g. RGB to multichannel)
 * Occasional "Width (-1) and height (-1) cannot be <= 0" error when opening an image
+* Warnings/errors reported when first loading libraries via JavaCPP
 
 
 ## Version 0.2.0

--- a/build.gradle
+++ b/build.gradle
@@ -313,15 +313,16 @@ allprojects {
 
     opencv "org.bytedeco:opencv:${opencvVersion}"
     if (nativesCPP != null) {
-	  opencv "org.bytedeco:openblas::${nativesCPP}" // Required for OpenCV with JavaCPP >= 1.5.1
-      if (useGPU) {
-      	logger.warn("Requested useGPU... so this will probably fail - please don't do that")
-        opencv "org.bytedeco:opencv:${opencvVersion}:${nativesCPP}-gpu"
-        // Isn't terribly clear if this is also needed when requesting GPU?
+  		opencv "org.bytedeco:openblas::${nativesCPP}" // Required for OpenCV with JavaCPP >= 1.5.1
+  		opencv "org.bytedeco:javacpp:{$javacppVersion}:${nativesCPP}"
+  	}
+  	if (useGPU) {
+  		logger.warn("Requested useGPU... so this will probably fail - please don't do that")
+    	opencv "org.bytedeco:opencv:${opencvVersion}:${nativesCPP}-gpu"
+    	// Isn't terribly clear if this is also needed when requesting GPU?
         //opencv "org.bytedeco:opencv:${opencvVersion}:${nativesCPP}"
-     } else
-        opencv "org.bytedeco:opencv:${opencvVersion}:${nativesCPP}"
-    }
+	} else
+    	opencv "org.bytedeco:opencv:${opencvVersion}:${nativesCPP}"
 
     jpen "net.sourceforge.jpen:jpen:${jpenVersion}"
     if (nativesClassifier != null)

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -71,6 +71,7 @@ import qupath.lib.common.ColorTools;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.ImageData.ImageType;
+import qupath.lib.images.servers.ColorTransforms;
 import qupath.lib.images.servers.ImageChannel;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerMetadata;
@@ -110,6 +111,8 @@ import qupath.lib.roi.GeometryTools;
 import qupath.lib.roi.ROIs;
 import qupath.lib.roi.RoiTools;
 import qupath.lib.roi.interfaces.ROI;
+import qupath.opencv.ml.objects.OpenCVMLClassifier;
+import qupath.opencv.ml.objects.features.FeatureExtractors;
 import qupath.opencv.ml.pixel.PixelClassifierTools;
 import qupath.opencv.ml.pixel.PixelClassifierTools.CreateObjectOptions;
 import qupath.opencv.ml.pixel.PixelClassifiers;
@@ -179,6 +182,27 @@ public class QP {
 	 * </pre>
 	 */
 	final public static String PROJECT_BASE_DIR = "{%PROJECT}";
+	
+	
+	/**
+	 * TODO: Figure out where this should go...
+	 * Its purpose is to prompt essential type adapters to be registered so that they function 
+	 * within scripts. See https://github.com/qupath/qupath/issues/514
+	 */
+	static {
+		logger.info("Initializing type adapters");
+		ObjectClassifiers.ObjectClassifierTypeAdapterFactory.registerSubtype(OpenCVMLClassifier.class);
+		
+		GsonTools.getDefaultBuilder()
+			.registerTypeAdapterFactory(PixelClassifiers.getTypeAdapterFactory())
+			.registerTypeAdapterFactory(FeatureExtractors.getTypeAdapterFactory())
+			.registerTypeAdapterFactory(ObjectClassifiers.getTypeAdapterFactory())
+			.registerTypeAdapter(ColorTransforms.ColorTransform.class, new ColorTransforms.ColorTransformTypeAdapter());
+		
+		// Currently, the type adapters are registered within the class
+		@SuppressWarnings("unused")
+		var init = new ImageOps();
+	}
 
 	
 	private final static List<Class<?>> CORE_CLASSES = Collections.unmodifiableList(Arrays.asList(

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerMetadata.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerMetadata.java
@@ -503,10 +503,11 @@ public class ImageServerMetadata {
 	 */
 	public double[] getPreferredDownsamplesArray() {
 		if (downsamples == null) {
-			downsamples = new double[nLevels()];
-			for (int i = 0; i < downsamples.length; i++) {
-				downsamples[i] = getDownsampleForLevel(i);
+			double[] temp = new double[nLevels()];
+			for (int i = 0; i < temp.length; i++) {
+				temp[i] = getDownsampleForLevel(i);
 			}
+			downsamples = temp;
 		}
 		return downsamples.clone();
 	}

--- a/qupath-core/src/main/java/qupath/lib/images/servers/RotatedImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/RotatedImageServer.java
@@ -158,7 +158,7 @@ public class RotatedImageServer extends TransformingImageServer<BufferedImage> {
 			return rotate90(request);
 		case ROTATE_NONE:
 		default:
-			// Don't apply annotation rotation
+			// Don't apply any rotation
 			return getWrappedServer().readBufferedImage(request);
 		}
 	}

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ProcessingExtension.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ProcessingExtension.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import javafx.application.Platform;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
-import qupath.lib.classifiers.object.ObjectClassifiers;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.ActionTools;
 import qupath.lib.gui.ActionTools.ActionAccelerator;
@@ -43,13 +42,9 @@ import qupath.lib.gui.extensions.QuPathExtension;
 import qupath.lib.gui.tools.IconFactory;
 import qupath.lib.gui.tools.IconFactory.PathIcons;
 import qupath.lib.gui.viewer.tools.PathTools;
-import qupath.lib.images.servers.ColorTransforms;
-import qupath.lib.io.GsonTools;
+import qupath.lib.scripting.QP;
 import qupath.opencv.CellCountsCV;
 import qupath.opencv.features.DelaunayClusteringPlugin;
-import qupath.opencv.ml.objects.OpenCVMLClassifier;
-import qupath.opencv.ml.objects.features.FeatureExtractors;
-import qupath.opencv.ml.pixel.PixelClassifiers;
 import qupath.opencv.ops.ImageOps;
 import qupath.process.gui.commands.CellIntensityClassificationCommand;
 import qupath.process.gui.commands.CreateChannelTrainingImagesCommand;
@@ -73,13 +68,8 @@ public class ProcessingExtension implements QuPathExtension {
 	private final static Logger logger = LoggerFactory.getLogger(ProcessingExtension.class);
 	
 	static {
-		ObjectClassifiers.ObjectClassifierTypeAdapterFactory.registerSubtype(OpenCVMLClassifier.class);
-		
-		GsonTools.getDefaultBuilder()
-			.registerTypeAdapterFactory(PixelClassifiers.getTypeAdapterFactory())
-			.registerTypeAdapterFactory(FeatureExtractors.getTypeAdapterFactory())
-			.registerTypeAdapterFactory(ObjectClassifiers.getTypeAdapterFactory())
-			.registerTypeAdapter(ColorTransforms.ColorTransform.class, new ColorTransforms.ColorTransformTypeAdapter());
+		// TODO: Consider a better way to force initialization of key processing classes
+		var qp = new QP();
 	}
 	
 	


### PR DESCRIPTION
See https://github.com/qupath/qupath/issues/514
This is a bit of a hack to ensure that type adapters are registered for scripts run from the command line, without making any substantial API changes to the point release.
It remains the case that QP must be initialized somewhere.