### PR TITLE
Fixed visibility of hidden classes name

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -668,8 +668,9 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 		dialog.getDialogPane().setHeaderText(entry.getImageName());
 		dialog.getDialogPane().setContent(editor);
 		Optional<ButtonType> result = dialog.showAndWait();
-		if (result.isPresent() && result.get() == ButtonType.OK) {
-			entry.setDescription(editor.getText());
+		if (result.isPresent() && result.get() == ButtonType.OK && editor.getText() != null) {	
+			var text = editor.getText();
+			entry.setDescription(text.isEmpty() ? null : text);
 			return true;
 		}
 		return false;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
@@ -320,7 +320,7 @@ public class HierarchyOverlay extends AbstractOverlay {
 				
 				var roi = annotation.getROI();
 				
-				if (name != null && !name.isBlank() && roi != null) {
+				if (name != null && !name.isBlank() && roi != null && !overlayOptions.isPathClassHidden(annotation.getPathClass())) {
 					g2d.setColor(ColorToolsAwt.TRANSLUCENT_BLACK);
 	
 					var bounds = metrics.getStringBounds(name, g2d);


### PR DESCRIPTION
- Hidden classes now don't have their name visible in the viewer (#557 )
- Description pane (see `ProjectBrowser` class) doesn't show anymore when setting an entry description with an empty String