### PR TITLE
Enable projects without past URIs to be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ List of bugs fixed:
 * Unable to resolve project URIs when moving a project across file systems (https://github.com/qupath/qupath/issues/543)
 * Polygons could sometimes be closed early when making annotations quickly (https://github.com/qupath/qupath/issues/553)
 * Shift+tab and Shift+/ to indent or comment caused script editor to scroll to the top
-* Updated to Bio-Formats 6.5.1
-  * See https://docs.openmicroscopy.org/bio-formats/6.5.1/about/whats-new.html for details
+* Project cannot be loaded if no previous URI is available
+* 'Delaunay cluster features 2D' could give wrong results when 'Add cluster measurements' is selected
+  * Bug likely introduced in ~v0.2.0-m5 (may want to recheck results if using this specific command)
+
+Dependency updates:
+* Bio-Formats 6.5.1; see https://docs.openmicroscopy.org/bio-formats/6.5.1/about/whats-new.html
 
 
 ## Version 0.2.1

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -1040,7 +1040,14 @@ class DefaultProject implements Project<BufferedImage> {
 			
 			creationTimestamp = element.get("createTimestamp").getAsLong();
 			modificationTimestamp = element.get("modifyTimestamp").getAsLong();
-			previousURI = new URI(element.get("uri").getAsString());
+			if (element.has("uri")) {
+				try {
+					previousURI = new URI(element.get("uri").getAsString());
+				} catch (URISyntaxException e) {
+					logger.warn("Error parsing previous URI: " + e.getLocalizedMessage(), e);
+				}
+			} else
+				logger.debug("No previous URI found in project");
 			
 			if (element.has("version"))
 				version = element.get("version").getAsString();
@@ -1068,7 +1075,7 @@ class DefaultProject implements Project<BufferedImage> {
 //				logger.warn("Could not find {} image(s): {}", troublesome.size(), troublesome);
 //			}
 
-		} catch (URISyntaxException e) {
+		} catch (Exception e) {
 			throw new IOException(e);
 		}
 	}


### PR DESCRIPTION
This is helpful if a .qpproj file has been created in some other way, not through QuPath.
See https://github.com/qupath/qupath/issues/568