### PR TITLE
Work around IndexedPointInAreaLocator threading issue

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/analysis/DistanceTools.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/DistanceTools.java
@@ -275,6 +275,9 @@ public class DistanceTools {
 				
 				
 				var locator = shapeGeometry == null ? null : new IndexedPointInAreaLocator(shapeGeometry);
+				// See https://github.com/locationtech/jts/issues/571
+				if (locator != null)
+					locator.locate(new Coordinate(0, 0));
 				sourceObjects.parallelStream().forEach(p -> {
 					var roi = PathObjectTools.getROI(p, preferNucleus);
 					if (roi.getZ() != zi || roi.getT() != ti)

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
@@ -801,6 +801,8 @@ public final class PathObjectHierarchy implements Serializable {
 		
 		var locator = tileCache.getLocator(roi, false);
 		var preparedGeometry = tileCache.getPreparedGeometry(tileCache.getGeometry(roi));
+		// Note: JTS 1.17.0 does not support parallel requests, see https://github.com/locationtech/jts/issues/571
+		// A change in getLocator() overcomes this - but watch out for future problems
 		return pathObjects.parallelStream().filter(child -> {
 			// Test plane first
 			if (!samePlane(roi, child.getROI(), false))

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
@@ -237,6 +237,8 @@ class PathObjectTileCache implements PathObjectHierarchyListener {
 				locator = new IndexedPointInAreaLocator(geometry);
 			else
 				locator = new SimplePointInAreaLocator(geometry);
+			// Workaround for multithreading bug in JTS 1.17.0 - see https://github.com/locationtech/jts/issues/571
+			locator.locate(new Coordinate());
 			locatorMap.put(roi, locator);
 		}
 		return locator;
@@ -363,7 +365,6 @@ class PathObjectTileCache implements PathObjectHierarchyListener {
 		if (mapObjects instanceof Quadtree) {
 			Envelope envelope = lastEnvelopeMap.get(pathObject);
 			envelope = MAX_ENVELOPE;
-//				System.err.println("Before: " + mapObjects.query(MAX_ENVELOPE).size());
 			if (envelope != null) {
 				if (mapObjects.remove(envelope, pathObject)) {
 					logger.debug("Removed {} from cache", pathObject);


### PR DESCRIPTION
See https://github.com/locationtech/jts/issues/571
This manifest itself in *sometimes* failing on the ObservableMeasurementTableDataTest due to incorrect object counts being returned. No errors could be reproduced if the locator was initialized before any parallel stream.