### PR TITLE
Improve reliability of cell expansion code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This is a *minor release* that aims to be fully compatible with v0.2.0 while fix
 List of bugs fixed:
 * Maximum memory setting is sometimes ignored (https://github.com/qupath/qupath/issues/582)
   * Memory cannot no longer be specified to be less than 1 GB
+* Improve reliability of cell expansion code, currently used with StarDist (https://github.com/qupath/qupath/issues/587)
 
 
 ## Version 0.2.2

--- a/qupath-core/src/main/java/qupath/lib/objects/CellTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/CellTools.java
@@ -140,18 +140,18 @@ public class CellTools {
 	private static Geometry estimateCellBoundary(Geometry geomNucleus, double distance, double nucleusScale, AffineTransformation transform) {
 		var geomCell = geomNucleus.buffer(distance);
 		if (nucleusScale > 1) {
-			geomNucleus = geomNucleus.convexHull();
-			var centroid = new Centroid(geomNucleus).getCentroid();
+			var geomNucleusHull = geomNucleus.convexHull();
+			var centroid = new Centroid(geomNucleusHull).getCentroid();
 			double x = centroid.getX();
 			double y = centroid.getY();
 			transform.setToTranslation(-x, -y);
 			transform.scale(nucleusScale, nucleusScale);
 			transform.translate(x, y);
-			var geomNucleusExpanded = transform.transform(geomNucleus);
+			var geomNucleusExpanded = transform.transform(geomNucleusHull);
 			if (!geomNucleusExpanded.covers(geomCell))
-				geomCell = geomCell.intersection(geomNucleusExpanded);
-			if (geomNucleus.getNumGeometries() == 1 && geomCell.getNumGeometries() == 1 && !geomCell.covers(geomNucleus))
-				geomCell = geomCell.union(geomNucleus);
+				geomCell = GeometryTools.attemptOperation(geomCell, g -> g.intersection(geomNucleusExpanded));
+			if (geomNucleusHull.getNumGeometries() == 1 && geomCell.getNumGeometries() == 1 && !geomCell.covers(geomNucleusHull))
+				geomCell = GeometryTools.attemptOperation(geomCell, g -> g.union(geomNucleusHull));
 		}
 		return geomCell;
 	}

--- a/qupath-extension-tensorflow/src/main/java/qupath/tensorflow/stardist/StarDist2D.java
+++ b/qupath-extension-tensorflow/src/main/java/qupath/tensorflow/stardist/StarDist2D.java
@@ -642,8 +642,16 @@ public class StarDist2D {
 		}
 		
 		// Convert to detections, dilating to approximate cells if necessary
+		// Drop cells if they fail (rather than catastropically give up)
 		var detections = nuclei.parallelStream()
-				.map(n -> convertToObject(n, plane, expansion, constrainToParent ? mask : null))
+				.map(n -> {
+					try {
+						return convertToObject(n, plane, expansion, constrainToParent ? mask : null);
+					} catch (Exception e) {
+						logger.warn("Error converting to object: " + e.getLocalizedMessage(), e);
+						return null;
+					}
+				}).filter(n -> n != null)
 				.collect(Collectors.toList());
 		
 		// Resolve cell overlaps, if needed


### PR DESCRIPTION
See https://github.com/qupath/qupath/issues/587
These changes don't correct cells that 'go wrong' (with TopologyExceptions), but instead try to recover more gracefully - so that *all* cells are not lost.