### PR TITLE
Fix adding .qpdata to an existing project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ List of bugs fixed:
 * Maximum memory setting is sometimes ignored (https://github.com/qupath/qupath/issues/582)
   * Note that memory can no longer be specified to be less than 1 GB
 * 'Locked status cannot be set' exception when adding pixel classifier measurements to full image (https://github.com/qupath/qupath/issues/595)
+* 'Too many open files' exceptions caused by streams not being closed (https://github.com/qupath/qupath/issues/594)
 * LabeledImageServer ignores updated pixel sizes (https://github.com/qupath/qupath/issues/591)
-* Improve reliability of cell expansion code, currently used with StarDist (https://github.com/qupath/qupath/issues/587)
+* Support adding an individual .qpdata file to an existing project (https://github.com/qupath/qupath/issues/592)
+* Improve reliability of cell expansion code, currently used only with StarDist (https://github.com/qupath/qupath/issues/587)
 
 
 ## Version 0.2.2

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -763,6 +764,15 @@ class DefaultProject implements Project<BufferedImage> {
 			var pathBackup = getBackupImageDataPath();
 			if (Files.exists(pathData))
 				Files.move(pathData, pathBackup, StandardCopyOption.REPLACE_EXISTING);
+			
+			// Set the entry property, if needed
+			// This handles cases where an ImageData is being moved to become part of this project, 
+			// so that it can be recognized later in calls to Project.getEntry(entry)
+			String id = getFullProjectEntryID();
+			if (!Objects.equals(id, imageData.getProperty(IMAGE_ID))) {
+				logger.warn("Updating ID property to {}", id);
+				imageData.setProperty(IMAGE_ID, id);
+			}
 			
 			// Write to a temp file first
 			long timestamp = 0L;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -734,9 +734,21 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 
 		var entry = ProjectCommands.addSingleImageToProject(project, imageData.getServer(), null);
 		if (entry != null) {
+			boolean expanded = tree.getRoot() != null && tree.getRoot().isExpanded();
 			tree.setRoot(model.getRootFX());
 			setSelectedEntry(tree, tree.getRoot(), project.getEntry(imageData));
 			syncProject(project);
+			if (expanded)
+				tree.getRoot().setExpanded(true);
+			// Copy the ImageData to the current entry
+			if (!entry.hasImageData()) {
+				try {
+					logger.info("Copying ImageData to {}", entry);
+					entry.saveImageData(imageData);
+				} catch (IOException e) {
+					logger.error("Unable to save ImageData: " + e.getLocalizedMessage(), e);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
See https://github.com/qupath/qupath/issues/592
Solution is to write the ImageData immediately to the project, setting the ID property. This means that calls to 'Save' will now use the 'project' path, rather than the path previously stored within the ImageData.