### PR TITLE
Fixed loading OMERO image data bug (#598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ List of bugs fixed:
 * LabeledImageServer ignores updated pixel sizes (https://github.com/qupath/qupath/issues/591)
 * Support adding an individual .qpdata file to an existing project (https://github.com/qupath/qupath/issues/592)
 * Improve reliability of cell expansion code, currently used only with StarDist (https://github.com/qupath/qupath/issues/587)
+* NullPointerException when loading .qpdata files corresponding to OMERO images (https://github.com/qupath/qupath/issues/598)
 
 
 ## Version 0.2.2
@@ -221,7 +222,7 @@ This is a *milestone* (i.e. still in development) version made available to try 
 #### Multiplexed analysis & Object classification
 * Completely rewritten object classifier (currently flagged with 'New'! in the menus)
   * Support for multi-class classification with composite classifiers
-  * New command to create single-measurement classifiers 
+  * New command to create single-measurement classifiers
   * New command to apply intensity (sub)classification
   * JSON serialization for classifiers
 * New 'Centroids only' cell display mode to visualize cells with complex classifications

--- a/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServerBuilder.java
+++ b/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServerBuilder.java
@@ -106,6 +106,12 @@ public class OmeroWebImageServerBuilder implements ImageServerBuilder<BufferedIm
 	private final static Pattern patternNewViewer = Pattern.compile("images=(\\d+)");
 	private final static Pattern patternWebViewer= Pattern.compile("/webclient/img_detail/(\\d+)");
 	private final static Pattern patternType = Pattern.compile("show=(\\w+-)");
+	
+	/**
+	 * Encoding differences
+	 */
+	private String equalSign = "%3D";
+	private String vertBarSign = "%7C";
 
 	@Override
 	public ImageServer<BufferedImage> buildServer(URI uri, String...args) {
@@ -280,7 +286,7 @@ public class OmeroWebImageServerBuilder implements ImageServerBuilder<BufferedIm
         }
 
         // If no simple pattern was matched, check for the last possible one: /webclient/?show=
-        if (shortPath.startsWith("/webclient/show=")) {
+        if (shortPath.startsWith("/webclient/show")) {
         	URI newURI = getStandardURI(uri);
             var patternElem = Pattern.compile("image-(\\d+)");
             var matcherElem = patternElem.matcher(newURI.toString());
@@ -298,10 +304,15 @@ public class OmeroWebImageServerBuilder implements ImageServerBuilder<BufferedIm
 		if (!canConnectToOmero(uri, args))
 			throw new IOException("Problem connecting to OMERO web server");
 		List<String> ids = new ArrayList<String>();
-		String vertBarSign = "%7C";
+		
 		// Identify the type of element shown (e.g. dataset)
         var type = "";
         String query = uri.getQuery() != null ? uri.getQuery() : "";
+
+        // Because of encoding, the equal sign might not be matched when loading .qpproj file
+        query = query.replace(equalSign, "=");
+
+        // Match pattern
         var matcherType = patternType.matcher(query);
         if (matcherType.find())
             type = matcherType.group(1);


### PR DESCRIPTION
Fixed #598:
- A difference in the encoding between saved and used URI made it impossible to match it with the known OMERO URL patterns (i.e `/webclient/show%3D...` vs `/webclient/show=...`).