### PR TITLE
New prefs. for navigation settings

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -242,6 +242,10 @@ public class PreferencePane {
 				"Navigation acceleration effects", category, 
 				"Apply acceleration/deceleration effects when holding and releasing a navigation key");
 		
+		addPropertyPreference(PathPrefs.ignoreMissingCoresProperty(), Boolean.class,
+				"Ignore missing TMA cores", category, 
+				"Jumps over missing TMA cores when navigating TMA grids using the arrow keys.");
+		
 		addPropertyPreference(PathPrefs.useScrollGesturesProperty(), Boolean.class,
 				"Use scroll touch gestures",
 				category,

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -234,6 +234,14 @@ public class PreferencePane {
 				"Scroll speed %", category, 
 				"Adjust the scrolling speed - 100% is 'normal', while lower values lead to slower scrolling");
 		
+		addPropertyPreference(PathPrefs.navigationSpeedProperty(), Integer.class,
+				"Navigation speed %", category, 
+				"Adjust the navigation speed - 100% is 'normal', while lower values lead to slower navigation");
+		
+		addPropertyPreference(PathPrefs.navigationAccelerationProperty(), Boolean.class,
+				"Navigation acceleration effects", category, 
+				"Apply acceleration/deceleration effects when holding and releasing a navigation key");
+		
 		addPropertyPreference(PathPrefs.useScrollGesturesProperty(), Boolean.class,
 				"Use scroll touch gestures",
 				category,

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -242,8 +242,8 @@ public class PreferencePane {
 				"Navigation acceleration effects", category, 
 				"Apply acceleration/deceleration effects when holding and releasing a navigation key");
 		
-		addPropertyPreference(PathPrefs.ignoreMissingCoresProperty(), Boolean.class,
-				"Ignore missing TMA cores", category, 
+		addPropertyPreference(PathPrefs.skipMissingCoresProperty(), Boolean.class,
+				"Skip missing TMA cores", category, 
 				"Jumps over missing TMA cores when navigating TMA grids using the arrow keys.");
 		
 		addPropertyPreference(PathPrefs.useScrollGesturesProperty(), Boolean.class,

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -436,6 +436,28 @@ public class PathPrefs {
 	}
 	
 	
+	private static BooleanProperty ignoreMissingCoresProperty = createPersistentPreference("Ignore missing TMA cores", false);
+	
+	/**
+	 * Ignore ('jumps over') missing cores when navigating through TMA grids.
+	 * 
+	 * @return ignoreMissingCoresProperty
+	 */
+	public static BooleanProperty ignoreMissingCoresProperty() {
+		return ignoreMissingCoresProperty;
+	}
+	
+	/**
+	 * Return whether the viewer ignores missing TMA cores when navigating TMA grids 
+	 * with arrow keys.
+	 * 
+	 * @return
+	 */
+	public static boolean getIgnoreMissingCoresProperty() {
+		return ignoreMissingCoresProperty.get();
+	}
+	
+	
 	
 	private static boolean showAllRGBTransforms = true;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -436,25 +436,25 @@ public class PathPrefs {
 	}
 	
 	
-	private static BooleanProperty ignoreMissingCoresProperty = createPersistentPreference("Ignore missing TMA cores", false);
+	private static BooleanProperty skipMissingCoresProperty = createPersistentPreference("Skip missing TMA cores", false);
 	
 	/**
-	 * Ignore ('jumps over') missing cores when navigating through TMA grids.
+	 * Skip ('jump over') missing cores when navigating through TMA grids.
 	 * 
-	 * @return ignoreMissingCoresProperty
+	 * @return skipMissingCoresProperty
 	 */
-	public static BooleanProperty ignoreMissingCoresProperty() {
-		return ignoreMissingCoresProperty;
+	public static BooleanProperty skipMissingCoresProperty() {
+		return skipMissingCoresProperty;
 	}
 	
 	/**
-	 * Return whether the viewer ignores missing TMA cores when navigating TMA grids 
+	 * Return whether the viewer skips missing TMA cores when navigating TMA grids 
 	 * with arrow keys.
 	 * 
 	 * @return
 	 */
-	public static boolean getIgnoreMissingCoresProperty() {
-		return ignoreMissingCoresProperty.get();
+	public static boolean getSkipMissingCoresProperty() {
+		return skipMissingCoresProperty.get();
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -390,6 +390,52 @@ public class PathPrefs {
 	}
 	
 	
+	private static IntegerProperty navigationSpeedProperty = createPersistentPreference("Navigation speed %", 100);
+	
+	/**
+	 * Percentage to scale navigation speed.
+	 * 
+	 * @return navigationSpeedProperty
+	 */
+	public static IntegerProperty navigationSpeedProperty() {
+		return navigationSpeedProperty;
+	}
+	
+	
+	/**
+	 * Get navigation speed scaled as a proportion and forced to be in the range 0-1. For example, 100% becomes 1.
+	 * 
+	 * @return speed
+	 */
+	public static double getScaledNavigationSpeed() {
+		double speed = navigationSpeedProperty.get() / 100.0;
+		if (!Double.isFinite(speed) || speed <= 0)
+			return 1;
+		return speed;
+	}
+	
+	private static BooleanProperty navigationAccelerationProperty = createPersistentPreference("Navigation acceleration effects", true);
+	
+	/**
+	 * Apply acceleration/deceleration effects when holding and releasing navigation key.
+	 * 
+	 * @return navigationAccelerationProperty
+	 */
+	public static BooleanProperty navigationAccelerationProperty() {
+		return navigationAccelerationProperty;
+	}
+	
+	
+	/**
+	 * Get whether to apply the navigation acceleration (& deceleration) effects or not.
+	 * 
+	 * @return
+	 */
+	public static boolean getNavigationAccelerationProperty() {
+		return navigationAccelerationProperty.get();
+	}
+	
+	
 	
 	private static boolean showAllRGBTransforms = true;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -3020,6 +3020,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 				return;
 
 			// Use arrow keys to navigate, either or directly or using a TMA grid
+			boolean skipMissingTMACores = PathPrefs.getIgnoreMissingCoresProperty();
 			TMAGrid tmaGrid = hierarchy.getTMAGrid();
 			List<TMACoreObject> cores = tmaGrid == null ? Collections.emptyList() : new ArrayList<>(tmaGrid.getTMACoreList());
 			if (!event.isShiftDown() && tmaGrid != null && tmaGrid.nCores() > 0) {
@@ -3039,7 +3040,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 					int i = -1;
 					for (TMACoreObject core : cores) {
 						i++;
-						if (core.isMissing())
+						if (core.isMissing() && skipMissingTMACores)
 							continue;
 						
 						ROI coreROI = core.getROI();
@@ -3057,22 +3058,22 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 				switch (code) {
 				case LEFT:
 					ind = --ind < 0 ? 0 : ind;
-					while (cores.get(ind).isMissing())
+					while (skipMissingTMACores && cores.get(ind).isMissing())
 						ind = --ind < 0 ? 0 : ind--;
 					break;
 				case UP:
 					ind = ind-w < 0 ? 0 : ind-w;
-					while (cores.get(ind).isMissing())
+					while (skipMissingTMACores && cores.get(ind).isMissing())
 						ind = ind-w < 0 ? 0 : ind-w;
 					break;
 				case RIGHT:
 					ind = ++ind >= w*h ? (w*h)-1 : ind;
-					while (cores.get(ind).isMissing())
+					while (skipMissingTMACores && cores.get(ind).isMissing())
 						ind = ++ind >= w*h ? (w*h)-1 : ind++;
 					break;
 				case DOWN:
 					ind = ind+w >= w*h ? (w*h)-1 : ind+w;
-					while (cores.get(ind).isMissing())
+					while (skipMissingTMACores && cores.get(ind).isMissing())
 						ind = ind+w >= w*h ? (w*h)-1 : ind+w;
 					break;
 				default:

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -3020,7 +3020,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 				return;
 
 			// Use arrow keys to navigate, either or directly or using a TMA grid
-			boolean skipMissingTMACores = PathPrefs.getIgnoreMissingCoresProperty();
+			boolean skipMissingTMACores = PathPrefs.getSkipMissingCoresProperty();
 			TMAGrid tmaGrid = hierarchy.getTMAGrid();
 			List<TMACoreObject> cores = tmaGrid == null ? Collections.emptyList() : new ArrayList<>(tmaGrid.getTMACoreList());
 			if (!event.isShiftDown() && tmaGrid != null && tmaGrid.nCores() > 0) {
@@ -3055,30 +3055,32 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 					}
 				}
 
+				int temp;
 				switch (code) {
 				case LEFT:
-					ind = --ind < 0 ? 0 : ind;
-					while (skipMissingTMACores && cores.get(ind).isMissing())
-						ind = --ind < 0 ? 0 : ind--;
+					temp = ind-1 < 0 ? 0 : ind-1;
+					while (skipMissingTMACores && cores.get(temp).isMissing() && temp > 0)
+						temp = temp-1 < 0 ? 0 : temp-1;
 					break;
 				case UP:
-					ind = ind-w < 0 ? 0 : ind-w;
-					while (skipMissingTMACores && cores.get(ind).isMissing())
-						ind = ind-w < 0 ? 0 : ind-w;
+					temp = ind == 0 ? ind : ind-w < 0 ? (w*h)-(w-ind+1) : ind-w;
+					while (skipMissingTMACores && cores.get(temp).isMissing() && temp != 0) 
+						temp = ind == 0 ? ind : temp-w <= 0 ? (w*h)-(w-temp+1) : temp-w;
 					break;
 				case RIGHT:
-					ind = ++ind >= w*h ? (w*h)-1 : ind;
-					while (skipMissingTMACores && cores.get(ind).isMissing())
-						ind = ++ind >= w*h ? (w*h)-1 : ind++;
+					temp = ind+1 >= w*h ? (w*h)-1 : ind+1;
+					while (skipMissingTMACores && cores.get(temp).isMissing() && temp < (w*h)-1)
+						temp = temp+1 >= w*h ? (w*h)-1 : temp+1;
 					break;
 				case DOWN:
-					ind = ind+w >= w*h ? (w*h)-1 : ind+w;
-					while (skipMissingTMACores && cores.get(ind).isMissing())
-						ind = ind+w >= w*h ? (w*h)-1 : ind+w;
+					temp = ind == (w*h)-1 ? ind : ind+w >= (w*h) ? ind%w + 1 : ind+w;
+					while (skipMissingTMACores && cores.get(temp).isMissing() && temp != (w*h)-1) 
+						temp = temp+w >= (w*h) ? temp%w + 1 : temp+w;
 					break;
 				default:
 					return;
 				}
+				ind = !skipMissingTMACores ? temp : cores.get(temp).isMissing() ? ind : temp;
 				// Set the selected object & center the viewer
 				if (ind >= 0 && ind < w*h) {
 					PathObject selectedObject = cores.get(ind);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/MoveTool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/MoveTool.java
@@ -451,6 +451,21 @@ public class MoveTool extends AbstractPathTool {
 		}
 		
 		/**
+		 * Cancel either the x- or y-axis direction of the movement. 
+		 * <p>
+		 * E.g. This can be used to change the direction from diagonal to straight 
+		 * (horizontal/vertical) when releasing an arrow key while another arrow key 
+		 * is pressed.
+		 * @param xAxis 
+		 */
+		public void cancelDirection(final boolean xAxis) {
+			if (xAxis)
+				this.dx = 0;
+			else
+				this.dy = 0;
+		}
+		
+		/**
 		 * Stop moving, by smoothly decelerating.
 		 */
 		public void decelerate() {


### PR DESCRIPTION
- Added diagonal navigation (e.g. `UP` + `LEFT` keys)
- Navigation speed can be modified
- Acceleration effects (e.g. slowing down when releasing keys) can be turned off
- Can turn on `ignore missing TMA cores` which will 'jump over' missing TMA cores when navigating a TMA grid with arrow keys 
- Preference options were added for `acceleration effects`, `navigation speed` and `ignore missing TMA cores`
