### PR TITLE
Added info to error message for left quotes

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -986,6 +986,14 @@ public class DefaultScriptEditor implements ScriptEditor {
 							sb.append("\n    import " + suggestedClass.getName() + "\nat the start of the script. Full error message below.\n");
 						}
 					}
+					
+					// Check if the error was to do with a special left quote character
+					var matcherQuotationMarks = Pattern.compile("Unexpected input: .*([‘“’”])' @ line (\\d+), column (\\d+).").matcher(message);
+					if (matcherQuotationMarks.find()) {
+						int nLine = Integer.parseInt(matcherQuotationMarks.group(2));
+						sb.append(String.format("At least one left quotation mark (%s) was found @ line %s column %s! ", matcherQuotationMarks.group(1), importDefaultMethods ? nLine-1 : nLine, matcherQuotationMarks.group(3)));
+						sb.append("You can try replacing it with a regular apostrophe (').\n");
+					}
 				}
 				if (sb.length() > 0)
 					errorWriter.append(sb.toString());

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -991,8 +991,10 @@ public class DefaultScriptEditor implements ScriptEditor {
 					var matcherQuotationMarks = Pattern.compile("Unexpected input: .*([‘“’”])' @ line (\\d+), column (\\d+).").matcher(message);
 					if (matcherQuotationMarks.find()) {
 						int nLine = Integer.parseInt(matcherQuotationMarks.group(2));
-						sb.append(String.format("At least one left quotation mark (%s) was found @ line %s column %s! ", matcherQuotationMarks.group(1), importDefaultMethods ? nLine-1 : nLine, matcherQuotationMarks.group(3)));
-						sb.append("You can try replacing it with a regular apostrophe (').\n");
+						String quotationMark = matcherQuotationMarks.group(1);
+						String suggestion = quotationMark.equals("‘") || quotationMark.equals("’") ? "'" : "\"";
+						sb.append(String.format("At least one invalid quotation mark (%s) was found @ line %s column %s! ", quotationMark, importDefaultMethods ? nLine-1 : nLine, matcherQuotationMarks.group(3)));
+						sb.append(String.format("You can try replacing it with a straight quotation mark (%s).%n", suggestion));
 					}
 				}
 				if (sb.length() > 0)


### PR DESCRIPTION
Left quotes have been known to lead to unexpected behaviours when running scripts.
Now, if a script throws an Exception, QuPath checks whether there is at least one left (single/double) quote and notify the user in the error message.