### PR TITLE
Upload object/pixel classifiers

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/PixelClassifierLoadCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/PixelClassifierLoadCommand.java
@@ -21,21 +21,38 @@
 
 package qupath.process.gui.commands;
 
+import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.geometry.Insets;
+import javafx.geometry.Side;
 import javafx.scene.Scene;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
 import javafx.scene.layout.GridPane;
 import javafx.stage.Stage;
 import qupath.lib.classifiers.pixel.PixelClassificationImageServer;
+import qupath.lib.classifiers.pixel.PixelClassifier;
+import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.dialogs.Dialogs;
+import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.gui.tools.PaneTools;
+import qupath.lib.io.GsonTools;
+import qupath.lib.projects.Project;
 import qupath.process.gui.ml.PixelClassificationOverlay;
 import qupath.process.gui.ml.PixelClassifierUI;
 
@@ -46,6 +63,8 @@ import qupath.process.gui.ml.PixelClassifierUI;
  *
  */
 public class PixelClassifierLoadCommand implements Runnable {
+	
+	private final static Logger logger = LoggerFactory.getLogger(PixelClassifierLoadCommand.class);
 	
 	private QuPathGUI qupath;
 	
@@ -121,6 +140,24 @@ public class PixelClassifierLoadCommand implements Runnable {
 		var label = new Label("Choose model");
 		label.setLabelFor(comboClassifiers);
 		
+		// Add file chooser
+		var menu = new ContextMenu();
+		var loadClassifierMI = new MenuItem("Add existing classifiers");
+		loadClassifierMI.setOnAction(e -> {
+			promptToAddExistingClassifier(project);
+			Collection<String> updatedNames;
+			try {
+				updatedNames = project.getPixelClassifiers().getNames();				
+				comboClassifiers.getItems().setAll(updatedNames);
+			} catch (IOException ex) {
+				Dialogs.showErrorMessage(title, ex);
+//				return;
+			}
+		});
+		
+		menu.getItems().add(loadClassifierMI);
+		var btnLoadExistingClassifier = GuiTools.createMoreButton(menu, Side.RIGHT);
+		
 		var classifierName = new SimpleStringProperty(null);
 		classifierName.bind(comboClassifiers.getSelectionModel().selectedItemProperty());
 		var tilePane = PixelClassifierUI.createPixelClassifierButtons(qupath.imageDataProperty(), selectedClassifier, classifierName);
@@ -134,10 +171,10 @@ public class PixelClassifierLoadCommand implements Runnable {
 		pane.setHgap(5);
 		pane.setVgap(10);
 		int row = 0;
-		PaneTools.addGridRow(pane, row++, 0, "Choose pixel classification model to apply to the current image", label, comboClassifiers);
+		PaneTools.addGridRow(pane, row++, 0, "Choose pixel classification model to apply to the current image", label, comboClassifiers, btnLoadExistingClassifier);
 		PaneTools.addGridRow(pane, row++, 0, "Control where the pixel classification is applied during preview",
 				labelRegion, comboRegionFilter, comboRegionFilter);
-		PaneTools.addGridRow(pane, row++, 0, "Apply pixel classification", tilePane, tilePane);
+		PaneTools.addGridRow(pane, row++, 0, "Apply pixel classification", tilePane, tilePane, tilePane);
 		
 		PaneTools.setMaxWidth(Double.MAX_VALUE, comboClassifiers, tilePane);
 		
@@ -176,6 +213,42 @@ public class PixelClassifierLoadCommand implements Runnable {
 			}
 		});
 		
+	}
+	
+	
+	
+	private void promptToAddExistingClassifier(Project<BufferedImage> project) {
+		List<File> files = Dialogs.promptForMultipleFiles(title, null, "QuPath classifier file", "json");
+		if (files == null || files.isEmpty())
+			return;
+		
+		List<File> fails = new ArrayList<>();
+		for (var file: files) {
+			try {
+				if (!GeneralTools.getExtension(file).get().equals(".json"))
+					throw new IOException(String.format("Classifier files should be JSON files (.json), not %s", GeneralTools.getExtension(file).get()));
+				var json = Files.newBufferedReader(file.toPath());
+				var classifier = GsonTools.getInstance().fromJson(json, PixelClassifier.class);
+				// TODO: Check if classifier is valid before adding it
+				project.getPixelClassifiers().put(GeneralTools.getNameWithoutExtension(file), classifier);
+			} catch (IOException e) {
+				Dialogs.showErrorNotification(String.format("Could not add %s", file.getName()), e.getLocalizedMessage());
+				logger.error(e.getLocalizedMessage());
+				fails.add(file);
+			}
+		}
+		
+		if (!fails.isEmpty()) {
+			String failedClassifiers = fails.stream().map(e -> "- " + e.getName()).collect(Collectors.joining(System.lineSeparator()));
+			Dialogs.showErrorMessage("Error adding classifiers", String.format("Could not add the following classifiers:%s%s", 
+					System.lineSeparator(), 
+					failedClassifiers)
+			);
+		}
+		
+		int nSuccess = files.size() - fails.size();
+		if (nSuccess > 0)
+			Dialogs.showInfoNotification("Classifiers added successfully", String.format("%d classifiers added", nSuccess));
 	}
 	
 

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/PixelClassifierUI.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/PixelClassifierUI.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.ObjectExpression;
 import javafx.beans.binding.StringExpression;
@@ -188,7 +189,9 @@ public class PixelClassifierUI {
 	 */
 	public static Pane createSavePixelClassifierPane(ObjectExpression<Project<BufferedImage>> project, ObjectExpression<PixelClassifier> classifier, StringProperty savedName) {
 		
-		var tooltip = new Tooltip("Save classifier in the current project - this is required to use the classifier to use the classifier later (e.g. to create objects, measurements)");
+		var tooltipText = "Save classifier in the current project - this is required to use the classifier to use the classifier later (e.g. to create objects, measurements)";
+		var tooltipText2 = "Cannot save a classifier outside a project. Please create a project to save the classifier.";
+		var tooltip = new Tooltip();
 		var label = new Label("Classifier name");
 		var defaultName = savedName.get();
 		var tfClassifierName = new TextField(defaultName == null ? "" : defaultName);
@@ -211,11 +214,16 @@ public class PixelClassifierUI {
 				classifier.isNull()
 					.or(project.isNull())
 					.or(tfClassifierName.textProperty().isEmpty()));
+		tfClassifierName.disableProperty().bind(project.isNull());
 		
 		label.setLabelFor(tfClassifierName);
 		label.setTooltip(tooltip);
 		tfClassifierName.setTooltip(tooltip);
 		btnSave.setTooltip(tooltip);
+		tooltip.textProperty().bind(Bindings
+				.when(project.isNull())
+				.then(Bindings.createStringBinding(() -> tooltipText2, project))
+				.otherwise(Bindings.createStringBinding(() -> tooltipText, project)));
 		
 		var pane = new GridPane();
 		PaneTools.addGridRow(pane, 0, 0, null, label, tfClassifierName, btnSave);


### PR DESCRIPTION
- Added tooltip in Pixel classifier UI to notify users that classifiers can't be saved if not working inside a project (tooltip only appears when no project is detected).
- Added ability to Drag & Drop classifier(s) onto the _Load object classifier_ pane to add a classifier from a different source (e.g. a different project).
- Added ability to add classifier(s) to the `comboBox` in _Load pixel classifier_ pane to add a classifier from a different source. (e.g. a different project).

Note (and possibly `TODO`): when adding a `PixelClassifier`, no check is made to ensure that the classifier is valid.