### PR TITLE
Adding of jdk.jsobject module into the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -715,7 +715,8 @@ task createRuntime(dependsOn:build, type:Exec) {
     def usefulModules = [
         'java.net.http',       // Add HttpClient support (may be used by scripts)
     	'java.management',     // Useful to check memory usage
-    	'jdk.management.agent' // Enables VisualVM to connect and sample CPU use
+    	'jdk.management.agent', // Enables VisualVM to connect and sample CPU use
+    	'jdk.jsobject'         // Allows to interact with WebView through JSObject
     ]
   
     def addModules


### PR DESCRIPTION
Hello,
Great work on the QuPath, really nice tool!

We are working on implementing a plugin for QuPath that will provide importing slides from the PMA.Core/PMA.Start/My Pathomation servers (https://www.pathomation.com/). We are trying to achieve that by integrating our web-based tool PMA.UI (https://host.pathomation.com/sdk/pma.ui.documentation/) that provides all sort of menus and interfaces for interacting with PMA products. Unfortunately, the current build of QuPath does not contain "jdk.jsobject" module which is required for interaction with the WebView component. 

In this PR I have introduced an adding of that "jdk.jsobject" to the build process and looking forward to PR being merged.

Please ping me back if you have any questions/concerns.

Kind Regards,
Egor