### PR TITLE
Fix setting maximum memory via "Help>Show setup options"

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -273,7 +273,7 @@ public class PathPrefs {
 						logger.warn("Cannot set memory to {}, must be >= 512 MB", n);
 						n = 512;
 					}
-					String memory = "-Xmx" + n.intValue() + "M";
+					String memory = "java-options=" + "-Xmx" + n.intValue() + "M";
 					Path config = getConfigPath();
 					if (!Files.exists(config)) {
 						logger.error("Cannot find config file!");


### PR DESCRIPTION
Setting up maximum memory via "QuPath>Help>Show setup options" fails on Windows. Adding the "java-options="  in from of the memory (i.e. -Xmx10240M) fixes the problem. This will match with java option pair values generated by the following line in the "build.gradle" file:
fileTemp << System.lineSeparator() << 'java-options=' << '-XX:MaxRAMPercentage=50' << 