### PR TITLE
Upload object/pixel classifiers

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/PixelClassifierUI.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/PixelClassifierUI.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.ObjectExpression;
 import javafx.beans.binding.StringExpression;
@@ -188,7 +189,9 @@ public class PixelClassifierUI {
 	 */
 	public static Pane createSavePixelClassifierPane(ObjectExpression<Project<BufferedImage>> project, ObjectExpression<PixelClassifier> classifier, StringProperty savedName) {
 		
-		var tooltip = new Tooltip("Save classifier in the current project - this is required to use the classifier to use the classifier later (e.g. to create objects, measurements)");
+		var tooltipText = "Save classifier in the current project - this is required to use the classifier to use the classifier later (e.g. to create objects, measurements)";
+		var tooltipText2 = "Cannot save a classifier outside a project. Please create a project to save the classifier.";
+		var tooltip = new Tooltip();
 		var label = new Label("Classifier name");
 		var defaultName = savedName.get();
 		var tfClassifierName = new TextField(defaultName == null ? "" : defaultName);
@@ -211,11 +214,16 @@ public class PixelClassifierUI {
 				classifier.isNull()
 					.or(project.isNull())
 					.or(tfClassifierName.textProperty().isEmpty()));
+		tfClassifierName.disableProperty().bind(project.isNull());
 		
 		label.setLabelFor(tfClassifierName);
 		label.setTooltip(tooltip);
 		tfClassifierName.setTooltip(tooltip);
 		btnSave.setTooltip(tooltip);
+		tooltip.textProperty().bind(Bindings
+				.when(project.isNull())
+				.then(Bindings.createStringBinding(() -> tooltipText2, project))
+				.otherwise(Bindings.createStringBinding(() -> tooltipText, project)));
 		
 		var pane = new GridPane();
 		PaneTools.addGridRow(pane, 0, 0, null, label, tfClassifierName, btnSave);

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/PixelClassifierUI.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/PixelClassifierUI.java
@@ -54,6 +54,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
+import javafx.util.Duration;
 import qupath.lib.classifiers.pixel.PixelClassifier;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.commands.Commands;
@@ -189,9 +190,6 @@ public class PixelClassifierUI {
 	 */
 	public static Pane createSavePixelClassifierPane(ObjectExpression<Project<BufferedImage>> project, ObjectExpression<PixelClassifier> classifier, StringProperty savedName) {
 		
-		var tooltipText = "Save classifier in the current project - this is required to use the classifier to use the classifier later (e.g. to create objects, measurements)";
-		var tooltipText2 = "Cannot save a classifier outside a project. Please create a project to save the classifier.";
-		var tooltip = new Tooltip();
 		var label = new Label("Classifier name");
 		var defaultName = savedName.get();
 		var tfClassifierName = new TextField(defaultName == null ? "" : defaultName);
@@ -215,21 +213,22 @@ public class PixelClassifierUI {
 					.or(project.isNull())
 					.or(tfClassifierName.textProperty().isEmpty()));
 		tfClassifierName.disableProperty().bind(project.isNull());
-		
 		label.setLabelFor(tfClassifierName);
-		label.setTooltip(tooltip);
-		tfClassifierName.setTooltip(tooltip);
-		btnSave.setTooltip(tooltip);
+		
+		var tooltip = new Tooltip();
+		var tooltipTextYes = "Save classifier in the current project - this is required to use the classifier to use the classifier later (e.g. to create objects, measurements)";
+		var tooltipTextNo = "Cannot save a classifier outside a project. Please create a project to save the classifier.";
+		tooltip.setShowDelay(Duration.millis(500));
 		tooltip.textProperty().bind(Bindings
 				.when(project.isNull())
-				.then(Bindings.createStringBinding(() -> tooltipText2, project))
-				.otherwise(Bindings.createStringBinding(() -> tooltipText, project)));
+				.then(Bindings.createStringBinding(() -> tooltipTextNo, project))
+				.otherwise(Bindings.createStringBinding(() -> tooltipTextYes, project)));
 		
 		var pane = new GridPane();
+		Tooltip.install(pane, tooltip);
 		PaneTools.addGridRow(pane, 0, 0, null, label, tfClassifierName, btnSave);
 		PaneTools.setToExpandGridPaneWidth(tfClassifierName);
 		pane.setHgap(5);
-		
 		
 		ProjectClassifierBindings.bindPixelClassifierNameInput(tfClassifierName, project);
 		


### PR DESCRIPTION
- Added tooltip in Pixel classifier UI to notify users that classifiers can't be saved if not working inside a project (tooltip only appears when no project is detected).
- Added ability to Drag & Drop classifier(s) onto the Load object classifier pane to add a classifier from a different source (e.g. a different project).
- Added ability to add classifier(s) to the `comboBox` in Load pixel classifier pane to add a classifier from a different source. (e.g. a different project).


Note (and possibly `TODO`): when adding a `PixelClassifier`, no check is made to ensure that the classifier is valid.