### PR TITLE
Command line option for script arguments

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -503,17 +503,17 @@ public class DefaultScriptEditor implements ScriptEditor {
 		
 		ScriptEditorTextArea control = new ScriptEditorTextArea(editor);
 		editor.addEventFilter(KeyEvent.KEY_PRESSED, (KeyEvent e) -> {
-			if (e.getCode() == KeyCode.TAB) {
-				handleTabPress(control, e.isShiftDown());
-				e.consume();
-			} else if (e.isShortcutDown() && e.getCode() == KeyCode.SLASH) {
-				handleLineComment(control);
-				e.consume();
-			} else if (e.getCode() == KeyCode.ENTER && control.getSelectedText().length() == 0) {
+	        if (e.getCode() == KeyCode.TAB) {
+	        	handleTabPress(control, e.isShiftDown());
+	        	e.consume();
+	        } else if (e.isShortcutDown() && e.getCode() == KeyCode.SLASH) {
+	        	handleLineComment(control);
+	        	e.consume();
+	        } else if (e.getCode() == KeyCode.ENTER && control.getSelectedText().length() == 0) {
 				handleNewLine(control);
 				e.consume();
 			} 
-		});
+	    });
 
 //		editor.getDocument().addUndoableEditListener(new UndoManager());
 //		// Handle tabs
@@ -646,13 +646,13 @@ public class DefaultScriptEditor implements ScriptEditor {
 		panelList.setCenter(titledScripts);
 		listScripts.getSelectionModel().selectedItemProperty().addListener((v, o, n) -> updateSelectedScript());
 		listScripts.setCellFactory(new Callback<ListView<ScriptTab>, 
-				ListCell<ScriptTab>>() {
-					@Override 
-					public ListCell<ScriptTab> call(ListView<ScriptTab> list) {
-						return new ScriptTabListCell();
-					}
-				}
-			);
+	            ListCell<ScriptTab>>() {
+	                @Override 
+	                public ListCell<ScriptTab> call(ListView<ScriptTab> list) {
+	                    return new ScriptTabListCell();
+	                }
+	            }
+	        );
 		listScripts.setMinWidth(150);
 		runningTask.addListener((v, o, n) -> listScripts.refresh());
 
@@ -769,8 +769,6 @@ public class DefaultScriptEditor implements ScriptEditor {
 		ScriptContext context = new SimpleScriptContext();
 		var writer = new ScriptConsoleWriter(console, false);
 		context.setWriter(writer);
-		String[] argsArray = new String[0];
-		context.setAttribute("args", argsArray, ScriptContext.ENGINE_SCOPE);
 		context.setErrorWriter(new ScriptConsoleWriter(console, true));
 		var argsArray = new String[0];
 		context.setAttribute("args", argsArray, ScriptContext.ENGINE_SCOPE);
@@ -1038,25 +1036,25 @@ public class DefaultScriptEditor implements ScriptEditor {
 	
 	
 	static class ScriptTabListCell extends ListCell<ScriptTab> {
-		@Override
-		public void updateItem(ScriptTab item, boolean empty) {
-			super.updateItem(item, empty);
-			if (item == null || empty) {
-				setText(null);
-				setTooltip(null);
-			 	return;
-			}
-			var text = item.toString();
-			if (item.isRunning) {
-				text = text + " (Running)";
-				setStyle("-fx-font-style: italic;");
-			} else
-				setStyle(null);
-			setText(text);
-			setTooltip(new Tooltip(text));
+        @Override
+        public void updateItem(ScriptTab item, boolean empty) {
+            super.updateItem(item, empty);
+            if (item == null || empty) {
+            	setText(null);
+            	setTooltip(null);
+             	return;
+            }
+            var text = item.toString();
+            if (item.isRunning) {
+            	text = text + " (Running)";
+            	setStyle("-fx-font-style: italic;");
+            } else
+            	setStyle(null);
+            setText(text);
+            setTooltip(new Tooltip(text));
 //            this.setOpacity(0);
-		}
-	}
+        }
+    }
 	
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -770,6 +770,8 @@ public class DefaultScriptEditor implements ScriptEditor {
 		var writer = new ScriptConsoleWriter(console, false);
 		context.setWriter(writer);
 		context.setErrorWriter(new ScriptConsoleWriter(console, true));
+		var argsArray = new String[0];
+		context.setAttribute("args", argsArray, ScriptContext.ENGINE_SCOPE);
 		var printWriter = new PrintWriter(writer);
 		
 		boolean attachToLog = sendLogToConsole.get();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -767,11 +767,11 @@ public class DefaultScriptEditor implements ScriptEditor {
 		ScriptEditorControl console = tab.getConsoleComponent();
 		
 		ScriptContext context = new SimpleScriptContext();
+		String[] argsArray = new String[0];
+		context.setAttribute("args", argsArray, ScriptContext.ENGINE_SCOPE);
 		var writer = new ScriptConsoleWriter(console, false);
 		context.setWriter(writer);
 		context.setErrorWriter(new ScriptConsoleWriter(console, true));
-		var argsArray = new String[0];
-		context.setAttribute("args", argsArray, ScriptContext.ENGINE_SCOPE);
 		var printWriter = new PrintWriter(writer);
 		
 		boolean attachToLog = sendLogToConsole.get();

--- a/src/main/java/qupath/QuPath.java
+++ b/src/main/java/qupath/QuPath.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.StringTokenizer;
 
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
@@ -254,6 +255,9 @@ class ScriptCommand implements Runnable {
 	@Option(names = {"-c", "--cmd"}, description = "Groovy script passed a a string", paramLabel = "command")
 	private String scriptCommand;
 	
+	@Option(names = {"-a", "--args"}, description = "Arguments for the Groovy script command, passed as a string", paramLabel = "arguments")
+	private String argsString;
+	
 	@Option(names = {"-i", "--image"}, description = {"Apply the script to the specified image.",
 			"This should be the image name if a project is also specified, otherwise it should be the full image path."}, 
 			paramLabel = "image")
@@ -268,6 +272,90 @@ class ScriptCommand implements Runnable {
 	@Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit.")
 	boolean usageHelpRequested;
 	
+	/**
+	* Code borrowed from ant.jar
+	* Original file ant/src/main/org/apache/tools/ant/types/Commandline.java
+	* Licensed to the Apache Software Foundation (ASF) under one or more
+	* contributor license agreements.  See the NOTICE file distributed with
+	* this work for additional information regarding copyright ownership.
+	* The ASF licenses this file to You under the Apache License, Version 2.0
+	* (the "License"); you may not use this file except in compliance with
+	* the License.  You may obtain a copy of the License at
+	*
+	*      https://www.apache.org/licenses/LICENSE-2.0
+	*
+	* Unless required by applicable law or agreed to in writing, software
+	* distributed under the License is distributed on an "AS IS" BASIS,
+	* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	* See the License for the specific language governing permissions and
+	* limitations under the License.
+	*
+	* Crack a command line.
+	* @param toProcess the command line to process.
+	* @return the command line broken into strings.
+	* An empty or null toProcess parameter results in a zero sized array.
+	*/
+	public static String[] translateCommandline(String toProcess) {
+		if (toProcess == null || toProcess.length() == 0) {
+			//no command? no string
+			return new String[0];
+		}
+		// parse with a simple finite state machine
+
+		final int normal = 0;
+		final int inQuote = 1;
+		final int inDoubleQuote = 2;
+		int state = normal;
+		final StringTokenizer tok = new StringTokenizer(toProcess, "\"\' ", true);
+		final ArrayList<String> result = new ArrayList<String>();
+		final StringBuilder current = new StringBuilder();
+		boolean lastTokenHasBeenQuoted = false;
+
+		while (tok.hasMoreTokens()) {
+			String nextTok = tok.nextToken();
+			switch (state) {
+			case inQuote:
+				if ("\'".equals(nextTok)) {
+					lastTokenHasBeenQuoted = true;
+					state = normal;
+				} else {
+					current.append(nextTok);
+				}
+				break;
+			case inDoubleQuote:
+				if ("\"".equals(nextTok)) {
+					lastTokenHasBeenQuoted = true;
+					state = normal;
+				} else {
+					current.append(nextTok);
+				}
+				break;
+			default:
+				if ("\'".equals(nextTok)) {
+					state = inQuote;
+				} else if ("\"".equals(nextTok)) {
+					state = inDoubleQuote;
+				} else if (" ".equals(nextTok)) {
+					if (lastTokenHasBeenQuoted || current.length() != 0) {
+						result.add(current.toString());
+						current.setLength(0);
+					}
+				} else {
+					current.append(nextTok);
+				}
+				lastTokenHasBeenQuoted = false;
+				break;
+			}
+		}
+		if (lastTokenHasBeenQuoted || current.length() != 0) {
+			result.add(current.toString());
+		}
+		if (state == inQuote || state == inDoubleQuote) {
+			throw new RuntimeException("unbalanced quotes in " + toProcess);
+		}
+		return result.toArray(new String[result.size()]);
+	}
+
 	@Override
 	public void run() {
 		try {
@@ -377,6 +465,11 @@ class ScriptCommand implements Runnable {
 		
 		// Try to make sure that the standard outputs are used
 		ScriptContext context = new SimpleScriptContext();
+
+        // Define "args" as a Groovy global variable
+        String[] argsArray = translateCommandline(argsString);
+        context.setAttribute("args", argsArray, ScriptContext.ENGINE_SCOPE);
+
 		PrintWriter outWriter = new PrintWriter(System.out, true);
 		PrintWriter errWriter = new PrintWriter(System.err, true);
 		context.setWriter(outWriter);


### PR DESCRIPTION
This pull request lets a user pass not only a Groovy script name via the qupath-console command line arguments, but also the script's arguments via a `-a` or `--args` option followed by quoted string.

This string is then split on whitespace into a list of strings (unless a block is surrounded by \\" \\" escaped quotes) and passed to the Groovy interpreter as the global variable args.

When no arguments are passed to a script, the global variable args is an empty list. With this change, the integrated script editor / interpreter also gets an empty, global args variable.

I explained in https://forum.image.sc/t/using-command-line-parameters-with-a-groovy-script-in-qupath/45949/4 why this is desirable.

Feel free to merge this pull request, or to adapt the idea, *any way you wish*.