### PR TITLE
Drag and Drop for URL

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -197,7 +197,7 @@ import qupath.lib.gui.tools.CommandFinderTools;
 import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.gui.tools.MenuTools;
 import qupath.lib.gui.tools.IconFactory.PathIcons;
-import qupath.lib.gui.viewer.DragDropFileImportListener;
+import qupath.lib.gui.viewer.DragDropImportListener;
 import qupath.lib.gui.viewer.OverlayOptions;
 import qupath.lib.gui.viewer.QuPathViewer;
 import qupath.lib.gui.viewer.QuPathViewerListener;
@@ -324,7 +324,7 @@ public class QuPathGUI {
 	private boolean isStandalone = false;
 	private ScriptMenuLoader sharedScriptMenuLoader;
 	
-	private DragDropFileImportListener dragAndDrop = new DragDropFileImportListener(this);
+	private DragDropImportListener dragAndDrop = new DragDropImportListener(this);
 	
 	private UndoRedoManager undoRedoManager;
 	
@@ -2120,7 +2120,7 @@ public class QuPathGUI {
 	 * 
 	 * @return
 	 */
-	public DragDropFileImportListener getDefaultDragDropListener() {
+	public DragDropImportListener getDefaultDragDropListener() {
 		return dragAndDrop;
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -128,8 +128,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 			} catch (IOException e) {
 				Dialogs.showErrorMessage("Drag & Drop", e);
 			}
-		}
-		if (dragboard.hasUrl() && !dragboard.getUrl().startsWith("file:/")) {
+		} else if (dragboard.hasUrl()) {
 			logger.debug("URL dragged onto {}", source);
 			try {
 				handleURLDrop(viewer, dragboard.getUrl());
@@ -156,11 +155,11 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 	
 
 	/**
-	 * Remove a DropHandler.
+	 * Remove a File DropHandler.
 	 * 
 	 * @param handler
 	 */
-	public void removeDropHandler(final DropHandler<File> handler) {
+	public void removeFileDropHandler(final DropHandler<File> handler) {
 		this.dropHandlers.remove(handler);
 	}
     

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -56,9 +56,10 @@ import qupath.lib.gui.scripting.DefaultScriptEditor;
 
 
 /**
- * Drag and drop support for main QuPath application, which supports a range of different supported file types as well as URLs.
+ * Drag and drop support for main QuPath application, which can support a range of different object types (Files, URLs, Strings,..)
  * 
  * @author Pete Bankhead
+ * @author Melvin Gelbard
  *
  */
 public class DragDropImportListener implements EventHandler<DragEvent> {
@@ -67,7 +68,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 
 	private QuPathGUI qupath;
 	
-	private List<DropHandler<?>> dropHandlers = new ArrayList<>();
+	private List<DropHandler<File>> dropHandlers = new ArrayList<>();
 
 	/**
 	 * Constructor.
@@ -128,7 +129,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 				Dialogs.showErrorMessage("Drag & Drop", e);
 			}
 		}
-		if (dragboard.hasUrl()) {
+		if (dragboard.hasUrl() && !dragboard.getUrl().startsWith("file:/")) {
 			logger.debug("URL dragged onto {}", source);
 			try {
 				handleURLDrop(viewer, dragboard.getUrl());
@@ -153,24 +154,13 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 		this.dropHandlers.add(handler);
 	}
 	
-	/**
-     * Add a new URL DropHandler.
-     * <p>
-     * This may be called on a drag-and-drop application on the main window, if no other 
-     * handler deals with the event.
-     * 
-     * @param handler
-     */
-	public void addURLDropHandler(final DropHandler<String> handler) {
-		this.dropHandlers.add(handler);
-	}
 
 	/**
-	 * Remove a DropHandler (can be either a File or a URL DropHandler).
+	 * Remove a DropHandler.
 	 * 
 	 * @param handler
 	 */
-	public void removeDropHandler(final DropHandler<?> handler) {
+	public void removeDropHandler(final DropHandler<File> handler) {
 		this.dropHandlers.remove(handler);
 	}
     
@@ -310,7 +300,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 
 			
 			// Check handlers
-			for (DropHandler handler: dropHandlers) {
+			for (DropHandler<File> handler: dropHandlers) {
 				if (handler.handleDrop(viewer, list))
 					return;
 			}
@@ -352,11 +342,13 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
      * Interface to define a new drop handler.
      * 
      * @author Pete Bankhead
+     * @author Melvin Gelbard
      * @param <T> 
      *
      */
+     @FunctionalInterface
     public static interface DropHandler<T> {
-    	
+    	 
     	/**
     	 * Handle drop onto a viewer.
     	 * This makes it possible to drop images (for example) onto a specific viewer to open them in that viewer, 


### PR DESCRIPTION
Implemented the Drag and Drop feature on the viewer for URLs (see https://forum.image.sc/t/feature-proposal-add-url-drag-and-drop-handler/40884).

Note: URL `DropHandler`s take a `List<String>` parameter. This could potentially be changed to take `List<URL>` parameter instead if needed (though the probability that an implementation of a 'String Drag and Drop' is needed in the future is *quite* low).