### PR TITLE
Feature/concat-duplicate-channels

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
@@ -1,6 +1,12 @@
 package qupath.lib.common;
 
-import qupath.lib.images.servers.AbstractImageServer;
+import qupath.lib.images.servers.*;
+import qupath.lib.regions.RegionRequest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
 //import java.lang.Object.com.imsl.stat.CrossCorrelation;
 
 /**
@@ -11,13 +17,53 @@ import qupath.lib.images.servers.AbstractImageServer;
  */
 
 public class ConcatChannelsABI {
-    public boolean normCrossCorrelation(float[][] firstChannel, float[][] secondChannel) {
-        //implement normalised cross-correlation here or find a package
+
+    /**
+     * This method is used to compare two channels together to see if they are similar or not using normalised cross-correlation.
+     *
+     * @param firstChannel
+     * @param secondChannel
+     */
+    public static boolean normCrossCorrelation(float[][] firstChannel, float[][] secondChannel) {
+        //TODO: implement normalised cross-correlation here or use a package
         double NCCResult = 0;
         if(NCCResult > 0.85) {
             return true;
         } else {
             return false;
         }
+    }
+
+    /**
+     * This method is used to convert a regular ImageChannel into a float array so it can be compared using
+     * normalised cross-correlation.
+     *
+     * @param imgChnl
+     */
+    public static float[][] convertChannelToFloatArray(ImageChannel imgChnl) {
+        //TODO: implement converting an ImageChannel object into an array of the pixel values for the individual channel.
+        float[][] channelArray = null;
+        return channelArray;
+    }
+
+    public static ImageServer concatDuplicateChannels(ImageServer imageServer){
+        int nChannels = imageServer.nChannels();
+        List<Integer> duplicateChannelNumbers = null;
+        float[][] tmpChannelOne;
+        float[][] tmpChannelTwo;
+
+        for(int i = 0; i < nChannels - 1; i++) {
+            for(int j = 1; j < nChannels; j++) {
+                tmpChannelOne = convertChannelToFloatArray(imageServer.getChannel(i));
+                tmpChannelTwo = convertChannelToFloatArray(imageServer.getChannel(j));
+                if(normCrossCorrelation(tmpChannelOne, tmpChannelTwo)) {
+                    duplicateChannelNumbers.add(j);
+                    i++;
+                    j++;
+                }
+            }
+        }
+        //TODO: remove duplicate channels from the image server using duplicateChannelNumbers.
+        return imageServer;
     }
 }

--- a/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
@@ -121,15 +121,6 @@ public class ConcatChannelsABI {
         imageData.updateServerMetadata(metadata2);
     }
 
-//    public static float[] getPixelIntensities(BufferedImage img, int channel, float[] array) {
-//        if (array == null || array.length < w * h)
-//            array = new float[w * h];
-//        int x = img.getWidth();
-//        int y = img.getHeight();
-//        float[] pixelIntensities = img.getRaster().getSamples(x, y, x, y, channel, array);
-//        return pixelIntensities;
-//    }
-
     /**
      * Call setChannelColors method with the channel colours used regularly with 7 channels
      *
@@ -144,7 +135,7 @@ public class ConcatChannelsABI {
         regularChannelColourArray[4] = ColorTools.makeRGB(0,0,0);
         regularChannelColourArray[5] = ColorTools.makeRGB(0,0,0);
         regularChannelColourArray[6] = ColorTools.makeRGB(0,0,0);
-        //TODO: set the regular 7 colours in the array
+        //TODO: set the regular 7 colours in the array (not black)
         setChannelColors(imageData, regularChannelColourArray);
     }
 
@@ -159,7 +150,7 @@ public class ConcatChannelsABI {
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            ArrayList<Integer> duplicates = new ArrayList<Integer>();
+            ArrayList<Integer> duplicates = new ArrayList<>();
             int width = img.getWidth();
             System.out.println("width: " + width);
             int height = img.getHeight();
@@ -182,11 +173,16 @@ public class ConcatChannelsABI {
                     }
                 }
             }
-            for(int dupe = 0; dupe < duplicates.size(); dupe++) {
-                System.out.println(duplicates.get(dupe));
+            ArrayList<Integer> notDuplicates = new ArrayList<>();
+            for(int i = 0; i < nChannels; i++) {
+                if(!duplicates.contains(i)) {
+                    notDuplicates.add(i);
+                    System.out.println(i);
+                }
             }
             setRegularChannelColours(imageData);
-            //TODO: remove duplicate channels from the image server using duplicateChannelNumbers.
+            //TODO: remove duplicate channels from the image server using duplicateChannelNumbers
+            //TODO: set imageData to reflect changes in this class
         }
     }
 }

--- a/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
@@ -125,17 +125,18 @@ public class ConcatChannelsABI {
 
     public static void concatDuplicateChannels(ImageData<?> imageData){
         int nChannels = imageData.getServer().nChannels();
-        List<Integer> duplicateChannelNumbers = null;
+        List<Integer> duplicates = null;
         float[][] tmpChannelOne;
         float[][] tmpChannelTwo;
         for(int i = 0; i < nChannels - 1; i++) {
-            for(int j = 1; j < nChannels; j++) {
+            //only check for duplicates in channels that aren't already considered duplicates
+            if(!duplicates.contains(i)) {
                 tmpChannelOne = convertChannelToFloatArray(imageData.getServer().getChannel(i));
-                tmpChannelTwo = convertChannelToFloatArray(imageData.getServer().getChannel(j));
-                if(normCrossCorrelation(tmpChannelOne, tmpChannelTwo)) {
-                    duplicateChannelNumbers.add(j);
-                    i++;
-                    j++;
+                for(int j = 1; j < nChannels; j++) {
+                    tmpChannelTwo = convertChannelToFloatArray(imageData.getServer().getChannel(j));
+                    if(normCrossCorrelation(tmpChannelOne, tmpChannelTwo)) {
+                        duplicates.add(j);
+                    }
                 }
             }
         }

--- a/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
@@ -3,10 +3,11 @@ package qupath.lib.common;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.*;
 
+import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-//import java.lang.Object.com.imsl.stat.CrossCorrelation;
+
 
 /**
  * Functions to help with combining fluorescent channels that are the same or similar.
@@ -24,9 +25,18 @@ public class ConcatChannelsABI {
      * @param secondChannel
      */
     public static boolean normCrossCorrelation(float[][] firstChannel, float[][] secondChannel) {
-        //TODO: implement normalised cross-correlation here or use a package
-        double NCCResult = 0;
-        if(NCCResult > 0.85) {
+        float nominator = 0;
+        float firstDenominator = 0;
+        float secondDenominator = 0;
+        //number of rows and columns should be the same in both channels
+        for(int i = 0; i < firstChannel.length; i++) {
+            for(int j = 0; j < firstChannel[0].length; j++) {
+                nominator += firstChannel[i][j] * secondChannel[i][j];
+                firstDenominator += (firstChannel[i][j] * firstChannel[i][j]);
+                secondDenominator += (secondChannel[i][j] * secondChannel[i][j]);
+            }
+        }
+        if(nominator/(float)(Math.sqrt((double)(firstDenominator * secondDenominator))) > 0.85) {
             return true;
         } else {
             return false;
@@ -123,7 +133,7 @@ public class ConcatChannelsABI {
         setChannelColors(imageData, regularChannelColourArray);
     }
 
-    public static void concatDuplicateChannels(ImageData<?> imageData){
+    public static void concatDuplicateChannels(ImageData<?> imageData, BufferedImage img){
         int nChannels = imageData.getServer().nChannels();
         List<Integer> duplicates = null;
         float[][] tmpChannelOne;

--- a/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
@@ -1,7 +1,10 @@
 package qupath.lib.common;
 
+import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.*;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 //import java.lang.Object.com.imsl.stat.CrossCorrelation;
 
@@ -42,6 +45,11 @@ public class ConcatChannelsABI {
         return channelArray;
     }
 
+    /**
+     * This method is used to check if there are more than 7 channels and therefore whether channels should be concatenated or not.
+     *
+     * @param nChannels
+     */
     public static boolean isExcessChannels(int nChannels) {
         if(nChannels >= 42) {
             return true;
@@ -50,16 +58,80 @@ public class ConcatChannelsABI {
         }
     }
 
-    public static ImageServer concatDuplicateChannels(ImageServer imageServer){
-        int nChannels = imageServer.nChannels();
+    /**
+     * @author Pete Bankhead
+     * Set the channel colors for the specified ImageData.
+     * It is not essential to pass names for all channels:
+     * by passing n values, the first n channel names will be set.
+     * Any name that is null will be left unchanged.
+     *
+     * @param imageData
+     * @param colors
+     */
+    public static void setChannelColors(ImageData<?> imageData, Integer... colors) {
+        List<ImageChannel> oldChannels = imageData.getServer().getMetadata().getChannels();
+        List<ImageChannel> newChannels = new ArrayList<>(oldChannels);
+        for (int i = 0; i < colors.length; i++) {
+            Integer color = colors[i];
+            if (color == null)
+                continue;
+            newChannels.set(i, ImageChannel.getInstance(newChannels.get(i).getName(), color));
+            if (i >= newChannels.size()) {
+                break;
+            }
+        }
+        setChannels(imageData, newChannels.toArray(ImageChannel[]::new));
+    }
+
+    /**
+     * @author Pete Bankhead
+     * Set the channels for the specified ImageData.
+     * Note that number of channels provided must match the number of channels of the current image.
+     * <p>
+     * Also, currently it is not possible to set channels for RGB images - attempting to do so
+     * will throw an IllegalArgumentException.
+     *
+     * @param imageData
+     * @param channels
+     */
+    public static void setChannels(ImageData<?> imageData, ImageChannel... channels) {
+        ImageServer<?> server = imageData.getServer();
+        if (server.isRGB()) {
+            throw new IllegalArgumentException("Cannot set channels for RGB images");
+        }
+        List<ImageChannel> oldChannels = server.getMetadata().getChannels();
+        List<ImageChannel> newChannels = Arrays.asList(channels);
+        if (oldChannels.size() != newChannels.size())
+            throw new IllegalArgumentException("Cannot set channels - require " + oldChannels.size() + " channels but you provided " + channels.length);
+
+        // Set the metadata
+        var metadata = server.getMetadata();
+        var metadata2 = new ImageServerMetadata.Builder(metadata)
+                .channels(newChannels)
+                .build();
+        imageData.updateServerMetadata(metadata2);
+    }
+
+    /**
+     * Call setChannelColors method with the channel colours used regularly with 7 channels
+     *
+     * @param imageData
+     */
+    public static void setRegularChannelColours(ImageData<?> imageData){
+        Integer[] regularChannelColourArray = new Integer[7];
+        //TODO: set the regular 7 colours in the array
+        setChannelColors(imageData, regularChannelColourArray);
+    }
+
+    public static void concatDuplicateChannels(ImageData<?> imageData){
+        int nChannels = imageData.getServer().nChannels();
         List<Integer> duplicateChannelNumbers = null;
         float[][] tmpChannelOne;
         float[][] tmpChannelTwo;
-
         for(int i = 0; i < nChannels - 1; i++) {
             for(int j = 1; j < nChannels; j++) {
-                tmpChannelOne = convertChannelToFloatArray(imageServer.getChannel(i));
-                tmpChannelTwo = convertChannelToFloatArray(imageServer.getChannel(j));
+                tmpChannelOne = convertChannelToFloatArray(imageData.getServer().getChannel(i));
+                tmpChannelTwo = convertChannelToFloatArray(imageData.getServer().getChannel(j));
                 if(normCrossCorrelation(tmpChannelOne, tmpChannelTwo)) {
                     duplicateChannelNumbers.add(j);
                     i++;
@@ -67,7 +139,7 @@ public class ConcatChannelsABI {
                 }
             }
         }
+        setRegularChannelColours(imageData);
         //TODO: remove duplicate channels from the image server using duplicateChannelNumbers.
-        return imageServer;
     }
 }

--- a/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
@@ -24,6 +24,17 @@ import java.util.List;
 
 public class ConcatChannelsABI {
 
+    //Macros
+    private static double SIMILARITY_THRESHOLD = 0.95;
+    private static int NUMBER_FOR_EXCESS_CHANNELS = 42;
+    private static int[] ALEXA_488 = {0, 204, 0}; //GREEN
+    private static int[] ALEXA_555 = {255, 255, 0}; //YELLOW
+    private static int[] ALEXA_594 = {255, 0, 0}; //RED
+    private static int[] ATTO_425 = {0, 255, 255}; //CYAN
+    private static int[] DAPI = {0, 0, 255}; //BLUE
+    private static int[] DL680_DUNBAR = {255, 255, 255}; //WHITE
+    private static int[] DL755_DUNBAR = {233, 150, 122}; //DARK SALMON
+
     /**
      * This method is used to compare two channels together to see if they are similar or not using normalised cross-correlation.
      *
@@ -46,7 +57,7 @@ public class ConcatChannelsABI {
         System.out.println("secondDenominator: " + secondDenominator);
         result = nominator/(float)(Math.sqrt((firstDenominator * secondDenominator)));
         System.out.println("result: " + result);
-        if(result > 0.95) {
+        if(result > SIMILARITY_THRESHOLD) {
             System.out.println("dupeChannel: true");
             return true;
         } else {
@@ -61,7 +72,7 @@ public class ConcatChannelsABI {
      * @param nChannels
      */
     public static boolean isExcessChannels(int nChannels) {
-        if(nChannels >= 42) {
+        if(nChannels >= NUMBER_FOR_EXCESS_CHANNELS) {
             System.out.println("excessChannels: true");
             return true;
         } else {
@@ -131,13 +142,13 @@ public class ConcatChannelsABI {
      */
     public static void setRegularChannelColours(ImageData<?> imageData){
         Integer[] regularChannelColourArray = new Integer[7];
-        regularChannelColourArray[0] = ColorTools.makeRGB(0,204,0); //Alexa 488
-        regularChannelColourArray[1] = ColorTools.makeRGB(255,255,0); //Alexa 555
-        regularChannelColourArray[2] = ColorTools.makeRGB(255,0,0); //Alexa 594
-        regularChannelColourArray[3] = ColorTools.makeRGB(0,255,255); //ATTO 425
-        regularChannelColourArray[4] = ColorTools.makeRGB(0,0,255); //DAPI
-        regularChannelColourArray[5] = ColorTools.makeRGB(255,255,255); //DL680_Dunbar
-        regularChannelColourArray[6] = ColorTools.makeRGB(233,150,122); //DL755_Dunabr
+        regularChannelColourArray[0] = ColorTools.makeRGB(ALEXA_488[0], ALEXA_488[1], ALEXA_488[2]); //Alexa 488
+        regularChannelColourArray[1] = ColorTools.makeRGB(ALEXA_555[0], ALEXA_555[1], ALEXA_555[2]); //Alexa 555
+        regularChannelColourArray[2] = ColorTools.makeRGB(ALEXA_594[0], ALEXA_594[1], ALEXA_594[2]); //Alexa 594
+        regularChannelColourArray[3] = ColorTools.makeRGB(ATTO_425[0], ATTO_425[1], ATTO_425[2]); //ATTO 425
+        regularChannelColourArray[4] = ColorTools.makeRGB(DAPI[0], DAPI[1], DAPI[2]); //DAPI
+        regularChannelColourArray[5] = ColorTools.makeRGB(DL680_DUNBAR[0], DL680_DUNBAR[1], DL680_DUNBAR[2]); //DL680_Dunbar
+        regularChannelColourArray[6] = ColorTools.makeRGB(DL755_DUNBAR[0], DL755_DUNBAR[1], DL755_DUNBAR[2]); //DL755_Dunbar
         setChannelColors(imageData, regularChannelColourArray);
     }
 

--- a/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
@@ -128,14 +128,13 @@ public class ConcatChannelsABI {
      */
     public static void setRegularChannelColours(ImageData<?> imageData){
         Integer[] regularChannelColourArray = new Integer[7];
-        regularChannelColourArray[0] = ColorTools.makeRGB(0,0,0);
-        regularChannelColourArray[1] = ColorTools.makeRGB(0,0,0);
-        regularChannelColourArray[2] = ColorTools.makeRGB(0,0,0);
-        regularChannelColourArray[3] = ColorTools.makeRGB(0,0,0);
-        regularChannelColourArray[4] = ColorTools.makeRGB(0,0,0);
-        regularChannelColourArray[5] = ColorTools.makeRGB(0,0,0);
-        regularChannelColourArray[6] = ColorTools.makeRGB(0,0,0);
-        //TODO: set the regular 7 colours in the array (not black)
+        regularChannelColourArray[0] = ColorTools.makeRGB(0,204,0); //Alexa 488
+        regularChannelColourArray[1] = ColorTools.makeRGB(255,255,0); //Alexa 555
+        regularChannelColourArray[2] = ColorTools.makeRGB(255,0,0); //Alexa 594
+        regularChannelColourArray[3] = ColorTools.makeRGB(0,255,255); //ATTO 425
+        regularChannelColourArray[4] = ColorTools.makeRGB(0,0,255); //DAPI
+        regularChannelColourArray[5] = ColorTools.makeRGB(255,255,255); //DL680_Dunbar
+        regularChannelColourArray[6] = ColorTools.makeRGB(233,150,122); //DL755_Dunabr
         setChannelColors(imageData, regularChannelColourArray);
     }
 
@@ -181,6 +180,10 @@ public class ConcatChannelsABI {
                 }
             }
             setRegularChannelColours(imageData);
+            ImageServerMetadata metadata = imageData.getServer().getMetadata();
+            ImageServerMetadata metadata2 = new ImageServerMetadata.Builder(metadata).build(); //set the correct channels in this line
+            imageData.updateServerMetadata(metadata2);
+
             //TODO: remove duplicate channels from the image server using duplicateChannelNumbers
             //TODO: set imageData to reflect changes in this class
         }

--- a/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
@@ -1,0 +1,23 @@
+package qupath.lib.common;
+
+import qupath.lib.images.servers.AbstractImageServer;
+//import java.lang.Object.com.imsl.stat.CrossCorrelation;
+
+/**
+ * Functions to help with combining fluorescent channels that are the same or similar.
+ *
+ * @author Jaedyn Ward
+ *
+ */
+
+public class ConcatChannelsABI {
+    public boolean normCrossCorrelation(float[][] firstChannel, float[][] secondChannel) {
+        //implement normalised cross-correlation here or find a package
+        double NCCResult = 0;
+        if(NCCResult > 0.85) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
@@ -1,11 +1,7 @@
 package qupath.lib.common;
 
 import qupath.lib.images.servers.*;
-import qupath.lib.regions.RegionRequest;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
 import java.util.List;
 //import java.lang.Object.com.imsl.stat.CrossCorrelation;
 
@@ -44,6 +40,14 @@ public class ConcatChannelsABI {
         //TODO: implement converting an ImageChannel object into an array of the pixel values for the individual channel.
         float[][] channelArray = null;
         return channelArray;
+    }
+
+    public static boolean isExcessChannels(int nChannels) {
+        if(nChannels >= 42) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public static ImageServer concatDuplicateChannels(ImageServer imageServer){

--- a/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
@@ -171,10 +171,10 @@ public class ConcatChannelsABI {
         BufferedImage resultImage = new BufferedImage(img.getColorModel(), resultRaster, img.getColorModel().isAlphaPremultiplied(), null);
         //May need to create a new image rather than duplicating
         //need to set 3 to number of channels. Currently does not work as channels are limited to 3 rather than 7.
-//        for(int i = 0; i < notDuplicates.size(); i++) {
-//            img.getRaster().getSamples(0, 0, width, height, notDuplicates.get(i), tempFloatArray);
-//            resultRaster.setSamples(0, 0, width, height, i, tempFloatArray);
-//        }
+        for(int i = 0; i < notDuplicates.size(); i++) {
+            img.getRaster().getSamples(0, 0, width, height, notDuplicates.get(i), tempFloatArray);
+            resultImage.getRaster().setSamples(0, 0, width, height, i, tempFloatArray);
+        }
         return resultImage;
     }
 

--- a/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ConcatChannelsABI.java
@@ -139,7 +139,6 @@ public class ConcatChannelsABI {
     public static void concatDuplicateChannels(ImageData<?> imageData) throws IOException {
         int nChannels = imageData.getServer().nChannels();
         if(isExcessChannels(nChannels)) {
-            ImageServerMetadata newMetadata = imageData.getServer().getMetadata().duplicate();
             RegionRequest request = RegionRequest.createInstance(imageData.getServer());
             BufferedImage img = (BufferedImage) imageData.getServer().readBufferedImage(request);
             List<Integer> duplicates = null;
@@ -160,7 +159,6 @@ public class ConcatChannelsABI {
                     }
                 }
             }
-            imageData.getServer().setMetadata(newMetadata);
             setRegularChannelColours(imageData);
             //TODO: remove duplicate channels from the image server using duplicateChannelNumbers.
         }

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerMetadata.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerMetadata.java
@@ -193,7 +193,7 @@ public class ImageServerMetadata {
 			metadata.width = width;
 			metadata.height = height;
 		}
-		
+
 		/**
 		 * Specify the full-resolution image width.
 		 * @param width

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -55,6 +55,7 @@ import javafx.collections.ObservableList;
 import qupath.lib.analysis.stats.Histogram;
 import qupath.lib.color.ColorTransformer;
 import qupath.lib.color.ColorTransformer.ColorTransformMethod;
+import qupath.lib.common.ConcatChannelsABI;
 import qupath.lib.display.ChannelDisplayInfo.ModifiableChannelDisplayInfo;
 import qupath.lib.gui.images.stores.AbstractImageRenderer;
 import qupath.lib.gui.prefs.PathPrefs;
@@ -125,7 +126,7 @@ public class ImageDisplay extends AbstractImageRenderer {
 	public void setImageData(ImageData<BufferedImage> imageData, boolean retainDisplaySettings) {
 		if (this.imageData == imageData)
 			return;
-
+		ConcatChannelsABI.concatDuplicateChannels(imageData);
 		// Retain display settings if requested *and* we have two similar images 
 		// (i.e. same bit depth, same number and names for channels)
 		String lastDisplayJSON = null;

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -126,7 +126,6 @@ public class ImageDisplay extends AbstractImageRenderer {
 	public void setImageData(ImageData<BufferedImage> imageData, boolean retainDisplaySettings) {
 		if (this.imageData == imageData)
 			return;
-		ConcatChannelsABI.concatDuplicateChannels(imageData);
 		// Retain display settings if requested *and* we have two similar images 
 		// (i.e. same bit depth, same number and names for channels)
 		String lastDisplayJSON = null;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -159,6 +159,7 @@ import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 import javafx.util.Duration;
 import jfxtras.scene.menu.CirclePopupMenu;
+import qupath.lib.common.ConcatChannelsABI;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.common.ThreadTools;
 import qupath.lib.gui.ActionTools.ActionAccelerator;
@@ -2932,8 +2933,8 @@ public class QuPathGUI {
 					}
 					imageData = createNewImageData(serverNew);
 				}
-				
-				viewer.setImageData(imageData);
+				ImageData imageData1 = ConcatChannelsABI.concatDuplicateChannels(imageData);
+				viewer.setImageData(imageData1);
 //				setInitialLocationAndMagnification(viewer);
 
 				if (imageData.getImageType() == ImageType.UNSET && PathPrefs.imageTypeSettingProperty().get() == ImageTypeSetting.PROMPT)


### PR DESCRIPTION
Adds a version where if the image has 43 different channels when imported, it will check for duplicate channels and remove those duplicates.