### PR TITLE
Set focus on magnification/downsample textfield

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SimpleThresholdCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SimpleThresholdCommand.java
@@ -237,7 +237,7 @@ public class SimpleThresholdCommand implements Runnable {
 				Bindings.createStringBinding(() -> GeneralTools.formatNumber(sigma.get(), 2), sigma)
 				);
 		labelSigma.setMinWidth(25); // Thanks to Melvin, to stop it jumping around
-		GuiTools.restrictSpinnerInputToNumber(sigmaSpinner, true);
+		GuiTools.restrictTextFieldInputToNumber(sigmaSpinner.getEditor(), true);
 		PaneTools.addGridRow(pane, row++, 0, "Select smoothing sigma value (higher values give a smoother result)", label, sigmaSpinner, labelSigma);
 
 		label = new Label("Threshold");
@@ -246,7 +246,7 @@ public class SimpleThresholdCommand implements Runnable {
 		labelThreshold.textProperty().bind(
 				Bindings.createStringBinding(() -> GeneralTools.formatNumber(threshold.get(), 2), threshold)
 				);
-		GuiTools.restrictSpinnerInputToNumber(spinner, true);
+		GuiTools.restrictTextFieldInputToNumber(spinner.getEditor(), true);
 		PaneTools.addGridRow(pane, row++, 0, "Select threshold value", label, spinner, labelThreshold);
 
 		Label labelAbove = new Label("Above threshold");

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/ImageDataTransformerBuilder.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/ImageDataTransformerBuilder.java
@@ -328,7 +328,7 @@ abstract class ImageDataTransformerBuilder {
 			var spinnerNormalize = new Spinner<Double>(0.0, 32.0, 8.0, 1.0);
 			normalizationSigma = spinnerNormalize.valueProperty();
 			spinnerNormalize.setEditable(true);
-			GuiTools.restrictSpinnerInputToNumber(spinnerNormalize, true);
+			GuiTools.restrictTextFieldInputToNumber(spinnerNormalize.getEditor(), true);
 			spinnerNormalize.focusedProperty().addListener((v, o, n) -> {
 				if (spinnerNormalize.getEditor().getText().equals(""))
 					spinnerNormalize.getValueFactory().valueProperty().set(0.0);

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/PixelClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/PixelClassifierPane.java
@@ -480,10 +480,10 @@ public class PixelClassifierPane {
 		btnFeatureAuto.setMaxHeight(Double.MAX_VALUE);
 		spinFeatureMin.disableProperty().bind(featureDisableBinding);
 		spinFeatureMin.setEditable(true);
-		GuiTools.restrictSpinnerInputToNumber(spinFeatureMin, true);
+		GuiTools.restrictTextFieldInputToNumber(spinFeatureMin.getEditor(), true);
 		spinFeatureMax.disableProperty().bind(featureDisableBinding);
 		spinFeatureMax.setEditable(true);
-		GuiTools.restrictSpinnerInputToNumber(spinFeatureMax, true);
+		GuiTools.restrictTextFieldInputToNumber(spinFeatureMax.getEditor(), true);
 		var paneFeatures = new GridPane();
 		comboDisplayFeatures.setTooltip(new Tooltip("Choose classification result or feature overlay to display (Warning: This requires a lot of memory & computation!)"));
 		spinFeatureMin.setTooltip(new Tooltip("Min display value for feature overlay"));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
@@ -177,26 +177,16 @@ class ToolBarComponent {
 				return;
 			double fullMagnification = viewer.getServer().getMetadata().getMagnification();
 			boolean hasMagnification = !Double.isNaN(fullMagnification);
-			ParameterList params = new ParameterList();
 			if (hasMagnification) {
 				double defaultValue = Math.rint(viewer.getMagnification() * 1000) / 1000;
-				params.addDoubleParameter("magnification", "Enter magnification", defaultValue);
+				Double value = Dialogs.showInputDialog("Set magnification", "Enter magnification", defaultValue);
+				if (value != null && !Double.isNaN(value))
+					viewer.setMagnification(value.doubleValue());
 			} else {
 				double defaultValue = Math.rint(viewer.getDownsampleFactor() * 1000) / 1000;
-				params.addDoubleParameter("downsample", "Enter downsample factor", defaultValue);			
-			}
-			
-			if (!Dialogs.showParameterDialog("Set magnification", params))
-				return;
-			
-			if (hasMagnification) {
-				double mag = params.getDoubleParameterValue("magnification");
-				if (!Double.isNaN(mag))
-					viewer.setMagnification(mag);
-			} else {
-				double downsample = params.getDoubleParameterValue("downsample");
-				if (!Double.isNaN(downsample))
-					viewer.setDownsampleFactor(downsample);
+				Double value = Dialogs.showInputDialog("Set downsample factor", "Enter downsample factor", defaultValue);
+				if (value != null && !Double.isNaN(value))
+					viewer.setDownsampleFactor(value.doubleValue());
 			}
 		}
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -101,6 +101,7 @@ import qupath.lib.gui.charts.HistogramPanelFX.ThresholdedChartWrapper;
 import qupath.lib.gui.dialogs.Dialogs;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.tools.ColorToolsFX;
+import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.gui.tools.PaneTools;
 import qupath.lib.gui.viewer.QuPathViewer;
 import qupath.lib.images.ImageData;
@@ -204,7 +205,8 @@ public class BrightnessContrastCommand implements Runnable, ChangeListener<Image
 		labelMinValue.textProperty().bind(Bindings.createStringBinding(() -> {
 //			if (table.getSelectionModel().getSelectedItem() == null)
 //				return blank;
-			return String.format("%.1f", sliderMin.getValue());
+			// If value < 10, return 2 dp, otherwise 1 dp. Should be more useful for 16-/32-bit images.
+			return sliderMin.getValue() < 10 ? String.format("%.2f", sliderMin.getValue()) : String.format("%.1f", sliderMin.getValue());
 		}, table.getSelectionModel().selectedItemProperty(), sliderMin.valueProperty()));
 		box.add(labelMin, 0, 0);
 		box.add(sliderMin, 1, 0);
@@ -217,7 +219,8 @@ public class BrightnessContrastCommand implements Runnable, ChangeListener<Image
 		labelMaxValue.textProperty().bind(Bindings.createStringBinding(() -> {
 //				if (table.getSelectionModel().getSelectedItem() == null)
 //					return blank;
-				return String.format("%.1f", sliderMax.getValue());
+			// If value < 10, return 2 dp, otherwise 1 dp. Should be more useful for 16-/32-bit images.
+			return sliderMax.getValue() < 10 ? String.format("%.2f", sliderMax.getValue()) : String.format("%.1f", sliderMax.getValue());
 			}, table.getSelectionModel().selectedItemProperty(), sliderMax.valueProperty()));
 		box.add(labelMax, 0, 1);
 		box.add(sliderMax, 1, 1);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -249,6 +249,7 @@ public class BrightnessContrastCommand implements Runnable, ChangeListener<Image
 						imageDisplay.setMinMaxDisplay(infoVisible, (float)value.floatValue(), (float)infoVisible.getMaxDisplay());
 //						infoVisible.setMinDisplay(value.floatValue());
 //						viewer.updateThumbnail();
+						updateSliders();
 						viewer.repaintEntireImage();
 					}
 				}
@@ -268,6 +269,7 @@ public class BrightnessContrastCommand implements Runnable, ChangeListener<Image
 						imageDisplay.setMinMaxDisplay(infoVisible, (float)infoVisible.getMinDisplay(), (float)value.floatValue());
 //						infoVisible.setMaxDisplay(value.floatValue());
 //						viewer.updateThumbnail();
+						updateSliders();
 						viewer.repaintEntireImage();
 					}
 				}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
@@ -220,13 +220,17 @@ public class Dialogs {
 	
 	
 	/**
-	 * Show an input dialog requesting a numeric value. Only digits and a decimal separator (e.g. ".") 
-	 * are permitted.
+	 * Show an input dialog requesting a numeric value. Only scientific notation and digits 
+	 * with/without a decimal separator (e.g. ".") are permitted.
+	 * <p>
+	 * The returned value might still not be in a valid state, as 
+	 * limited by {@link GuiTools#restrictTextFieldInputToNumber(javafx.scene.control.TextField, boolean)}.
 	 * 
 	 * @param title
 	 * @param message
 	 * @param initialInput
 	 * @return Number input by the user, or NaN if no valid number was entered, or null if cancel was pressed.
+	 * @see GuiTools#restrictTextFieldInputToNumber(javafx.scene.control.TextField, boolean)
 	 */
 	public static Double showInputDialog(final String title, final String message, final Double initialInput) {
 		if (Platform.isFxApplicationThread()) {
@@ -244,7 +248,7 @@ public class Dialogs {
 				try {
 					return Double.parseDouble(result.get());
 				} catch (Exception e) {
-					// Should not happen since the TextField is restricted to Double format
+					// Can still happen since the TextField restrictions allow intermediate (invalid) formats
 					logger.error("Unable to parse numeric value from {}", result);
 					return Double.NaN;
 				}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -113,6 +113,11 @@ import qupath.lib.roi.interfaces.ROI;
 public class GuiTools {
 	
 	/**
+	 * Pattern object to match any letter except E/e
+	 */
+	private static final Pattern pattern = Pattern.compile("[a-zA-Z&&[^Ee]]+");
+	
+	/**
 	 * Vertical ellipsis, which can be used to indicate a 'more' button.
 	 */
 	private static String MORE_ELLIPSIS = "\u22EE";
@@ -692,7 +697,6 @@ public class GuiTools {
 		    	String newText = c.getControlNewText().toUpperCase();
 		    	
 		    	// Check for invalid characters (weak check)
-		    	Pattern pattern = Pattern.compile("[a-zA-Z&&[^Ee]]+");
 		        Matcher matcher = pattern.matcher(newText);
 		        if (matcher.find())
 		        	return null;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -35,6 +35,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.controlsfx.control.CheckComboBox;
@@ -668,7 +670,7 @@ public class GuiTools {
 	 * <li> character deletion is always permitted (e.g. -1.5e5 -> -1.5e; deletion of last character).</li>
 	 * <li>users are allowed to input a minus sign, in order to permit manual typing, which then needs to accept intermediate (invalid) states.</li>
 	 * <li>users are allowed to input an 'E'/'e' character, in order to permit manual typing as well, which then needs to accept intermediate (invalid) states.</li>
-	 * <li>copy-pasting is not as strictly restricted (e.g. -1.6e--5 is accepted, but won't be parsed).</li>
+	 * <li>copy-pasting is not as strictly restricted (e.g. -1.6e--5 and 1.6e4e9 are accepted, but won't be parsed).</li>
 	 * <p>
 	 * Some invalid states are accepted and should therefore be caught after this method returns.
 	 * <p>
@@ -688,6 +690,12 @@ public class GuiTools {
 		    if (c.isContentChange()) {
 		    	String text = c.getControlText().toUpperCase();
 		    	String newText = c.getControlNewText().toUpperCase();
+		    	
+		    	// Check for invalid characters (weak check)
+		    	Pattern pattern = Pattern.compile("[a-zA-Z&&[^Ee]]+");
+		        Matcher matcher = pattern.matcher(newText);
+		        if (matcher.find())
+		        	return null;
 		    	
 		    	// Accept minus sign if starting character OR if following 'E'
 		    	if ((newText.length() == 1 || text.toUpperCase().endsWith("E")) && newText.endsWith("-"))

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -663,11 +663,12 @@ public class GuiTools {
 	
 	
 	/**
-	 * Restrict the possible spinner input to integer (or double) format.
-	 * @param spinner
+	 * Restrict the {@link TextField} input to integer (or double) format.
+	 * 
+	 * @param textField
 	 * @param allowDecimals
 	 */
-	public static void restrictSpinnerInputToNumber(Spinner<? extends Number> spinner, boolean allowDecimals) {
+	public static void restrictTextFieldInputToNumber(TextField textField, boolean allowDecimals) {
 		NumberFormat format;
 		if (allowDecimals)
 			format = NumberFormat.getNumberInstance();
@@ -686,7 +687,7 @@ public class GuiTools {
 		    return c;
 		};
 		TextFormatter<Integer> normalizeFormatter = new TextFormatter<Integer>(filter);
-		spinner.getEditor().setTextFormatter(normalizeFormatter);		
+		textField.setTextFormatter(normalizeFormatter);
 	}
 	
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -662,7 +662,17 @@ public class GuiTools {
 	
 	
 	/**
-	 * Restrict the {@link TextField} input to integer (or double) format.
+	 * Restrict the {@link TextField} input to positive/negative integer (or double) format (including scientific notation).
+	 * <p>
+	 * N.B: the {@code TextArea} might still finds itself in an invalid state at any moment, as:
+	 * <li> character deletion is always permitted (e.g. -1.5e5 -> -1.5e; deletion of last character).</li>
+	 * <li>users are allowed to input a minus sign, in order to permit manual typing, which then needs to accept intermediate (invalid) states.</li>
+	 * <li>users are allowed to input an 'E'/'e' character, in order to permit manual typing as well, which then needs to accept intermediate (invalid) states.</li>
+	 * <li>copy-pasting is not as strictly restricted (e.g. -1.6e--5 is accepted, but won't be parsed).</li>
+	 * <p>
+	 * Some invalid states are accepted and should therefore be caught after this method returns.
+	 * <p>
+	 * P.S: 'copy-pasting' an entire value (e.g. {@code '' -> '1.2E-6'}) is regarded as the opposite of 'manual typing' (e.g. {@code '' -> '-', '-' -> '-1', ...}).
 	 * 
 	 * @param textField
 	 * @param allowDecimals
@@ -676,7 +686,23 @@ public class GuiTools {
 		
 		UnaryOperator<TextFormatter.Change> filter = c -> {
 		    if (c.isContentChange()) {
-		    	String newText = c.getControlNewText();
+		    	String text = c.getControlText().toUpperCase();
+		    	String newText = c.getControlNewText().toUpperCase();
+		    	
+		    	// Accept minus sign if starting character OR if following 'E'
+		    	if ((newText.length() == 1 || text.toUpperCase().endsWith("E")) && newText.endsWith("-"))
+		    		return c;
+		    	
+		    	// Accept 'E' (scientific notation) if not starting character
+		    	if ((newText.length() > 1 && !newText.startsWith("-") || (newText.length() > 2 && newText.startsWith("-"))) && 
+		    			!text.toUpperCase().contains("E") && 
+		    			newText.toUpperCase().contains("E"))
+		    		return c;
+		    	
+		    	// Accept any deletion of characters (which means the text area might be left in an invalid state)
+		    	if (newText.length() < text.length())
+		    		return c;
+
 		        ParsePosition parsePosition = new ParsePosition(0);
 		        format.parse(newText, parsePosition);
 		        if (parsePosition.getIndex() < c.getControlNewText().length()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -64,7 +64,6 @@ import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.Slider;
-import javafx.scene.control.Spinner;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;


### PR DESCRIPTION
- When setting the magnification/downsample for an image, the `TextField` is now directly in focus.
- Fix #667: All the dialogs requesting for a numeric input (such as the one above) are now restricted to digits and decimal separator only (e.g. "1.20" is permitted, while "1.2f0" is not). N.B.: Scientific notation is accepted only on copy/paste, as the filter will reject any intermediate representation of scientific notation (i.e. 1.23E4 **is** fine whereas 1.23E is **not**).