### PR TITLE
Added recursive PathObject transform

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -991,36 +991,12 @@ public class PathObjectTools {
 	 * @param copyMeasurements
 	 * @return
 	 */
-	public static List<PathObject> transformObjects(PathObject pathObject, AffineTransform transform, boolean copyMeasurements) {
-		List<PathObject> newObjs = new ArrayList<>();
-		transformRecursive(pathObject, transform, copyMeasurements, null, newObjs);
-		return newObjs;
-	}
-	
-	/**
-	 * Helper method for {@link #transformObjects(PathObject, AffineTransform, boolean)}.
-	 * 
-	 * @param parent the original parent
-	 * @param transform the transformation to apply
-	 * @param copyMeasurements whether new objects will keep their measurements
-	 * @param transformedParent transformed object to which the transformed children will be linked to
-	 * @param list where to store the newly-transformed objects
-	 */
-	private static void transformRecursive(PathObject parent, AffineTransform transform, boolean copyMeasurements, PathObject transformedParent, List<PathObject> list) {
-	    var children = parent.getChildObjectsAsArray();
-	    for (PathObject child: children) {
-	        PathObject transformedObj = PathObjectTools.transformObject(child, transform, copyMeasurements);
-	        
-	        // Add parent (if the transformed parent is null, assume that it's because it is the root object)
-	        if (transformedParent != null)
-	        	transformedParent.addPathObject(transformedObj);
-	        else
-	        	parent.addPathObject(transformedObj);
-	        	
-	        list.add(transformedObj);
-	        
-	        transformRecursive(child, transform, copyMeasurements, transformedObj, list);
-	    }
+	public static PathObject transformObjectRecursive(PathObject pathObject, AffineTransform transform, boolean copyMeasurements) {
+		var newObj = transformObject(pathObject, transform, copyMeasurements);
+		for (var child: pathObject.getChildObjects()) {
+			newObj.addPathObject(transformObjectRecursive(child, transform, copyMeasurements));
+		}
+		return newObj;
 	}
 	
 	private static ROI maybeTransformROI(ROI roi, AffineTransform transform) {
@@ -1028,7 +1004,6 @@ public class PathObjectTools {
 			return roi;
 		return RoiTools.transformROI(roi, transform);
 	}
-	
 	
 	/**
 	 * Duplicate all the selected objects in a hierarchy.

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -981,6 +981,48 @@ public class PathObjectTools {
 		return newObject;
 	}
 	
+	/**
+	 * Create (optionally) transformed versions of the {@link PathObject} and all its descendants, recursively. 
+	 * This method can be applied to all objects in a hierarchy by supplying its root object. The parent-children 
+	 * relationships are kept after transformation.
+	 * 
+	 * @param pathObject
+	 * @param transform
+	 * @param copyMeasurements
+	 * @return
+	 */
+	public static List<PathObject> transformObjects(PathObject pathObject, AffineTransform transform, boolean copyMeasurements) {
+		List<PathObject> newObjs = new ArrayList<>();
+		transformRecursive(pathObject, transform, copyMeasurements, null, newObjs);
+		return newObjs;
+	}
+	
+	/**
+	 * Helper method for {@link #transformObjects(PathObject, AffineTransform, boolean)}.
+	 * 
+	 * @param parent the original parent
+	 * @param transform the transformation to apply
+	 * @param copyMeasurements whether new objects will keep their measurements
+	 * @param transformedParent transformed object to which the transformed children will be linked to
+	 * @param list where to store the newly-transformed objects
+	 */
+	private static void transformRecursive(PathObject parent, AffineTransform transform, boolean copyMeasurements, PathObject transformedParent, List<PathObject> list) {
+	    var children = parent.getChildObjectsAsArray();
+	    for (PathObject child: children) {
+	        PathObject transformedObj = PathObjectTools.transformObject(child, transform, copyMeasurements);
+	        
+	        // Add parent (if the transformed parent is null, assume that it's because it is the root object)
+	        if (transformedParent != null)
+	        	transformedParent.addPathObject(transformedObj);
+	        else
+	        	parent.addPathObject(transformedObj);
+	        	
+	        list.add(transformedObj);
+	        
+	        transformRecursive(child, transform, copyMeasurements, transformedObj, list);
+	    }
+	}
+	
 	private static ROI maybeTransformROI(ROI roi, AffineTransform transform) {
 		if (roi == null || transform == null || transform.isIdentity())
 			return roi;

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -966,9 +966,7 @@ public class PathObjectTools {
 		} else if (pathObject instanceof PathDetectionObject) {
 			newObject = PathObjects.createDetectionObject(roi, pathClass, null);			
 		} else if (pathObject instanceof PathAnnotationObject) {
-			newObject = PathObjects.createAnnotationObject(roi, pathClass, null);
-		} else if (pathObject instanceof PathRootObject) {
-			newObject = new PathRootObject();
+			newObject = PathObjects.createAnnotationObject(roi, pathClass, null);			
 		} else
 			throw new UnsupportedOperationException("Unable to transform object " + pathObject);
 		if (copyMeasurements && !pathObject.getMeasurementList().isEmpty()) {

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -966,7 +966,9 @@ public class PathObjectTools {
 		} else if (pathObject instanceof PathDetectionObject) {
 			newObject = PathObjects.createDetectionObject(roi, pathClass, null);			
 		} else if (pathObject instanceof PathAnnotationObject) {
-			newObject = PathObjects.createAnnotationObject(roi, pathClass, null);			
+			newObject = PathObjects.createAnnotationObject(roi, pathClass, null);
+		} else if (pathObject instanceof PathRootObject) {
+			newObject = new PathRootObject();
 		} else
 			throw new UnsupportedOperationException("Unable to transform object " + pathObject);
 		if (copyMeasurements && !pathObject.getMeasurementList().isEmpty()) {

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -946,7 +946,8 @@ public class PathObjectTools {
 	 * Create a(n optionally) transformed version of a {@link PathObject}.
 	 * <p>
 	 * Note: only detections (including tiles and cells) and annotations are supported by this method.
-	 * Other object types (e.g. TMA cores) result in an {@link UnsupportedOperationException} being thrown.
+	 * Root objects are duplicated and other object types (e.g. TMA cores) result in an 
+	 * {@link UnsupportedOperationException} being thrown.
 	 * 
 	 * @param pathObject the object to transform; this will be unchanged
 	 * @param transform optional affine transform; if {@code null}, this effectively acts to duplicate the object
@@ -962,11 +963,13 @@ public class PathObjectTools {
 			ROI roiNucleus = maybeTransformROI(((PathCellObject)pathObject).getNucleusROI(), transform);
 			newObject = PathObjects.createCellObject(roi, roiNucleus, pathClass, null);
 		} else if (pathObject instanceof PathTileObject) {
-			newObject = PathObjects.createTileObject(roi, pathClass, null);			
+			newObject = PathObjects.createTileObject(roi, pathClass, null);
 		} else if (pathObject instanceof PathDetectionObject) {
-			newObject = PathObjects.createDetectionObject(roi, pathClass, null);			
+			newObject = PathObjects.createDetectionObject(roi, pathClass, null);
 		} else if (pathObject instanceof PathAnnotationObject) {
-			newObject = PathObjects.createAnnotationObject(roi, pathClass, null);			
+			newObject = PathObjects.createAnnotationObject(roi, pathClass, null);
+		} else if (pathObject instanceof PathRootObject) {
+			newObject = new PathRootObject();
 		} else
 			throw new UnsupportedOperationException("Unable to transform object " + pathObject);
 		if (copyMeasurements && !pathObject.getMeasurementList().isEmpty()) {

--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -169,6 +169,14 @@ public class RoiTools {
 		logger.trace("Applying affine transform {} to ROI {}", transform, roi);
 		if (roi == null || transform == null || transform.isIdentity())
 			return roi;
+		if (roi instanceof EllipseROI) {
+			var bounds = new Rectangle2D.Double(roi.getBoundsX(), roi.getBoundsY(), roi.getBoundsWidth(), roi.getBoundsHeight());
+			var shape = transform.createTransformedShape(bounds);
+			if (new Area(shape).isRectangular()) {
+				bounds.setRect(shape.getBounds2D());
+				return ROIs.createEllipseROI(bounds.x, bounds.y, bounds.width, bounds.height, roi.getImagePlane());
+			}
+		}
 		var t = GeometryTools.convertTransform(transform);
 		var geometry2 = t.transform(roi.getGeometry());
 		return GeometryTools.geometryToROI(geometry2, roi.getImagePlane());


### PR DESCRIPTION
- Added transformObjects(..) in PathObjectTools, which recursively transform a PathObject and all its descendants, 'transforming all the parents-children relationships' along with the newly-created objects.
- TODO: Create tests