### PR TITLE
Command line improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ List of bugs fixed:
 * 'Selection mode' keyboard shortcut did not work; not activate it with Shift + S (https://github.com/qupath/qupath/issues/638)
 * Exception when showing details for an extension that is missing a Manifest file (https://github.com/qupath/qupath/issues/664)
 * Exception when resetting an annotation description to an empty string (https://github.com/qupath/qupath/issues/661)
+* QuPath exits with a zero exit code if an exception is thrown from the command line (https://github.com/qupath/qupath/issues/654)
 
 ### Dependency updates*
 * Apache Commons Text 1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 *In progress*
 
 Enhancements:
+* Improved command line
+  * Specify script parameters with the --args option
+  * Return a non-zero exit code if an exception is thrown (https://github.com/qupath/qupath/issues/654)
 * New preferences for slide navigation using arrow keys
   * Control navigation speed & acceleration
   * Optionally skip TMA cores marked as 'ignored'
@@ -17,7 +20,6 @@ List of bugs fixed:
 * 'Selection mode' keyboard shortcut did not work; not activate it with Shift + S (https://github.com/qupath/qupath/issues/638)
 * Exception when showing details for an extension that is missing a Manifest file (https://github.com/qupath/qupath/issues/664)
 * Exception when resetting an annotation description to an empty string (https://github.com/qupath/qupath/issues/661)
-* QuPath exits with a zero exit code if an exception is thrown from the command line (https://github.com/qupath/qupath/issues/654)
 
 ### Dependency updates*
 * Apache Commons Text 1.9

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
@@ -178,6 +178,9 @@ public class ImageServerProvider {
 				try {
 					if (!cls.isAssignableFrom(provider.getImageType()))
 						continue;
+					// Check classnames
+					if (!requestedClassnames.isEmpty() && !requestedClassnames.contains(provider.getClass().getName()) && !requestedClassnames.contains(provider.getClass().getSimpleName()))
+						continue;
 					UriImageSupport<T> support = (UriImageSupport<T>)provider.checkImageSupport(uri, args);
 					if (support != null && support.getSupportLevel() > 0f)
 						supports.add(support);

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
@@ -37,6 +37,7 @@ import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.extensions.Subcommand;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerProvider;
+import qupath.lib.images.servers.bioformats.BioFormatsServerBuilder;
 import qupath.lib.images.writers.ome.OMEPyramidWriter.Builder;
 import qupath.lib.images.writers.ome.OMEPyramidWriter.CompressionType;
 import qupath.lib.regions.RegionRequest;
@@ -96,7 +97,7 @@ public class ConvertCommand implements Runnable, Subcommand {
 	@Option(names = {"--overwrite"}, defaultValue = "false", description = "Overwrite any existing file with the same name as the output.")
 	private boolean overwrite = false;
 	
-	@Option(names = {"--series"}, defaultValue = "0", description = "Series number. This applies only to images opened using Bio-Formats.")
+	@Option(names = {"--series"}, defaultValue = "0", description = "Series number. Setting this will ensure the image is opened using Bio-Formats.")
 	private int series = 0;
 	
 	@Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit.")
@@ -126,8 +127,8 @@ public class ConvertCommand implements Runnable, Subcommand {
 		}
 		
 		String[] args;
-		if (series > 0)
-			args = new String[]{"--series", Integer.toString(series)};
+		if (series >= 0)
+			args = new String[]{"--classname", BioFormatsServerBuilder.class.getName(), "--series", Integer.toString(series)};
 		else
 			args = new String[0];
 		

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
@@ -97,8 +97,9 @@ public class ConvertCommand implements Runnable, Subcommand {
 	@Option(names = {"--overwrite"}, defaultValue = "false", description = "Overwrite any existing file with the same name as the output.")
 	private boolean overwrite = false;
 	
-	@Option(names = {"--series"}, defaultValue = "0", description = "Series number. Setting this will ensure the image is opened using Bio-Formats.")
-	private int series = 0;
+	@Option(names = {"--series"}, description = "Series number. Setting this will ensure the image is opened using Bio-Formats and control which image is read from the file. "
+			+ "If it is not specified, the default image will be read (typically series 0).")
+	private int series = -1;
 	
 	@Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit.")
 	private boolean usageHelpRequested;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -3025,7 +3025,7 @@ public class QuPathGUI {
 		return installCommand(menuPath, () -> {
 			try {
 				runScript(file, getImageData());
-			} catch (IOException e) {
+			} catch (IOException | ScriptException e) {
 				Dialogs.showErrorMessage("Script error", e);
 			}
 		});
@@ -3041,7 +3041,13 @@ public class QuPathGUI {
 	 * @see #installGroovyCommand(String, File)
 	 */
 	public MenuItem installGroovyCommand(String menuPath, final String script) {
-		return installCommand(menuPath, () -> runScript(script, getImageData()));
+		return installCommand(menuPath, () -> {
+			try {
+				runScript(script, getImageData());
+			} catch (ScriptException e) {
+				Dialogs.showErrorMessage("Script error", e);
+			}
+		});
 	}
 	
 	/**
@@ -3130,8 +3136,9 @@ public class QuPathGUI {
 	 * @param script the script to run
 	 * @param imageData an {@link ImageData} object for the current image (may be null)
 	 * @return result of the script execution
+	 * @throws ScriptException 
 	 */
-	private Object runScript(final String script, final ImageData<BufferedImage> imageData) {
+	private Object runScript(final String script, final ImageData<BufferedImage> imageData) throws ScriptException {
 		return DefaultScriptEditor.executeScript(Language.GROOVY, script, getProject(), imageData, true, null);
 	}
 	
@@ -3142,8 +3149,9 @@ public class QuPathGUI {
 	 * @param imageData an {@link ImageData} object for the current image (may be null)
 	 * @return result of the script execution
 	 * @throws IOException 
+	 * @throws ScriptException 
 	 */
-	private Object runScript(final File file, final ImageData<BufferedImage> imageData) throws IOException {
+	private Object runScript(final File file, final ImageData<BufferedImage> imageData) throws IOException, ScriptException {
 		var script = GeneralTools.readFileAsString(file.getAbsolutePath());
 		return runScript(script, imageData);
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -785,6 +785,8 @@ public class DefaultScriptEditor implements ScriptEditor {
 			}
 			if (outputScriptStartTime.get())
 				printWriter.println(String.format("Script run time: %.2f seconds", (System.currentTimeMillis() - startTime)/1000.0));
+		} catch (ScriptException e) {
+			// TODO: Consider exception logging here, rather than via the called method
 		} finally {
 			if (attachToLog)
 				Platform.runLater(() -> LogManager.removeTextAppendableFX(console));	
@@ -853,8 +855,9 @@ public class DefaultScriptEditor implements ScriptEditor {
 	 * @param importDefaultMethods
 	 * @param context
 	 * @return
+	 * @throws ScriptException 
 	 */
-	public static Object executeScript(final Language language, final String script, final Project<BufferedImage> project, final ImageData<BufferedImage> imageData, final boolean importDefaultMethods, final ScriptContext context) {
+	public static Object executeScript(final Language language, final String script, final Project<BufferedImage> project, final ImageData<BufferedImage> imageData, final boolean importDefaultMethods, final ScriptContext context) throws ScriptException {
 		ScriptEngine engine = manager.getEngineByName(language.toString());
 		return executeScript(engine, script, project, imageData, importDefaultMethods, context);
 	}
@@ -870,8 +873,9 @@ public class DefaultScriptEditor implements ScriptEditor {
 	 * @param importDefaultMethods
 	 * @param context
 	 * @return
+	 * @throws ScriptException 
 	 */
-	public static Object executeScript(final ScriptEngine engine, final String script, final Project<BufferedImage> project, final ImageData<BufferedImage> imageData, final boolean importDefaultMethods, final ScriptContext context) {
+	public static Object executeScript(final ScriptEngine engine, final String script, final Project<BufferedImage> project, final ImageData<BufferedImage> imageData, final boolean importDefaultMethods, final ScriptContext context) throws ScriptException {
 		
 		// Set the current ImageData if we can
 		QP.setBatchProjectAndImage(project, imageData);
@@ -1024,6 +1028,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 				logger.error("Script error: {}", e1.getLocalizedMessage(), e1);
 //				e1.printStackTrace();
 			}
+			throw e;
 		} finally {
 			QP.resetBatchProjectAndImage();
 		}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -767,6 +767,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 		ScriptEditorControl console = tab.getConsoleComponent();
 		
 		ScriptContext context = new SimpleScriptContext();
+		context.setAttribute("args", new String[0], ScriptContext.ENGINE_SCOPE);
 		var writer = new ScriptConsoleWriter(console, false);
 		context.setWriter(writer);
 		context.setErrorWriter(new ScriptConsoleWriter(console, true));
@@ -797,6 +798,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 	
 	private static ScriptContext createDefaultContext() {
 		ScriptContext context = new SimpleScriptContext();
+		context.setAttribute("args", new String[0], ScriptContext.ENGINE_SCOPE);
 		context.setWriter(new LoggerInfoWriter());
 		context.setErrorWriter(new LoggerErrorWriter());
 		return context;

--- a/src/main/java/qupath/QuPath.java
+++ b/src/main/java/qupath/QuPath.java
@@ -268,10 +268,13 @@ class ScriptCommand implements Runnable {
 	@Option(names = {"-s", "--save"}, description = "Request that data files are updated for each image in the project.", paramLabel = "save")
 	private boolean save;
 	
-	@Option(names = {"-a", "--args"}, description = "Arguments to pass to the script, stored in an 'args' array variable.")
+	@Option(names = {"-a", "--args"}, description = "Arguments to pass to the script, stored in an 'args' array variable. "
+			+ "Multiple args can be passed by using --args multiple times, or by using a \"[quoted,comma,separated,list]\".", paramLabel = "arguments")
 	private String[] args;
 
-	@Option(names = {"-e", "--server"}, description = "Arguments to pass when building an ImageSever (only relevant when using --image).")
+	@Option(names = {"-e", "--server"}, description = "Arguments to pass when building an ImageSever (only relevant when using --image). "
+			+ "For example, --server \"[--classname,BioFormatsServerBuilder,--series,2]\" may be used to read the image with Bio-Formats and "
+			+ "extract the third series within the file.", paramLabel = "server-arguments")
 	private String[] serverArgs;
 
 	@Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit.")


### PR DESCRIPTION
Proposed fix for https://github.com/qupath/qupath/issues/654

Note that from the command line the exit code should be 0 if a script succeeded or 1 if an exception was thrown.

Note that this applies to running the `script` subcommand for a single image. If an exception is thrown when attempting to apply the script to *multiple* images in a project, QuPath will attempt to recover and continue processing the next image. The exit code will then be 0.