### PR TITLE
Fix test for GeneralTools.toPath

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -39,6 +39,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -371,8 +372,8 @@ public final class GeneralTools {
 	/**
 	 * Try to identify a Path from a URI, dropping any query or fragment elements.
 	 * <p>
-	 * This returns the Path if successful and null otherwise (e.g. if not a file). 
-	 * There is no check whether the Path exists.
+	 * This returns the Path if successful and null otherwise (e.g. if the URI does not correspond to a file). 
+	 * There is no check whether the Path exists, and support for an authority is platform-dependent.
 	 * 
 	 * @param uri
 	 * @return
@@ -385,8 +386,8 @@ public final class GeneralTools {
 			if (uri.getFragment() != null || uri.getQuery() != null)
 				uri = new URI(uri.getScheme(), uri.getHost(), uri.getPath(), null);
 			return Paths.get(uri);
-		} catch (URISyntaxException e) {
-			logger.warn("Problem parsing file from URI", e);
+		} catch (URISyntaxException | IllegalArgumentException | FileSystemNotFoundException e) {
+			logger.warn("Problem parsing file from URI " + uri + " (" + e.getLocalizedMessage() + ")", e);
 		}
 		return null;
 	}

--- a/qupath-core/src/test/java/qupath/lib/common/TestGeneralTools.java
+++ b/qupath-core/src/test/java/qupath/lib/common/TestGeneralTools.java
@@ -263,10 +263,18 @@ public class TestGeneralTools {
 	public void test_toPath() {
 		try {
 			assertEquals(null, GeneralTools.toPath(new URI("https://host.com")));
-			assertEquals(Path.of(new URI("file://www.host.com/some/path")), GeneralTools.toPath(new URI("file://www.host.com/some/path")));
-			assertEquals(Path.of(new URI("file://users/user/path/to/file.ext")), GeneralTools.toPath(new URI("file://users/user/path/to/file.ext")));
-			assertEquals(Path.of(new URI("file://users/user/path/to/file.ext")), GeneralTools.toPath(new URI("file://users/user/path/to/file.ext#fragment")));
-			assertEquals(Path.of(new URI("file://users/user/path/to/file.ext")), GeneralTools.toPath(new URI("file://users/user/path/to/file.ext/?query=test")));
+			assertEquals(Path.of(new URI("file:/www.host.com/some/path")), GeneralTools.toPath(new URI("file:/www.host.com/some/path")));
+			
+			// At time or writing https://en.wikipedia.org/wiki/File_URI_scheme#How_many_slashes?
+			// specifies that file:/ can have 1 or 3 slashes; 2 is often used but never correct
+			assertEquals(Path.of(new URI("file:/users/user/path/to/file.ext")), GeneralTools.toPath(new URI("file:/users/user/path/to/file.ext")));
+			assertEquals(Path.of(new URI("file:/users/user/path/to/file.ext")), GeneralTools.toPath(new URI("file:///users/user/path/to/file.ext")));
+			assertEquals(Path.of(new URI("file:///users/user/path/to/file.ext")), GeneralTools.toPath(new URI("file:/users/user/path/to/file.ext")));
+			assertEquals(Path.of(new URI("file:///users/user/path/to/file.ext")), GeneralTools.toPath(new URI("file:///users/user/path/to/file.ext")));
+			
+			// Fragment and query elements should be dropped
+			assertEquals(Path.of(new URI("file:/users/user/path/to/file.ext")), GeneralTools.toPath(new URI("file:/users/user/path/to/file.ext#fragment")));
+			assertEquals(Path.of(new URI("file:/users/user/path/to/file.ext")), GeneralTools.toPath(new URI("file:/users/user/path/to/file.ext/?query=test")));
 		} catch (URISyntaxException e) {
 			throw new AssertionError();
 		}


### PR DESCRIPTION
Previously failed on macOS due to file:// rather than file:/ or file://