### PR TITLE
Add read only mode to QuPathGUI

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -265,6 +265,8 @@ public class QuPathGUI {
 			);
 	
 	private BooleanProperty selectedToolLocked = new SimpleBooleanProperty(false);
+
+	private BooleanProperty readOnly = new SimpleBooleanProperty(false);
 	
 	// ExecutorServices for single & multiple threads
 	private Map<Object, ExecutorService> mapSingleThreadPools = new HashMap<>();
@@ -2738,7 +2740,7 @@ public class QuPathGUI {
 	 * @return
 	 */
 	boolean checkSaveChanges(ImageData<BufferedImage> imageData) {
-		if (!imageData.isChanged())
+		if (!imageData.isChanged() || isReadOnly())
 			return true;
 		ProjectImageEntry<BufferedImage> entry = getProjectImageEntry(imageData);
 		String name = entry == null ? ServerTools.getDisplayableImageName(imageData.getServer()) : entry.getImageName();
@@ -3240,7 +3242,7 @@ public class QuPathGUI {
 		
 		
 		if (promptToSaveChanges && imageData != null && imageData.isChanged()) {
-			if (!promptToSaveChangesOrCancel("Save changes", imageData))
+			if (!isReadOnly() && !promptToSaveChangesOrCancel("Save changes", imageData))
 				return false;
 		}
 		
@@ -3594,6 +3596,36 @@ public class QuPathGUI {
 		return !selectedToolLocked.get();
 	}
 	
+	/**
+	 * Query whether QuPath is in 'read-only' mode. This suppresses dialogs that ask about saving changes.
+	 * @return
+	 * @apiNote Read only mode is an experimental feature; its behavior is subject to change in future versions.
+	 * @see #setReadOnly(boolean)
+	 */
+	public boolean isReadOnly() {
+		return readOnly.get();
+	}
+	
+	/**
+	 * Property indicating whether QuPath is in 'read-only' mode.
+	 * @return
+	 * @apiNote Read only mode is an experimental feature; its behavior is subject to change in future versions.
+	 * @see #isReadOnly()
+	 * @see #setReadOnly(boolean)
+	 */
+	public ReadOnlyBooleanProperty readOnlyProperty() {
+		return readOnly;
+	}
+	
+	/**
+	 * Specify whether QuPath should be in 'read-only' mode.
+	 * @param readOnly
+	 * @apiNote Read only mode is an experimental feature; its behavior is subject to change in future versions.
+	 * @see #isReadOnly()
+	 */
+	public void setReadOnly(boolean readOnly) {
+		this.readOnly.set(readOnly);
+	}
 	
 	/**
 	 * Get a list of the current available tools.
@@ -4406,7 +4438,7 @@ public class QuPathGUI {
 				return true;
 			// Deal with saving, if necessary
 			if (imageData.isChanged()) {
-				if (!promptToSaveChangesOrCancel(dialogTitle, imageData))
+				if (!isReadOnly() && !promptToSaveChangesOrCancel(dialogTitle, imageData))
 					return false;
 			}
 			viewer.setImageData(null);


### PR DESCRIPTION
This provides a mechanism to suppress 'save' dialogs if QuPath is being run simply as a viewer but without the ability to save changes to any image.

Note that this minimal implementation is for feedback; it may need to be changed in a future version if it proves insufficient in practice.