### PR TITLE
Allow multiple channels to be displayed with inverted LUTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ List of bugs fixed:
 * setIntensityClassification method in PathClassifierTools now correctly ignores ignored classes such as 'myClass*' (https://github.com/qupath/qupath/issues/691)
 * Dialogs.showConfirmDialog(title, text) shows the text in the title bar, rather than the title (https://github.com/qupath/qupath/issues/662)
 * Error in StarDist intensity measurements for 8-bit RGB fluorescence images (https://github.com/qupath/qupath/issues/686)
+* Not possible to view multiple channels simultaneously with inverted lookup tables (max display < min display)
 * Exception when converting PathObject with name but no color to GeoJSON
 
 ### Dependency updates

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/AbstractSingleChannelInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/AbstractSingleChannelInfo.java
@@ -77,7 +77,7 @@ abstract class AbstractSingleChannelInfo extends AbstractChannelInfo implements 
 
 	private int updateRGBAdditive(float value, int rgb, boolean useColorLUT) {
 		// Don't do anything with an existing pixel if display range is 0, or it is lower than the min display
-		if (maxDisplay == minDisplay || value <= minDisplay)
+		if (maxDisplay == minDisplay)// || value <= minDisplay)
 			return rgb;
 		// Just return the (scaled) RGB value for this pixel if we don't have to update anything
 		int rgbNew = getRGB(value, useColorLUT);
@@ -85,7 +85,7 @@ abstract class AbstractSingleChannelInfo extends AbstractChannelInfo implements 
 			return rgbNew;
 		if (rgbNew == 0)
 			return rgb;
-
+		
 		int r2 = ((rgbNew & ColorTools.MASK_RED) >> 16) + ((rgb & ColorTools.MASK_RED) >> 16);
 		int g2 = ((rgbNew & ColorTools.MASK_GREEN) >> 8) + ((rgb & ColorTools.MASK_GREEN) >> 8);
 		int b2 = (rgbNew & ColorTools.MASK_BLUE) + (rgb & ColorTools.MASK_BLUE);

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -568,8 +568,9 @@ public class ImageDisplay extends AbstractImageRenderer {
 				if (firstChannel) {
 					pixels = info.getRGB(imgInput, pixels, !useGrayscaleLuts);
 					firstChannel = false;
-				} else
+				} else {
 					info.updateRGBAdditive(imgInput, pixels, !useGrayscaleLuts);
+				}
 			}
 		} catch (Exception e) {
 			logger.error("Error extracting pixels for display", e);


### PR DESCRIPTION
This allows max display < min display for more than one channel in the brightness/contrast dialog.