### PR TITLE
OMERO fixes

### DIFF
--- a/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroExtension.java
+++ b/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroExtension.java
@@ -44,9 +44,7 @@ import qupath.lib.gui.tools.MenuTools;
 import qupath.lib.gui.tools.PaneTools;
 
 /**
- * 
  * Extension to access images hosted on OMERO.
- * 
  */
 public class OmeroExtension implements QuPathExtension {
 	
@@ -61,9 +59,9 @@ public class OmeroExtension implements QuPathExtension {
 		var actionSendObjects = ActionTools.createAction(new OmeroWritePathObjectsCommand(qupath), "Send annotations to OMERO");
 		Menu browseServerMenu = new Menu("Browse server...");
 		
-		actionClients.disabledProperty().bind(qupath.projectProperty().isNull());
+//		actionClients.disabledProperty().bind(qupath.projectProperty().isNull());
+//		browseServerMenu.disableProperty().bind(qupath.projectProperty().isNull());
 		actionSendObjects.disabledProperty().bind(qupath.imageDataProperty().isNull());
-		browseServerMenu.disableProperty().bind(qupath.projectProperty().isNull());
 		
 		MenuTools.addMenuItems(qupath.getMenu("Extensions", false), 
 				MenuTools.createMenu("OMERO", 
@@ -86,7 +84,7 @@ public class OmeroExtension implements QuPathExtension {
 		return "Adds the ability to browse OMERO servers and open images hosted on OMERO servers.";
 	}
 	
-	private Menu createServerListMenu(QuPathGUI qupath, Menu browseServerMenu) {
+	private static Menu createServerListMenu(QuPathGUI qupath, Menu browseServerMenu) {
 		EventHandler<Event> validationHandler = e -> {
 			browseServerMenu.getItems().clear();
 			
@@ -172,7 +170,7 @@ public class OmeroExtension implements QuPathExtension {
 	}
 	
 	/**
-	 * Return map of currently opened browsers
+	 * Return map of currently opened browsers.
 	 * 
 	 * @return browsers
 	 */

--- a/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroWebClient.java
+++ b/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroWebClient.java
@@ -207,7 +207,6 @@ public class OmeroWebClient {
 //	        try {
 //				System.err.println(client.send(request, BodyHandlers.ofString()).body());
 //			} catch (InterruptedException e) {
-//				// TODO Auto-generated catch block
 //				e.printStackTrace();
 //			}
 
@@ -238,20 +237,21 @@ public class OmeroWebClient {
 	 * <p>
 	 * N.B. being logged on the server doesn't necessarily mean that the user has 
 	 * permission to access all the objects on the server.
-	 * 
+	 * @param uri
+	 * @param type
 	 * @return success
+	 * @throws IllegalArgumentException
 	 * @throws ConnectException 
 	 */
-	boolean canBeAccessed(URI uri, OmeroObjectType type) throws IllegalArgumentException, ConnectException {
+	static boolean canBeAccessed(URI uri, OmeroObjectType type) throws IllegalArgumentException, ConnectException {
 		try {
 			logger.debug("Attempting to access {}...", type.toString().toLowerCase());
 			int id = OmeroTools.parseOmeroObjectId(uri, type);
 			if (id == -1)
 				throw new NullPointerException("No object ID found in: " + uri);
-			
-			String query;
-			
+						
 			// Implementing this as a switch because of future plates/wells/.. implementations
+			String query;
 			switch (type) {
 			case PROJECT:
 			case DATASET:
@@ -322,10 +322,12 @@ public class OmeroWebClient {
 	 * @see #getURIs()
 	 */
 	void addURI(URI uri) {
-		if (!uris.contains(uri))
-			Platform.runLater(() -> uris.add(uri));
-		else
-			logger.debug("URI already exists in the list. Ignoring operation.");
+		Platform.runLater(() -> {
+			if (!uris.contains(uri))
+				uris.add(uri);
+			else
+				logger.debug("URI already exists in the list. Ignoring operation.");
+		});
 	}
 	
 	/**
@@ -499,12 +501,12 @@ public class OmeroWebClient {
 		}
 	}
 
-	private <T> T parseJSON(Class<T> cls, String base, String... query) throws JsonSyntaxException, MalformedURLException, IOException {
+	private static <T> T parseJSON(Class<T> cls, String base, String... query) throws JsonSyntaxException, MalformedURLException, IOException {
 		return GsonTools.getInstance().fromJson(getJSONString(base, query), cls);
 	}
 
 	@SuppressWarnings("unchecked")
-	private <T> T parseJSON(Type type, String base, String... query) throws JsonSyntaxException, MalformedURLException, IOException {
+	private static <T> T parseJSON(Type type, String base, String... query) throws JsonSyntaxException, MalformedURLException, IOException {
 		return (T) GsonTools.getInstance().fromJson(getJSONString(base, query), type);
 	}
 	

--- a/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
+++ b/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
@@ -276,7 +276,7 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 		if (Double.isFinite(zSpacingMicrons) && zSpacingMicrons > 0)
 			builder.zSpacingMicrons(zSpacingMicrons);
 
-		if (tileSize != null && tileSize.length >= 2) {
+		if (tileSize.length >= 2) {
 			builder.preferredTileSize(tileSize[0], tileSize[1]);
 		}
 
@@ -352,8 +352,8 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 		String urlFile;
 
 		if (nResolutions() > 1) {
-			int x = (int)(request.getTileX() / getPreferredTileWidth());
-			int y = (int)(request.getTileY() / getPreferredTileHeight());
+			int x = request.getTileX() / getPreferredTileWidth();
+			int y = request.getTileY() / getPreferredTileHeight();
 
 			// Note!  It's important to use the preferred tile size so that the correct x & y can be used
 			//			int width = request.getTileWidth();

--- a/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServerBuilder.java
+++ b/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServerBuilder.java
@@ -99,7 +99,7 @@ public class OmeroWebImageServerBuilder implements ImageServerBuilder<BufferedIm
 	 * @param args
 	 * @return success
 	 */
-	boolean canConnectToOmero(URI uri, String... args) {
+	static boolean canConnectToOmero(URI uri, String... args) {
 		try {
 			if (supportLevel(uri) <= 0) {
 				logger.debug("OMERO web server does not support {}", uri);
@@ -116,7 +116,7 @@ public class OmeroWebImageServerBuilder implements ImageServerBuilder<BufferedIm
 			
 			// Check if client can reach the image. If not, prompt login
 			boolean isLoggedIn = true;
-			if (!client.canBeAccessed(uri, OmeroTools.parseOmeroObjectType(uri)))
+			if (!OmeroWebClient.canBeAccessed(uri, OmeroTools.parseOmeroObjectType(uri)))
 				isLoggedIn = client.logIn(args);
 			
 			if (!isLoggedIn)
@@ -126,7 +126,7 @@ public class OmeroWebImageServerBuilder implements ImageServerBuilder<BufferedIm
 				OmeroWebClients.addClient(client);
 
 				// Check if client can reach the OMERO object while being logged in
-				if (!client.canBeAccessed(uri, OmeroTools.parseOmeroObjectType(uri)))
+				if (!OmeroWebClient.canBeAccessed(uri, OmeroTools.parseOmeroObjectType(uri)))
 					throw new AccessDeniedException(String.format("\"%s\" does not have permission to read %s", client.getUsername(), uri));
 			}
 			


### PR DESCRIPTION
- Fixed a bug preventing OMERO images from opening when using 'Import OMERO image to QuPath'
- Users can now browse OMERO servers without a project.
- Users can now open an OMERO image (but not multiple images simultaneously) without a project.
- OMERO images that are not supported by the JSON API will show in the entry's tooltip *why* it is not supported.
- Refactoring