### PR TITLE
Bug and build fixes for Java 16 and RichTextFX 0.10.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -765,14 +765,28 @@ task createPackage(dependsOn:createRuntime, type:Exec) {
     
     // Set the library path to the app directory, for loading native libraries
    	javaOptions << '-Djava.library.path=$APPDIR'		
+   	
+   	// Revert to pre-Java-16 behavior
+   	// See https://openjdk.java.net/jeps/396
+   	// If this is removed, things like adding metadata to a project entry will fail with errors such as
+   	//   ERROR: QuPath exception: class org.controlsfx.control.textfield.AutoCompletionBinding 
+   	//   (in unnamed module @0x298a5e20) cannot access class com.sun.javafx.event.EventHandlerManager 
+   	//   (in module javafx.base) because module javafx.base does not export com.sun.javafx.event to unnamed module
+   	// This Java option will hopefully be temporary, until dependencies are updated to make it unnecessary.
+   	javaOptions << '--illegal-access=permit'
 
-    // Temp workaround for kyro and Bio-Formats memoization - see https://github.com/ome/bioformats/issues/3659
-   	javaOptions << '--add-opens=java.base/java.util.regex=ALL-UNNAMED'		
-   	// Needed to set style/theme
-   	javaOptions << '--add-opens=javafx.graphics/com.sun.javafx.css=ALL-UNNAMED'
-   	// Needed for ControlsFX/BreadcrumbBar (could export to org.controlsfx if it was on the module path)
-   	javaOptions << '--add-exports=javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED'
-	javaOptions << '--add-exports=javafx.graphics/com.sun.javafx.scene.traversal=ALL-UNNAMED'
+	/*
+	 * Previous attempts to avoid setting '--illegal-access' globally.
+	 * Errors still turned up intermittently.
+	 * 
+     * // Temp workaround for kyro and Bio-Formats memoization - see https://github.com/ome/bioformats/issues/3659
+   	 * javaOptions << '--add-opens=java.base/java.util.regex=ALL-UNNAMED'		
+   	 * // Needed to set style/theme
+   	 * javaOptions << '--add-opens=javafx.graphics/com.sun.javafx.css=ALL-UNNAMED'
+   	 * // Needed for ControlsFX/BreadcrumbBar (could export to org.controlsfx if it was on the module path)
+   	 * javaOptions << '--add-exports=javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED'
+	 * javaOptions << '--add-exports=javafx.graphics/com.sun.javafx.scene.traversal=ALL-UNNAMED'
+	 */
 
     def params = ["${jdkHome}/bin/jpackage"]
 

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -240,7 +240,22 @@ public class RichScriptEditor extends DefaultScriptEditor {
 	protected ScriptEditorControl getNewEditor() {
 		try {
 			CodeArea codeArea = new CustomCodeArea();
-			codeArea.setParagraphGraphicFactory(LineNumberFactory.get(codeArea));
+			
+			/*
+			 * Using LineNumberFactory.get(codeArea) gives errors related to the new paragraph folding introduced in RichTextFX 0.10.6.
+			 *  java.lang.IllegalArgumentException: Visible paragraphs' last index is [-1] but visibleParIndex was [0]
+			 *  
+			 * To replicate
+			 *  - Run using codeArea.setParagraphGraphicFactory(LineNumberFactory.get(codeArea));
+			 *  - Add some code (including line breaks) to the code area
+			 *  - Select all text (Ctrl/Cmd + A)
+			 *  - Delete text (backspace)
+			 *  - Add more text
+			 *  
+			 * The change below avoids code folding being used.
+			 */
+			codeArea.setParagraphGraphicFactory(LineNumberFactory.get(codeArea, digits -> "%1$" + digits + "s", null, null));
+//			codeArea.setParagraphGraphicFactory(LineNumberFactory.get(codeArea));
 			
 			codeArea.setStyle("-fx-background-color: -fx-control-inner-background;");
 			


### PR DESCRIPTION
* Add `--illegal-access=permit` Java option, intended to work around bugs such as https://github.com/qupath/qupath/issues/717 (and the inability to set project entry metadata, spotted by @Svidro)
* Avoid using paragraph folding, new in RichTextFX 0.10.6, which could result in script editor exceptions (thanks to @melvingelbard for spotting that)