### PR TITLE
Bump dependencies, fix AbstractImageRegionStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Code changes:
 * New 2D/3D thinning & interpolation classes
 * New ImageOps for reducing channels
 * ImageOps.Normalize.percentiles now warns if normalization values are equal; fixed exception if choosing '100'
-* When building from source with TensorFlow support, now uses TensorFlow Java 0.3.0 (corresponding to TensorFlow v2.4.1)
+* When building from source with TensorFlow support, now uses TensorFlow Java 0.3.1 (corresponding to TensorFlow v2.4.1)
 
 List of bugs fixed:
 * 'Detect centroid distances 2D' doesn't work on different planes of a z-stack (https://github.com/qupath/qupath/issues/696)
@@ -80,14 +80,14 @@ List of bugs fixed:
 * Apache Commons Text 1.9
 * Bio-Formats 6.6.1
 * ControlsFX 11.1.0
-* Groovy 3.0.7
+* Groovy 3.0.8
 * Guava 30.1.1-jre
 * ImageJ 1.53i
 * JavaFX 16
 * Java Topology suite 1.18.1
 * JavaCPP 1.5.5
 * JFreeSVG 4.2
-* jfxtras 11-r1
+* jfxtras 11-r2
 * OpenCV 4.5.1
 * picocli 4.6.1
 * RichTextFX 0.10.6

--- a/build.gradle
+++ b/build.gradle
@@ -219,11 +219,11 @@ allprojects {
     commonsMathVersion = '3.6.1'
     commonsTextVersion = '1.9'
     controlsfxVersion  = '11.1.0'
-    groovyVersion      = '3.0.7'
+    groovyVersion      = '3.0.8'
     gsonVersion        = '2.8.6'
     guavaVersion       = '30.1.1-jre'
     imagejVersion      = '1.53i'
-    jfxtrasVersion     = '11-r1'
+    jfxtrasVersion     = '11-r2'
     jpenVersion        = '2-150301'
     jtsVersion         = '1.18.1'
     openslideVersion   = '3.4.1_2'
@@ -240,7 +240,7 @@ allprojects {
     junitVersion       = '5.7.1'
     
     // Optional versions
-    tensorflowVersion  = "0.3.0" // Really 2.4.1
+    tensorflowVersion  = "0.3.1" // Really 2.4.1
 //    mkldnnVersion      = "0.21.4-${javacppVersion}"
     
     /*


### PR DESCRIPTION
Bump dependencies and attempt to avoid ConcurrentModificationExceptions when clearing the waitingMap.
These could occur (rarely) when using Measurement maps. Since the errors were hard to reproduce, it's not entirely clear if they are solved.