### PR TITLE
Optional args on import, Bio-Formats dimension swapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Enhancements:
 * Improved command line
   * Specify script parameters with the --args option
   * Return a non-zero exit code if an exception is thrown (https://github.com/qupath/qupath/issues/654)
+* New 'Optional args' when importing images
+  * This allows options such as `--swap XYTZC --series 2` to be passed to Bio-Formats to customize image import
 * New 'ContourTracing' class to simplify converting thresholded and labeled images to ROIs and objects
 * New PathObjectTools.transformObjectRecursive method to simplify applying an affine transformation to objects
 * Many improvements to ImageOps and OpenCVTools to make scripting with OpenCV much easier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Enhancements:
   * Specify script parameters with the --args option
   * Return a non-zero exit code if an exception is thrown (https://github.com/qupath/qupath/issues/654)
 * New 'Optional args' when importing images
-  * This allows options such as `--swap XYTZC --series 2` to be passed to Bio-Formats to customize image import
+  * This allows options such as `--dims XYTZC --series 2` to be passed to Bio-Formats to customize image import
+  * Reordering of RGB channels can be done with `--order BGR` or similar combinations
 * New 'ContourTracing' class to simplify converting thresholded and labeled images to ROIs and objects
 * New PathObjectTools.transformObjectRecursive method to simplify applying an affine transformation to objects
 * Many improvements to ImageOps and OpenCVTools to make scripting with OpenCV much easier

--- a/qupath-core-processing/src/main/java/qupath/imagej/images/servers/ImageJServerBuilder.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/images/servers/ImageJServerBuilder.java
@@ -94,5 +94,18 @@ public class ImageJServerBuilder implements ImageServerBuilder<BufferedImage> {
 	public Class<BufferedImage> getImageType() {
 		return BufferedImage.class;
 	}
+	
+	@Override
+	public boolean matchClassName(String... classNames) {
+		for (var className : classNames) {
+			if (this.getClass().getName().equals(className) ||
+					this.getClass().getSimpleName().equals(className) ||
+					ImageJServer.class.getName().equals(className) ||
+					ImageJServer.class.getSimpleName().equals(className) ||
+					"imagej".equalsIgnoreCase(className))
+				return true;			
+		}
+		return false;
+	}
 
 }

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -1440,7 +1441,7 @@ public class QP {
 	}
 
 	/**
-	 * Build an {@link ImageServer} with the class {@link BufferedImage}.
+	 * Build an {@link ImageServer} with a specified class.
 	 * 
 	 * @param path image path (usually a file path or URI)
 	 * @param args optional arguments
@@ -1448,7 +1449,11 @@ public class QP {
 	 * @return an {@link ImageServer}, if one could be build from the supplied arguments
 	 * 
 	 * @throws IOException if unable to build the server
+	 * @deprecated In the usual case where {@link BufferedImage} is the class, use {@link #buildServer(String, String...)} instead 
+	 *             because it handles default args.
+	 * @see ImageServers#buildServer(URI, String...)
 	 */
+	@Deprecated
 	public static <T> ImageServer<T> buildServer(String path, Class<T> cls, String... args) throws IOException {
 		return ImageServerProvider.buildServer(path, cls, args);
 	}
@@ -1461,9 +1466,26 @@ public class QP {
 	 * @return an {@link ImageServer}, if one could be build from the supplied arguments
 	 * 
 	 * @throws IOException if unable to build the server
+	 * @apiNote In v0.3 the behavior of this method changed to support more default arguments.
+	 * @see ImageServers#buildServer(URI, String...)
 	 */
 	public static ImageServer<BufferedImage> buildServer(String path, String... args) throws IOException {
-		return buildServer(path, BufferedImage.class, args);
+		return ImageServers.buildServer(path, args);
+	}
+	
+	/**
+	 * Build an {@link ImageServer} with the class {@link BufferedImage}.
+	 * 
+	 * @param uri image URI
+	 * @param args optional arguments
+	 * @return an {@link ImageServer}, if one could be build from the supplied arguments
+	 * 
+	 * @throws IOException if unable to build the server
+	 * @since v0.3
+	 * @see ImageServers#buildServer(URI, String...)
+	 */
+	public static ImageServer<BufferedImage> buildServer(URI uri, String... args) throws IOException {
+		return ImageServers.buildServer(uri, args);
 	}
 	
 	

--- a/qupath-core/build.gradle
+++ b/qupath-core/build.gradle
@@ -8,4 +8,5 @@ configurations {
   implementation.extendsFrom commonsmath
   implementation.extendsFrom guava
   implementation.extendsFrom opencv
+  implementation.extendsFrom picocli
 }

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
@@ -233,7 +233,7 @@ public class ContourTracing {
 			request = parseRegion(name, img.getWidth(), img.getHeight());
 		}
 		if (img == null) {
-			var server = ImageServerProvider.buildServer(path.toUri().toString(), BufferedImage.class);
+			var server = ImageServers.buildServer(path.toUri());
 			img = server.readBufferedImage(request);
 		}
 		return new RequestImage(request, img);

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
@@ -84,6 +84,26 @@ public interface ImageServerBuilder<T> {
 	 */
 	public Class<T> getImageType();
 	
+	/**
+	 * Check if this provider matches one or more specified classnames.
+	 * <p>
+	 * The default implementation checks the full and simple name of the class.
+	 * Subclasses may override this behavior to support more intuitive names, 
+	 * e.g. "bioformats", "openslide", "imagej", "imageio".
+	 * However, this should not be overused, so as to prevent future conflicts.
+	 * 
+	 * @param classNames
+	 * @return true if there is any classname match, false otherwise
+	 */
+	public default boolean matchClassName(String... classNames) {
+		for (var className : classNames) {
+			if (this.getClass().getName().equals(className) ||
+					this.getClass().getSimpleName().equals(className))
+				return true;			
+		}
+		return false;
+	}
+	
 	
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
@@ -295,7 +295,7 @@ public interface ImageServerBuilder<T> {
 		}
 
 		private DefaultImageServerBuilder(Class<? extends ImageServerBuilder<T>> providerClass, URI uri, String[] args, ImageServerMetadata metadata) {
-			this(providerClass.getName(), uri, args, metadata);
+			this(providerClass == null ? null : providerClass.getName(), uri, args, metadata);
 		}
 		
 		/**
@@ -342,14 +342,18 @@ public interface ImageServerBuilder<T> {
 		@Override
 		protected ImageServer<T> buildOriginal() throws Exception {
 			boolean failedWithRequestedProvider = false;
-			for (ImageServerBuilder<?> provider : ImageServerProvider.getInstalledImageServerBuilders()) {
-				if (provider.getClass().getName().equals(providerClassName)) {
-					ImageServer<T> server = (ImageServer<T>)provider.buildServer(uri, args);
-					if (server != null)
-						return server;
-					else
-						failedWithRequestedProvider = true;
+			if (providerClassName != null) {
+				for (ImageServerBuilder<?> provider : ImageServerProvider.getInstalledImageServerBuilders()) {
+					if (provider.getClass().getName().equals(providerClassName)) {
+						ImageServer<T> server = (ImageServer<T>)provider.buildServer(uri, args);
+						if (server != null)
+							return server;
+						else
+							failedWithRequestedProvider = true;
+					}
 				}
+			} else {
+				return (ImageServer<T>)ImageServers.buildServer(uri, args);
 			}
 			String msg = "Unable to build ImageServer for " + uri + " (args=" + Arrays.asList(args) + ")";
 			if (providerClassName != null) {

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
@@ -220,6 +220,10 @@ public class ImageServerProvider {
 	
 	/**
 	 * Attempt to create {@code ImageServer<T>} from the specified path and arguments.
+	 * <p>
+	 * In general, since v0.3 {@link ImageServers#buildServer(URI, String...)} is usually preferable to this method because it parses 
+	 * and applies known args (e.g. to reorder RGB channels or rotate the image). 
+	 * Here, all args apart from {@code --classname} are passed to builders - which may or may not do anything with them.
 	 * 
 	 * @param path path to an image - typically a URI
 	 * @param cls desired generic type for the ImageServer, e.g. BufferedImage.class
@@ -285,7 +289,7 @@ public class ImageServerProvider {
 	 *
 	 * @param <T>
 	 */
-	private static class UriImageSupportComparator<T> implements Comparator<UriImageSupport<T>> {
+	static class UriImageSupportComparator<T> implements Comparator<UriImageSupport<T>> {
 
 		@Override
 		public int compare(UriImageSupport<T> o1, UriImageSupport<T> o2) {

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
@@ -127,7 +127,15 @@ public class ImageServerProvider {
 	}
 	
 	
-	static URI pathToUri(String path) throws IOException {
+	/**
+	 * Method to help with converting legacy image paths to URIs.
+	 * This is intended for compatibility with data files used in QuPath v0.1.2, where servers 
+	 * were represented using paths only (rather than JSON).
+	 * @param path
+	 * @return a URI parsed from a path, if possible
+	 * @throws IOException
+	 */
+	public static URI legacyPathToURI(String path) throws IOException {
 		URI uriTemp;
 		try {
 			if (path.startsWith("file:")) { 
@@ -150,9 +158,9 @@ public class ImageServerProvider {
 					uriTemp = new URI(uriTemp.getScheme(), uriTemp.getAuthority(), uriTemp.getPath(), "name="+seriesName, null);
 				}
 			}
-			if ("file".equals(uriTemp.getScheme()) && !new File(uriTemp).exists()) {
-				throw new IOException(uriTemp.toString() + " does not exist!");
-			}
+//			if ("file".equals(uriTemp.getScheme()) && !new File(uriTemp).exists()) {
+//				throw new IOException(uriTemp.toString() + " does not exist!");
+//			}
 		} catch (URISyntaxException e) {
 			throw new IOException(e.getLocalizedMessage());
 		}
@@ -161,7 +169,10 @@ public class ImageServerProvider {
 	
 
 	private static <T> List<UriImageSupport<T>> getServerBuilders(final Class<T> cls, final String path, String...args) throws IOException {
-		URI uri = pathToUri(path);
+		URI uri = legacyPathToURI(path);
+		if ("file".equals(uri.getScheme()) && !new File(uri).exists()) {
+			throw new IOException(uri.toString() + " does not exist!");
+		}
 
 		Collection<String> requestedClassnames = new HashSet<>();
 		String key = "--classname";

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
@@ -126,8 +126,8 @@ public class ImageServerProvider {
 		return builders;
 	}
 	
-
-	private static <T> List<UriImageSupport<T>> getServerBuilders(final Class<T> cls, final String path, String...args) throws IOException {
+	
+	static URI pathToUri(String path) throws IOException {
 		URI uriTemp;
 		try {
 			if (path.startsWith("file:")) { 
@@ -156,8 +156,12 @@ public class ImageServerProvider {
 		} catch (URISyntaxException e) {
 			throw new IOException(e.getLocalizedMessage());
 		}
+		return uriTemp;
+	}
+	
 
-		URI uri = uriTemp;
+	private static <T> List<UriImageSupport<T>> getServerBuilders(final Class<T> cls, final String path, String...args) throws IOException {
+		URI uri = pathToUri(path);
 
 		Collection<String> requestedClassnames = new HashSet<>();
 		String key = "--classname";

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
@@ -25,7 +25,6 @@ import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,7 +54,6 @@ import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Unmatched;
 import qupath.lib.color.ColorDeconvolutionStains;
-import qupath.lib.common.GeneralTools;
 import qupath.lib.images.servers.ColorTransforms.ColorTransform;
 import qupath.lib.images.servers.ImageServerBuilder.AbstractServerBuilder;
 import qupath.lib.images.servers.ImageServerBuilder.DefaultImageServerBuilder;
@@ -252,10 +250,9 @@ public class ImageServers {
 	 * @param args
 	 * @return
 	 * @throws IOException
-	 * @throws URISyntaxException 
 	 */
-	public static ImageServer<BufferedImage> buildServer(String path, String... args) throws IOException, URISyntaxException {
-		return buildServer(GeneralTools.toURI(path), args);
+	public static ImageServer<BufferedImage> buildServer(String path, String... args) throws IOException {
+		return buildServer(ImageServerProvider.pathToUri(path), args);
 	}
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
@@ -252,7 +252,7 @@ public class ImageServers {
 	 * @throws IOException
 	 */
 	public static ImageServer<BufferedImage> buildServer(String path, String... args) throws IOException {
-		return buildServer(ImageServerProvider.pathToUri(path), args);
+		return buildServer(ImageServerProvider.legacyPathToURI(path), args);
 	}
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
@@ -25,12 +25,18 @@ import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,11 +51,17 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Unmatched;
 import qupath.lib.color.ColorDeconvolutionStains;
+import qupath.lib.common.GeneralTools;
 import qupath.lib.images.servers.ColorTransforms.ColorTransform;
 import qupath.lib.images.servers.ImageServerBuilder.AbstractServerBuilder;
 import qupath.lib.images.servers.ImageServerBuilder.DefaultImageServerBuilder;
 import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
+import qupath.lib.images.servers.ImageServerBuilder.UriImageSupport;
+import qupath.lib.images.servers.ImageServerProvider.UriImageSupportComparator;
 import qupath.lib.images.servers.RotatedImageServer.Rotation;
 import qupath.lib.images.servers.SparseImageServer.SparseImageServerManagerRegion;
 import qupath.lib.images.servers.SparseImageServer.SparseImageServerManagerResolution;
@@ -78,6 +90,7 @@ public class ImageServers {
 			.registerSubtype(SparseImageServerBuilder.class, "sparse")
 			.registerSubtype(CroppedImageServerBuilder.class, "cropped")
 			.registerSubtype(PyramidGeneratingServerBuilder.class, "pyramidize") // For consistency, this would ideally be pyramidalize... but need to keep backwards-compatibility
+			.registerSubtype(ReorderRGBServerBuilder.class, "swapRedBlue")
 			.registerSubtype(ColorDeconvolutionServerBuilder.class, "color_deconvolved")
 			;
 	
@@ -228,6 +241,223 @@ public class ImageServers {
 		}
 		return new PyramidGeneratingImageServer(server, tileWidth, tileHeight, downsamples);
 	}
+	
+	
+	/**
+	 * Build a {@link ImageServer} for the specified URI path and optional args.
+	 * <p>
+	 * See {@link #buildServer(URI, String...)} for more information about how args are applied.
+	 * 
+	 * @param path path for the image; it should be possible to convert this to a URI
+	 * @param args
+	 * @return
+	 * @throws IOException
+	 * @throws URISyntaxException 
+	 */
+	public static ImageServer<BufferedImage> buildServer(String path, String... args) throws IOException, URISyntaxException {
+		return buildServer(GeneralTools.toURI(path), args);
+	}
+	
+	/**
+	 * Build a {@link ImageServer} for the specified URI and optional args.
+	 * This differs from {@link ImageServerProvider#buildServer(String, Class, String...)} in two main ways:
+	 * <ol>
+	 *   <li>it always uses {@link BufferedImage} as the server class</li>
+	 *   <li>where possible, args that request a transformed server are applied</li>
+	 * </ol>
+	 * 
+	 * Supported arguments include
+	 * <ol>
+	 *   <li>{@code --classname} to request an image provider class</li>
+	 *   <li>{@code --order RGB/BGR} etc. to request reordering for RGB channels</li>
+	 *   <li>{@code --rotate ROTATE_90/ROTATE_180/ROTATE_270} to request rotation</li>
+	 * </ol>
+	 * More arguments are likely to be added in future versions. All unmatched arguments are passed to the 
+	 * image reading library.
+	 * 
+	 * @param uri
+	 * @param args
+	 * @return
+	 * @throws IOException
+	 */
+	public static ImageServer<BufferedImage> buildServer(URI uri, String... args) throws IOException {
+		var supports = getAllImageSupports(uri, args);
+		List<Exception> exceptions = new ArrayList<>();
+		for (var support : supports) {
+			try {
+				return support.getBuilders().iterator().next().build();
+			} catch (Exception e) {
+				exceptions.add(e);
+			}
+		}
+		var exception = new IOException(buildBaseExceptionMessage(uri, args));
+		for (var e : exceptions)
+			exception.addSuppressed(e);
+		throw exception;
+	}
+	
+	private static String buildBaseExceptionMessage(URI uri, String... args) {
+		if (args.length == 0)
+			return "Unable to open " + uri;
+		else
+			return "Unable to open " + uri + " with args [" + Arrays.stream(args).collect(Collectors.joining(", ")) + "]";
+	}
+	
+	/**
+	 * Get all {@link UriImageSupport} that claim to be able to open the specified URI with optional args.
+	 * <p>
+	 * See {@link #buildServer(URI, String...)} for more information about how args are applied.
+	 * 
+	 * @param uri
+	 * @param args
+	 * @return a list or {@link UriImageSupport}, ranked in descending order of support level.
+	 * @throws IOException
+	 */
+	public static List<UriImageSupport<BufferedImage>> getAllImageSupports(URI uri, String... args) throws IOException {
+		
+		var serverArgs = parseServerArgs(args);
+		String[] requestedClassnames = serverArgs.requestedClassnames;
+		
+		List<UriImageSupport<BufferedImage>> supports = new ArrayList<>();
+		var availableBuilders = ImageServerProvider.getInstalledImageServerBuilders(BufferedImage.class);
+		List<Exception> exceptions = new ArrayList<>();
+		
+		// If we've requested a particular builder, only check that
+		if (requestedClassnames.length > 0) {
+			for (var builder : availableBuilders) {
+				if (builder.matchClassName(requestedClassnames)) {
+					try {
+						var support = getImageSupport(builder, uri, serverArgs);
+						if (support != null)
+							supports.add(support);
+						else
+							exceptions.add(new IOException("Unable to open " + uri + " with " + builder));
+					} catch (IOException e) {
+						exceptions.add(e);
+					}
+				}
+			}
+			if (supports.isEmpty()) {
+				throw new IOException("No compatible readers found with classnames [" + Arrays.stream(requestedClassnames).collect(Collectors.joining(", ")) + "]");
+			}
+		} else {
+			// If we don't know what builder we want, check all of them
+			for (var builder : availableBuilders) {
+				try {
+					var support = getImageSupport(builder, uri, serverArgs);
+					if (support != null && support.getSupportLevel() > 0f)
+						supports.add(support);
+				} catch (IOException e) {
+					exceptions.add(e);
+				}
+			}
+		}
+		if (supports.isEmpty()) {
+			var exception = new IOException(buildBaseExceptionMessage(uri, args));
+			for (var e : exceptions)
+				exception.addSuppressed(e);
+			throw exception;
+		}
+		Comparator<UriImageSupport<BufferedImage>> comparator = Collections.reverseOrder(new UriImageSupportComparator<>());
+		supports.sort(comparator);
+		return supports;
+	}
+	
+	private static UriImageSupport<BufferedImage> getImageSupport(ImageServerBuilder<BufferedImage> builder, URI uri, ServerArgs serverArgs) throws IOException {
+		var extraArgs = serverArgs.unmatched.clone();
+		var support = builder.checkImageSupport(uri, extraArgs);
+		return transformSupport(support, serverArgs);
+	}
+	
+	/**
+	 * Get the {@link UriImageSupport} that is best able to open the specified image with optional args.
+	 * <p>
+	 * See {@link #buildServer(URI, String...)} for more information about how args are applied.
+	 * 
+	 * @param uri
+	 * @param args
+	 * @return a list or {@link UriImageSupport}, ranked in descending order of support level.
+	 * @throws IOException
+	 */
+	public static UriImageSupport<BufferedImage> getImageSupport(URI uri, String... args) throws IOException {
+		var supports = getAllImageSupports(uri, args);
+		return supports.isEmpty() ? null : supports.get(0);
+	}
+	
+	/**
+	 * Get the {@link UriImageSupport} associated with an {@link ImageServerBuilder}, or null if the builder does not support the image.
+	 * <p>
+	 * See {@link #buildServer(URI, String...)} for more information about how args are applied.
+	 * 
+	 * @param builder
+	 * @param uri
+	 * @param args
+	 * @return
+	 * @throws IOException
+	 */
+	public static UriImageSupport<BufferedImage> getImageSupport(ImageServerBuilder<BufferedImage> builder, URI uri, String... args) throws IOException {
+		var serverArgs = parseServerArgs(args);
+		return getImageSupport(builder, uri, serverArgs);
+	}
+	
+	
+	private static ServerArgs parseServerArgs(String... args) {
+		var serverArgs = new ServerArgs();
+		new CommandLine(serverArgs).parseArgs(args);
+		return serverArgs;
+	}
+	
+	
+	/**
+	 * In the case that we are working with BufferedImages, we can apply some default operations based on 
+	 * requested arguments.
+	 * @param support
+	 * @param args
+	 * @return
+	 */
+	static UriImageSupport<BufferedImage> transformSupport(UriImageSupport<BufferedImage> support, ServerArgs args) {
+		if (support == null)
+			return null;
+		List<Function<ServerBuilder<BufferedImage>, ServerBuilder<BufferedImage>>> functions = new ArrayList<>();
+		if (args.rotation != null && args.rotation != Rotation.ROTATE_NONE)
+			functions.add(b -> RotatedImageServer.getRotatedBuilder(b, args.rotation));
+		String orderRGB = args.getOrderRGB();
+		if (orderRGB != null) {
+			functions.add(b -> RearrangeRGBImageServer.getSwapRedBlueBuilder(b, orderRGB));
+		}
+		if (functions.isEmpty())
+			return support;
+		List<ServerBuilder<BufferedImage>> buildersNew = new ArrayList<>();
+		for (var builder : support.getBuilders()) {
+			for (var fun : functions)
+				builder = fun.apply(builder);
+			buildersNew.add(builder);
+		}
+		return new UriImageSupport<>(support.getProviderClass(), support.getSupportLevel(), buildersNew);
+	}
+	
+	
+	
+	static class ServerArgs {
+		
+		@Option(names = {"--classname"}, description = "Requested classnames for the ImageServerProvider")
+		String[] requestedClassnames = new String[0];
+
+		@Option(names = {"--rotate"}, description = "Rotate the image during reading by an increment of 90 degrees.")
+		Rotation rotation = Rotation.ROTATE_NONE;
+		
+		@Option(names = {"--order"}, description = "Rearrange the channels of an RGB image (to correct errors in the image reader)")
+		String orderRGB = null;
+		
+		@Unmatched
+		String[] unmatched = new String[0];
+		
+		String getOrderRGB() {
+			return orderRGB == null || orderRGB.isBlank() ? null : orderRGB.trim().toUpperCase();
+		}
+		
+	}
+	
 	
 	
 	static class CroppedImageServerBuilder extends AbstractServerBuilder<BufferedImage> {
@@ -447,6 +677,37 @@ public class ImageServers {
 			return new RotatedImageServerBuilder(getMetadata(), newBuilder, rotation);
 		}
 	
+	}
+	
+	static class ReorderRGBServerBuilder extends AbstractServerBuilder<BufferedImage> {
+		
+		private ServerBuilder<BufferedImage> builder;
+		private String order;
+		
+		ReorderRGBServerBuilder(ImageServerMetadata metadata, ServerBuilder<BufferedImage> builder, String order) {
+			super(metadata);
+			this.builder = builder;
+			this.order = order;
+		}
+		
+		@Override
+		protected ImageServer<BufferedImage> buildOriginal() throws Exception {
+			return new RearrangeRGBImageServer(builder.build(), order);
+		}
+		
+		@Override
+		public Collection<URI> getURIs() {
+			return builder.getURIs();
+		}
+
+		@Override
+		public ServerBuilder<BufferedImage> updateURIs(Map<URI, URI> updateMap) {
+			ServerBuilder<BufferedImage> newBuilder = builder.updateURIs(updateMap);
+			if (newBuilder == builder)
+				return this;
+			return new ReorderRGBServerBuilder(getMetadata(), newBuilder, order);
+		}
+		
 	}
 	
 	static class ImageServerTypeAdapterFactory implements TypeAdapterFactory {

--- a/qupath-core/src/main/java/qupath/lib/images/servers/RearrangeRGBImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/RearrangeRGBImageServer.java
@@ -1,0 +1,93 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2021 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.lib.images.servers;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import qupath.lib.awt.common.BufferedImageTools;
+import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
+import qupath.lib.regions.RegionRequest;
+
+/**
+ * Simple image server to swap the red and blue channels of an RGB image.
+ * This is intended for use whenever an image has erroneously been read as RGB or BGR.
+ * 
+ * @author Pete Bankhead
+ */
+public class RearrangeRGBImageServer extends TransformingImageServer<BufferedImage> {
+	
+	private static List<String> VALID_ORDERS = Arrays.asList(
+			"RGB", "RBG", "GRB", "GBR", "BRG", "BGR"
+			);
+	
+	private String order = "RGB";
+
+	protected RearrangeRGBImageServer(ImageServer<BufferedImage> server, String order) {
+		super(server);
+		if (!server.isRGB())
+			throw new IllegalArgumentException("Red and blue channels can only be swapped for an RGB image server!");
+		this.order = order;
+		if (!VALID_ORDERS.contains(order))
+			throw new IllegalArgumentException("Unsupported order " + order);
+	}
+	
+	@Override
+	public BufferedImage readBufferedImage(RegionRequest request) throws IOException {
+		var img = super.readBufferedImage(request);
+		if (img == null)
+			return null;
+		BufferedImageTools.swapRGBOrder(img, order);
+		return img;
+	}
+
+	@Override
+	public String getServerType() {
+		return super.getWrappedServer().getServerType() + " [reorder " + order + "]";
+	}
+
+	@Override
+	protected ServerBuilder<BufferedImage> createServerBuilder() {
+		return new ImageServers.ReorderRGBServerBuilder(getMetadata(), getWrappedServer().getBuilder(), order);
+	}
+
+	@Override
+	protected String createID() {
+		return getWrappedServer().getPath() + " [reorder " + order + "]";
+	}
+	
+	/**
+	 * Get a ServerBuilder that swaps red and blue channels for another (RGB) server.
+	 * @param builder
+	 * @param order
+	 * @return
+	 */
+	public static ServerBuilder<BufferedImage> getSwapRedBlueBuilder(ServerBuilder<BufferedImage> builder, String order) {
+		if (!VALID_ORDERS.contains(order))
+			throw new IllegalArgumentException("Unsupported order " + order);
+		return new ImageServers.ReorderRGBServerBuilder(null, builder, order);		
+	}
+
+}

--- a/qupath-core/src/main/java/qupath/lib/images/servers/TransformedServerBuilder.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/TransformedServerBuilder.java
@@ -91,6 +91,17 @@ public class TransformedServerBuilder {
 	}
 	
 	/**
+	 * Rearrange the channel order of an RGB image.
+	 * This is intended for cases where an image has wrongly been interpreted as RGB or BGR.
+	 * @param order
+	 * @return
+	 */
+	public TransformedServerBuilder reorderRGB(String order) {
+		server = new RearrangeRGBImageServer(server, order);
+		return this;
+	}
+	
+	/**
 	 * Rotate the image, using an increment of 90 degrees.
 	 * @param rotation
 	 * @return

--- a/qupath-core/src/main/java/qupath/lib/io/PathIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathIO.java
@@ -202,12 +202,12 @@ public class PathIO {
 						logger.warn("Unsupported object of class {} will be skipped: {}", input.getClass().getName(), input);
 
 				} catch (ClassNotFoundException e) {
-					logger.error("Unable to find class", e);
+					logger.error("Unable to find class: " + e.getLocalizedMessage(), e);
 				} catch (EOFException e) {
 					// Try to recover from EOFExceptions - we may already have enough info
 					logger.error("Reached end of file...");
 					if (hierarchy == null)
-						e.printStackTrace();
+						logger.error(e.getLocalizedMessage(), e);
 					break;
 				}
 			}

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -61,6 +61,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
@@ -78,6 +79,7 @@ import loci.common.DataTools;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.formats.ClassList;
+import loci.formats.DimensionSwapper;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
@@ -166,7 +168,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 	 * Path to the base image file - will be the same as path, unless the path encodes the name of a specific series, in which case this refers to the file without the series included
 	 */
 	private String filePath;
-	
+		
 	/**
 	 * Fix issue related to VSI images having (wrong) z-slices
 	 */
@@ -223,9 +225,9 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 	private String path;
 	
 	/**
-	 * Specific options used by some Bio-Formats readers, e.g. Map.of("zeissczi.autostitch", "false")
+	 * Wrapper to the args passed to the reader, after parsing.
 	 */
-	private Map<String, String> readerOptions = new LinkedHashMap<>();
+	private BioFormatsArgs bfArgs;
 	
 //	/**
 //	 * Try to parallelize multichannel requests (experimental!)
@@ -284,10 +286,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		this.uri = uri;
 		
 		// Parse the arguments
-		var bfArgs = BioFormatsArgs.parse(args);
-		readerOptions.putAll(options.getReaderOptions());
-		if (bfArgs.readerOptions != null)
-			readerOptions.putAll(bfArgs.readerOptions);
+		bfArgs = BioFormatsArgs.parse(args);
 		
 		// Try to parse args, extracting the series if present
 		int seriesIndex = bfArgs.series;
@@ -299,7 +298,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		filePath = Paths.get(uri).toString();
 
 		// Create a reader & extract the metadata
-		readerWrapper = manager.getPrimaryReaderWrapper(options, filePath, readerOptions);
+		readerWrapper = manager.getPrimaryReaderWrapper(options, filePath, bfArgs);
 		IFormatReader reader = readerWrapper.getReader();
 		meta = (OMEPyramidStore)reader.getMetadataStore();
 
@@ -326,14 +325,14 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 				try {
 					if (!imageName.isEmpty())
 						name += " (" + imageName + ")";
-
+					
 					// Set this to be the series, if necessary
 					long sizeX = meta.getPixelsSizeX(s).getNumberValue().longValue();
 					long sizeY = meta.getPixelsSizeY(s).getNumberValue().longValue();
 					long sizeC = meta.getPixelsSizeC(s).getNumberValue().longValue();
 					long sizeZ = meta.getPixelsSizeZ(s).getNumberValue().longValue();
 					long sizeT = meta.getPixelsSizeT(s).getNumberValue().longValue();
-
+					
 					// Check the resolutions
 					//						int nResolutions = meta.getResolutionCount(s);
 					//						for (int r = 1; r < nResolutions; r++) {
@@ -370,7 +369,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 							}
 							imageMap.put(name, DefaultImageServerBuilder.createInstance(
 									BioFormatsServerBuilder.class, null, uri,
-									new BioFormatsArgs(s, readerOptions).backToArgs()
+									bfArgs.backToArgs(s)
 									));
 						}
 					}
@@ -812,7 +811,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 	private IFormatReader getReader() {
 		try {
 			if (willParallelize())
-				return manager.getReaderForThread(options, filePath, readerOptions);
+				return manager.getReaderForThread(options, filePath, bfArgs);
 			else
 				return readerWrapper.getReader();
 		} catch (Exception e) {
@@ -1167,39 +1166,39 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		 * 
 		 * @param options
 		 * @param path
-		 * @param readerOptions 
+		 * @param args 
 		 * @return
 		 * @throws DependencyException
 		 * @throws ServiceException
 		 * @throws FormatException
 		 * @throws IOException
 		 */
-		public synchronized IFormatReader getReaderForThread(final BioFormatsServerOptions options, final String path, Map<String, String> readerOptions) throws DependencyException, ServiceException, FormatException, IOException {
+		public synchronized IFormatReader getReaderForThread(final BioFormatsServerOptions options, final String path, BioFormatsArgs args) throws DependencyException, ServiceException, FormatException, IOException {
 			
 			LocalReaderWrapper wrapper = localReader.get();
 			
 			// Check if we already have the correct reader
 			IFormatReader reader = wrapper == null ? null : wrapper.getReader();
 			if (reader != null) {
-				if (path.equals(reader.getCurrentFile()) && wrapper.argsMatch(readerOptions))
+				if (path.equals(reader.getCurrentFile()) && wrapper.argsMatch(args))
 					return reader;		
 				else
 					reader.close(false);
 			}
 			
 			// Create a new reader
-			reader = createReader(options, path, null, readerOptions);
+			reader = createReader(options, path, null, args);
 			
 			// Store wrapped reference with associated cleaner
-			wrapper = wrapReader(reader, readerOptions);
+			wrapper = wrapReader(reader, args);
 			localReader.set(wrapper);
 			
 			return reader;
 		}
 		
 		
-		private static LocalReaderWrapper wrapReader(IFormatReader reader, Map<String, String> readerOptions) {
-			LocalReaderWrapper wrapper = new LocalReaderWrapper(reader, readerOptions);
+		private static LocalReaderWrapper wrapReader(IFormatReader reader, BioFormatsArgs args) {
+			LocalReaderWrapper wrapper = new LocalReaderWrapper(reader, args);
 			logger.debug("Constructing reader for {}", Thread.currentThread());
 			cleaner.register(
 					wrapper,
@@ -1218,14 +1217,15 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		 * 
 		 * @param options
 		 * @param path
+		 * @param args
 		 * @return
 		 * @throws DependencyException
 		 * @throws ServiceException
 		 * @throws FormatException
 		 * @throws IOException
 		 */
-		synchronized IFormatReader createPrimaryReader(final BioFormatsServerOptions options, final String path, IMetadata metadata, Map<String, String> readerOptions) throws DependencyException, ServiceException, FormatException, IOException {
-			return createReader(options, path, metadata == null ? MetadataTools.createOMEXMLMetadata() : metadata, readerOptions);
+		synchronized IFormatReader createPrimaryReader(final BioFormatsServerOptions options, final String path, IMetadata metadata, BioFormatsArgs args) throws DependencyException, ServiceException, FormatException, IOException {
+			return createReader(options, path, metadata == null ? MetadataTools.createOMEXMLMetadata() : metadata, args);
 		}
 		
 		
@@ -1234,18 +1234,19 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		 * one must be careful to synchronize the actual use of the reader.
 		 * @param options
 		 * @param path
+		 * @param args
 		 * @return
 		 * @throws DependencyException
 		 * @throws ServiceException
 		 * @throws FormatException
 		 * @throws IOException
 		 */
-		synchronized LocalReaderWrapper getPrimaryReaderWrapper(final BioFormatsServerOptions options, final String path, Map<String, String> readerOptions) throws DependencyException, ServiceException, FormatException, IOException {
-			for (LocalReaderWrapper wrapper : primaryReaders) {
-				if (path.equals(wrapper.getReader().getCurrentFile()) && wrapper.argsMatch(readerOptions))
-					return wrapper;
-			}
-			LocalReaderWrapper wrapper = wrapReader(createPrimaryReader(options, path, null, readerOptions), readerOptions);
+		synchronized LocalReaderWrapper getPrimaryReaderWrapper(final BioFormatsServerOptions options, final String path, BioFormatsArgs args) throws DependencyException, ServiceException, FormatException, IOException {
+//			for (LocalReaderWrapper wrapper : primaryReaders) {
+//				if (path.equals(wrapper.getReader().getCurrentFile()) && wrapper.argsMatch(args))
+//					return wrapper;
+//			}
+			LocalReaderWrapper wrapper = wrapReader(createPrimaryReader(options, path, null, args), args);
 			primaryReaders.add(wrapper);
 			return wrapper;
 		}
@@ -1257,12 +1258,13 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		 * @param options 
 		 * @param id File path for the image
 		 * @param store optional MetadataStore; this will be set in the reader if needed
+		 * @param args
 		 * @return the IFormatReader
 		 * @throws FormatException
 		 * @throws IOException
 		 */
-		static IFormatReader createReader(final BioFormatsServerOptions options, final String id, final MetadataStore store, Map<String, String> readerOptions) throws FormatException, IOException {
-			return createReader(options, null, id, store, readerOptions);
+		static IFormatReader createReader(final BioFormatsServerOptions options, final String id, final MetadataStore store, BioFormatsArgs args) throws FormatException, IOException {
+			return createReader(options, null, id, store, args);
 		}
 		
 		/**
@@ -1282,12 +1284,14 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		 * @param cls 		optionally specify a IFormatReader class if it is already known, to avoid a search.
 		 * @param id 		file path for the image.
 		 * @param store 	optional MetadataStore; this will be set in the reader if needed.
+		 * @param args      optional args to customize reading
 		 * @return the {@code IFormatReader}
 		 * @throws FormatException
 		 * @throws IOException
 		 */
+		@SuppressWarnings("resource")
 		private static synchronized IFormatReader createReader(final BioFormatsServerOptions options, final Class<? extends IFormatReader> cls, 
-				final String id, final MetadataStore store, Map<String, String> readerOptions) throws FormatException, IOException {
+				final String id, final MetadataStore store, BioFormatsArgs args) throws FormatException, IOException {
 			IFormatReader imageReader;
 			if (cls != null) {
 				ClassList<IFormatReader> list = new ClassList<>(IFormatReader.class);
@@ -1295,17 +1299,21 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 				imageReader = new ImageReader(list);
 			} else
 				imageReader = new ImageReader();
-			
+						
 			imageReader.setFlattenedResolutions(false);
 			
 			// Try to set any reader options that we have
 			MetadataOptions metadataOptions = imageReader.getMetadataOptions();
+			var readerOptions = args.readerOptions;
 			if (!readerOptions.isEmpty() && metadataOptions instanceof DynamicMetadataOptions) {
 				for (var option : readerOptions.entrySet()) {
 					((DynamicMetadataOptions)metadataOptions).set(option.getKey(), option.getValue());
 				}
 			}
 			
+			// TODO: Warning! Memoization does not play nicely with options like 
+			// --bfOptions zeissczi.autostitch=false
+			// in a way that options don't have an effect unless QuPath is restarted.
 			Memoizer memoizer = null;
 			int memoizationTimeMillis = options.getMemoizationTimeMillis();
 			File dir = null;
@@ -1341,11 +1349,17 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 				}
 			}
 			
+			
 			if (store != null) {
 				imageReader.setMetadataStore(store);
 			}
 			else
 				imageReader.setMetadataStore(new DummyMetadata());
+			
+			var swapDimensions = args.getSwapDimensions();
+			if (swapDimensions != null)
+				logger.debug("Creating DimensionSwapper for {}", swapDimensions);
+			
 			
 			if (id != null) {
 				if (memoizer != null) {
@@ -1357,6 +1371,8 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 					long memoizationFileSize = fileMemo == null ? 0L : fileMemo.length();
 					boolean memoFileExists = fileMemo != null && fileMemo.exists();
 					try {
+						if (swapDimensions != null)
+							imageReader = DimensionSwapper.makeDimensionSwapper(imageReader);
 						imageReader.setId(id);
 					} catch (Exception e) {
 						if (memoFileExists) {
@@ -1364,6 +1380,8 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 							fileMemo.delete();
 						}
 						imageReader.close();
+						if (swapDimensions != null)
+							imageReader = DimensionSwapper.makeDimensionSwapper(imageReader);
 						imageReader.setId(id);
 					}
 					memoizationFileSize = fileMemo == null ? 0L : fileMemo.length();
@@ -1380,9 +1398,19 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 					else
 						logger.debug("Memoization file exists at {}", fileMemo.getAbsolutePath());
 				} else {
+					if (swapDimensions != null)
+						imageReader = DimensionSwapper.makeDimensionSwapper(imageReader);
 					imageReader.setId(id);
 				}
 			}
+						
+			if (swapDimensions != null) {
+				// The series needs to be set before swapping dimensions
+				if (args.series >= 0)
+					imageReader.setSeries(args.series);
+				((DimensionSwapper)imageReader).swapDimensions(swapDimensions);
+			}
+
 			return imageReader;
 		}
 		
@@ -1449,20 +1477,19 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		static class LocalReaderWrapper {
 			
 			private IFormatReader reader;
-			private Map<String, String> readerOptions;
+			private BioFormatsArgs args;
 			
-			LocalReaderWrapper(IFormatReader reader, Map<String, String> readerOptions) {
+			LocalReaderWrapper(IFormatReader reader, BioFormatsArgs args) {
 				this.reader = reader;
-				this.readerOptions = readerOptions == null || readerOptions.isEmpty() ? Collections.emptyMap() :
-					new LinkedHashMap<>(readerOptions);
+				this.args = args;
 			}
 			
 			public IFormatReader getReader() {
 				return reader;
 			}
 
-			public boolean argsMatch(Map<String, String> readerOptions) {
-				return this.readerOptions.equals(readerOptions);
+			public boolean argsMatch(BioFormatsArgs args) {
+				return Objects.equals(this.args, args);
 			}
 
 		}
@@ -1501,7 +1528,12 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 
 		@Option(names = {"--name", "-n"}, defaultValue = "", description = "Series name (legacy option, please use --series instead)")
 		String seriesName = "";
+		
+		@Option(names = {"--swap", "-d"}, defaultValue = "", description = "Swap dimensions. "
+				+ "This should be a String of the form XYCZT, ordered according to how the image plans should be interpreted.")
+		String swapDimensions = null;
 
+		// Specific options used by some Bio-Formats readers, e.g. Map.of("zeissczi.autostitch", "false")
 		@Option(names = {"--bfOptions"}, description = "Bio-Formats reader options")
 		Map<String, String> readerOptions = new LinkedHashMap<>();
 		
@@ -1510,20 +1542,25 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		
 		BioFormatsArgs() {}
 		
-		BioFormatsArgs(int series, Map<String, String> readerOptions) {
-			this.series = series;
-			if (readerOptions != null)
-				this.readerOptions.putAll(readerOptions);
-		}
-		
-		String[] backToArgs() {
+		/**
+		 * Return to an array of String args.
+		 * @return
+		 */
+		String[] backToArgs(int series) {
 			var args = new ArrayList<String>();
 			if (series >= 0) {
 				args.add("--series");
 				args.add(Integer.toString(series));
+			} else if (this.series >= 0) {
+				args.add("--series");
+				args.add(Integer.toString(this.series));				
 			} else if (seriesName != null && !seriesName.isBlank()) {
 				args.add("--name");
 				args.add(seriesName);				
+			}
+			if (swapDimensions != null && !swapDimensions.isBlank()) {
+				args.add("--swap");
+				args.add(swapDimensions);
 			}
 			for (var option : readerOptions.entrySet()) {
 				// Note: this assumes that options & values contain no awkwardness (e.g. quotes, spaces)
@@ -1534,11 +1571,63 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			return args.toArray(String[]::new);
 		}
 		
+		String getSwapDimensions() {
+			return swapDimensions == null || swapDimensions.isBlank() ? null : swapDimensions.toUpperCase();
+		}
+		
 		static BioFormatsArgs parse(String[] args) {
 			var bfArgs = new BioFormatsArgs();
 			new CommandLine(bfArgs).parseArgs(args);
 			return bfArgs;
 		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((readerOptions == null) ? 0 : readerOptions.hashCode());
+			result = prime * result + series;
+			result = prime * result + ((seriesName == null) ? 0 : seriesName.hashCode());
+			result = prime * result + ((swapDimensions == null) ? 0 : swapDimensions.hashCode());
+			result = prime * result + ((unmatched == null) ? 0 : unmatched.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			BioFormatsArgs other = (BioFormatsArgs) obj;
+			if (readerOptions == null) {
+				if (other.readerOptions != null)
+					return false;
+			} else if (!readerOptions.equals(other.readerOptions))
+				return false;
+			if (series != other.series)
+				return false;
+			if (seriesName == null) {
+				if (other.seriesName != null)
+					return false;
+			} else if (!seriesName.equals(other.seriesName))
+				return false;
+			if (swapDimensions == null) {
+				if (other.swapDimensions != null)
+					return false;
+			} else if (!swapDimensions.equals(other.swapDimensions))
+				return false;
+			if (unmatched == null) {
+				if (other.unmatched != null)
+					return false;
+			} else if (!unmatched.equals(other.unmatched))
+				return false;
+			return true;
+		}
+		
+		
 		
 	}
 	

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -1529,7 +1529,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		@Option(names = {"--name", "-n"}, defaultValue = "", description = "Series name (legacy option, please use --series instead)")
 		String seriesName = "";
 		
-		@Option(names = {"--dims", "-d"}, defaultValue = "", description = "Swap dimensions. "
+		@Option(names = {"--dims"}, defaultValue = "", description = "Swap dimensions. "
 				+ "This should be a String of the form XYCZT, ordered according to how the image plans should be interpreted.")
 		String swapDimensions = null;
 

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -832,7 +832,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		return series;
 	}
 	
-
+	
 	@Override
 	public BufferedImage readTile(TileRequest tileRequest) throws IOException {
 		int level = tileRequest.getLevel();
@@ -1529,7 +1529,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		@Option(names = {"--name", "-n"}, defaultValue = "", description = "Series name (legacy option, please use --series instead)")
 		String seriesName = "";
 		
-		@Option(names = {"--swap", "-d"}, defaultValue = "", description = "Swap dimensions. "
+		@Option(names = {"--dims", "-d"}, defaultValue = "", description = "Swap dimensions. "
 				+ "This should be a String of the form XYCZT, ordered according to how the image plans should be interpreted.")
 		String swapDimensions = null;
 

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerBuilder.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerBuilder.java
@@ -177,6 +177,20 @@ public class BioFormatsServerBuilder implements ImageServerBuilder<BufferedImage
 		return BufferedImage.class;
 	}
 	
+	@Override
+	public boolean matchClassName(String... classNames) {
+		for (var className : classNames) {
+			if (this.getClass().getName().equals(className) ||
+					this.getClass().getSimpleName().equals(className) ||
+					BioFormatsImageServer.class.getName().equals(className) ||
+					BioFormatsImageServer.class.getSimpleName().equals(className) ||
+					"bioformats".equalsIgnoreCase(className))
+				return true;			
+		}
+		return false;
+	}
+	
+	
 	/**
 	 * Request the Bio-Formats version number from {@code loci.formats.FormatTools.VERSION}.
 	 * <p>

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
@@ -36,7 +36,7 @@ import picocli.CommandLine.Parameters;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.extensions.Subcommand;
 import qupath.lib.images.servers.ImageServer;
-import qupath.lib.images.servers.ImageServerProvider;
+import qupath.lib.images.servers.ImageServers;
 import qupath.lib.images.servers.bioformats.BioFormatsServerBuilder;
 import qupath.lib.images.writers.ome.OMEPyramidWriter.Builder;
 import qupath.lib.images.writers.ome.OMEPyramidWriter.CompressionType;
@@ -133,7 +133,7 @@ public class ConvertCommand implements Runnable, Subcommand {
 		else
 			args = new String[0];
 		
-		try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(inputFile.getPath(), BufferedImage.class, args)) {
+		try (ImageServer<BufferedImage> server = ImageServers.buildServer(inputFile.toURI(), args)) {
 			
 			// Get compression from user (or CompressionType.DEFAULT)
 //			CompressionType compressionType = stringToCompressionType(compression);

--- a/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServerBuilder.java
+++ b/qupath-extension-omero/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServerBuilder.java
@@ -34,6 +34,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import qupath.imagej.images.servers.ImageJServer;
 import qupath.lib.gui.dialogs.Dialogs;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerBuilder;
@@ -180,5 +181,18 @@ public class OmeroWebImageServerBuilder implements ImageServerBuilder<BufferedIm
 	@Override
 	public Class<BufferedImage> getImageType() {
 		return BufferedImage.class;
+	}
+	
+	@Override
+	public boolean matchClassName(String... classNames) {
+		for (var className : classNames) {
+			if (this.getClass().getName().equals(className) ||
+					this.getClass().getSimpleName().equals(className) ||
+					OmeroWebImageServer.class.getName().equals(className) ||
+					OmeroWebImageServer.class.getSimpleName().equals(className) ||
+					"omero-web".equalsIgnoreCase(className))
+				return true;			
+		}
+		return false;
 	}
 }

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
@@ -161,4 +161,17 @@ public class OpenslideServerBuilder implements ImageServerBuilder<BufferedImage>
 		return BufferedImage.class;
 	}
 	
+	@Override
+	public boolean matchClassName(String... classNames) {
+		for (var className : classNames) {
+			if (this.getClass().getName().equals(className) ||
+					this.getClass().getSimpleName().equals(className) ||
+					OpenslideImageServer.class.getName().equals(className) ||
+					OpenslideImageServer.class.getSimpleName().equals(className) ||
+					"openslide".equalsIgnoreCase(className))
+				return true;			
+		}
+		return false;
+	}
+	
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -3214,7 +3214,7 @@ public class QuPathGUI {
 			server = imageData.getServer();
 		else {
 			try {
-				server = ImageServerProvider.buildServer(serverPath, BufferedImage.class);
+				server = ImageServers.buildServer(serverPath);
 			} catch (IOException e) {
 				logger.error("Unable to open server path " + serverPath, e);
 			}
@@ -3224,7 +3224,7 @@ public class QuPathGUI {
 					serverPath = Dialogs.promptForFilePathOrURL("Set path to missing file", serverPath, new File(serverPath).getParentFile(), null);
 					if (serverPath == null)
 						return false;
-					server = ImageServerProvider.buildServer(serverPath, BufferedImage.class);
+					server = ImageServers.buildServer(serverPath);
 					if (server == null)
 						return false;
 //				}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -106,6 +106,7 @@ import qupath.lib.gui.tools.PaneTools;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerProvider;
+import qupath.lib.images.servers.ImageServers;
 import qupath.lib.plugins.parameters.ParameterList;
 import qupath.lib.projects.Project;
 import qupath.lib.projects.ProjectIO;
@@ -788,42 +789,6 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 		return false;
 	}
 	
-	
-	
-	
-	Image requestThumbnail(final String serverPath, final File fileThumbnail) throws IOException {
-//		serversRequested.clear();
-		
-		// Check if we've already asked for this server... if so, stop
-		if (serversRequested.contains(serverPath))
-			return null;
-		// Put in the request now
-		serversRequested.add(serverPath);
-		// Check if it exists
-		if (fileThumbnail.exists())
-			return SwingFXUtils.toFXImage(ImageIO.read(fileThumbnail), null);
-		// Try to load the server
-		ImageData<BufferedImage> imageData = getCurrentImageData();
-		ImageServer<BufferedImage> server = null;
-		boolean newServer = false;
-		if (imageData != null && imageData.getServerPath().equals(serverPath))
-			server = imageData.getServer();
-		else {
-			server = ImageServerProvider.buildServer(serverPath, BufferedImage.class);
-			newServer = true;
-		}
-		BufferedImage img2 = ProjectCommands.getThumbnailRGB(server);
-		if (newServer) {
-			try {
-				server.close();
-			} catch (Exception e) {
-				logger.warn("Problem closing server", e);
-			}
-		}
-		ImageIO.write(img2, THUMBNAIL_EXT, fileThumbnail);
-		return SwingFXUtils.toFXImage(img2, null);
-	}
-
 	
 	/**
 	 * Resize an image so that its dimensions fit inside thumbnailWidth x thumbnailHeight.

--- a/src/main/java/qupath/QuPath.java
+++ b/src/main/java/qupath/QuPath.java
@@ -27,6 +27,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,6 +65,7 @@ import qupath.lib.gui.tma.QuPathTMAViewer;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerProvider;
+import qupath.lib.images.servers.ImageServers;
 import qupath.lib.projects.Project;
 import qupath.lib.projects.ProjectIO;
 
@@ -323,7 +325,8 @@ class ScriptCommand implements Runnable {
 				}
 			} else if (imagePath != null && !imagePath.equals("")) {
 				String path = QuPath.getEncodedPath(imagePath);
-				ImageServer<BufferedImage> server = ImageServerProvider.buildServer(path, BufferedImage.class, parseArgs(serverArgs));
+				URI uri = GeneralTools.toURI(path);
+				ImageServer<BufferedImage> server = ImageServers.buildServer(uri, parseArgs(serverArgs));
 				imageData = new ImageData<>(server);
 				Object result = runScript(null, imageData);
 				if (result != null)


### PR DESCRIPTION
Support specifying optional (currently space-delimited) arguments in the import dialog for images.
Enable DimensionSwapper with Bio-Formats.

Putting these together, one can use a String such as
```
  --dims XYTZC --series 2
```
to specify that only the third series should be read from a file with Bio-Formats and the dimension order should (possibly) be changed.

One can also use pass custom arguments for specific readers, e.g.
```
--bfOptions zeissczi.autostitch=false
```
however be warned that these do not play nicely with memoization, meaning that QuPath may need to be restarted for them to work.