### PR TITLE
Allow Bio-Formats to work with URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Enhancements:
 * Load object & pixel classifier dialogs support importing classifiers from other locations
 * Brightness/Contrast panel shows small min/max values to 2 decimal places
 * Better validation when entering numeric values in text fields
+* Bio-Formats now optionally accepts URLs, not only local files (requires opt-in through the preferences)
 
 Code changes:
 * GeoJSON features now use "properties>object_type" rather than "id" property to map to a QuPath object type (e.g. "annotation", "detection", "cell")

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -51,7 +51,6 @@ import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -141,10 +140,10 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 	 */
 	private static int DEFAULT_TILE_SIZE = 512;
 
-	/**
-	 * Maximum tile size - larger values will be ignored.
-	 */
-	private static int MAX_TILE_SIZE = 4096;
+//	/**
+//	 * Maximum tile size - larger values will be ignored.
+//	 */
+//	private static int MAX_TILE_SIZE = 4096;
 	
 	/**
 	 * Image names (in lower case) normally associated with 'extra' images, but probably not representing the main image in the file.
@@ -295,8 +294,20 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		if (requestedSeriesName.isBlank())
 			requestedSeriesName = null;
 		
-		// This appears to work more reliably than converting to a File
-		filePath = Paths.get(uri).toString();
+		// Try to get a local file path, but accept something else (since Bio-Formats handles other URIs)
+		try {
+			var path = GeneralTools.toPath(uri);
+			if (path != null)
+				filePath = path.toString();
+//			filePath = Paths.get(uri).toString();
+		} catch (Exception e) {
+			logger.error(e.getLocalizedMessage(), e);
+		} finally {
+			if (filePath == null) {
+				logger.debug("Using URI as file path: {}", uri);
+				filePath = uri.toString();
+			}
+		}
 
 		// Create a reader & extract the metadata
 		readerWrapper = manager.getPrimaryReaderWrapper(options, filePath, readerOptions);

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -1320,7 +1320,8 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			Memoizer memoizer = null;
 			int memoizationTimeMillis = options.getMemoizationTimeMillis();
 			File dir = null;
-			if (memoizationTimeMillis >= 0) {
+			// We can only use memoization if we don't have an illegal character
+			if (memoizationTimeMillis >= 0 && !id.contains(":")) {
 				// Try to use a specified directory
 				String pathMemoization = options.getPathMemoization();
 				if (pathMemoization != null && !pathMemoization.trim().isEmpty()) {

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsOptionsExtension.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsOptionsExtension.java
@@ -81,6 +81,7 @@ public class BioFormatsOptionsExtension implements QuPathExtension {
 		
 		// Create persistent properties
 		BooleanProperty enableBioformats = PathPrefs.createPersistentPreference("bfEnableBioformats", options.bioformatsEnabled());
+		BooleanProperty filesOnly = PathPrefs.createPersistentPreference("bfFilesOnly", options.getFilesOnly());
 		BooleanProperty useParallelization = PathPrefs.createPersistentPreference("bfUseParallelization", options.requestParallelization());
 		IntegerProperty memoizationTimeMillis = PathPrefs.createPersistentPreference("bfMemoizationTimeMS", options.getMemoizationTimeMillis());
 //		BooleanProperty parallelizeMultichannel = PathPrefs.createPersistentPreference("bfParallelizeMultichannel", options.requestParallelizeMultichannel());
@@ -92,6 +93,7 @@ public class BioFormatsOptionsExtension implements QuPathExtension {
 		StringProperty skipExtensions = PathPrefs.createPersistentPreference("bfSkipAlwaysExtensions", String.join(" ", options.getSkipAlwaysExtensions()));
 		
 		// Set options using any values previously stored
+		options.setFilesOnly(filesOnly.get());
 		options.setPathMemoization(pathMemoization.get());
 		options.setBioformatsEnabled(enableBioformats.get());
 		options.setRequestParallelization(useParallelization.get());
@@ -103,6 +105,7 @@ public class BioFormatsOptionsExtension implements QuPathExtension {
 
 		// Listen for property changes
 		enableBioformats.addListener((v, o, n) -> options.setBioformatsEnabled(n));
+		filesOnly.addListener((v, o, n) -> options.setFilesOnly(n));
 		useParallelization.addListener((v, o, n) -> options.setRequestParallelization(n));
 		memoizationTimeMillis.addListener((v, o, n) -> options.setMemoizationTimeMillis(n.intValue()));
 //		parallelizeMultichannel.addListener((v, o, n) -> options.setRequestParallelizeMultichannel(n));
@@ -116,6 +119,8 @@ public class BioFormatsOptionsExtension implements QuPathExtension {
 		// Add preferences to QuPath GUI
 		PreferencePane prefs = QuPathGUI.getInstance().getPreferencePane();
 		prefs.addPropertyPreference(enableBioformats, Boolean.class, "Enable Bio-Formats", "Bio-Formats", "Allow QuPath to use Bio-Formats for image reading");
+		prefs.addPropertyPreference(filesOnly, Boolean.class, "Local files only", "Bio-Formats", "Limit Bio-Formats to only opening local files, not other URLs.\n"
+				+ "Allowing Bio-Formats to open URLs can cause performance issues if this results in attempting to open URLs intended to be read using other image servers.");
 		prefs.addPropertyPreference(useParallelization, Boolean.class, "Enable Bio-Formats tile parallelization", "Bio-Formats", "Enable reading image tiles in parallel when using Bio-Formats");
 //		prefs.addPropertyPreference(parallelizeMultichannel, Boolean.class, "Enable Bio-Formats channel parallelization (experimental)", "Bio-Formats", "Request multiple image channels in parallel, even if parallelization of tiles is turned off - "
 //				+ "only relevant for multichannel images, and may fail for some image formats");

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerBuilder.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerBuilder.java
@@ -97,13 +97,17 @@ public class BioFormatsServerBuilder implements ImageServerBuilder<BufferedImage
 			return 0;
 		
 		ImageCheckType type = FileFormatInfo.checkType(uri);
-		if (type.isURL())
-			return 0;
-				
 		String path = uri.getPath();
-		
+		if (path == null)
+			return 0;
+								
 		// Check the options to see whether we really really do or don't want to read this
 		BioFormatsServerOptions options = BioFormatsServerOptions.getInstance();
+		
+		if (type.isURL() && options.getFilesOnly()) {
+			return 0;
+		}
+		
 		switch (checkPath(options, path)) {
 			case YES:
 				return 5;
@@ -115,8 +119,8 @@ public class BioFormatsServerBuilder implements ImageServerBuilder<BufferedImage
 		
 		path = path.toLowerCase();
 		
-		// We don't want to handle zip files (which are very slow)
-		float support = 3f;
+		// We don't want to handle zip files (which are very slow), and only try URL as last resort
+		float support = type.isURL() ? 1f : 3f;
 				
 		String description = type.getDescription();
 		if (path.endsWith(".zip"))
@@ -141,16 +145,20 @@ public class BioFormatsServerBuilder implements ImageServerBuilder<BufferedImage
 		} else {
 			// Check if we know the file type
 			File file = type.getFile();
-			if (file != null) {
+			path = file != null ? file.getAbsolutePath() : path;
+			if (path != null) {
 				String supportedReader = null;
 				try {
-					supportedReader = BioFormatsImageServer.getSupportedReaderClass(file.getAbsolutePath());
+					supportedReader = BioFormatsImageServer.getSupportedReaderClass(path);
 				} catch (Exception e) {
-					logger.warn("Error checking file " + file.getAbsolutePath(), e);
+					logger.warn("Error checking file " + path, e);
 				}
 				if (supportedReader == null) {
-					logger.debug("No supported reader found for {}", file.getAbsolutePath());
-					return 1f;
+					// If we have a file, still provide support level of 1 because we might still be able to 
+					// read the image with a more thorough check - but return 0 for a URL, because a thorough 
+					// check might be extremely slow.
+					logger.debug("No supported reader found for {}", path);
+					return file == null ? 0 : 1f;
 				} 
 				logger.debug("Potential Bio-Formats reader: {}", supportedReader);
 			}

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerOptions.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerOptions.java
@@ -56,6 +56,7 @@ public class BioFormatsServerOptions {
 	private Set<String> useExtensions = new TreeSet<>();
 	
 	private boolean requestParallelization = true;
+	private boolean filesOnly = true;
 	private int memoizationTimeMillis = 500;
 //	private boolean requestParallelizeMultichannel = false;
 	private String pathMemoization;
@@ -108,7 +109,7 @@ public class BioFormatsServerOptions {
 	}
 
 	/**
-	 * Set additional arguments that should be passed to viewers.
+	 * Set additional arguments that should be passed to readers.
 	 * Example:
 	 * <pre>
 	 * 	BioFormatsServerOptions.setReaderOptions(Map.of("zeissczi.autostitch", "false"));
@@ -150,6 +151,22 @@ public class BioFormatsServerOptions {
 	 */
 	public void setBioformatsEnabled(final boolean bioformatsEnabled) {
 		this.bioformatsEnabled = bioformatsEnabled;
+	}
+	
+	/**
+	 * Set whether Bio-Formats should support only local files (rather than any URL).
+	 * @param filesOnly
+	 */
+	public void setFilesOnly(boolean filesOnly) {
+		this.filesOnly = filesOnly;
+	}
+	
+	/**
+	 * Returns true if Bio-Formats is restricted to support only local files, not other URLs.
+	 * @return
+	 */
+	public boolean getFilesOnly() {
+		return filesOnly;
 	}
 	
 	/**


### PR DESCRIPTION
Relax the requirements that any image has to be a local file to work with Bio-Formats. For example, https://qupath.github.io/images/qupath-banner-web-logo.jpg can now be opened directly. This may become more important if Zarr support becomes available through Bio-Formats.

One risk with this is that it will make adding an OMERO (or similar) image very slow, as Bio-Formats tries and fails to read it. To mitigate the problem, the image is tested based upon its URI path only - if no potentially-compatible reader is found then the image read won't be attempted.

The option to read other URLs is turned off by default through the preferences.