### PR TITLE
Log any errors occurring in a script

### DIFF
--- a/qupath-core/src/test/java/qupath/lib/objects/classes/TestPathClassFactory.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/classes/TestPathClassFactory.java
@@ -66,7 +66,7 @@ public class TestPathClassFactory {
 		var colorOnePlus = ColorTools.makeScaledRGB(ColorTools.packRGB(255, 215, 0), 1.25);
 		var colorTwoPlus = ColorTools.makeScaledRGB(ColorTools.packRGB(225, 150, 50), 1.25);
 		var colorThreePlus = ColorTools.makeScaledRGB(ColorTools.packRGB(200, 50, 50), 1.25);
-		checkFields("test", "test", color1, new PathClass("test", color1));
+		checkFields("test", "test", color1, PathClassFactory.getPathClass("test", color1));
 		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(null, color1));
 		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(PathClassFactory.getPathClassUnclassified().getName(), color1));
 		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(PathClassFactory.getPathClassUnclassified().getName(), color1));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -837,6 +837,10 @@ public class DefaultScriptEditor implements ScriptEditor {
 				printWriter.println(String.format("Script run time: %.2f seconds", (System.currentTimeMillis() - startTime)/1000.0));
 		} catch (ScriptException e) {
 			// TODO: Consider exception logging here, rather than via the called method
+		} catch (Throwable t) {
+			// This can happen when something goes very wrong - like attempting to load a missing native library
+			// We need to somehow let the user know, rather than swallowing the problem silently
+			logger.error(t.getLocalizedMessage(), t);
 		} finally {
 			if (attachToLog)
 				Platform.runLater(() -> LogManager.removeTextAppendableFX(console));	


### PR DESCRIPTION
This is for cases where something terrible happens in a script, and currently the user gets less info than if something minor had gone wrong. An example is the silence that greets a doomed attempt to load a native library.