### PR TITLE
Improve PathClass robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Enhancements:
 * Bio-Formats now optionally accepts URLs, not only local files (requires opt-in through the preferences)
 
 Code changes:
+* Revised PathClass code to be more strict with invalid class names & prevent accidentally calling the constructor (please report any related bugs!)
 * GeoJSON features now use "properties>object_type" rather than "id" property to map to a QuPath object type (e.g. "annotation", "detection", "cell")
   * 'id' is likely to be used as a unique identifier in a later QuPath version
 * GeneralTools readAsString methods now assume UTF-8 encoding

--- a/qupath-core-processing/src/test/java/qupath/imagej/images/writers/TestImageWriterIJ.java
+++ b/qupath-core-processing/src/test/java/qupath/imagej/images/writers/TestImageWriterIJ.java
@@ -43,7 +43,10 @@ public class TestImageWriterIJ {
 	@Test
 	public void testTiffAndZip() {
 		var imp = IJ.createImage("Temp", 128, 256, 4, 32);
-		IJ.run(imp, "Add Specified Noise...", "standard=500 stack");
+		// Need to call without using a macro, to avoid java.awt.HeadlessException 
+		for (int s = 1; s < imp.getStackSize(); s++)
+			imp.getStack().getProcessor(s).noise(500);
+//		IJ.run(imp, "Add Specified Noise...", "standard=500 stack");
 		testTiff(imp);
 		testZip(imp);
 	}

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
@@ -24,13 +24,21 @@
 package qupath.lib.objects.classes;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 
 import qupath.lib.common.ColorTools;
 
 /**
  * Representation of an object's classification - which can be defined using any unique string identifier (e.g. tumour, lymphocyte, gland, benign, malignant).
  * <p>
- * In order to keep the construction of PathClasses under control, they should be generated using the static methods within PathClassFactory.
+ * The constructors in this class should never be called directly.
+ * In order to keep the construction of PathClasses under control, they should be accessed using the static methods within {@link PathClassFactory}.
  * 
  * @see PathClassFactory
  * 
@@ -48,15 +56,30 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 	private final String name;
 	private Integer colorRGB;
 	
+	private final static UUID secret = UUID.randomUUID();
+	
 	/**
 	 * Cached String representation
 	 */
 	private transient String stringRep = null;
+	
+	private static PathClass NULL_CLASS = new PathClass(secret);
+	
+	private static List<String> illegalCharacters = Arrays.asList("\n", ":", "\r");
+	
+	private static Map<String, PathClass> existingClasses = Collections.synchronizedMap(new HashMap<>());
 
-	PathClass() {
+	private PathClass(UUID mySecret) {
+		if (!Objects.equals(secret, mySecret))
+			throw new IllegalStateException("You should not access the PathClass constructor!");
+		if (NULL_CLASS != null) {
+			throw new IllegalStateException("The NULL PathClass should not be created more than once!");
+		}
 		parentClass = null;
 		name = null;
 		colorRGB = null;
+//		if (!existingClasses.add(null))
+//			throw new IllegalArgumentException("PathClass constructor has been called multiple times!");
 	}
 
 	/**
@@ -68,26 +91,62 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 	 * @param name
 	 * @param colorRGB
 	 */
-	PathClass(PathClass parent, String name, Integer colorRGB) {
-		if (!PathClassTools.isValidName(name))
-			throw new IllegalArgumentException("PathClass names cannot contain colon (:) or new line characters!");
-		if (parent != null && name == null)
-			throw new IllegalArgumentException("Cannot create a derived PathClass with name == null");
+	private PathClass(UUID mySecret, PathClass parent, String name, Integer colorRGB) {
+		if (!Objects.equals(secret, mySecret))
+			throw new IllegalStateException("You should not access the PathClass constructor!");
+		
+		if (name != null)
+			name = name.strip();
+
+		if (!isValidName(name))
+			throw new IllegalArgumentException(name + " is not a valid PathClass name!");
 		
 		this.parentClass = parent;
-		this.name = name == null ? null : name.trim();
+		this.name = name;
+		
 		if (colorRGB == null)
 			this.colorRGB = DEFAULT_COLOR;
 		else
 			this.colorRGB = colorRGB;
 		
 		if (PathClassFactory.classExists(toString()))
-			throw new UnsupportedOperationException("PathClass '" + toString() + "' already exists! Use PathClassFactory.getPathClass() instead of calling the the PathClass constructor directly.");
+			throw new IllegalStateException("Cannot create the same PathClass more than once!");
+		
 	}
 	
-	PathClass(String name, Integer colorRGB) {
-		this(null, name, colorRGB);
+	/**
+	 * Return whether the specified name is a valid name for a PathClass.
+	 * To be valid, it should be non-null, non-blank, and not contain any illegal characters (colons, linebreaks).
+	 * @param name
+	 */
+	private static boolean isValidName(String name) {
+		if (name == null || name.isBlank())
+			return false;
+		for (var illegal : illegalCharacters)
+			if (name.contains(illegal))
+				return false;
+		return true;
 	}
+	
+	synchronized static PathClass getNullClass() {
+		return NULL_CLASS;
+	}
+	
+	synchronized static PathClass getInstance(PathClass parent, String name, Integer colorRGB) {
+		if (parent == getNullClass())
+			parent = null;
+		
+		if (parent == null && name == null)
+			return getNullClass();
+		
+		var pathClass = new PathClass(secret, parent, name, colorRGB);
+		var s = pathClass.toString();
+		
+		// Make a last attempt to return an existing class with the same name, if we can
+		var previous = existingClasses.putIfAbsent(s, pathClass);
+		return previous == null ? pathClass : previous;
+	}
+	
 	
 	/**
 	 * Get the parent classification, or null if this classification has no parent.
@@ -237,5 +296,7 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 //			return 1;
 //		return name.compareTo(o.getName());
 	}
+	
+	
 	
 }

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassFactory.java
@@ -126,7 +126,7 @@ public final class PathClassFactory {
 
 	private static Map<String, PathClass> mapPathClasses = new HashMap<>();
 
-	private final static PathClass NULL_CLASS = new PathClass();
+	private final static PathClass NULL_CLASS = PathClass.getNullClass();
 	
 	final static String POSITIVE = "Positive";
 	final static String NEGATIVE = "Negative";
@@ -146,6 +146,15 @@ public final class PathClassFactory {
 	static boolean classExists(String classString) {
 		return mapPathClasses.containsKey(classString);
 	}
+	
+	/**
+	 * Get a {@link PathClass}, without specifying any color.
+	 * @param name
+	 * @return
+	 */
+	public static PathClass getPathClass(String name) {
+		return getPathClass(name, (Integer)null);
+	}
 		
 	/**
 	 * Get the PathClass object associated with a specific name. Note that this name must not contain newline; 
@@ -160,7 +169,8 @@ public final class PathClassFactory {
 		if (name == null)
 			return NULL_CLASS;
 		
-		name = name.trim();
+		
+		name = name.strip();
 		if (name.isEmpty() || name.equals(NULL_CLASS.toString()) || name.equals(NULL_CLASS.getName()))
 			return NULL_CLASS;
 		
@@ -169,7 +179,7 @@ public final class PathClassFactory {
 		if (split.length > 1) {
 			var pathClass = getPathClass(split[0], rgb);
 			for (int i = 1; i < split.length; i++) {
-				var temp = split[i].trim();
+				var temp = split[i].strip();
 				if (!temp.isBlank())
 					pathClass = getDerivedPathClass(pathClass, temp, rgb);
 			}
@@ -202,7 +212,7 @@ public final class PathClassFactory {
 								random.nextInt(256));
 					}
 				}
-				pathClass = new PathClass(null, name, rgb);
+				pathClass = PathClass.getInstance(null, name, rgb);
 				mapPathClasses.put(pathClass.toString(), pathClass);
 			}
 			return pathClass;
@@ -293,7 +303,7 @@ public final class PathClassFactory {
 					}
 				}
 	//				rgb = new Color(parentClass.getColor()).brighter().getRGB();
-				pathClass = new PathClass(parentClass, name, rgb);
+				pathClass = PathClass.getInstance(parentClass, name, rgb);
 				mapPathClasses.put(pathClass.toString(), pathClass);
 			}
 			return pathClass;

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassTools.java
@@ -291,16 +291,6 @@ public final class PathClassTools {
 		return ColorTools.packRGB(r, g, b);
 	}
 	
-	
-	/**
-	 * Return whether the specified name is a valid name for a PathClass. <p>
-	 * I.e. a name that does not contain a line break or colons (:).
-	 * @param name
-	 */
-	static boolean isValidName(String name) {
-		return name == null || (!name.contains("\n") && !name.contains(":"));
-	}
-	
 	/**
 	 * Query whether a {@link PathClass} or any of its ancestor classes contains a specified name.
 	 * <p>

--- a/qupath-core/src/test/java/qupath/lib/objects/classes/TestPathClass.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/classes/TestPathClass.java
@@ -24,268 +24,122 @@
 package qupath.lib.objects.classes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import qupath.lib.common.ColorTools;
 
 @SuppressWarnings("javadoc")
 public class TestPathClass {
 	
-	private static PathClass pathClass1;
-	private static PathClass pathClass2;
-	private static PathClass pathClass3;
-	private static PathClass pathClass4;
-	private static PathClass pathClass5;
-	private static PathClass pathClass6;
-	private static PathClass pathClass7;
-	private static PathClass pathClass8;
-	private static PathClass pathClass9;
-	private static PathClass pathClass10;
-	private static PathClass pathClass11;
-	private static PathClass pathClass12;
-	private static PathClass pathClass13;
+	private static List<Integer> colors = Arrays.asList(
+			ColorTools.BLACK,
+			ColorTools.BLUE,
+			ColorTools.RED,
+			ColorTools.GREEN,
+			ColorTools.CYAN,
+			ColorTools.MAGENTA,
+			ColorTools.WHITE,
+			ColorTools.YELLOW
+			);
+	
+	
+	@Test
+	public void test_classes() {
+		// Check we can get the same null class
+		assertSame(PathClass.getNullClass(), PathClass.getInstance(null, null, null));
+		assertSame(PathClass.getNullClass(), PathClass.getInstance(null, null, ColorTools.RED));
+		
+		// Check we can create a parent
+		PathClass parent = PathClass.getInstance(null, "parent", null);
+		assertNotNull(parent);
+		assertNotEquals(PathClass.getNullClass(), parent);
+		assertTrue(parent.isValid());
+		
+		// Can't have a parent but null name
+		assertThrows(IllegalArgumentException.class, () -> PathClass.getInstance(parent, null, null));
 
-	@BeforeAll
-	public static void test_constructor() {
-		// No arg constructor
-		pathClass1 = new PathClass();
-		assertEquals(null, pathClass1.getName());
-		assertEquals(null, pathClass1.getParentClass());
-		assertEquals(null, pathClass1.getColor());
+		// Can't have invalid characters
+		List<String> invalidNames = Arrays.asList(
+				"", ":", "any\nthing", "some:thing", "  ", "\t"
+				);
+		for (String invalid : invalidNames) {
+			assertThrows(IllegalArgumentException.class, () -> PathClass.getInstance(null, invalid, null));
+			assertThrows(IllegalArgumentException.class, () -> PathClass.getInstance(parent, invalid, null));
+		}
 		
-		// Two-arg constructor
-		pathClass2 = new PathClass("", Color.RED.getRGB());
-		assertEquals("", pathClass2.getName());
-		assertEquals(null, pathClass2.getParentClass());
-		assertEquals(Color.RED.getRGB(), pathClass2.getColor());
-		
-		pathClass3 = new PathClass("test", Color.BLUE.getRGB());
-		assertEquals("test", pathClass3.getName());
-		assertEquals(null, pathClass3.getParentClass());
-		assertEquals(Color.BLUE.getRGB(), pathClass3.getColor());		
+		// Check parent and base classes
+		assertNull(PathClass.getNullClass().getParentClass());
+		assertNull(parent.getParentClass());
+		assertSame(PathClass.getNullClass(), PathClass.getNullClass().getBaseClass());
+		assertSame(parent, parent.getBaseClass());
 
-		pathClass4 = new PathClass("test", null);
-		assertEquals("test", pathClass4.getName());
-		assertEquals(null, pathClass4.getParentClass());
-		assertNotEquals(null, pathClass4.getColor());	// Should be default
+		// Check we can create derived classes
+		List<PathClass> derived = new ArrayList<>();
+		PathClass lastClass = parent;
+		for (int i = 0; i < colors.size(); i++) {
+			String name = "Derived " + i;
+			var color = colors.get(i);
+			var nextClass = PathClass.getInstance(lastClass, name, color);
+			assertSame(lastClass, nextClass.getParentClass());
+			assertSame(parent, nextClass.getBaseClass());
+			assertEquals(name, nextClass.getName());
+			assertEquals(color, nextClass.getColor());
+			
+			// Check toString() method contains what it should
+			assertTrue(nextClass.getName().endsWith(name));
+			assertEquals(i, countColons(lastClass.toString()));
+			assertEquals(i+1, countColons(nextClass.toString()));
+			
+			derived.add(nextClass);
+			lastClass = nextClass;
+		}
 		
-		pathClass5 = new PathClass(null, Color.BLUE.getRGB());
-		assertEquals(null, pathClass5.getName());
-		assertEquals(null, pathClass5.getParentClass());
-		assertEquals(Color.BLUE.getRGB(), pathClass5.getColor());
+		// Try to create derived classes again - these should be identical
+		lastClass = parent;
+		for (int i = 0; i < colors.size(); i++) {
+			String name = "Derived " + i;
+			// Change the color
+			var color = colors.get(colors.size()-1-i);
+			var nextClass = PathClass.getInstance(lastClass, name, color);
+			
+			// What we should receive is actually the original class - not a new one
+			assertEquals(derived.get(i).toString(), nextClass.toString());
+			assertSame(derived.get(i), nextClass);
+			
+			assertSame(lastClass, nextClass.getParentClass());
+			assertSame(parent, nextClass.getBaseClass());
+			assertEquals(name, nextClass.getName());
+			// Color isn't necessarily the same!
+//			assertEquals(color, nextClass.getColor());
+			
+			// Check toString() method contains what it should
+			assertTrue(nextClass.getName().endsWith(name));
+			assertEquals(i, countColons(lastClass.toString()));
+			assertEquals(i+1, countColons(nextClass.toString()));
+			
+			derived.add(nextClass);
+			lastClass = nextClass;
+		}
 		
-		pathClass6 = new PathClass(null, null);
-		assertEquals(null, pathClass6.getName());
-		assertEquals(null, pathClass6.getParentClass());
-		assertNotEquals(null, pathClass6.getColor());	// Should be default
+		// Check class names are trimmed
+		assertEquals("Something", PathClass.getInstance(null, " Something", null).toString());
+		assertEquals("Else", PathClass.getInstance(null, "Else   ", null).toString());
 		
-		// Three-arg constructor		
-		pathClass7 = new PathClass(null, "", Color.RED.getRGB());
-		assertEquals("", pathClass7.getName());
-		assertEquals(null, pathClass7.getParentClass());
-		assertEquals(Color.RED.getRGB(), pathClass7.getColor());	
-		
-		pathClass8 = new PathClass(pathClass1, "", Color.BLUE.getRGB());
-		assertEquals("", pathClass8.getName());
-		assertEquals(pathClass1, pathClass8.getParentClass());
-		assertEquals(Color.BLUE.getRGB(), pathClass8.getColor());
-		
-		pathClass9 = new PathClass(pathClass1, "test", Color.GREEN.getRGB());
-		assertEquals("test", pathClass9.getName());
-		assertEquals(pathClass1, pathClass9.getParentClass());
-		assertEquals(Color.GREEN.getRGB(), pathClass9.getColor());
-		
-		pathClass10 = new PathClass(pathClass1, "", null);
-		assertEquals("", pathClass10.getName());
-		assertEquals(pathClass1, pathClass10.getParentClass());
-		assertNotEquals(null, pathClass10.getColor());	// Should be default
-		
-		pathClass11 = new PathClass(null, null, null);
-		assertEquals(null, pathClass11.getName());
-		assertEquals(null, pathClass11.getParentClass());
-		assertNotEquals(null, pathClass11.getColor());	// Should be default
-		
-		pathClass12 = new PathClass(pathClass9, "child", Color.CYAN.getRGB());
-		assertEquals("child", pathClass12.getName());
-		assertEquals(pathClass9, pathClass12.getParentClass());
-		assertEquals(Color.CYAN.getRGB(), pathClass12.getColor());
-
-		pathClass13 = new PathClass(pathClass7, "badChild", Color.CYAN.getRGB());
-		assertEquals("badChild", pathClass13.getName());
-		assertEquals(pathClass7, pathClass13.getParentClass());
-		assertEquals(Color.CYAN.getRGB(), pathClass13.getColor());
-		
-		Assertions.assertThrows(IllegalArgumentException.class, () -> new PathClass(pathClass1, null, Color.BLUE.getRGB()));
 	}
 	
-	@Test
-	public void test_isValid() {
-		assertFalse(pathClass1.isValid());
-		assertTrue(pathClass2.isValid());
-		assertTrue(pathClass3.isValid());
-		assertTrue(pathClass4.isValid());
-		assertFalse(pathClass5.isValid());
-		assertFalse(pathClass6.isValid());
-		assertTrue(pathClass7.isValid());
-		assertTrue(pathClass8.isValid());
-		assertTrue(pathClass9.isValid());
-		assertTrue(pathClass10.isValid());
-		assertFalse(pathClass11.isValid());
-		assertTrue(pathClass12.isValid());
-		assertTrue(pathClass13.isValid());
+	private static int countColons(String s) {
+		return s.length() - s.replaceAll(":", "").length();
 	}
 	
-	@Test
-	public void test_isDerivedClass() {
-		assertFalse(pathClass1.isDerivedClass());
-		assertFalse(pathClass2.isDerivedClass());
-		assertFalse(pathClass3.isDerivedClass());
-		assertFalse(pathClass4.isDerivedClass());
-		assertFalse(pathClass5.isDerivedClass());
-		assertFalse(pathClass6.isDerivedClass());
-		assertFalse(pathClass7.isDerivedClass());
-		assertTrue(pathClass8.isDerivedClass());
-		assertTrue(pathClass9.isDerivedClass());
-		assertTrue(pathClass10.isDerivedClass());
-		assertFalse(pathClass11.isDerivedClass());
-		assertTrue(pathClass12.isDerivedClass());
-		assertTrue(pathClass13.isDerivedClass());
-	}
-	
-	@Test
-	public void test_isDerivedFrom() {
-		// Same class
-		assertTrue(pathClass1.isDerivedFrom(pathClass1));
-		
-		// No parent class
-		assertFalse(pathClass2.isDerivedFrom(pathClass1));
-		assertFalse(pathClass3.isDerivedFrom(pathClass1));
-		assertFalse(pathClass4.isDerivedFrom(pathClass1));
-		assertFalse(pathClass5.isDerivedFrom(pathClass1));
-		assertFalse(pathClass6.isDerivedFrom(pathClass1));
-		assertFalse(pathClass7.isDerivedFrom(pathClass1));
-		
-		// Parent class
-		assertTrue(pathClass8.isDerivedFrom(pathClass1));
-		assertFalse(pathClass8.isDerivedFrom(pathClass2));
-		assertTrue(pathClass9.isDerivedFrom(pathClass1));
-		assertFalse(pathClass9.isDerivedFrom(pathClass2));
-		assertTrue(pathClass10.isDerivedFrom(pathClass1));
-		assertFalse(pathClass10.isDerivedFrom(pathClass2));
-		assertFalse(pathClass11.isDerivedFrom(pathClass1));
-		
-		// '2' parent classes
-		assertTrue(pathClass12.isDerivedFrom(pathClass9));	// Parent
-		assertTrue(pathClass12.isDerivedFrom(pathClass1));	// Parent of parent
-		assertFalse(pathClass12.isDerivedFrom(pathClass2));
-		
-		assertTrue(pathClass13.isDerivedFrom(pathClass7));	// Parent
-		assertFalse(pathClass13.isDerivedFrom(pathClass2));
-		
-		// Check ancestor
-		assertFalse(pathClass9.isDerivedFrom(pathClass12));
-		assertFalse(pathClass7.isDerivedFrom(pathClass13));
-	}
-	
-	@Test
-	public void test_isAncestorOf() {
-		// Same class
-		assertTrue(pathClass1.isAncestorOf(pathClass1));
-		
-		// No ancestor 
-		assertFalse(pathClass1.isAncestorOf(pathClass2));
-		assertFalse(pathClass1.isAncestorOf(pathClass3));
-		assertFalse(pathClass1.isAncestorOf(pathClass4));
-		assertFalse(pathClass1.isAncestorOf(pathClass5));
-		assertFalse(pathClass1.isAncestorOf(pathClass6));
-		assertFalse(pathClass1.isAncestorOf(pathClass7));
-		
-		// One ancestor
-		assertTrue(pathClass1.isAncestorOf(pathClass8));
-		assertFalse(pathClass2.isAncestorOf(pathClass8));
-		assertTrue(pathClass1.isAncestorOf(pathClass9));
-		assertFalse(pathClass2.isAncestorOf(pathClass9));
-		assertTrue(pathClass1.isAncestorOf(pathClass10));
-		assertFalse(pathClass2.isAncestorOf(pathClass10));
-		assertFalse(pathClass1.isAncestorOf(pathClass11));
-		assertFalse(pathClass2.isAncestorOf(pathClass11));
-		
-		// 2 ancestors
-		assertTrue(pathClass9.isAncestorOf(pathClass12));
-		assertTrue(pathClass1.isAncestorOf(pathClass12));
-		
-		assertTrue(pathClass7.isAncestorOf(pathClass13));
-		assertFalse(pathClass2.isAncestorOf(pathClass13));
-	}
-	
-	@Test
-	public void test_getBaseClass() {
-		assertEquals(pathClass1, pathClass1.getBaseClass());
-		assertEquals(pathClass2, pathClass2.getBaseClass());
-		assertEquals(pathClass3, pathClass3.getBaseClass());
-		assertEquals(pathClass4, pathClass4.getBaseClass());
-		assertEquals(pathClass5, pathClass5.getBaseClass());
-		assertEquals(pathClass6, pathClass6.getBaseClass());
-		assertEquals(pathClass7, pathClass7.getBaseClass());
-		assertEquals(pathClass1, pathClass8.getBaseClass());
-		assertEquals(pathClass1, pathClass9.getBaseClass());
-		assertEquals(pathClass1, pathClass10.getBaseClass());
-		assertEquals(pathClass11, pathClass11.getBaseClass());
-		assertEquals(pathClass1, pathClass12.getBaseClass());
-		assertEquals(pathClass7, pathClass13.getBaseClass());
-	}
-	
-	@Test
-	public void test_setColor() {
-		var tempPathClass1 = new PathClass();
-		var tempPathClass2 = new PathClass("colorTest", null);
-		var tempPathClass3 = new PathClass("colorTest", Color.GREEN.getRGB());
-		var tempPathClass4 = new PathClass("colorTest", Color.RED.getRGB());
-		var tempPathClass5 = new PathClass("colorTest", Color.RED.getRGB());
-		
-		tempPathClass1.setColor(Color.GREEN.getRGB());
-		tempPathClass2.setColor(Color.GREEN.getRGB());
-		tempPathClass3.setColor(Color.GREEN.getRGB());
-		tempPathClass4.setColor(Color.GREEN.getRGB());
-		tempPathClass5.setColor(null);
-		
-		assertEquals(Color.GREEN.getRGB(), tempPathClass1.getColor());
-		assertEquals(Color.GREEN.getRGB(), tempPathClass2.getColor());
-		assertEquals(Color.GREEN.getRGB(), tempPathClass3.getColor());
-		assertEquals(Color.GREEN.getRGB(), tempPathClass4.getColor());
-		assertEquals(null, tempPathClass5.getColor());
-	}
-	
-	@Test
-	public void test_derivedClassToString() {
-		assertEquals("Unclassified: child", PathClass.derivedClassToString(pathClass1, "child"));
-		assertEquals(": child", PathClass.derivedClassToString(pathClass2, "child"));
-		assertEquals("test: child", PathClass.derivedClassToString(pathClass3, "child"));
-		assertEquals("test: child", PathClass.derivedClassToString(pathClass4, "child"));
-		assertEquals("Unclassified: child", PathClass.derivedClassToString(pathClass5, "child"));
-		assertEquals("Unclassified: child", PathClass.derivedClassToString(pathClass6, "child"));
-		assertEquals(": child", PathClass.derivedClassToString(pathClass7, "child"));
-		assertEquals("Unclassified: : child", PathClass.derivedClassToString(pathClass8, "child"));
-		assertEquals("Unclassified: test: child", PathClass.derivedClassToString(pathClass9, "child"));
-		assertEquals("Unclassified: : child", PathClass.derivedClassToString(pathClass10, "child"));
-		assertEquals("Unclassified: child", PathClass.derivedClassToString(pathClass11, "child"));
-		assertEquals("Unclassified: test: child: child", PathClass.derivedClassToString(pathClass12, "child"));
-		assertEquals(": badChild: child", PathClass.derivedClassToString(pathClass13, "child"));
-
-		assertEquals("child", PathClass.derivedClassToString(null, "child"));
-		assertEquals(null, PathClass.derivedClassToString(null, null));
-		assertEquals("Unclassified: null", PathClass.derivedClassToString(pathClass1, null));
-	}
-	
-	@Test
-	public void test_equality() {
-		// Test to assert that the compareTo() method works as intended (see method's javadoc)
-		assertNotEquals(0, PathClassFactory.getPathClass("Tumor: Positive", Color.GREEN.getRGB()).compareTo(PathClassFactory.getPathClass("Stroma: Positive", Color.GREEN.getRGB())));
-	}
 }

--- a/qupath-core/src/test/java/qupath/lib/objects/classes/TestPathClassFactory.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/classes/TestPathClassFactory.java
@@ -25,7 +25,6 @@ package qupath.lib.objects.classes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.awt.Color;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Assertions;
@@ -51,7 +50,7 @@ public class TestPathClassFactory {
 	
 	@Test
 	public void test_getPathClass2() {
-		Assertions.assertThrows(IllegalArgumentException.class, () -> PathClassFactory.getPathClass("Class with\nnew line", Color.RED.getRGB()));
+		Assertions.assertThrows(IllegalArgumentException.class, () -> PathClassFactory.getPathClass("Class with\nnew line", ColorTools.RED));
 		
 		assertEquals("Third", PathClassFactory.getPathClass("First", "Second", "Third").getName());
 		assertEquals("First: Second: Third", PathClassFactory.getPathClass("First", "Second", "Third").toString());
@@ -66,7 +65,7 @@ public class TestPathClassFactory {
 		var colorOnePlus = ColorTools.makeScaledRGB(ColorTools.packRGB(255, 215, 0), 1.25);
 		var colorTwoPlus = ColorTools.makeScaledRGB(ColorTools.packRGB(225, 150, 50), 1.25);
 		var colorThreePlus = ColorTools.makeScaledRGB(ColorTools.packRGB(200, 50, 50), 1.25);
-		checkFields("test", "test", color1, new PathClass("test", color1));
+		checkFields("test", "test", color1, PathClass.getInstance(null, "test", color1));
 		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(null, color1));
 		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(PathClassFactory.getPathClassUnclassified().getName(), color1));
 		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(PathClassFactory.getPathClassUnclassified().getName(), color1));
@@ -99,14 +98,15 @@ public class TestPathClassFactory {
 		var invalidClasses = Arrays.asList(":\n", "My::Invalid\nClass");
 		
 		for (var clazz: sameClasses) {
-			assertEquals("My", PathClassFactory.getPathClass(clazz, Color.CYAN.getRGB()).getParentClass().getName());
-			assertEquals("Class", PathClassFactory.getPathClass(clazz, Color.CYAN.getRGB()).getName());
+			assertEquals("My", PathClassFactory.getPathClass(clazz, ColorTools.CYAN).getParentClass().getName());
+			assertEquals("Class", PathClassFactory.getPathClass(clazz, ColorTools.CYAN).getName());
+			assertEquals("My: Class", PathClassFactory.getPathClass(clazz, ColorTools.RED).toString());
 		}
 		for (var clazz: unclassifiedClasses) {
-			assertEquals(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(clazz, Color.CYAN.getRGB()));
+			assertEquals(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(clazz, ColorTools.CYAN));
 		}
 		for (var clazz: invalidClasses) {
-			Assertions.assertThrows(IllegalArgumentException.class, () -> PathClassFactory.getPathClass(clazz, Color.CYAN.getRGB()));
+			Assertions.assertThrows(IllegalArgumentException.class, () -> PathClassFactory.getPathClass(clazz, ColorTools.CYAN));
 		}
 	}
 	
@@ -140,7 +140,8 @@ public class TestPathClassFactory {
 	
 	@Test
 	public void test_getPathClassUnclassified() {
-		sameClass(new PathClass(), PathClassFactory.getPathClassUnclassified().getBaseClass());
+		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClassUnclassified().getBaseClass());
+		sameClass(PathClassFactory.getPathClass((String)null), PathClassFactory.getPathClassUnclassified().getBaseClass());
 	}
 	
 	private static void sameClass(PathClass expected, PathClass actual) {

--- a/qupath-core/src/test/java/qupath/lib/objects/classes/TestPathClassFactory.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/classes/TestPathClassFactory.java
@@ -26,6 +26,7 @@ package qupath.lib.objects.classes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -65,7 +66,8 @@ public class TestPathClassFactory {
 		var colorOnePlus = ColorTools.makeScaledRGB(ColorTools.packRGB(255, 215, 0), 1.25);
 		var colorTwoPlus = ColorTools.makeScaledRGB(ColorTools.packRGB(225, 150, 50), 1.25);
 		var colorThreePlus = ColorTools.makeScaledRGB(ColorTools.packRGB(200, 50, 50), 1.25);
-		checkFields("test", "test", color1, PathClass.getInstance(null, "test", color1));
+		String uniqueName = UUID.randomUUID().toString();
+		checkFields(uniqueName, uniqueName, color1, PathClassFactory.getPathClass(uniqueName, color1));
 		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(null, color1));
 		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(PathClassFactory.getPathClassUnclassified().getName(), color1));
 		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(PathClassFactory.getPathClassUnclassified().getName(), color1));


### PR DESCRIPTION
Make it harder to generate invalid PathClasses accidentally by removing or modifying constructors. Simplify tests and add a stronger validity check for names.