### PR TITLE
Create gradle.yml

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,26 @@
+# This workflow will build a Java project with Gradle
+ # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+ name: Java CI with Gradle
+
+ on: [pull_request]
+
+ jobs:
+   build:
+
+     strategy:
+       matrix:
+         platform: [ubuntu-latest, macos-latest, windows-latest]
+     runs-on: ${{ matrix.platform }}
+
+     steps:
+     - uses: actions/checkout@v2
+     - name: Set up JDK 16
+       uses: actions/setup-java@v2
+       with:
+         java-version: '16'
+         distribution: 'adopt-hotspot'
+     - name: Grant execute permission for gradlew
+       run: chmod +x gradlew
+     - name: Build with Gradle
+       run: ./gradlew build


### PR DESCRIPTION
Create workflow for CI.
Note that this is only expected to work with v0.3+ because of the use of Java 16, and because of failing headless-related tests in v0.2.