### PR TITLE
Fix bug in using arrow keys to navigate slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ For full details, see the [Commit log](https://github.com/qupath/qupath/commits/
 * Error in StarDist intensity measurements for 8-bit RGB fluorescence images (https://github.com/qupath/qupath/issues/686)
 * Opening images with very narrow tiles can fail with Bio-Formats (https://github.com/qupath/qupath/issues/715)
 * `OMEPyramidSeries` is not public (https://github.com/qupath/qupath/issues/726)
+* Bug in using arrow keys to navigate z-stacks and timeseries (https://github.com/qupath/qupath/issues/748)
 * Not possible to view multiple channels simultaneously with inverted lookup tables (max display < min display)
 * Exception when converting `PathObject` with name but no color to GeoJSON
 * Cannot write valid 16-bit PNG labelled images

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -3160,7 +3160,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 				switch (code) {
 				case LEFT:
 					if (nTimepoints > 1) {
-						setTPosition(Math.max(nTimepoints-1, 0));
+						setTPosition(Math.max(getTPosition()-1, 0));
 						event.consume();
 						return;
 					}
@@ -3174,7 +3174,8 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 					break;
 				case UP:
 					if (nZSlices > 1) {
-						setZPosition(Math.max(0, getZPosition() - 1));	
+						int inc = PathPrefs.invertZSliderProperty().get() ? -1 : 1;
+						setZPosition(GeneralTools.clipValue(getZPosition() + inc, 0, nZSlices));	
 						event.consume();
 						return;
 					}
@@ -3202,7 +3203,8 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 					break;
 				case DOWN:
 					if (nZSlices > 1) {
-						setZPosition(Math.min(nZSlices-1, getZPosition() + 1));						
+						int inc = PathPrefs.invertZSliderProperty().get() ? 1 : -1;
+						setZPosition(GeneralTools.clipValue(getZPosition() + inc, 0, nZSlices));	
 						event.consume();
 						return;
 					}


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/748
Also uses PathPrefs.invertZSliderProperty() for more intuitive behavior with z-stacks.