### PR TITLE
Improved synchronization on PathObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ For full details, see the [Commit log](https://github.com/qupath/qupath/commits/
 * When building from source with TensorFlow support, now uses TensorFlow Java 0.3.1 (corresponding to TensorFlow v2.4.1)
 
 ### Bugs fixed
+* Multithreading issue with creation or removal of objects (https://github.com/qupath/qupath/issues/744)
 * *Detect centroid distances 2D* doesn't work on different planes of a z-stack (https://github.com/qupath/qupath/issues/696)
 * Deleting a TMA grid deletes all objects (https://github.com/qupath/qupath/issues/646)
 * *Subcellular detection (experimental)* does't work for z-stacks or images without pixel size information (https://github.com/qupath/qupath/issues/701)


### PR DESCRIPTION
Attempt to resolve https://github.com/qupath/qupath/issues/744

The underlying problem is that concurrent modification exceptions occurred whenever nDescendants() was called by the UI thread while another thread was adding/removing objects.

Adding *more* synchronization to try to overcome this resulted in deadlocks.

This commit tries to resolve the issue in two ways:
- Making the childList a synchronized collection (actually a Set)
- Reducing synchronization on the PathObject itself, and synchonizing more sparingly on the childList

This is hopefully sufficient to avoid simply counting objects in one thread interfering with adding/removing objects in another. Since most adding/removing access is via a PathObjectHierarchy, counting is (I think...) the main concurrency risk, and the resulting code should be more robust.

Along the way, the childList was also given a better default capacity.