### PR TITLE
Fix memory leak in pixel classifier

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/opencv/CellCountsCV.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/CellCountsCV.java
@@ -229,7 +229,7 @@ public class CellCountsCV extends AbstractTileableDetectionPlugin<BufferedImage>
 				Mat matValid = new Mat();
 				compare(mat, matStain2, matValid, CMP_GE);
 				min(matThresh, matValid, matThresh);
-				matValid.release();
+				matValid.close();
 			}
 			
 			// Do Difference of Gaussians, if required
@@ -267,7 +267,7 @@ public class CellCountsCV extends AbstractTileableDetectionPlugin<BufferedImage>
 			MatVector contours = new MatVector();
 			Mat temp = new Mat();
 			opencv_imgproc.findContours(matMaxima, contours, temp, opencv_imgproc.RETR_EXTERNAL, opencv_imgproc.CHAIN_APPROX_SIMPLE);
-			temp.release();
+			temp.close();
 			ArrayList<qupath.lib.geom.Point2> points = new ArrayList<>();
 
 			Shape shape = pathROI != null && pathROI.isArea() ? RoiTools.getShape(pathROI) : null;

--- a/qupath-core-processing/src/main/java/qupath/opencv/DetectCytokeratinCV.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/DetectCytokeratinCV.java
@@ -235,10 +235,10 @@ public class DetectCytokeratinCV extends AbstractDetectionPlugin<BufferedImage> 
 			}
 
 
-			matOD.release();
-			matDAB.release();
-			matBinaryDAB.release();
-			matBinaryTissue.release();
+			matOD.close();
+			matDAB.close();
+			matBinaryDAB.close();
+			matBinaryTissue.close();
 			
 			lastResultsDescription = String.format("Detected %s", pathObjects.toString());
 
@@ -271,14 +271,14 @@ public class DetectCytokeratinCV extends AbstractDetectionPlugin<BufferedImage> 
 		Mat hierarchy = new Mat();
 		opencv_imgproc.findContours(mat, contours, hierarchy, opencv_imgproc.RETR_TREE, opencv_imgproc.CHAIN_APPROX_SIMPLE);
 		if (contours.empty()) {
-			hierarchy.release();
+			hierarchy.close();
 			return null;
 		}
 
 		Area area = new Area();
 		updateArea(contours, hierarchy, area, 0, 0);
 
-		hierarchy.release();
+		hierarchy.close();
 
 		return area;
 	}

--- a/qupath-core-processing/src/main/java/qupath/opencv/classify/OpenCvClassifier.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/classify/OpenCvClassifier.java
@@ -270,8 +270,8 @@ public abstract class OpenCvClassifier<T extends StatModel> implements PathObjec
 			classifier.train(matTraining, ROW_SAMPLE, matResponses);			
 		}
 		
-		matTraining.release();
-		matResponses.release();
+		matTraining.close();
+		matResponses.close();
 		
 		logger.info("Classifier trained with " + arrayResponses.length + " samples");
 	}
@@ -341,8 +341,8 @@ public abstract class OpenCvClassifier<T extends StatModel> implements PathObjec
 			counter++;
 		}
 		
-		samples.release();
-		results.release();
+		samples.close();
+		results.close();
 				
 		return counter;
 	}

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/OpenCVClassifiers.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/OpenCVClassifiers.java
@@ -832,7 +832,7 @@ public class OpenCVClassifiers {
 				idxResults.put(i, prediction);
 				row++;
 			}
-			votes.release();
+			votes.close();
 		}
 		
 		

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/OpenCVMLClassifier.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/OpenCVMLClassifier.java
@@ -253,10 +253,10 @@ public class OpenCVMLClassifier<T> extends AbstractObjectClassifier<T> {
 				predictTime, pathObjects.size(),
 				GeneralTools.formatNumber((double)predictTime/pathObjects.size() * 1000.0, 2));
 
-		samples.release();
-		results.release();
+		samples.close();
+		results.close();
 		if (probabilities != null)
-			probabilities.release();
+			probabilities.close();
 
 		// Apply classifications now
 		reclassifiers.stream().forEach(p -> p.apply());

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/features/Preprocessing.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/features/Preprocessing.java
@@ -107,7 +107,7 @@ public class Preprocessing {
 		indexer.release();
 
 		if (features != samples)
-			features.release();
+			features.close();
 
 		return Normalizer.createNormalizer(offsets, scales, missingValue);
 	}
@@ -254,11 +254,11 @@ public class Preprocessing {
 
 		@Override
 		public void close() throws Exception {
-			mean.release();
-			eigenvectors.release();
-			eigenvalues.release();
+			mean.close();
+			eigenvectors.close();
+			eigenvalues.close();
 			if (eigenvaluesSqrt != null)
-				eigenvaluesSqrt.release();
+				eigenvaluesSqrt.close();
 		}
 
 	}

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -1184,7 +1184,7 @@ public class ImageOps {
 				Mat temp = new Mat();
 				opencv_imgproc.morphologyEx(input, temp, opencv_imgproc.MORPH_DILATE, getKernel());
 				input.put(opencv_core.equals(input, temp));
-				temp.release();
+				temp.close();
 				return input;
 			}
 			
@@ -1216,7 +1216,7 @@ public class ImageOps {
 				Mat temp = new Mat();
 				opencv_imgproc.morphologyEx(input, temp, opencv_imgproc.MORPH_ERODE, getKernel());
 				input.put(opencv_core.equals(input, temp));
-				temp.release();
+				temp.close();
 				return input;
 			}
 			
@@ -2452,7 +2452,7 @@ public class ImageOps {
 				if (requestProbabilities) {
 					var temp = new Mat();
 					model.predict(input, temp, matResult);
-					temp.release();
+					temp.close();
 				} else
 					model.predict(input, matResult, null);
 				input.put(matResult.reshape(matResult.cols(), h));

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/LocalNormalization.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/LocalNormalization.java
@@ -479,9 +479,9 @@ public class LocalNormalization {
 				
 				opencv_core.divide(mat, matSmooth, mat);
 				
-				matSquaredSmooth.release();
+				matSquaredSmooth.close();
 			}
-			matSmooth.release();
+			matSmooth.close();
 		}
 		
 		// Give 32-bit output, unless the input was 64-bit

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/MultiscaleFeatures.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/MultiscaleFeatures.java
@@ -701,12 +701,12 @@ public class MultiscaleFeatures {
 //			if (hessian != null)
 //				hessian.close();
 
-			kx0.release();
-			kx1.release();
-			kx2.release();
-			ky0.release();
-			ky1.release();
-			ky2.release();
+			kx0.close();
+			kx1.close();
+			kx2.close();
+			ky0.close();
+			ky1.close();
+			ky2.close();
 			
 			return results;
 		}
@@ -1597,7 +1597,7 @@ public class MultiscaleFeatures {
 		var matAbs = opencv_core.abs(mat).asMat();
 		// Get sorted indices
 		opencv_core.sortIdx(matAbs, matAbs, opencv_core.CV_SORT_DESCENDING + opencv_core.CV_SORT_EVERY_ROW);
-		mat.release();
+		mat.close();
 		return matAbs;
 	}
 	

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
@@ -1220,7 +1220,7 @@ public class OpenCVTools {
 //		FloatBuffer buffer = mat.createBuffer();
 //		buffer.get(pixels);
 		if (mat2 != mat)
-			mat2.release();
+			mat2.close();
 		return pixels;
 	}
 	
@@ -1261,7 +1261,7 @@ public class OpenCVTools {
 		idx.release();
 		
 		if (mat2 != mat)
-			mat2.release();
+			mat2.close();
 		
 //		assert mat.total() == pixels.length;
 		return pixels;
@@ -1403,7 +1403,7 @@ public class OpenCVTools {
 	    	Mat mat2 = new Mat();
 	        mat.convertTo(mat2, opencv_core.CV_32F);
 	        ImageProcessor ip = matToImageProcessor(mat2);
-	        mat2.release();
+	        mat2.close();
 	        return ip;
 	    }
 	}

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/WandToolCV.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/WandToolCV.java
@@ -318,7 +318,7 @@ public class WandToolCV extends BrushTool {
 		
 		// Ensure we have Mats & the correct channel number
 		if (mat != null && (mat.channels() != nChannels || mat.depth() != opencv_core.CV_8U)) {
-			mat.release();
+			mat.close();
 			mat = null;
 		}
 		if (mat == null || mat.empty())


### PR DESCRIPTION
Aims to fix https://github.com/qupath/qupath/issues/753

Use of Mat.release() seems to be a misunderstanding of how deallocation is handled in JavaCPP/OpenCV (or a throwback to the pre-JavaCPP days). It seems that Indexer.release() is valid, but Mat.release() is unhelpful.

Probably most meaningful change is the use of PointerScope in OpenCVPixelClassifier, since this could result in particularly high memory use.