### PR TITLE
Handle cases where cached Mat may be null

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -971,7 +971,7 @@ public class ImageOps {
 			protected abstract int getOp();
 			
 			private Mat getKernel() {
-				if (kernel == null)
+				if (kernel == null || kernel.isNull())
 					kernel = createDefaultKernel(radius);
 				return kernel;
 			}
@@ -1189,7 +1189,7 @@ public class ImageOps {
 			}
 			
 			private Mat getKernel() {
-				if (kernel == null)
+				if (kernel == null || kernel.isNull())
 					kernel = createDefaultKernel(radius);
 				return kernel;
 			}
@@ -1221,7 +1221,7 @@ public class ImageOps {
 			}
 			
 			private Mat getKernel() {
-				if (kernel == null)
+				if (kernel == null || kernel.isNull())
 					kernel = createDefaultKernel(radius);
 				return kernel;
 			}
@@ -1332,7 +1332,7 @@ public class ImageOps {
 			}
 			
 			private Mat getMatInv() {
-				if (matInv == null) {
+				if (matInv == null || matInv.isNull()) {
 					matInv = new Mat(3, 3, opencv_core.CV_64FC1, Scalar.ZERO);
 					var inv = stains.getMatrixInverse();
 					try (DoubleIndexer idx = matInv.createIndexer()) {

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
@@ -1158,7 +1158,7 @@ public class OpenCVTools {
 		
 		Map<Integer, Mat> cache = doMean ? cachedMeanDisks : cachedSumDisks;
 		Mat kernel = cache.get(radius);
-		if (kernel != null)
+		if (kernel != null && !kernel.isNull())
 			return kernel.clone();
 		kernel = new Mat();
 		

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/WandToolCV.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/WandToolCV.java
@@ -321,7 +321,7 @@ public class WandToolCV extends BrushTool {
 			mat.close();
 			mat = null;
 		}
-		if (mat == null || mat.empty())
+		if (mat == null || mat.isNull() || mat.empty())
 			mat = new Mat(w, w, CV_8UC(nChannels));
 //		if (matMask == null)
 //			matMask = new Mat(w+2, w+2, CV_8U);


### PR DESCRIPTION
This happens when the caching was performed under a PointerScope.