### PR TITLE
Update OpenCV classifiers to use default name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ For full details, see the [Commit log](https://github.com/qupath/qupath/commits/
 ### Bugs fixed
 * Multithreading issue with creation or removal of objects (https://github.com/qupath/qupath/issues/744)
 * Excessive memory use during pixel classification (https://github.com/qupath/qupath/issues/753)
+* Cannot reload a KNN classifier (https://github.com/qupath/qupath/issues/752)
+  * Note! This change means classifiers written with v0.3 cannot be used in v0.2 (but v0.2 classifiers should work in v0.3)
 * *Detect centroid distances 2D* doesn't work on different planes of a z-stack (https://github.com/qupath/qupath/issues/696)
 * Deleting a TMA grid deletes all objects (https://github.com/qupath/qupath/issues/646)
 * *Subcellular detection (experimental)* does't work for z-stacks or images without pixel size information (https://github.com/qupath/qupath/issues/701)


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/752
This means that classifiers written with v0.3 won't work in v0.2 - but classifiers written with v0.2 should still be ok in v0.3.