### PR TITLE
Update image names in both project & server metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ For full details, see the [Commit log](https://github.com/qupath/qupath/commits/
 ### Bugs fixed
 * Multithreading issue with creation or removal of objects (https://github.com/qupath/qupath/issues/744)
 * Excessive memory use during pixel classification (https://github.com/qupath/qupath/issues/753)
+* Measurement export ignores the image name in the project (https://github.com/qupath/qupath/issues/593)
 * *Detect centroid distances 2D* doesn't work on different planes of a z-stack (https://github.com/qupath/qupath/issues/696)
 * Deleting a TMA grid deletes all objects (https://github.com/qupath/qupath/issues/646)
 * *Subcellular detection (experimental)* does't work for z-stacks or images without pixel size information (https://github.com/qupath/qupath/issues/701)

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ServerTools.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ServerTools.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import qupath.lib.common.GeneralTools;
@@ -136,6 +137,25 @@ public class ServerTools {
 			return server.getPath();
 		} else
 			return name;
+	}
+	
+	
+	/**
+	 * Set the name property of the metadata for an {@link ImageServer}.
+	 * @param server the server to update
+	 * @param name the new name to use
+	 * @return true if the metadata was updated, false otherwise (i.e. if the name is unchanged)
+	 */
+	public static boolean setImageName(ImageServer<?> server, String name) {
+		Objects.nonNull(server);
+		Objects.nonNull(name);
+		if (name.equals(server.getMetadata().getName()))
+			return false;
+		var metadata2 = new ImageServerMetadata.Builder(server.getMetadata())
+				.name(name)
+				.build();
+		server.setMetadata(metadata2);
+		return true;
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -64,6 +64,7 @@ import qupath.lib.common.GeneralTools;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.ImageData.ImageType;
 import qupath.lib.images.servers.ImageServer;
+import qupath.lib.images.servers.ServerTools;
 import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
 import qupath.lib.io.GsonTools;
 import qupath.lib.io.PathIO;
@@ -750,6 +751,10 @@ class DefaultProject implements Project<BufferedImage> {
 			
 			if (imageData == null)
 				imageData = new ImageData<>(server);
+			// Ensure the names match
+			var name = getOriginalImageName();
+			if (name != null)
+				ServerTools.setImageName(server, name);
 			imageData.setProperty(IMAGE_ID, getFullProjectEntryID()); // Required to be able to test for the ID later
 			imageData.setChanged(false);
 			return imageData;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -2757,6 +2757,8 @@ public class QuPathGUI {
 	
 	
 	ProjectImageEntry<BufferedImage> getProjectImageEntry(ImageData<BufferedImage> imageData) {
+		if (imageData == null)
+			return null;
 		var project = getProject();
 		return project == null ? null : project.getEntry(imageData);
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SummaryMeasurementTableCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SummaryMeasurementTableCommand.java
@@ -44,7 +44,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.ListChangeListener;
 import javafx.collections.transformation.SortedList;
@@ -179,12 +181,14 @@ public class SummaryMeasurementTableCommand {
 				synchronizeSelectionModelToTable(hierarchy, c, table);
 			}
 		});
-		String displayedName = ServerTools.getDisplayableImageName(imageData.getServer());
-		String name;
-		if (type == null)
-			name = "Results " + displayedName;
-		else
-			name = PathObjectTools.getSuitableName(type, false) + " results - " + displayedName;
+		StringProperty displayedName = new SimpleStringProperty(ServerTools.getDisplayableImageName(imageData.getServer()));
+		var title = Bindings.createStringBinding(() -> {
+			if (type == null)
+				return "Results " + displayedName.get();
+			else
+				return PathObjectTools.getSuitableName(type, false) + " results - " + displayedName.get();			
+		}, displayedName);
+		
 
 		// Handle double-click as a way to center on a ROI
 //		var enter = new KeyCodeCombination(KeyCode.ENTER);
@@ -364,7 +368,7 @@ public class SummaryMeasurementTableCommand {
 
 		Stage frame = new Stage();
 		frame.initOwner(qupath.getStage());
-		frame.setTitle(name);
+		frame.titleProperty().bind(title);
 
 
 		BorderPane paneTable = new BorderPane();
@@ -425,6 +429,8 @@ public class SummaryMeasurementTableCommand {
 					Platform.runLater(() -> hierarchyChanged(event));
 					return;
 				}
+				if (imageData != null)
+					displayedName.set(ServerTools.getDisplayableImageName(imageData.getServer()));
 				model.refreshEntries();
 				table.refresh();
 				if (histogramDisplay != null)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -135,7 +135,8 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		builderMap.clear();
 		
 		// Add the image name
-		builderMap.put("Image", new ImageNameMeasurementBuilder(imageData));
+		if (!PathPrefs.maskImageNamesProperty().get())
+			builderMap.put("Image", new ImageNameMeasurementBuilder(imageData));
 				
 		// Check if we have any annotations / TMA cores
 		boolean containsDetections = false;
@@ -1302,8 +1303,9 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 			if (imageData == null)
 				return null;
 			var hierarchy = imageData.getHierarchy();
-			if (PathObjectTools.hierarchyContainsObject(hierarchy, pathObject))
+			if (PathObjectTools.hierarchyContainsObject(hierarchy, pathObject)) {
 				return imageData.getServer().getMetadata().getName();
+			}
 			return null;
 		}
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
@@ -187,7 +187,7 @@ public class SelectedMeasurementTableView implements PathObjectSelectionListener
 		tableModel.setImageData(this.imageData, getSelectedObjectList());
 		tableMeasurements.getItems().setAll(tableModel.getAllNames());
 		
-//		tableMeasurements.refresh();
+		tableMeasurements.refresh();
 		
 //		// Check if objects are outside hierarchy
 //		if (imageData != null) {


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/593
When the image name is set for an image open in the viewer, the metadata is update immediately. Otherwise, the name is set only in the project (as before) and update in the server as entry.readImageData() is called.
Potentially, getting an image some other way (i.e. via a serverBuilder) could fail to give the updated name.