### PR TITLE
Publish to scijava maven

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,18 @@
-# This workflow will publish jars to GitHub Packages.
+# This workflow will publish jars to maven.scijava.org.
 # Currently, it must be triggered manually and uses Java 11
 # (because there is no requirement for jpackage).
 
-name: Publish to GitHub Packages
+name: Publish to SciJava Maven
 
-on: [workflow_dispatch]
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
@@ -21,4 +22,5 @@ jobs:
       - name: Publish package
         run: ./gradlew publish -P toolchain=11
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USER: ${{ secrets.MAVEN_USER }}
+          MAVEN_PASS: ${{ secrets.MAVEN_PASS }}

--- a/buildSrc/src/main/groovy/qupath.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.publishing-conventions.gradle
@@ -1,17 +1,20 @@
 publishing {
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/qupath/qupath")
+            name = "SciJava"
+            def releasesRepoUrl = uri("https://maven.scijava.org/content/repositories/releases")
+            def snapshotsRepoUrl = uri("https://maven.scijava.org/content/repositories/snapshots")
+            // Use gradle -Prelease publish
+            url = project.hasProperty('release') ? releasesRepoUrl : snapshotsRepoUrl
             credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
+                username = System.getenv("MAVEN_USER")
+                password = System.getenv("MAVEN_PASS")
             }
         }
     }
 
     publications {
-        gpr(MavenPublication) {
+        mavenJava(MavenPublication) {
             groupId = 'io.github.qupath'
             from components.java
 


### PR DESCRIPTION
See https://forum.image.sc/t/which-maven-repository-for-qupath/53622
Attempting to replace GitHub Packages, because of the token trouble it causes for consumers.