### PR TITLE
Fix command line troubles

### DIFF
--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -68,6 +68,7 @@ import qupath.lib.images.servers.ImageServerProvider;
 import qupath.lib.images.servers.ImageServers;
 import qupath.lib.projects.Project;
 import qupath.lib.projects.ProjectIO;
+import qupath.lib.scripting.QP;
 
 /**
  * Main QuPath launcher.
@@ -297,9 +298,13 @@ class ScriptCommand implements Runnable {
 			// Ensure we have a tile cache set
 			createTileCache();
 			
+			// Unfortunately necessary to force initialization (including GsonTools registration of some classes)
+			QP.getCoreClasses();
+			
 			ImageData<BufferedImage> imageData;
 			
 			if (projectPath != null && !projectPath.equals("")) {
+								
 				String path = QuPath.getEncodedPath(projectPath);
 				Project<BufferedImage> project = ProjectIO.loadProject(new File(path), BufferedImage.class);
 				for (var entry: project.getImageList()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
@@ -26,6 +26,7 @@ package qupath.lib.gui;
 import java.awt.Desktop;
 import java.awt.Desktop.Action;
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -67,16 +68,20 @@ public class QuPathApp extends Application {
 		String imagePath = namedParams.getOrDefault("image", unnamed);
 		
 		if (projectPath != null) {
-			var uri = GeneralTools.toURI(projectPath);
-			var project = ProjectIO.loadProject(uri, BufferedImage.class);
-			gui.setProject(project);
-			// If the project is specified, try to open the named image within the project
-			if (imagePath != null) {
-				var entry = project.getImageList().stream().filter(p -> imagePath.equals(p.getImageName())).findFirst().orElse(null);
-				if (entry == null) {
-					logger.warn("No image found in project with name {}", imagePath);
-				} else
-					gui.openImageEntry(entry);
+			try {
+				var uri = GeneralTools.toURI(projectPath);
+				var project = ProjectIO.loadProject(uri, BufferedImage.class);
+				gui.setProject(project);
+				// If the project is specified, try to open the named image within the project
+				if (imagePath != null) {
+					var entry = project.getImageList().stream().filter(p -> imagePath.equals(p.getImageName())).findFirst().orElse(null);
+					if (entry == null) {
+						logger.warn("No image found in project with name {}", imagePath);
+					} else
+						gui.openImageEntry(entry);
+				}
+			} catch (IOException e2) {
+				logger.error("Unable to open project {}", projectPath, e2);
 			}
 		} else if (imagePath != null) {
 			gui.openImage(imagePath, false, false);


### PR DESCRIPTION
Fixes exception thrown when trying to run a script for a project, and avoids catastrophic failure (inability to start up) if a project is specified that isn't available.