### PR TITLE
Allow logging level to be specified through preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ For full details, see the [Commit log](https://github.com/qupath/qupath/commits/
 * Better validation when entering numeric values in text fields
 * BufferedImageOverlays are now tied to the the pixel classification display setting (rather than the detection display)
 * Bio-Formats now optionally accepts URLs, not only local files (requires opt-in through the preferences)
+* Specify the logging level for the current QuPath session through the preferences, e.g. to emit extra debugging messages
+  * Log files are now turned off by default; this can be changed in the preferences if a QuPath user directory is set
 
 ### Code changes
 * Revised PathClass code to be more strict with invalid class names & prevent accidentally calling the constructor (please report any related bugs!)

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -762,7 +762,11 @@ public class QP {
 		PathObjectHierarchy hierarchy = getCurrentHierarchy();
 		if (hierarchy == null)
 			return null;
-		return hierarchy.getSelectionModel().getSelectedObject();
+		var selected = hierarchy.getSelectionModel().getSelectedObject();
+		if (selected == null && !hierarchy.getSelectionModel().noSelection())
+			logger.debug("getSelectedObject() is null because there is no primary selected object, "
+					+ "you might want getSelectedObjects() instead");
+		return selected;
 	}
 	
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -46,6 +46,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.paint.Color;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.dialogs.Dialogs;
+import qupath.lib.gui.logging.LogManager;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.prefs.PathPrefs.FontSize;
 import qupath.lib.gui.prefs.PathPrefs.ImageTypeSetting;
@@ -142,6 +143,10 @@ public class PreferencePane {
 				category,
 				"Create log files when using QuPath inside the QuPath user directory (useful for debugging & reporting errors)");
 		
+		addPropertyPreference(LogManager.rootLogLevelProperty(), LogManager.LogLevel.class, "Log level", category,
+				"Logging level, which determines the number of logging messages.\n"
+				+ "It is recommended to use only INFO or DEBUG; more frequent logging (e.g. TRACE, ALL) will likely cause performance issues.");
+
 		addPropertyPreference(PathPrefs.numCommandThreadsProperty(), Integer.class,
 				"Number of processors for parallel commands",
 				category,
@@ -161,7 +166,7 @@ public class PreferencePane {
 				"Command bar display mode",
 				category,
 				"Mode used to display command finder text field on top of the viewer");
-
+		
 		addPropertyPreference(PathPrefs.showExperimentalOptionsProperty(), Boolean.class,
 				"Show experimental menu items",
 				category,

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -572,7 +572,7 @@ public class PathPrefs {
 	}
 	
 	
-	private static BooleanProperty doCreateLogFilesProperty = createPersistentPreference("requestCreateLogFiles", true);
+	private static BooleanProperty doCreateLogFilesProperty = createPersistentPreference("requestCreateLogFiles", false);
 
 	/**
 	 * Request a log file to be generated.  Requires the <code>userPathProperty()</code> to be set to a directory.


### PR DESCRIPTION
Also turn off logging to a file by default.
Add debug level message if getSelectedObject() returns null but getSelectedObjects() does not, in reference to https://github.com/qupath/qupath/issues/758