### PR TITLE
Support qupath.prefs.name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ For full details, see the [Commit log](https://github.com/qupath/qupath/commits/
 * Bio-Formats now optionally accepts URLs, not only local files (requires opt-in through the preferences)
 * Specify the logging level for the current QuPath session through the preferences, e.g. to emit extra debugging messages
   * Log files are now turned off by default; this can be changed in the preferences if a QuPath user directory is set
+* Optionally use `qupath.prefs.name` system property to use a different preferences location, enabling multiple QuPath installations to have distinct preferences
 
 ### Code changes
 * Revised PathClass code to be more strict with invalid class names & prevent accidentally calling the constructor (please report any related bugs!)
@@ -76,6 +77,7 @@ For full details, see the [Commit log](https://github.com/qupath/qupath/commits/
 * New ImageOps for reducing channels
 * `ImageOps.Normalize.percentiles` now warns if normalization values are equal; fixed exception if choosing '100'
 * When building from source with TensorFlow support, now uses TensorFlow Java 0.3.1 (corresponding to TensorFlow v2.4.1)
+* Default number of threads is now based upon `ForkJoinPool.getCommonPoolParallelism()`
 
 ### Bugs fixed
 * Multithreading issue with creation or removal of objects (https://github.com/qupath/qupath/issues/744)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -107,7 +107,7 @@ public class PathPrefs {
 		} else
 			NODE_NAME = DEFAULT_NODE_NAME;
 		
-		System.err.println("Common pool parallelism: " + ForkJoinPool.getCommonPoolParallelism());
+		logger.debug("Common ForkJoinPool parallelism: {}", ForkJoinPool.getCommonPoolParallelism());
 	}
 
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -38,6 +38,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Locale.Category;
+import java.util.concurrent.ForkJoinPool;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.InvalidPreferencesFormatException;
 import java.util.prefs.Preferences;
@@ -77,10 +78,37 @@ import qupath.lib.projects.ProjectIO;
  */
 public class PathPrefs {
 	
+	private static Logger logger = LoggerFactory.getLogger(PathPrefs.class);
+	
+	/**
+	 * Allow preference node name to be specified in system property.
+	 * This is especially useful for debugging without using the same user directory.
+	 */
+	private final static String PROP_PREFS = "qupath.prefs.name";
+	
+//	private final static String PROP_USER_PATH = "qupath.path.user";
+	
+	
+	/**
+	 * Default name for preference node in this QuPath version
+	 */
+	private final static String DEFAULT_NODE_NAME = "io.github.qupath/0.3";
+	
 	/**
 	 * Name for preference node
 	 */
-	private final static String NODE_NAME = "io.github.qupath/0.3";
+	private final static String NODE_NAME;
+	
+	static {
+		var name = System.getProperty(PROP_PREFS);
+		if (name != null && !name.isBlank()) {
+			logger.info("Setting preference node to {}", name);
+			NODE_NAME = name;
+		} else
+			NODE_NAME = DEFAULT_NODE_NAME;
+		
+		System.err.println("Common pool parallelism: " + ForkJoinPool.getCommonPoolParallelism());
+	}
 
 	/**
 	 * Previous preference node, in case these need to be restored.
@@ -88,8 +116,6 @@ public class PathPrefs {
 	 */
 	@SuppressWarnings("unused")
 	private final static String PREVIOUS_NODE_NAME = "io.github.qupath.0.2.0";
-
-	private static Logger logger = LoggerFactory.getLogger(PathPrefs.class);
 	
 	/**
 	 * Flag used to trigger when properties should be reset to their default values.
@@ -137,7 +163,7 @@ public class PathPrefs {
 
 	private static StringProperty scriptsPath = createPersistentPreference("scriptsPath", (String)null); // Base directory containing scripts
 	
-	private static IntegerProperty numCommandThreads = createPersistentPreference("Requested number of threads", Runtime.getRuntime().availableProcessors());
+	private static IntegerProperty numCommandThreads = createPersistentPreference("Requested number of threads", ForkJoinPool.getCommonPoolParallelism());
 	
 	/**
 	 * Property specifying the preferred number of threads QuPath should use for multithreaded commands.


### PR DESCRIPTION
This allows multiple QuPath instances to use different preferences.
Also set default parallelism to use ForkJoinPool.getCommonPoolParallelism(), since this can be controlled with the 'java.util.concurrent.ForkJoinPool.common.parallelism' property.