### PR TITLE
Much improved concurrency & memory use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Release highlights
 * **New 'Create density map' command** to visualize hotspots & generate annotations based on object densities
-* **_Many_ code fixes** & **performance improvements**
+* **_Many_ code fixes** & **performance improvements** - especially for pixel classification
 * **Revised code structure**, with non-core features now separated out as optional **extensions**, including:
   * **OMERO**
     * https://github.com/qupath/qupath-extension-omero
@@ -78,6 +78,7 @@ For full details, see the [Commit log](https://github.com/qupath/qupath/commits/
 * `ImageOps.Normalize.percentiles` now warns if normalization values are equal; fixed exception if choosing '100'
 * When building from source with TensorFlow support, now uses TensorFlow Java 0.3.1 (corresponding to TensorFlow v2.4.1)
 * Default number of threads is now based upon `ForkJoinPool.getCommonPoolParallelism()`
+  * `ThreadTools` can be used to get requested number of threads within core modules, controlled via `PathPrefs`
 
 ### Bugs fixed
 * Multithreading issue with creation or removal of objects (https://github.com/qupath/qupath/issues/744)

--- a/qupath-core-processing/src/main/java/qupath/lib/analysis/heatmaps/DensityMaps.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/analysis/heatmaps/DensityMaps.java
@@ -469,8 +469,9 @@ public class DensityMaps {
 	 * @param threshold threshold value
 	 * @param options additional objects when creating the annotations
 	 * @return true if changes were made, false otherwise
+	 * @throws IOException 
 	 */
-	public static boolean threshold(PathObjectHierarchy hierarchy, ImageServer<BufferedImage> densityServer, int channel, double threshold, CreateObjectOptions... options) {
+	public static boolean threshold(PathObjectHierarchy hierarchy, ImageServer<BufferedImage> densityServer, int channel, double threshold, CreateObjectOptions... options) throws IOException {
 		var pathClassName = densityServer.getChannel(channel).getName();
 		return threshold(hierarchy, densityServer, Map.of(channel, threshold), pathClassName, options);
 	}
@@ -484,8 +485,9 @@ public class DensityMaps {
 	 * @param pathClassName name of the classification to apply to the generated annotations
 	 * @param options additional options to customize how annotations are created
 	 * @return true if changes were made, false otherwise
+	 * @throws IOException 
 	 */
-	public static boolean threshold(PathObjectHierarchy hierarchy, ImageServer<BufferedImage> densityServer, Map<Integer, ? extends Number> thresholds, String pathClassName, CreateObjectOptions... options) {
+	public static boolean threshold(PathObjectHierarchy hierarchy, ImageServer<BufferedImage> densityServer, Map<Integer, ? extends Number> thresholds, String pathClassName, CreateObjectOptions... options) throws IOException {
 
 		// Apply threshold to densities
 		PathClass lessThan = PathClassFactory.getPathClass(StandardPathClasses.IGNORE);

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -3334,10 +3334,11 @@ public class QP {
 	 * @param thresholds map between channels to threshold (zero-based index) and thresholds to apply
 	 * @param pathClassName name of the classification for the annotations that will be created
 	 * @param options additional options when creating the annotations
+	 * @throws IOException 
 	 * @see #loadDensityMap(String)
 	 * @see CreateObjectOptions
 	 */
-	public static void createAnnotationsFromDensityMap(String densityMapName, Map<Integer, ? extends Number> thresholds, String pathClassName, String... options) {
+	public static void createAnnotationsFromDensityMap(String densityMapName, Map<Integer, ? extends Number> thresholds, String pathClassName, String... options) throws IOException {
 		createAnnotationsFromDensityMap(getCurrentImageData(), densityMapName, thresholds, pathClassName, options);
 	}
 	
@@ -3349,10 +3350,11 @@ public class QP {
 	 * @param thresholds map between channels to threshold (zero-based index) and thresholds to apply
 	 * @param pathClassName name of the classification for the annotations that will be created
 	 * @param options additional options when creating the annotations
+	 * @throws IOException 
 	 * @see #loadDensityMap(String)
 	 * @see CreateObjectOptions
 	 */
-	public static void createAnnotationsFromDensityMap(ImageData<BufferedImage> imageData, String densityMapName, Map<Integer, ? extends Number> thresholds, String pathClassName, String... options) {
+	public static void createAnnotationsFromDensityMap(ImageData<BufferedImage> imageData, String densityMapName, Map<Integer, ? extends Number> thresholds, String pathClassName, String... options) throws IOException {
 		var densityMap = loadDensityMap(densityMapName);
 		createAnnotationsFromDensityMap(imageData, densityMap, thresholds, pathClassName, parseEnumOptions(CreateObjectOptions.class, null, options));
 	}
@@ -3365,10 +3367,11 @@ public class QP {
 	 * @param thresholds map between channels to threshold (zero-based index) and thresholds to apply
 	 * @param pathClassName name of the classification for the annotations that will be created
 	 * @param options additional options when creating the annotations
+	 * @throws IOException 
 	 * @see #loadDensityMap(String)
 	 * @see CreateObjectOptions
 	 */
-	public static void createAnnotationsFromDensityMap(ImageData<BufferedImage> imageData, DensityMapBuilder densityMap, Map<Integer, ? extends Number> thresholds, String pathClassName, CreateObjectOptions... options) {
+	public static void createAnnotationsFromDensityMap(ImageData<BufferedImage> imageData, DensityMapBuilder densityMap, Map<Integer, ? extends Number> thresholds, String pathClassName, CreateObjectOptions... options) throws IOException {
 		var densityServer = densityMap.buildServer(imageData);
 		DensityMaps.threshold(imageData.getHierarchy(), densityServer, thresholds, pathClassName, options);
 	}
@@ -3435,10 +3438,12 @@ public class QP {
 	 * @param minArea the minimum area of connected regions to retain
 	 * @param minHoleArea the minimum area of connected 'hole' regions to retain
      * @param options additional options to control how objects are created
+	 * @throws IOException 
+	 * @throws IllegalArgumentException 
 	 * @see #loadPixelClassifier(String)
 	 */
 	public static void createDetectionsFromPixelClassifier(
-			String classifierName, double minArea, double minHoleArea, String... options) {
+			String classifierName, double minArea, double minHoleArea, String... options) throws IllegalArgumentException, IOException {
 		createDetectionsFromPixelClassifier(loadPixelClassifier(classifierName), minArea, minHoleArea, options);
 	}
 
@@ -3450,9 +3455,10 @@ public class QP {
 	 * @param minArea the minimum area of connected regions to retain
 	 * @param minHoleArea the minimum area of connected 'hole' regions to retain
      * @param options additional options to control how objects are created
+	 * @throws IOException 
 	 */
 	public static void createDetectionsFromPixelClassifier(
-			PixelClassifier classifier, double minArea, double minHoleArea, String... options) {
+			PixelClassifier classifier, double minArea, double minHoleArea, String... options) throws IOException {
 		var imageData = (ImageData<BufferedImage>)getCurrentImageData();
 		PixelClassifierTools.createDetectionsFromPixelClassifier(imageData, classifier, minArea, minHoleArea, parseEnumOptions(CreateObjectOptions.class, null, options));
 	}
@@ -3466,10 +3472,12 @@ public class QP {
 	 * @param minArea the minimum area of connected regions to retain
 	 * @param minHoleArea the minimum area of connected 'hole' regions to retain
      * @param options additional options to control how objects are created
+	 * @throws IOException 
+	 * @throws IllegalArgumentException 
 	 * @see #loadPixelClassifier(String)
 	 */
 	public static void createAnnotationsFromPixelClassifier(
-			String classifierName, double minArea, double minHoleArea, String... options) {
+			String classifierName, double minArea, double minHoleArea, String... options) throws IllegalArgumentException, IOException {
 		createAnnotationsFromPixelClassifier(loadPixelClassifier(classifierName), minArea, minHoleArea, options);
 	}
 
@@ -3481,9 +3489,10 @@ public class QP {
 	 * @param minArea the minimum area of connected regions to retain
 	 * @param minHoleArea the minimum area of connected 'hole' regions to retain
      * @param options additional options to control how objects are created
+	 * @throws IOException 
 	 */
 	public static void createAnnotationsFromPixelClassifier(
-			PixelClassifier classifier, double minArea, double minHoleArea, String... options) {
+			PixelClassifier classifier, double minArea, double minHoleArea, String... options) throws IOException {
 		var imageData = (ImageData<BufferedImage>)getCurrentImageData();
 		PixelClassifierTools.createAnnotationsFromPixelClassifier(imageData, classifier, minArea, minHoleArea, parseEnumOptions(CreateObjectOptions.class, null, options));
 	}

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/OpenCVPixelClassifier.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/OpenCVPixelClassifier.java
@@ -93,10 +93,12 @@ class OpenCVPixelClassifier implements PixelClassifier {
     @Override
     public BufferedImage applyClassification(final ImageData<BufferedImage> imageData, final RegionRequest request) throws IOException {
     	
+//    	logger.debug("Before: \n" + OpenCVTools.memoryReport(", "));
+    	
     	try (@SuppressWarnings("unchecked")
 		var scope = new PointerScope()) {
 	    	var matResult = getOp().apply(imageData, request);
-	    	
+
 	    	var type = getMetadata().getOutputType();
 	    	ColorModel colorModelLocal = null;
 	    	if (type == ImageServerMetadata.ChannelType.PROBABILITY) {
@@ -108,10 +110,12 @@ class OpenCVPixelClassifier implements PixelClassifier {
 	        // Create & return BufferedImage
 	        BufferedImage imgResult = OpenCVTools.matToBufferedImage(matResult, colorModelLocal);
 	
-	        // Free matrix
-	        matResult.close();
-	        
+	        // Return memory as quickly as we can
+	        scope.deallocate();
 	        return imgResult;
+    	} finally {
+//        	System.gc(); // Shouldn't be needed if deallocate is used?
+//    		logger.debug("After: \n" + OpenCVTools.memoryReport(", "));
     	}
     }
     

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
@@ -130,10 +130,11 @@ public class PixelClassifierTools {
      * @param minHoleArea the minimum area of connected 'hole' regions to retain
      * @param options additional options to control how objects are created
      * @return true if changes were made to the hierarchy, false otherwise
+	 * @throws IOException 
 	 */
     public static boolean createDetectionsFromPixelClassifier(
 			PathObjectHierarchy hierarchy, ImageServer<BufferedImage> classifierServer, 
-			double minArea, double minHoleArea, CreateObjectOptions... options) {
+			double minArea, double minHoleArea, CreateObjectOptions... options) throws IOException {
 		var selected = hierarchy.getSelectionModel().getSelectedObjects();
 		if (selected.isEmpty())
 			selected = Collections.singleton(hierarchy.getRootObject());
@@ -155,9 +156,10 @@ public class PixelClassifierTools {
      * @param minHoleArea the minimum area of connected 'hole' regions to retain
      * @param options additional options to control how objects are created
      * @return true if changes were made to the hierarchy, false otherwise
+     * @throws IOException 
      */
     public static boolean createDetectionsFromPixelClassifier(
-			ImageData<BufferedImage> imageData, PixelClassifier classifier, double minArea, double minHoleArea, CreateObjectOptions... options) {
+			ImageData<BufferedImage> imageData, PixelClassifier classifier, double minArea, double minHoleArea, CreateObjectOptions... options) throws IOException {
 		return createDetectionsFromPixelClassifier(
 				imageData.getHierarchy(),
 				createPixelClassificationServer(imageData, classifier),
@@ -176,11 +178,12 @@ public class PixelClassifierTools {
      * @param options additional options to control how objects are created
 	 * 
 	 * @return true if the command ran successfully to completion, false otherwise.
+	 * @throws IOException 
 	 * @see GeometryTools#refineAreas(Geometry, double, double)
 	 */
 	public static boolean createObjectsFromPredictions(
 			ImageServer<BufferedImage> server, PathObjectHierarchy hierarchy, Collection<PathObject> selectedObjects, 
-			Function<ROI, ? extends PathObject> creator, double minArea, double minHoleArea, CreateObjectOptions... options) {
+			Function<ROI, ? extends PathObject> creator, double minArea, double minHoleArea, CreateObjectOptions... options) throws IOException {
 		
 		if (selectedObjects.isEmpty())
 			return false;
@@ -274,9 +277,10 @@ public class PixelClassifierTools {
      * @param minHoleArea the minimum area of connected 'hole' regions to retain
      * @param options additional options to control how objects are created
      * @return true if changes were made to the hierarchy, false otherwise
+	 * @throws IOException 
      */
 	public static boolean createAnnotationsFromPixelClassifier(
-			ImageData<BufferedImage> imageData, PixelClassifier classifier, double minArea, double minHoleArea, CreateObjectOptions... options) {
+			ImageData<BufferedImage> imageData, PixelClassifier classifier, double minArea, double minHoleArea, CreateObjectOptions... options) throws IOException {
 		return createAnnotationsFromPixelClassifier(
 				imageData.getHierarchy(),
 				createPixelClassificationServer(imageData, classifier),
@@ -295,9 +299,10 @@ public class PixelClassifierTools {
      * @param minHoleArea the minimum area of connected 'hole' regions to retain
      * @param options additional options to control how objects are created
      * @return true if changes were made to the hierarchy, false otherwise
+	 * @throws IOException 
 	 */
 	public static boolean createAnnotationsFromPixelClassifier(
-			PathObjectHierarchy hierarchy, ImageServer<BufferedImage> classifierServer, double minArea, double minHoleArea, CreateObjectOptions... options) {
+			PathObjectHierarchy hierarchy, ImageServer<BufferedImage> classifierServer, double minArea, double minHoleArea, CreateObjectOptions... options) throws IOException {
 		var selected = hierarchy.getSelectionModel().getSelectedObjects();
 		if (selected.isEmpty())
 			selected = Collections.singleton(hierarchy.getRootObject());
@@ -346,6 +351,7 @@ public class PixelClassifierTools {
 	 * @param minHoleArea minimum area for a hole to fill, in calibrated units based on the pixel calibration
      * @param doSplit if true, split connected regions into separate objects
 	 * @return the objects created within the ROI
+	 * @throws IOException 
 	 */
 	public static Collection<PathObject> createObjectsFromPixelClassifier(
 			ImageServer<BufferedImage> server,
@@ -353,7 +359,7 @@ public class PixelClassifierTools {
 			ROI roi, 
 			Function<ROI, ? extends PathObject> creator, 
 			double minArea, double minHoleArea, 
-			boolean doSplit) {
+			boolean doSplit) throws IOException {
 		
 		// We need classification labels to do anything
 		if (labels == null)

--- a/qupath-core-processing/src/test/java/qupath/opencv/ml/pixel/TestPixelClassifierTools.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/ml/pixel/TestPixelClassifierTools.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferByte;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -166,7 +167,7 @@ class TestPixelClassifierTools {
 	}
 	
 	
-	private void checkCreateObjects(ImageServer<BufferedImage> server, int[] hist, Map<PathClass, Integer> classificationLabelsReverse) {
+	private void checkCreateObjects(ImageServer<BufferedImage> server, int[] hist, Map<PathClass, Integer> classificationLabelsReverse) throws IOException {
 		var hierarchy = new PathObjectHierarchy();
 		boolean success = PixelClassifierTools.createObjectsFromPredictions(
 				server,
@@ -201,7 +202,7 @@ class TestPixelClassifierTools {
 		
 	}
 	
-	private void checkCreateObjectsSplit(ImageServer<BufferedImage> server, int[] hist, Map<PathClass, Integer> classificationLabelsReverse) {
+	private void checkCreateObjectsSplit(ImageServer<BufferedImage> server, int[] hist, Map<PathClass, Integer> classificationLabelsReverse) throws IOException {
 		var hierarchy = new PathObjectHierarchy();
 		boolean success = PixelClassifierTools.createObjectsFromPredictions(
 				server,

--- a/qupath-core/src/main/java/qupath/lib/common/ThreadTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ThreadTools.java
@@ -23,8 +23,12 @@
 
 package qupath.lib.common;
 
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Create a thread factory that supports adding a prefix to the name and setting daemon status.
@@ -35,6 +39,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  */
 public class ThreadTools {
+	
+	private final static Logger logger = LoggerFactory.getLogger(ThreadTools.class);
+	
+	private static int requestedThreads = ForkJoinPool.getCommonPoolParallelism();
 	
 	/**
 	 * Create a named thread factory with a specified priority.
@@ -58,6 +66,30 @@ public class ThreadTools {
 	public static ThreadFactory createThreadFactory(String prefix, boolean daemon) {
 		return createThreadFactory(prefix, daemon, Thread.NORM_PRIORITY);
 	}
+	
+	/**
+	 * Set the requested level of parallelism.
+	 * Note that for interactive use this is usually set through the user interface and shouldn't be modified 
+	 * elsewhere to maintain consistency.
+	 * @param nThreads
+	 */
+	public static void setParallelism(int nThreads) {
+		if (nThreads <= 0)
+			throw new IllegalArgumentException("Number of threads must be >= 1, but requested number is " + nThreads);
+		logger.info("Setting parallelism to {}", nThreads);
+		requestedThreads = nThreads;
+	}
+	
+	/**
+	 * Get the requested level of parallelism. 
+	 * Other classes that make use of thread pools can use this to help balance multithreading with memory use.
+	 * The default value is {@link ForkJoinPool#getCommonPoolParallelism()}.
+	 * @return
+	 */
+	public static int getParallelism() {
+		return requestedThreads;
+	}
+	
 	
 	
 	static class SimpleThreadFactory implements ThreadFactory {

--- a/qupath-core/src/main/java/qupath/lib/plugins/AbstractPluginRunner.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/AbstractPluginRunner.java
@@ -55,10 +55,10 @@ public abstract class AbstractPluginRunner<T> implements PluginRunner<T> {
 	
 	final private static Logger logger = LoggerFactory.getLogger(AbstractPluginRunner.class);
 
-	private static int numThreadsRequested = Runtime.getRuntime().availableProcessors();
 	private static int counter = 0;
 
-	private static ExecutorService pool;
+//	private static ExecutorService pool;
+	private ExecutorService pool;
 	private ExecutorCompletionService<Runnable> service;
 
 	private Map<Future<Runnable>, Runnable> pendingTasks = Collections.synchronizedMap(new HashMap<>());
@@ -67,56 +67,6 @@ public abstract class AbstractPluginRunner<T> implements PluginRunner<T> {
 	
 	private boolean tasksCancelled = false;
 	
-	/**
-	 * Set the number of threads requested to be used for the next threadpool created.
-	 * <p>
-	 * The request is stored as-is, but may be adjusted if it is outside a valid range, i.e. &gt; 0 and &lt;= available processors.
-	 * 
-	 * @see #getNumThreadsRequested
-	 * @see #getNumThreads
-	 * 
-	 * @param n
-	 */
-	public synchronized static void setNumThreadsRequested(int n) {
-		if (numThreadsRequested == n)
-			return;
-		numThreadsRequested = n;
-		// Need to shutdown the pool for this to take effect
-		if (pool != null)
-			pool.shutdown();
-	}
-	
-	/**
-	 * Get the number of threads requested.  This isn't necessarily the number that will be used for the next threadpool,
-	 * since it may be &lt;= 0 or &gt; the available processors.
-	 * 
-	 * @see #setNumThreadsRequested
-	 * @see #getNumThreads
-	 * 
-	 * @return
-	 */
-	public synchronized static int getNumThreadsRequested() {
-		return numThreadsRequested;
-	}
-	
-	/**
-	 * Get the number of threads that will actually be used the next time a threadpool is constructed.
-	 * <p>
-	 * If getNumProcessorsRequested() returns a value between 1 and Runtime.getRuntime().availableProcessors() then this 
-	 * is used.  Otherwise, Runtime.getRuntime().availableProcessors() is used.
-	 * <p>
-	 * This implementation may change (most likely to increase the upper limit, if it turns out to be too strict.)
-	 * 
-	 * @see #setNumThreadsRequested
-	 * @see #getNumThreadsRequested
-	 * 
-	 * @return
-	 */
-	public synchronized static int getNumThreads() {
-		int max = Runtime.getRuntime().availableProcessors();
-		return numThreadsRequested <= 0 || numThreadsRequested > max ? max : numThreadsRequested;
-	}
-
 	protected abstract SimpleProgressMonitor makeProgressMonitor();
 	
 	/* (non-Javadoc)
@@ -139,7 +89,7 @@ public abstract class AbstractPluginRunner<T> implements PluginRunner<T> {
 		
 		// Ensure we have a pool
 		if (pool == null || pool.isShutdown()) {
-			int n = getNumThreads();
+			int n = ThreadTools.getParallelism();
 			pool = Executors.newFixedThreadPool(n, ThreadTools.createThreadFactory("plugin-runner-"+(+counter)+"-", false));
 			logger.debug("New threadpool created with {} threads", n);
 			service = new ExecutorCompletionService<>(pool);

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapUI.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapUI.java
@@ -623,7 +623,7 @@ public class DensityMapUI {
 					if (densityMapName != null) {
 						imageData.getHistoryWorkflow().addStep(
 								new DefaultScriptableWorkflowStep("Density map find hotspots",
-										String.format("findDensityMapHotspots(\"%s\", %d, %d, %f, $s, %s)",
+										String.format("findDensityMapHotspots(\"%s\", %d, %d, %f, %s, %s)",
 												densityMapName,
 												band, numHotspots,
 												minDensity, deleteExisting, peaksOnly)
@@ -830,7 +830,12 @@ public class DensityMapUI {
 			
 			var pathClassName = densityServer.getChannel(0).getName();
 			
-			DensityMaps.threshold(imageData.getHierarchy(), densityServer, thresholds, pathClassName, options.toArray(CreateObjectOptions[]::new));
+			try {
+				DensityMaps.threshold(imageData.getHierarchy(), densityServer, thresholds, pathClassName, options.toArray(CreateObjectOptions[]::new));
+			} catch (IOException e1) {
+				Dialogs.showErrorMessage(title, e1);
+				return;
+			}
 			
 			if (densityMapName != null) {
 				String optionsString = "";

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierUI.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierUI.java
@@ -87,6 +87,8 @@ import qupath.opencv.ml.pixel.PixelClassifierTools.CreateObjectOptions;
 public class PixelClassifierUI {
 	
 	private final static Logger logger = LoggerFactory.getLogger(PixelClassifierUI.class);
+	
+	private final static String title = "Pixel classifier";
 
 	/**
 	 * Create a {@link ComboBox} that can be used to select the pixel classification region filter.
@@ -196,7 +198,7 @@ public class PixelClassifierUI {
 				.labelText("Classifier name")
 				.tooltip(tooltipText)
 				.savedName(savedName)
-				.title("Pixel classifier")
+				.title(title)
 				.build();
 	}
 	
@@ -368,34 +370,38 @@ public class PixelClassifierUI {
 		if (!options.isEmpty())
 			optionsString = ", " + options.stream().map(o -> "\"" + o.name() + "\"").collect(Collectors.joining(", "));
 
-		if (createDetections) {
-			if (PixelClassifierTools.createDetectionsFromPixelClassifier(imageData, classifier, minSize, minHoleSize, optionsArray)) {
-				if (classifierName != null) {
-					imageData.getHistoryWorkflow().addStep(
-							new DefaultScriptableWorkflowStep("Pixel classifier create detections",
-									String.format("createDetectionsFromPixelClassifier(\"%s\", %s, %s)",
-											classifierName,
-											minSize,
-											minHoleSize + optionsString)
-									)
-							);
+		try {
+			if (createDetections) {
+				if (PixelClassifierTools.createDetectionsFromPixelClassifier(imageData, classifier, minSize, minHoleSize, optionsArray)) {
+					if (classifierName != null) {
+						imageData.getHistoryWorkflow().addStep(
+								new DefaultScriptableWorkflowStep("Pixel classifier create detections",
+										String.format("createDetectionsFromPixelClassifier(\"%s\", %s, %s)",
+												classifierName,
+												minSize,
+												minHoleSize + optionsString)
+										)
+								);
+					}
+					return true;
 				}
-				return true;
-			}
-		} else {
-			if (PixelClassifierTools.createAnnotationsFromPixelClassifier(imageData, classifier, minSize, minHoleSize, optionsArray)) {
-				if (classifierName != null) {
-					imageData.getHistoryWorkflow().addStep(
-							new DefaultScriptableWorkflowStep("Pixel classifier create annotations",
-									String.format("createAnnotationsFromPixelClassifier(\"%s\", %s, %s)",
-											classifierName,
-											minSize,
-											minHoleSize + optionsString)
-									)
-							);
+			} else {
+				if (PixelClassifierTools.createAnnotationsFromPixelClassifier(imageData, classifier, minSize, minHoleSize, optionsArray)) {
+					if (classifierName != null) {
+						imageData.getHistoryWorkflow().addStep(
+								new DefaultScriptableWorkflowStep("Pixel classifier create annotations",
+										String.format("createAnnotationsFromPixelClassifier(\"%s\", %s, %s)",
+												classifierName,
+												minSize,
+												minHoleSize + optionsString)
+										)
+								);
+					}
+					return true;
 				}
-				return true;
 			}
+		} catch (IOException e) {
+			Dialogs.showErrorMessage(title, e);
 		}
 		return false;
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -226,7 +226,6 @@ import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.objects.hierarchy.TMAGrid;
-import qupath.lib.plugins.AbstractPluginRunner;
 import qupath.lib.plugins.PathInteractivePlugin;
 import qupath.lib.plugins.PathPlugin;
 import qupath.lib.plugins.parameters.ParameterList;
@@ -836,10 +835,6 @@ public class QuPathGUI {
 		
 		// Create preferences panel
 		prefsPane = new PreferencePane();
-		
-		// Set the number of threads at an early stage...
-		AbstractPluginRunner.setNumThreadsRequested(PathPrefs.numCommandThreadsProperty().get());
-		PathPrefs.numCommandThreadsProperty().addListener(o -> AbstractPluginRunner.setNumThreadsRequested(PathPrefs.numCommandThreadsProperty().get()));
 		
 		// Activate the log at an early stage
 		// TODO: NEED TO TURN ON LOG!

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
@@ -325,7 +325,7 @@ class ProjectImportImagesCommand {
 				
 				// Limit the size of the thread pool
 				// The previous use of a cached thread pool caused trouble when importing may large, non-pyramidal images
-				var pool = Executors.newFixedThreadPool(PathPrefs.numCommandThreadsProperty().get(), ThreadTools.createThreadFactory("project-import", true));
+				var pool = Executors.newFixedThreadPool(ThreadTools.getParallelism(), ThreadTools.createThreadFactory("project-import", true));
 //				var pool = Executors.newCachedThreadPool(ThreadTools.createThreadFactory("project-import", true));
 				List<Future<List<ServerBuilder<BufferedImage>>>> results = new ArrayList<>();
 				List<ProjectImageEntry<BufferedImage>> projectImages = new ArrayList<>();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -64,6 +64,7 @@ import javafx.collections.ListChangeListener.Change;
 import javafx.collections.ObservableList;
 import qupath.lib.common.ColorTools;
 import qupath.lib.common.GeneralTools;
+import qupath.lib.common.ThreadTools;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.projects.ProjectIO;
 
@@ -107,7 +108,7 @@ public class PathPrefs {
 		} else
 			NODE_NAME = DEFAULT_NODE_NAME;
 		
-		logger.debug("Common ForkJoinPool parallelism: {}", ForkJoinPool.getCommonPoolParallelism());
+		logger.debug("Common ForkJoinPool parallelism: {}", ThreadTools.getParallelism());
 	}
 
 	/**
@@ -164,6 +165,19 @@ public class PathPrefs {
 	private static StringProperty scriptsPath = createPersistentPreference("scriptsPath", (String)null); // Base directory containing scripts
 	
 	private static IntegerProperty numCommandThreads = createPersistentPreference("Requested number of threads", ForkJoinPool.getCommonPoolParallelism());
+	
+	static {
+		numCommandThreads.addListener((v, o, n) -> {
+			int threads = n.intValue();
+			if (threads > 0)
+				ThreadTools.setParallelism(threads);
+			else
+				logger.warn("Cannot set parallelism to {}", threads);
+		});
+		// Make sure initialized
+		int threads = numCommandThreads.get();
+		if (threads > 0)
+			ThreadTools.setParallelism(numCommandThreads.get());	}
 	
 	/**
 	 * Property specifying the preferred number of threads QuPath should use for multithreaded commands.


### PR DESCRIPTION
Major improvements when using pixel classification (and some other commands) through:
- More frequent use of PointerScope to keep memory in check
- New ThreadTools methods to set/get parallel threads, so this value is accessible within core modules
- Multithreading within ContourTracing uses ThreadTools value to enable memory use to be better controlled (rather than a parallel stream, which could get out of control)
- ContourTracing also now parallelized geometry manipulations whenever applying multiple thresholds to an ImageServer

Much of this prompted by @MarkZaidi's benchmarking thread at https://forum.image.sc/t/designing-a-qupath-workstation/54849

Along the way, a small bug fix to DensityMaps scripting.