### PR TITLE
LabeledImageServer updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ For full details, see the [Commit log](https://github.com/qupath/qupath/commits/
 * `GeneralTools.readAsString` methods now assume UTF-8 encoding
 * `PixelClassificationOverlay` has moved to the main GUI module
 * Scripting method `getColorRGB()` has been replaced by `makeRBG()` and `makeARGB()`; further related changes in ColorTools class
+* `LabeledImageServer.Builder.useInstanceLabels()` method replaces `useUniqueLabels()`, improved performance
 * StarDist supports frozen models that are compatible with OpenCV's DNN module
 * New 2D/3D thinning & interpolation classes
 * New ImageOps for reducing channels

--- a/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
+++ b/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import qupath.lib.awt.common.BufferedImageTools;
 import qupath.lib.common.GeneralTools;
+import qupath.lib.common.ThreadTools;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.LabeledImageServer;
@@ -432,7 +433,7 @@ public class TileExporter  {
 				extLabeled = serverLabeled.getMetadata().getChannelType() == ChannelType.CLASSIFICATION ? ".png" : ".tif";
 		}
 
-		var pool = Executors.newWorkStealingPool(4);
+		var pool = Executors.newFixedThreadPool(ThreadTools.getParallelism(), ThreadTools.createThreadFactory("tile-exporter", true));
 
 		var server = this.server;
 		var labeledServer = serverLabeled;
@@ -459,6 +460,8 @@ public class TileExporter  {
 			logger.warn("No regions to export!");
 			return;
 		}
+		if (requests.size() > 1)
+			logger.info("Exporting {} tiles", requests.size());
 		
 		String imageName = GeneralTools.stripInvalidFilenameChars(
 				GeneralTools.getNameWithoutExtension(server.getMetadata().getName())


### PR DESCRIPTION
useInstanceLabels() replaces useUniqueLabels(), and new getInstanceLabels() method can be used to query labels later.
Improved performance when working with large numbers of objects and better parallelization.