### PR TITLE
Fix density map thread interruption bug

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapDialog.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapDialog.java
@@ -577,6 +577,11 @@ public class DensityMapDialog {
 				if (alphaCountBand > 0 || autoUpdateSomething) {
 					try {
 						minMax = DensityMapUI.getMinMax(densityMapServer);
+						// This can happen if the density map is replaced too quickly, so min/max calculations aren't performed
+						if (minMax == null) {
+							logger.debug("Min/max calculation interrupted!");
+							return;
+						}
 					} catch (IOException e) {
 						logger.warn("Error setting display ranges: " + e.getLocalizedMessage(), e);
 					}


### PR DESCRIPTION
Recover when going wild with the 'radius' slider and generating density maps