### PR TITLE
Stain vector updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ For full details, see the [Commit log](https://github.com/qupath/qupath/commits/
   * Log files are now turned off by default; this can be changed in the preferences if a QuPath user directory is set
 * Optionally use `qupath.prefs.name` system property to use a different preferences location, enabling multiple QuPath installations to have distinct preferences
 * Provide optional launch scripts and `-Pld-path=true` Gradle options for Linux to set LD_LIBRARY_PATH and work around pixman problems (https://github.com/qupath/qupath/issues/628)
+* When setting stain vectors, do not overwrite the last workflow step if it was also used to set stain vectors
+  * This makes it possible to go back to earlier stains if needed
 
 ### Code changes
 * Revised PathClass code to be more strict with invalid class names & prevent accidentally calling the constructor (please report any related bugs!)

--- a/qupath-core/src/main/java/qupath/lib/images/ImageData.java
+++ b/qupath-core/src/main/java/qupath/lib/images/ImageData.java
@@ -315,9 +315,10 @@ public class ImageData<T> implements WorkflowListener, PathObjectHierarchyListen
 				map,
 				"setColorDeconvolutionStains(\'" + arg + "');");
 		
-		if (lastStep != null && commandName.equals(lastStep.getName()))
-			imageData.getHistoryWorkflow().replaceLastStep(newStep);
-		else
+//		if (lastStep != null && commandName.equals(lastStep.getName()))
+//			imageData.getHistoryWorkflow().replaceLastStep(newStep);
+//		else
+		if (!Objects.equals(newStep, lastStep))
 			imageData.getHistoryWorkflow().addStep(newStep);
 
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
@@ -169,11 +169,17 @@ class EstimateStainVectorsCommand {
 			return;
 		}
 		if (!stains.equals(stainsUpdated)) {
-			String name = stainsUpdated.getName();
-			String newName = Dialogs.showInputDialog(TITLE, "Set name for stain vectors", name);
+			String suggestedName;
+			String collectiveNameBefore = stainsUpdated.getName();
+			if (collectiveNameBefore.endsWith("default"))
+				suggestedName = collectiveNameBefore.substring(0, collectiveNameBefore.lastIndexOf("default")) + "estimated";
+			else
+				suggestedName = collectiveNameBefore;
+			
+			String newName = Dialogs.showInputDialog(TITLE, "Set name for stain vectors", suggestedName);
 			if (newName == null)
 				return;
-			if (!name.equals(newName) && !newName.trim().isEmpty())
+			if (!newName.isBlank())
 				stainsUpdated = stainsUpdated.changeName(newName);
 			imageData.setColorDeconvolutionStains(stainsUpdated);
 		}


### PR DESCRIPTION
Do not overwrite the last workflow step when setting stain vectors multiple times in a row. This is to address a recent workshop confusion in which it wasn't possible to restore previous values.
Also update the default stain names when using 'Estimate stain vectors'.