### PR TITLE
Default build with Java 11

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,12 +15,12 @@
 
      steps:
      - uses: actions/checkout@v2
-     - name: Set up JDK 16
+     - name: Set up JDK 11
        uses: actions/setup-java@v2
        with:
-         java-version: '16'
+         java-version: '11'
          distribution: 'adopt-hotspot'
      - name: Grant execute permission for gradlew
        run: chmod +x gradlew
      - name: Build with Gradle
-       run: ./gradlew build
+       run: ./gradlew build -P toolchain=11

--- a/buildSrc/src/main/groovy/qupath.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.java-conventions.gradle
@@ -86,3 +86,13 @@ if (!strictJavadoc) {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
 }
+
+
+/*
+ * On Apple Silicon (at least), there are problems running tests involving JavaCPP 1.5.5 with 
+ * java.lang.OutOfMemoryError: Physical memory usage is too high: physicalBytes (1028M) > maxPhysicalBytes (1024M)
+ * https://github.com/bytedeco/javacpp/issues/468
+ */
+test {
+  maxHeapSize = '2G'
+}

--- a/qupath-core/src/main/java/qupath/lib/common/UriUpdater.java
+++ b/qupath-core/src/main/java/qupath/lib/common/UriUpdater.java
@@ -299,10 +299,10 @@ public class UriUpdater<T extends UriResource> {
 	public Collection<SingleUriItem> getItems(UriStatus status) {
 		if (status == null)
 			return Collections.unmodifiableCollection(items);
-		return items.stream().filter(i -> i.getStatus() == status).toList();
+		return items.stream().filter(i -> i.getStatus() == status).collect(Collectors.toList());
 	}
 
-
+	
 
 	private static int updateReplacementsRelative(Collection<SingleUriItem> items, Path pathPrevious, Path pathBase, Map<SingleUriItem, SingleUriItem> replacements) {
 
@@ -367,7 +367,7 @@ public class UriUpdater<T extends UriResource> {
 		for (var item : uriResources) {
 			imageUris.addAll(item.getUris());
 		}
-		return imageUris.stream().map(u -> new SingleUriItem(u)).toList();
+		return imageUris.stream().map(u -> new SingleUriItem(u)).collect(Collectors.toList());
 	}
 
 

--- a/qupath-core/src/test/java/qupath/lib/io/TypeAdaptersCVTest.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TypeAdaptersCVTest.java
@@ -44,13 +44,12 @@ public class TypeAdaptersCVTest {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void testGetOpenCVTypeAdaptorFactory() {
+	public void testMats() {
 		
 		var gson = new GsonBuilder()
 				.registerTypeAdapterFactory(OpenCVTypeAdapters.getOpenCVTypeAdaptorFactory())
 				.create();
 
-		
 		try (PointerScope scope = new PointerScope()) {
 			
 			// Check writing/reading a Mat
@@ -65,6 +64,20 @@ public class TypeAdaptersCVTest {
 			var sparseMatRead = gson.fromJson(jsonSparse, SparseMat.class);
 			
 			assertTrue(matEquals(sparseMatOrig, sparseMatRead));
+			
+		}
+		
+	}
+		
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testStatModels() {
+
+		var gson = new GsonBuilder()
+				.registerTypeAdapterFactory(OpenCVTypeAdapters.getOpenCVTypeAdaptorFactory())
+				.create();
+		
+		try (PointerScope scope = new PointerScope()) {
 
 			// Create a model with some non-default parameters
 			var model = EM.create();
@@ -92,6 +105,23 @@ public class TypeAdaptersCVTest {
 			assertEquals(nClusters, modelRead2.getClustersNumber());
 			assertEquals(nIterations, modelRead2.getTermCriteria().maxCount());
 			
+			
+		}
+			
+	}
+	
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testSizeAndScalars() {
+		
+		var gson = new GsonBuilder()
+				.registerTypeAdapterFactory(OpenCVTypeAdapters.getOpenCVTypeAdaptorFactory())
+				.create();
+
+		
+		try (PointerScope scope = new PointerScope()) {
+
 			// Test scalar
 			var scalarArray = new double[] {1.1, 2.2, 3.3, 4.4};
 			for (int n = 0; n <= 4; n++) {
@@ -122,7 +152,6 @@ public class TypeAdaptersCVTest {
 				assertEquals(size.width(), size2.width());
 				assertEquals(size.height(), size2.height());
 			}
-			
 			
 		}
 	}


### PR DESCRIPTION
Remove accidental use of Java 16 Stream.toList() and update Action to catch such problems earlier.
Increase available memory for testing to avoid errors on Apple Silicon.