### PR TITLE
Made 'input display dialog' command a selectable item

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
@@ -764,7 +764,7 @@ class Menus {
 		@ActionDescription("Show mouse clicks and keypresses on screen. "
 				+ "This is particularly useful for demos and tutorials.")
 		@ActionMenu("Show input display")
-		public final Action INPUT_DISPLAY = createAction(() -> Commands.showInputDisplay(qupath));
+		public final Action INPUT_DISPLAY = createSelectableCommandAction(qupath.showInputDisplayProperty());
 
 		@ActionDescription("Show a dialog to track memory usage within QuPath, and clear the cache if required.")
 		@ActionMenu("Show memory monitor")

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -174,6 +174,7 @@ import qupath.lib.gui.ActionTools.ActionIcon;
 import qupath.lib.gui.commands.BrightnessContrastCommand;
 import qupath.lib.gui.commands.Commands;
 import qupath.lib.gui.commands.CountingPanelCommand;
+import qupath.lib.gui.commands.InputDisplayCommand;
 import qupath.lib.gui.commands.LogViewerCommand;
 import qupath.lib.gui.commands.ProjectCommands;
 import qupath.lib.gui.commands.TMACommands;
@@ -354,6 +355,7 @@ public class QuPathGUI {
 	private BooleanProperty scriptRunning = new SimpleBooleanProperty(false);
 	private BooleanBinding uiBlocked = pluginRunning.or(scriptRunning);
 	
+	private SimpleBooleanProperty showInputDisplayProperty = new SimpleBooleanProperty(false);
 	
 	/**
 	 * Create an {@link Action} that depends upon an {@link ImageData}.
@@ -382,6 +384,14 @@ public class QuPathGUI {
 	 */
 	BooleanProperty pluginRunningProperty() {
 		return pluginRunning;
+	}
+	
+	/**
+	 * Property to indicate whether the input display is currently showing
+	 * @return input display property
+	 */
+	public BooleanProperty showInputDisplayProperty() {
+		return showInputDisplayProperty;
 	}
 	
 	
@@ -926,6 +936,17 @@ public class QuPathGUI {
 		// Remove this to only accept drag-and-drop into a viewer
 		dragAndDrop.setupTarget(scene);
 		TMACommands.installDragAndDropHandler(this);
+		
+		
+		// Add listener to the inputDisplayDialogProperty to show/hide dialog
+		showInputDisplayProperty.addListener((v, o, n) -> {
+			var dialogInstance = InputDisplayCommand.getInstance(this);
+			if (n)
+				dialogInstance.show();
+			else {
+				dialogInstance.requestClose();
+			}
+		});
 		
 		stage.setOnCloseRequest(e -> {
 			

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -940,12 +940,11 @@ public class QuPathGUI {
 		
 		// Add listener to the inputDisplayDialogProperty to show/hide dialog
 		showInputDisplayProperty.addListener((v, o, n) -> {
-			var dialogInstance = InputDisplayCommand.getInstance(this);
+			var dialogInstance = InputDisplayCommand.getInstance(getStage(), showInputDisplayProperty);
 			if (n)
 				dialogInstance.show();
-			else {
+			else
 				dialogInstance.requestClose();
-			}
 		});
 		
 		stage.setOnCloseRequest(e -> {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -560,23 +560,6 @@ public class Commands {
 		scriptInterpreter.getStage().show();
 	}
 	
-	
-	/**
-	 * Create and show a new input display dialog.
-	 * <p>
-	 * This makes input such as key-presses and mouse button presses visible on screen, and is therefore
-	 *  useful for demos and tutorials where shortcut keys are used.
-	 *  
-	 * @param qupath the QuPath instance
-	 */
-	public static void showInputDisplay(QuPathGUI qupath) {
-		try {
-			new InputDisplayDialog(qupath.getStage()).show();
-		} catch (Exception e) {
-			Dialogs.showErrorMessage("Error showing input display", e);
-		}
-	}
-	
 	/**
 	 * Create a window summarizing license information for QuPath and its third party dependencies.
 	 * @param qupath the current QuPath instance


### PR DESCRIPTION
- Made 'input display dialog' command a 'selectable' item (ticked/not ticked).
- Restricted the amount of input display dialogs to 1.

Spurred by #799 .