### PR TITLE
Improved 'Find' in Script Editor

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -2467,6 +2467,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 		
 		private Dialog<Void> dialog;
 		private TextField tfFind = new TextField();
+		private ButtonType btNext = new ButtonType("Next");
 		
 		@Override
 		public void run() {
@@ -2474,6 +2475,15 @@ public class DefaultScriptEditor implements ScriptEditor {
 				createFindDialog();
 			dialog.show();
 			tfFind.requestFocus();
+			
+			// If some text is selected in the main text component, use it as search query
+			var selectedText = getCurrentTextComponent().getSelectedText();
+			if (!selectedText.isEmpty())
+				tfFind.setText(selectedText);
+			
+			// If search is already set, focus on 'Next'
+			if (!tfFind.getText().isEmpty())
+				((Button)dialog.getDialogPane().lookupButton(btNext)).requestFocus();
 		}
 		
 		private void createFindDialog() {
@@ -2482,7 +2492,6 @@ public class DefaultScriptEditor implements ScriptEditor {
 			dialog.initOwner(DefaultScriptEditor.this.dialog);
 			dialog.initModality(Modality.NONE);
 			
-			ButtonType btNext = new ButtonType("Next");
 			ButtonType btPrevious = new ButtonType("Previous");
 			ButtonType btClose = new ButtonType("Close", ButtonData.CANCEL_CLOSE);
 			dialog.getDialogPane().getButtonTypes().setAll(btPrevious, btNext, btClose);


### PR DESCRIPTION
Tiny changes to ease coding with the script editor:
1. If some text in the script editor is selected, it will automatically use it as query to search when hitting `Ctrl + F`/`CMD + F`.
2. If some text is already present in the search `TextField` when opening the search dialog, the 'Next' button will have the focus (meaning that the user can directly hit `Enter` to look for the next match) 