### PR TITLE
ImageOps and pixel classification updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,10 @@ For full details, see the [Commit log](https://github.com/qupath/qupath/commits/
   * Export objects as GeoJSON without via *File > Object data... > ...*
   * Import objects from .json, .geojson & .qpdata files via *File > Object data... > Import objects* or with drag & drop
 * Pixel classifier usability improvements
+  * Set number of threads for live prediction (under 'Advanced options' during training, or the vertical ellipsis button when loading a previous classifier)
   * New 'Show as text' option to check classifier parameters
   * Switch between pixel classifiers & density maps by bringing the corresponding window into focus
+  * Perform live prediction starting from the center of the field of view or image
 * Script editor improvements
   * New 'Auto clear cache (batch processing)' option to reduce memory use when running scripts across many images
   * Default to project script directory when choosing a location to save a new script

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnTools.java
@@ -158,6 +158,7 @@ public class DnnTools {
 			for (int i = 0; i < n; i++) {
 				var bkend = backends.first(i);
 				var target = backends.second(i);
+				logger.trace("Available backend {}, target {}", bkend, target);
 				if (bkend == opencv_dnn.DNN_BACKEND_CUDA && target == opencv_dnn.DNN_TARGET_CUDA) {
 					logger.info("CUDA detected and will be used if possible. Use DnnTools.setUseCuda(false) to turn this off.");
 					cudaAvailable = true;
@@ -175,6 +176,24 @@ public class DnnTools {
 			logger.debug("CUDA is not available (OpenCV not compiled with CUDA support)");			
 		}
 	}
+	
+	
+	/**
+	 * Temp method to help debugging through scripts.
+	 * Likely to be replaced in the future with a proper public API to allow the backend to be set, 
+	 * however, this may require new enums (rather than OpenCV's ints) for ease of use 
+	 * and better compatibility checks.
+	 */
+	static void logAvailableBackends() {
+		var backends = opencv_dnn.getAvailableBackends();
+		long n = backends.size();
+		for (int i = 0; i < n; i++) {
+			var bkend = backends.first(i);
+			var target = backends.second(i);
+			logger.info("Available backend {}, target {}", bkend, target);
+		}
+	}
+	
 
 	/**
 	 * Query whether CUDA is reported as available by OpenCV.

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -41,7 +41,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.math3.util.FastMath;
-import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerScope;
 import org.bytedeco.javacpp.indexer.DoubleIndexer;
 import org.bytedeco.javacpp.indexer.FloatIndexer;
@@ -72,7 +71,6 @@ import qupath.lib.regions.Padding;
 import qupath.lib.regions.RegionRequest;
 import qupath.opencv.dnn.DnnModel;
 import qupath.opencv.dnn.DnnShape;
-import qupath.opencv.dnn.OpenCVDnn;
 import qupath.opencv.dnn.PredictionFunction;
 import qupath.opencv.ml.FeaturePreprocessor;
 import qupath.opencv.ml.OpenCVClassifiers.OpenCVStatModel;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MiniViewers.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MiniViewers.java
@@ -427,17 +427,19 @@ public class MiniViewers {
 //				Platform.runLater(() -> updateViewers());
 //				return;
 //			}
-			// Update mouse position if we are synchronizing
-			mousePosition = mainViewer.getMousePosition();
-			if (mousePosition != null) {
-				mainViewer.componentPointToImagePoint(mousePosition, mousePosition, false);
-				if (synchronizeToMainViewer.get() && !shiftDown.get())
-					centerPosition.setLocation(mousePosition);
+			if (this.pane != null && this.pane.isVisible()) {
+				// Update mouse position if we are synchronizing
+				mousePosition = mainViewer.getMousePosition();
+				if (mousePosition != null) {
+					mainViewer.componentPointToImagePoint(mousePosition, mousePosition, false);
+					if (synchronizeToMainViewer.get() && !shiftDown.get())
+						centerPosition.setLocation(mousePosition);
+				}
+	
+				// Repaint all viewers
+				for (MiniViewer viewer : miniViewers)
+					viewer.repaint();
 			}
-
-			// Repaint all viewers
-			for (MiniViewer viewer : miniViewers)
-				viewer.repaint();
 			requestUpdate = false;
 		}
 		


### PR DESCRIPTION
* Further reduce memory use with ImageOps / ImageDataOp
* Fix multithreading ImageOps color deconvolution bug
* Allow the number of live prediction threads to be adjusted with pixel classifiers
* Reduce the length of the server path used with pixel classifiers (could cause performance issues for some classifiers, e.g. Trees, with long JSON representations)
* Add extra checks in DelaunayTools to reduce risk of trying to access a coordinate that isn't there