### PR TITLE
Update location text when navigating with keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This is a *minor release* that aims to be fully compatible with v0.3.0 while fix
 
 List of bugs fixed:
 * Up arrow can cause viewer to move beyond nSlices for Z-stack (https://github.com/qupath/qupath/issues/821)
+* Location text does not update when navigating with keyboard (https://github.com/qupath/qupath/issues/819)
 
 
 ## Version 0.3.0

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
@@ -310,6 +310,12 @@ public class QuPathViewerPlus extends QuPathViewer {
 	private boolean useCalibratedLocationString() {
 		return useCalibratedLocationString.get();
 	}
+	
+	@Override
+	protected void updateAffineTransform() {
+		super.updateAffineTransform();
+		updateLocationString();
+	}
 
 	@Override
 	void paintCanvas() {
@@ -330,11 +336,6 @@ public class QuPathViewerPlus extends QuPathViewer {
 		}
 	}
 
-	@Override
-	public void setDownsampleFactor(double downsampleFactor, double cx, double cy) {
-		super.setDownsampleFactor(downsampleFactor, cx, cy);
-		updateLocationString();
-	}
 	
 	@Override
 	public void repaintEntireImage() {


### PR DESCRIPTION
Trigger update to location text with any viewer movement, not just a change of downsample factor.
Fixes https://github.com/qupath/qupath/issues/819