### PR TITLE
Added predicate parameter to Measurement Exporter

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementExporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementExporter.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -137,6 +137,7 @@ public class MeasurementExporter {
 	 * Filter the {@code PathObject}s before export (objects returning {@code true} for the predicate will be exported).
 	 * @param filter
 	 * @return this exporter
+	 * @since v0.3.2
 	 */
 	public MeasurementExporter filter(Predicate<PathObject> filter) {
 		this.filter = filter;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementExporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementExporter.java
@@ -63,9 +63,9 @@ public class MeasurementExporter {
 	
 	private final static Logger logger = LoggerFactory.getLogger(MeasurementExporter.class);
 	
-	private List<String> includeOnlyColumns = new ArrayList<String>();
-	private List<String> excludeColumns = new ArrayList<String>();
-	private Predicate<PathObject> filter = obj -> true;
+	private List<String> includeOnlyColumns = new ArrayList<>();
+	private List<String> excludeColumns = new ArrayList<>();
+	private Predicate<PathObject> filter;
 	
 	// Default: Exporting annotations
 	private Class<? extends PathObject> type = PathRootObject.class;
@@ -211,9 +211,9 @@ public class MeasurementExporter {
 	public void exportMeasurements(OutputStream stream) {
 		long startTime = System.currentTimeMillis();
 		
-		Map<ProjectImageEntry<?>, String[]> imageCols = new HashMap<ProjectImageEntry<?>, String[]>();
-		Map<ProjectImageEntry<?>, Integer> nImageEntries = new HashMap<ProjectImageEntry<?>, Integer>();
-		List<String> allColumns = new ArrayList<String>();
+		Map<ProjectImageEntry<?>, String[]> imageCols = new HashMap<>();
+		Map<ProjectImageEntry<?>, Integer> nImageEntries = new HashMap<>();
+		List<String> allColumns = new ArrayList<>();
 		Multimap<String, String> valueMap = LinkedListMultimap.create();
 		String pattern = "(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)";
 		
@@ -221,7 +221,10 @@ public class MeasurementExporter {
 			try {
 				ImageData<?> imageData = entry.readImageData();
 				ObservableMeasurementTableData model = new ObservableMeasurementTableData();
-				Collection<PathObject> pathObjects = imageData == null ? Collections.emptyList() : imageData.getHierarchy().getObjects(null, type).parallelStream().filter(filter).collect(Collectors.toList());
+				Collection<PathObject> pathObjects = imageData == null ? Collections.emptyList() : imageData.getHierarchy().getObjects(null, type);
+				if (filter != null)
+					pathObjects = pathObjects.stream().filter(filter).collect(Collectors.toList());
+				
 				model.setImageData(imageData, pathObjects);
 				List<String> data = SummaryMeasurementTableCommand.getTableModelStrings(model, separator, excludeColumns);
 				


### PR DESCRIPTION
Users can now add this parameter to the measurement exporter builder:
```
.filter(obj -> obj.getPathClass() == getPathClass("Tumor"))
```

to filter the path objects that will be exported (in this example, only the path class with 'Tumor' class will be exported).

N.B.: the filter indicates what should be kept, *not* filtered out.