### PR TITLE
Small enhancement that enables Delete or backspace key in the AnnotationPane

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
@@ -52,6 +52,7 @@ import javafx.scene.control.SelectionMode;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.input.KeyCode;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
@@ -432,10 +433,18 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 	 * @return
 	 */
 	public PathObjectHierarchy getHierarchy() {
-		ImageData<BufferedImage> temp = imageDataProperty.get();
+		ImageData<BufferedImage> temp = getImageData();
 		return temp == null ? null : temp.getHierarchy();
 	}
 	
+	/**
+	 * Get the image data currently being displayed within thie viewer.
+	 * @return
+	 */
+	public ImageData<BufferedImage> getImageData() {
+		return imageDataProperty.getValue();
+	}
+
 	class KeyEventHandler implements EventHandler<KeyEvent> {
 
 		private KeyCode lastPressed = null;


### PR DESCRIPTION
Hi 

I just thought this might be useful to others too. I found myself pressing the "Del" key to delete annotation in the annotation pane. As a workaround pressing the Delete button or clicking in the viewer and pressing the "Del" key. 

This change allows to use the key too. Code was copied over and slightly modified from the viewer code.

Best
Thomas

