### PR TITLE
Include measurements when creating annotations from imported GeoJSON data

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
@@ -435,12 +435,12 @@ class PathObjectTypeAdapters {
 			case ("annotation"):
 			case ("unknown"):
 				// Default is to create an annotation
-				pathObject = PathObjects.createAnnotationObject(roi, pathClass);
+				pathObject = PathObjects.createAnnotationObject(roi, pathClass, measurementList);
 				break;
 			default:
 				// Should be called if the type has been specified as *something*, but not something we recognize
 				logger.warn("Unknown object type {}, I will create an annotation", type);
-				pathObject = PathObjects.createAnnotationObject(roi, pathClass);
+				pathObject = PathObjects.createAnnotationObject(roi, pathClass, measurementList);
 			}
 			if (name != null)
 				pathObject.setName(name);


### PR DESCRIPTION
### Reason for change

- Previously, only 'detections' supported importing measurements from GeoJSON, as the `measurementList` is ignored for annotations
- This fixes this, allowing measurements to be imported from a GeoJSON file

### Changes

- Measurements are now not ignored when creating annotations
- Before this, measurements were fetched but not actually used in `PathObjects.createAnnotationObject`
- This does not change behaviour when the `measurements` array is not provided for a feature
  - `measurementList` is `null` initially, and only populated if `measurements` is in the GeoJSON
  - The previous code didn't pass in any list, which calls the overloaded `PathObjects.createAnnotationObject`, which just returns `createAnnotationObject(roi, pathClass, null);` anyway
  - This means code-flow is unchanged if `measurements` are not provided

### Images

#### Custom measurements extracted from GeoJSON:
![image](https://user-images.githubusercontent.com/38670946/139694740-375af432-4cd4-4e56-90f6-57dd7be8970d.png)
![image](https://user-images.githubusercontent.com/38670946/139695945-1d0af088-ff6a-4287-8951-e3fe81f3c59f.png)

### Testing

- Works perfectly fine with GeoJSON files that create annotations both with and without a `measurements` field
- Example GeoJSON file I used for testing: https://pastebin.com/trYDYLXM
  - Tested this file with and without the `measurements`
