### PR TITLE
Revert to creating new PathPlugin each time plugin is launched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 This is a *minor release* that aims to be fully compatible with v0.3.0 while fixing bugs.
 
 List of bugs fixed:
+* 'Add intensity features' does not reinitialize options (including channels) when new images are opened (https://github.com/qupath/qupath/issues/836)
 * Up arrow can cause viewer to move beyond nSlices for Z-stack (https://github.com/qupath/qupath/issues/821)
 * Location text does not update when navigating with keyboard (https://github.com/qupath/qupath/issues/819)
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -3585,8 +3585,15 @@ public class QuPathGUI {
 	 */
 	private static Action createPluginAction(final String name, final Class<? extends PathPlugin> pluginClass, final QuPathGUI qupath, final String arg) {
 		try {
-			PathPlugin<BufferedImage> plugin = qupath.createPlugin(pluginClass);
-			var action = qupath.createPluginAction(name, plugin, arg);
+			var action = new Action(name, event -> {
+				try {
+					PathPlugin<BufferedImage> plugin = qupath.createPlugin(pluginClass);
+					qupath.runPlugin(plugin, arg, true);
+				} catch (Exception e) {
+					logger.error("Error running " + name + ": " + e.getLocalizedMessage(), e);
+				}
+			});
+			// We assume that plugins require image data
 			action.disabledProperty().bind(qupath.noImageData);
 			ActionTools.parseAnnotations(action, pluginClass);
 			return action;


### PR DESCRIPTION
This is intended to fix the intensity features bug #836

Creating a new PathPlugin each time the action was invoked was the default behavior in v0.1.2: https://github.com/qupath/qupath/blob/v0.1.2/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java#L3013

Creating the PathPlugin earlier & then reusing it seems to be a regression introduced in v0.3 around a3b0c21
While harmless most of the time, it can cause problems - particularly with the intensity measurement command.