### PR TITLE
Refactored ProjectBrowser

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
@@ -661,12 +661,10 @@ class ProjectImportImagesCommand {
 	 */
 	static ProjectImageEntry<BufferedImage> initializeEntry(ProjectImageEntry<BufferedImage> entry, ImageType type, boolean pyramidalizeSingleResolution, boolean importObjects) throws Exception {
 		try (ImageServer<BufferedImage> server = entry.getServerBuilder().build()) {
-			var img = getThumbnailRGB(server, null);
 			// Set the image name
 			String name = ServerTools.getDisplayableImageName(server);
 			entry.setImageName(name);
-			// Write a thumbnail if we can
-			entry.setThumbnail(img);
+			// The thumbnail generation has been moved to ProjectBrowser to avoid overhead
 			
 			// Pyramidalize this if we need to
 			@SuppressWarnings("resource")

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -1363,7 +1363,11 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 					// Fetch the thumbnail or generate it if not present
 					BufferedImage img = entry.getThumbnail();
 					if (img != null) {
-						logger.warn("Recalculating: " + entry + " \t\t\t" + entryCell);
+						
+						// If the cell contains the same object, no need to repaint the graphic
+						if (entryCell == entry && getGraphic() != null)
+							return;
+						
 						Image image = SwingFXUtils.toFXImage(img, null);
 						viewTooltip.setImage(image);
 						tooltip.setGraphic(viewTooltip);
@@ -1371,7 +1375,6 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 						entryCell = entry;
 						if (getGraphic() == null)
 							setGraphic(label);
-						tree.refresh();
 					} else {
 						executor.submit(() -> {
 							final ProjectImageEntry<BufferedImage> entryTemp = (ProjectImageEntry<BufferedImage>)getItem();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectObject.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectObject.java
@@ -1,0 +1,194 @@
+package qupath.lib.gui.panes;
+
+import java.awt.image.BufferedImage;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import qupath.lib.projects.Project;
+import qupath.lib.projects.ProjectImageEntry;
+
+/**
+ * Abstract class to represent all different objects that can go into a Project browser's tree.
+ * @author Melvin Gelbard
+ */
+abstract class ProjectObject {
+	
+	/**
+	 * Types of possible {@code ProjectObject}s.
+	 */
+	public enum Type {
+		/**
+		 * Either the {@code Project} or a String displaying 'No Project'.
+		 */
+		ROOT,
+		
+		/**
+		 * Tags associated with {@code ProjectImageEntry}s.
+		 */
+		METADATA,
+		
+		/**
+		 * {@code ProjectImageEntry}s.
+		 */
+		IMAGE
+	}
+	
+	/**
+	 * String that will be used to display the object ({@code setText()}.
+	 * @return displayableString
+	 */
+	abstract String getDisplayableString();
+	
+	/**
+	 * Return the type of ProjectObject this object represents.
+	 * <p>
+	 * E.g. {@code ROOT}, {@code TAG}, etc..
+	 * @return type
+	 */
+	abstract Type getType();
+	
+	/**
+	 * Get all the {@link ProjectImageEntry} objects inside the specified collection.
+	 * @param imageRows
+	 * @return collection of ProjectImageEntry 
+	 */
+	static Collection<ProjectImageEntry<BufferedImage>> getEntries(Collection<ImageRow> imageRows) {
+		return imageRows.stream().map(row -> row.getEntry()).collect(Collectors.toList());
+	}
+
+	/**
+	 * Get the {@link #ProjectImageEntry} corresponding to the specified {@link #ProjectObject}.
+	 * <p>
+	 * If the specified object is not an {@link ImageRow} (e.g. {@link MetadataRow}), return {@code null}.
+	 * @param projectObject
+	 * @return
+	 */
+	static ProjectImageEntry<BufferedImage> getEntry(ProjectObject projectObject) {
+		if (projectObject.getType() == Type.IMAGE)
+			return ((ImageRow)projectObject).getEntry();
+		return null;
+	}
+	
+	/**
+	 * Object representing the root of the TreeView in {@link ProjectBrowser}. Either a 'No project' String or the project (name).
+	 */
+	static class RootRow extends ProjectObject {
+
+		private Project<?> project;
+		private String originalString;
+
+		RootRow(Project<?> project) {
+			this.originalString = project == null ? "No project" : project.getName();
+			this.project = project;
+		}
+
+		@Override
+		String getDisplayableString() {
+			return originalString;
+		}
+
+		@Override
+		Type getType() {
+			return Type.ROOT;
+		}
+		@Override
+		public int hashCode() {
+			return Objects.hash(project);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			RootRow other = (RootRow) obj;
+			return Objects.equals(project, other.project);
+		}
+	}
+	
+	/**
+	 * Object representing a metadata row in the TreeView in {@link ProjectBrowser}. Represented as Strings.
+	 */
+	static class MetadataRow extends ProjectObject {
+	
+		private String originalString;
+		
+		MetadataRow(String value) {
+			this.originalString = value;
+		}
+
+		@Override
+		String getDisplayableString() {
+			return originalString;
+		}
+		
+		@Override
+		Type getType() {
+			return Type.METADATA;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(originalString);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			MetadataRow other = (MetadataRow) obj;
+			return Objects.equals(originalString, other.originalString);
+		}
+	}
+	
+	/**
+	 * Object representing a {@link ProjectImageEntry}/row in the TreeView in {@link ProjectBrowser}.
+	 */
+	public static class ImageRow extends ProjectObject {
+		
+		private ProjectImageEntry<BufferedImage> entry;
+		
+		ImageRow(ProjectImageEntry<BufferedImage> entry) {
+			this.entry = entry;
+		}
+
+		@Override
+		String getDisplayableString() {
+			return entry.getImageName();
+		}
+
+		@Override
+		Type getType() {
+			return Type.IMAGE;
+		}
+		
+		ProjectImageEntry<BufferedImage> getEntry() {
+			return entry;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(entry);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			ImageRow other = (ImageRow) obj;
+			return Objects.equals(entry, other.entry);
+		}
+	}
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectTreeRow.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectTreeRow.java
@@ -12,12 +12,12 @@ import qupath.lib.projects.ProjectImageEntry;
  * Abstract class to represent all different objects that can go into a Project browser's tree.
  * @author Melvin Gelbard
  */
-abstract class ProjectObject {
+abstract class ProjectTreeRow {
 	
 	/**
-	 * Types of possible {@code ProjectObject}s.
+	 * Types of possible {@code ProjectTreeRow}s.
 	 */
-	public enum Type {
+	enum Type {
 		/**
 		 * Either the {@code Project} or a String displaying 'No Project'.
 		 */
@@ -41,7 +41,7 @@ abstract class ProjectObject {
 	abstract String getDisplayableString();
 	
 	/**
-	 * Return the type of ProjectObject this object represents.
+	 * Return the type of {@code ProjectTreeRow} this object represents.
 	 * <p>
 	 * E.g. {@code ROOT}, {@code TAG}, etc..
 	 * @return type
@@ -58,22 +58,22 @@ abstract class ProjectObject {
 	}
 
 	/**
-	 * Get the {@link #ProjectImageEntry} corresponding to the specified {@link #ProjectObject}.
+	 * Get the {@link #ProjectImageEntry} corresponding to the specified {@link #ProjectTreeRow}.
 	 * <p>
 	 * If the specified object is not an {@link ImageRow} (e.g. {@link MetadataRow}), return {@code null}.
-	 * @param projectObject
-	 * @return
+	 * @param projectTreeRow
+	 * @return Project image entry
 	 */
-	static ProjectImageEntry<BufferedImage> getEntry(ProjectObject projectObject) {
-		if (projectObject.getType() == Type.IMAGE)
-			return ((ImageRow)projectObject).getEntry();
+	static ProjectImageEntry<BufferedImage> getEntry(ProjectTreeRow projectTreeRow) {
+		if (projectTreeRow.getType() == Type.IMAGE)
+			return ((ImageRow)projectTreeRow).getEntry();
 		return null;
 	}
 	
 	/**
 	 * Object representing the root of the TreeView in {@link ProjectBrowser}. Either a 'No project' String or the project (name).
 	 */
-	static class RootRow extends ProjectObject {
+	static class RootRow extends ProjectTreeRow {
 
 		private Project<?> project;
 		private String originalString;
@@ -113,7 +113,7 @@ abstract class ProjectObject {
 	/**
 	 * Object representing a metadata row in the TreeView in {@link ProjectBrowser}. Represented as Strings.
 	 */
-	static class MetadataRow extends ProjectObject {
+	static class MetadataRow extends ProjectTreeRow {
 	
 		private String originalString;
 		
@@ -152,7 +152,7 @@ abstract class ProjectObject {
 	/**
 	 * Object representing a {@link ProjectImageEntry}/row in the TreeView in {@link ProjectBrowser}.
 	 */
-	public static class ImageRow extends ProjectObject {
+	public static class ImageRow extends ProjectTreeRow {
 		
 		private ProjectImageEntry<BufferedImage> entry;
 		


### PR DESCRIPTION
- Refactored `ProjectBrowser`, which now uses `ProjectTreeRow` objects to display info about projects, tags and project entries.
- Project entry thumbnails are now generated in the background (only the thumbnails of the currently visible project entries will be generated).