### PR TITLE
Synchronize channel colors to ImageDisplay when opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This is a *minor release* that aims to be fully compatible with v0.3.0 while fix
 
 List of bugs fixed:
 * 'Add intensity features' does not reinitialize options (including channels) when new images are opened (https://github.com/qupath/qupath/issues/836)
+* 'Keep settings' in Brightness/Contrast dialog does not always retain channel colors (https://github.com/qupath/qupath/issues/843)
 * Up arrow can cause viewer to move beyond nSlices for Z-stack (https://github.com/qupath/qupath/issues/821)
 * Location text does not update when navigating with keyboard (https://github.com/qupath/qupath/issues/819)
 * Multichannel .tif output is broken in TileExporter (https://github.com/qupath/qupath/issues/838)

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -151,11 +152,14 @@ public class ImageDisplay extends AbstractImageRenderer {
 			// Load any existing color properties
 			loadChannelColorProperties();
 			// Update from the last image, if required
-			if (lastDisplayJSON != null && !lastDisplayJSON.isEmpty())
+			if (lastDisplayJSON != null && !lastDisplayJSON.isEmpty()) {
 				updateFromJSON(lastDisplayJSON);
+			}
 		}
 		changeTimestamp.set(System.currentTimeMillis());
 	}
+	
+	
 	
 	/**
 	 * Get the current image data
@@ -318,7 +322,7 @@ public class ImageDisplay extends AbstractImageRenderer {
 				var option = channelOptions.get(c);
 				if (option instanceof DirectServerChannelInfo && c < server.nChannels()) {
 					var channel = server.getChannel(c);
-					if (option.getColor() != channel.getColor()) {
+					if (!Objects.equals(option.getColor(), channel.getColor())) {
 						((DirectServerChannelInfo)option).setLUTColor(channel.getColor());
 						colorsUpdated = true;
 					}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -102,6 +102,7 @@ import qupath.lib.awt.common.AwtTools;
 import qupath.lib.color.ColorToolsAwt;
 import qupath.lib.common.ColorTools;
 import qupath.lib.common.GeneralTools;
+import qupath.lib.display.DirectServerChannelInfo;
 import qupath.lib.display.ImageDisplay;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.images.servers.PathHierarchyImageServer;
@@ -123,7 +124,9 @@ import qupath.lib.gui.viewer.tools.MoveTool;
 import qupath.lib.gui.viewer.tools.PathTool;
 import qupath.lib.gui.viewer.tools.PathTools;
 import qupath.lib.images.ImageData;
+import qupath.lib.images.servers.ImageChannel;
 import qupath.lib.images.servers.ImageServer;
+import qupath.lib.images.servers.ImageServerMetadata;
 import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.objects.PathDetectionObject;
 import qupath.lib.objects.PathObject;
@@ -1542,6 +1545,19 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 			}
 			if (!displaySet)
 				imageDisplay.setImageData(imageDataNew, keepDisplay);
+			
+			// For non-RGB images, the channel colors in our server metadata might now be out of sync with the 
+			// brightness/contrast, based upon whatever we extracted from the image properties or kept from the last image.
+			// If this happens, we need to update the metadata.
+			// See https://github.com/qupath/qupath/issues/843
+			if (server != null && !server.isRGB()) {
+				var colors = imageDisplay.availableChannels().stream()
+						.filter(c -> c instanceof DirectServerChannelInfo)
+						.map(c -> c.getColor())
+						.collect(Collectors.toList());
+				if (server.nChannels() == colors.size())
+					updateServerChannels(server, colors);
+			}
 		}
 		long endTime = System.currentTimeMillis();
 		logger.debug("Setting ImageData time: {} ms", endTime - startTime);
@@ -1587,6 +1603,46 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 			repaint();
 		
 		logger.info("Image data set to {}", imageDataNew);
+	}
+	
+	
+	
+	/**
+	 * Update the channel colors, as stored in the server metadata, to match the specified colors.
+	 * This is used in the fix for See https://github.com/qupath/qupath/issues/843
+	 * @param server
+	 * @param colors
+	 * @return
+	 * @throws IllegalArgumentException if the number of colors does not match the number of channels
+	 */
+	private static boolean updateServerChannels(ImageServer<BufferedImage> server, List<Integer> colors) throws IllegalArgumentException {
+		var channels = server.getMetadata().getChannels();
+		if (channels.size() != colors.size())
+			throw new IllegalArgumentException(String.format("Number of channels (%d) does not match the number of colors (%d)!", channels.size(), colors.size()));
+		var serverChannelColors = channels.stream().map(c -> c.getColor()).collect(Collectors.toList());
+		if (colors.equals(serverChannelColors))
+			return false;
+		channels = new ArrayList<>(channels);
+		int n = 0;
+		for (int i = 0; i < channels.size(); i++) {
+			var channel = channels.get(i);
+			var color = colors.get(i);
+			if (!Objects.equals(channel.getColor(), color)) {
+				channels.set(i, ImageChannel.getInstance(channel.getName(), color));
+				n++;
+			}
+		}
+		if (n == 0)
+			return false; // Shouldn't happen
+		var newMetadata = new ImageServerMetadata.Builder(server.getMetadata())
+			.channels(channels)
+			.build();
+		server.setMetadata(newMetadata);
+		if (n == 1)
+			logger.info("Updating server metadata for 1 channel");
+		else
+			logger.info("Updating server metadata for {} channels", n);			
+		return true;
 	}
 	
 	


### PR DESCRIPTION
Aims to fix https://github.com/qupath/qupath/issues/843
Synchronization is performed in QuPathViewer and does not fire a property update (should it?). In the end, may be preferable to separate and simplify this logic.