### PR TITLE
Handle backspace and delete when the annotation list is in focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ List of bugs fixed:
 * Multichannel .tif output is broken in TileExporter (https://github.com/qupath/qupath/issues/838)
 * Main class and classpath missing from app jar (https://github.com/qupath/qupath/issues/818)
 * MeasurementList is ignored for some objects when importing from GeoJSON (https://github.com/qupath/qupath/issues/845)
+* Backspace and delete don't do anything when the annotation list is in focus (https://github.com/qupath/qupath/issues/847)
 
 
 ## Version 0.3.0

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
@@ -50,6 +50,9 @@ import javafx.scene.control.MultipleSelectionModel;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.Tooltip;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
@@ -222,6 +225,16 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 		btnSelectAll.disableProperty().bind(disableButtons);
 		btnDelete.disableProperty().bind(disableButtons);
 		btnMore.disableProperty().bind(disableButtons);
+		
+		// Add support for delete/backspace
+		listAnnotations.addEventFilter(KeyEvent.KEY_RELEASED, e -> {
+			if (e.isConsumed())
+				return;
+			if (e.getCode() == KeyCode.BACK_SPACE || e.getCode() == KeyCode.DELETE) {
+				btnDelete.fire();
+				e.consume();
+			}
+		});
 
 		panelObjects.setBottom(panelButtons);
 		return panelObjects;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
@@ -51,7 +51,6 @@ import javafx.scene.control.SelectionMode;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;


### PR DESCRIPTION
See https://github.com/qupath/qupath/issues/847 and https://github.com/qupath/qupath/pull/830

This takes a simpler approach than https://github.com/qupath/qupath/pull/830 by just triggering the *Delete* button below the list. This matches the behavior of Ctrl+A, which acts like 'the *Select all* button.