### PR TITLE
Fix reading ICC_Profile in viewer

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -989,6 +989,8 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 			tPosition.set(0);
 			return;
 		}
+		
+		updateICCTransform();
 
 		zPosition.set(server.nZSlices() / 2);
 		tPosition.set(0);
@@ -2142,7 +2144,11 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 	 * @return the <code>ColorConvertOp</code> if an appropriate conversion could be found, or <code>null</code> otherwise.
 	 */
 	ColorConvertOp createICCConvertOp() {
-		ICC_Profile iccSource = readICC(new File(getServerPath()));
+		var server = getServer();
+		var uris = server == null ? null : server.getURIs();
+		if (uris == null || uris.isEmpty())
+			return null;
+		ICC_Profile iccSource = readICC(new File(uris.iterator().next()));
 		if (iccSource == null)
 			return null;
 		return new ColorConvertOp(new ICC_Profile[]{
@@ -2176,7 +2182,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 	}
 	
 	void updateICCTransform() {
-		if (getServerPath() != null && getDoICCTransform())
+		if (getDoICCTransform())
 			iccTransformOp = createICCConvertOp();
 		else
 			iccTransformOp = null;


### PR DESCRIPTION
This relied upon the server path, which doesn't work since v0.2.0.
Note that this feature is not used, but is retained for testing, e.g. in a script via
```
getCurrentViewer().setDoICCTransform(false)
```
Activating the ICC Profile makes repainting performance substantially worse.
See also https://forum.image.sc/t/color-discrepancy-qupath-x-imagescope-leica-gt450/57948