### PR TITLE
Avoid exceptions when calling simple Dialogs without UI

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
@@ -23,7 +23,6 @@
 
 package qupath.lib.gui.dialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -350,7 +349,8 @@ public class Dialogs {
 			logger.error(title , e);
 		if (message == null)
 			message = "QuPath has encountered a problem, sorry.\nIf you can replicate it, please report it with 'Help > Report bug'.\n\n" + e;
-		showNotifications(createNotifications().title(title).text(message), AlertType.ERROR);
+		if (!isHeadless())
+			showNotifications(createNotifications().title(title).text(message), AlertType.ERROR);
 	}
 
 	/**
@@ -360,7 +360,8 @@ public class Dialogs {
 	 */
 	public static void showErrorNotification(final String title, final String message) {
 		logger.error(title + ": " + message);
-		showNotifications(createNotifications().title(title).text(message), AlertType.ERROR);
+		if (!isHeadless())
+			showNotifications(createNotifications().title(title).text(message), AlertType.ERROR);
 	}
 
 	/**
@@ -370,7 +371,8 @@ public class Dialogs {
 	 */
 	public static void showWarningNotification(final String title, final String message) {
 		logger.warn(title + ": " + message);
-		showNotifications(createNotifications().title(title).text(message), AlertType.WARNING);
+		if (!isHeadless())
+			showNotifications(createNotifications().title(title).text(message), AlertType.WARNING);
 	}
 
 	/**
@@ -380,7 +382,8 @@ public class Dialogs {
 	 */
 	public static void showInfoNotification(final String title, final String message) {
 		logger.info(title + ": " + message);
-		showNotifications(createNotifications().title(title).text(message), AlertType.INFORMATION);
+		if (!isHeadless())
+			showNotifications(createNotifications().title(title).text(message), AlertType.INFORMATION);
 	}
 
 	/**
@@ -390,7 +393,8 @@ public class Dialogs {
 	 */
 	public static void showPlainNotification(final String title, final String message) {
 		logger.info(title + ": " + message);
-		showNotifications(createNotifications().title(title).text(message), AlertType.NONE);
+		if (!isHeadless())
+			showNotifications(createNotifications().title(title).text(message), AlertType.NONE);
 	}
 	
 	/**
@@ -398,6 +402,10 @@ public class Dialogs {
 	 * @param notification
 	 */
 	private static void showNotifications(Notifications notification, AlertType type) {
+		if (isHeadless()) {
+			logger.warn("Cannot show notifications in headless mode!");
+			return;
+		}
 		if (Platform.isFxApplicationThread()) {
 			switch (type) {
 			case CONFIRMATION:
@@ -463,7 +471,8 @@ public class Dialogs {
 	 */
 	public static void showErrorMessage(final String title, final String message) {
 		logger.error(title + ": " + message);
-		showErrorMessage(title, createContentLabel(message));
+		if (!isHeadless())
+			showErrorMessage(title, createContentLabel(message));
 	}
 	
 	/**
@@ -486,11 +495,13 @@ public class Dialogs {
 	 */
 	public static void showPlainMessage(final String title, final String message) {
 		logger.info(title + ": " + message);
-		new Builder()
-			.alertType(AlertType.INFORMATION)
-			.title(title)
-			.content(createContentLabel(message))
-			.show();
+		if (!isHeadless()) {
+			new Builder()
+				.alertType(AlertType.INFORMATION)
+				.title(title)
+				.content(createContentLabel(message))
+				.show();
+		}
 	}
 	
 	/**
@@ -660,6 +671,10 @@ public class Dialogs {
 		return new Builder();
 	}
 	
+	
+	private static boolean isHeadless() {
+		return QuPathGUI.getInstance() == null;
+	}
 
 	/**
 	 * Builder class to create a custom {@link Dialog}.
@@ -930,13 +945,14 @@ public class Dialogs {
 			return dialog;
 		}
 		
+		
 		/**
 		 * Show the dialog.
 		 * This is similar to {@code build().show()} except that it will automatically 
 		 * be called on the JavaFX application thread even if called from another thread.
 		 */
 		public void show() {
-			if (GraphicsEnvironment.isHeadless()) {
+			if (isHeadless()) {
 				logger.warn("Cannot show dialog in headless mode!");
 				return;
 			}

--- a/qupath-gui-fx/src/test/java/qupath/lib/gui/dialogs/DialogsTest.java
+++ b/qupath-gui-fx/src/test/java/qupath/lib/gui/dialogs/DialogsTest.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2021 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.dialogs;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class DialogsTest {
+
+	/**
+	 * Ensure there are no exceptions when showing basic messages and notifications without the UI.
+	 */
+	@Test
+	void testNoUI() {
+		
+		assertDoesNotThrow(() -> Dialogs.showErrorMessage("Error", "Message"));
+		assertDoesNotThrow(() -> Dialogs.showErrorMessage("Error", new RuntimeException("This RuntimeException is intentional")));
+//		assertDoesNotThrow(() -> Dialogs.showMessageDialog(title, message)); // This returns true/false depending upon button
+		assertDoesNotThrow(() -> Dialogs.showNoImageError("No image title"));
+		assertDoesNotThrow(() -> Dialogs.showNoProjectError("No project title"));
+		
+		assertDoesNotThrow(() -> Dialogs.showInfoNotification("Info", "Notification"));
+		assertDoesNotThrow(() -> Dialogs.showPlainNotification("Plain", "Notification"));
+		assertDoesNotThrow(() -> Dialogs.showWarningNotification("Warning", "Notification"));
+		assertDoesNotThrow(() -> Dialogs.showErrorNotification("Error", "Notification"));
+
+	}
+
+}


### PR DESCRIPTION
This prevents extensions from failing if they show text notifications when run from the command line, logging the content instead. However there will still be exceptions if any dialog requires a response, or if the content is anything other than simple text.