### PR TITLE
Reduce unnecessary tile reads in AbstractImageServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This is a *minor release* that aims to be fully compatible with v0.3.0 while fix
 
 List of bugs fixed:
 * 'Add intensity features' does not reinitialize options (including channels) when new images are opened (https://github.com/qupath/qupath/issues/836)
+* Reading images with ImageJ is too slow and memory-hungry (https://github.com/qupath/qupath/issues/860)
 * 'Keep settings' in Brightness/Contrast dialog does not always retain channel colors (https://github.com/qupath/qupath/issues/843)
 * ImageServers can request the same tile in multiple threads simultaneously (https://github.com/qupath/qupath/issues/861)
 * Up arrow can cause viewer to move beyond nSlices for Z-stack (https://github.com/qupath/qupath/issues/821)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This is a *minor release* that aims to be fully compatible with v0.3.0 while fix
 List of bugs fixed:
 * 'Add intensity features' does not reinitialize options (including channels) when new images are opened (https://github.com/qupath/qupath/issues/836)
 * 'Keep settings' in Brightness/Contrast dialog does not always retain channel colors (https://github.com/qupath/qupath/issues/843)
+* ImageServers can request the same tile in multiple threads simultaneously (https://github.com/qupath/qupath/issues/861)
 * Up arrow can cause viewer to move beyond nSlices for Z-stack (https://github.com/qupath/qupath/issues/821)
 * Location text does not update when navigating with keyboard (https://github.com/qupath/qupath/issues/819)
 * Multichannel .tif output is broken in TileExporter (https://github.com/qupath/qupath/issues/838)
@@ -15,6 +16,7 @@ List of bugs fixed:
 * 'Automate -> Show workflow command history' displays empty workflow (https://github.com/qupath/qupath/pull/851)
 * Extensions are sometimes loaded too late when running command line scripts (https://github.com/qupath/qupath/issues/852)
 * ICC Profiles could not be set in the viewer (unused preview feature, https://github.com/qupath/qupath/pull/850)
+* convert-ome command doesn't report when it is finished (https://github.com/qupath/qupath/issues/859)
 
 ### Dependency updates
 * JavaFX 17.0.1

--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -388,7 +388,7 @@ class ScriptCommand implements Runnable {
 			percentage = 10;
 		} else if (percentage > 90) {
 			logger.warn("No more than 90% of available memory can be used for tile caching (you requested {}%)", percentage);
-			percentage = 00;			
+			percentage = 90;			
 		}
 		long tileCacheSize = Math.round(maxAvailable * (percentage / 100.0));
 		logger.info(String.format("Setting tile cache size to %.2f MB (%.1f%% max memory)", tileCacheSize/(1024.*1024.), percentage));

--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2021 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -458,7 +458,7 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 	private void prerequestTiles(Collection<TileRequest> tiles) {
 		var cache = getCache();
 		for (var tile : tiles) {
-			if (!cache.containsKey(tile.getRegionRequest()) && !pendingTiles.containsKey(tile)) {
+			if (cache != null && !cache.containsKey(tile.getRegionRequest()) && !pendingTiles.containsKey(tile)) {
 				var futureTask = pendingTiles.computeIfAbsent(tile, t -> new TileTask(Thread.currentThread(), () -> readTile(t)));
 				if (futureTask.thread == Thread.currentThread())
 					futureTask.run();

--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -458,7 +458,7 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 	private void prerequestTiles(Collection<TileRequest> tiles) {
 		var cache = getCache();
 		for (var tile : tiles) {
-			if (cache != null && !cache.containsKey(tile.getRegionRequest()) && !pendingTiles.containsKey(tile)) {
+			if (cache == null || !cache.containsKey(tile.getRegionRequest()) && !pendingTiles.containsKey(tile)) {
 				var futureTask = pendingTiles.computeIfAbsent(tile, t -> new TileTask(Thread.currentThread(), () -> readTile(t)));
 				if (futureTask.thread == Thread.currentThread())
 					futureTask.run();

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
@@ -78,6 +78,8 @@ import qupath.lib.regions.ImageRegion;
  */
 public class ImageServers {
 	
+	private final static Logger logger = LoggerFactory.getLogger(ImageServers.class);
+	
 	private static SubTypeAdapterFactory<ServerBuilder> serverBuilderFactory = 
 			GsonTools.createSubTypeAdapterFactory(ServerBuilder.class, "builderType")
 			.registerSubtype(DefaultImageServerBuilder.class, "uri")
@@ -282,7 +284,11 @@ public class ImageServers {
 		List<Exception> exceptions = new ArrayList<>();
 		for (var support : supports) {
 			try {
-				return support.getBuilders().iterator().next().build();
+				var builders = support.getBuilders();
+				if (!builders.isEmpty())
+					return builders.get(0).build();
+				else
+					logger.debug("No builders available for {}", support);
 			} catch (Exception e) {
 				exceptions.add(e);
 			}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -4398,7 +4398,7 @@ public class QuPathGUI {
 			percentage = 10;
 		} else if (percentage > 90) {
 			logger.warn("No more than 90% of available memory can be used for tile caching (you requested {}%)", percentage);
-			percentage = 00;			
+			percentage = 90;			
 		}
 		long tileCacheSize = Math.round(maxAvailable * (percentage / 100.0));
 		logger.info(String.format("Setting tile cache size to %.2f MB (%.1f%% max memory)", tileCacheSize/(1024.*1024.), percentage));


### PR DESCRIPTION
Aims to resolve
* https://github.com/qupath/qupath/issues/861
* https://github.com/qupath/qupath/issues/859

Achieves this primarily by changing `AbstractTileableImageServer` to retain pending requests as Futures, which can be reused by other threads who need the same tiles.
