### PR TITLE
Implement AutoCloseable with DnnModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ List of bugs fixed:
 * 'Automate -> Show workflow command history' displays empty workflow (https://github.com/qupath/qupath/pull/851)
 * Extensions are sometimes loaded too late when running command line scripts (https://github.com/qupath/qupath/issues/852)
 * ICC Profiles could not be set in the viewer (unused preview feature, https://github.com/qupath/qupath/pull/850)
+* DnnModel implements AutoCloseable, so that calling DnnModel.close() can resolve
+  * GPU memory not freed when using OpenCV DNN (https://github.com/qupath/qupath/issues/841)
+  * QuPath with CUDA doesn’t release GPU memory after StarDist segmentation (https://github.com/qupath/qupath-extension-stardist/issues/11)
 * Image writing fixes, including
   * convert-ome command doesn't report when it is finished (https://github.com/qupath/qupath/issues/859)
   * OMEPyramidWriter ignores file extension to always write ome.tif (https://github.com/qupath/qupath/issues/857)

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DefaultDnnModel.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DefaultDnnModel.java
@@ -22,6 +22,7 @@
 
 package qupath.opencv.dnn;
 
+import java.io.Closeable;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -70,6 +71,24 @@ class DefaultDnnModel<T> implements DnnModel<T> {
 	@Override
 	public PredictionFunction<T> getPredictionFunction() {
 		return predictFun;
+	}
+	
+	/**
+	 * Calls {@code close()} on the blob and prediction functions, if they are instances of 
+	 * {@link Closeable} or {@link AutoCloseable}.
+	 */
+	@Override
+	public void close() throws Exception {
+		logger.debug("Closing {}", this);
+		tryToClose(blobFun);
+		tryToClose(predictFun);
+	}
+	
+	private void tryToClose(Object o) throws Exception {
+		if (o instanceof AutoCloseable)
+			((AutoCloseable)o).close();
+		else if (o instanceof Closeable)
+			((Closeable)o).close();
 	}
 
 }

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModel.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModel.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * @see PredictionFunction
  * @version 0.3.0
  */
-public interface DnnModel<T> {
+public interface DnnModel<T> extends AutoCloseable {
 		
 	/**
 	 * Default input layer name. This should be used when the input layer name is known or 
@@ -136,5 +136,17 @@ public interface DnnModel<T> {
 		var output = getBlobFunction().fromBlob(prediction);
 		return output;
 	}
+	
+	/**
+	 * Close this model if it will not be needed again.
+	 * Subclasses that require cleanup may override this.
+	 * A default, do-nothing implementation implementation is provided for backwards compatibility with v0.3.0.
+	 * 
+	 * @since v0.3.1
+	 * @implNote this was introduced to provide a mechanism to deal with a GPU memory leak when 
+	 *           using OpenCV and CUDA. New code using any DnnModel should call this method if it can 
+	 *           be known that the model will not be needed again in the future.
+	 */
+	public default void close() throws Exception {}
 	
 }

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVDnn.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVDnn.java
@@ -645,7 +645,7 @@ public class OpenCVDnn implements UriResource, DnnModel<Mat> {
 
 	
 	
-	class OpenCVNetFunction implements PredictionFunction<Mat> { //, UriResource {
+	class OpenCVNetFunction implements PredictionFunction<Mat>, AutoCloseable { //, UriResource {
 				
 		private transient Net net;
 		private transient List<String> outputLayerNames;
@@ -797,6 +797,19 @@ public class OpenCVDnn implements UriResource, DnnModel<Mat> {
 				return outputs;
 			return DnnTools.getOutputLayers(net, inputShapes);
 		}
+
+		@Override
+		public synchronized void close() throws Exception {
+			if (net != null) {
+				logger.debug("Closing {}", net);
+				net.close();
+				net.deallocate();
+			}
+			if (outputLayerNamesVector != null) {
+				outputLayerNamesVector.close();
+				outputLayerNamesVector.deallocate();
+			}
+		}
 		
 	}
 
@@ -891,6 +904,13 @@ public class OpenCVDnn implements UriResource, DnnModel<Mat> {
 			}
 		}
 		return predFun;
+	}
+	
+	@Override
+	public void close() throws Exception {
+		if (predFun instanceof AutoCloseable) {
+			((AutoCloseable)predFun).close();
+		}
 	}
 
 }


### PR DESCRIPTION
Aims to provide a mechanism to address
* https://github.com/qupath/qupath/issues/841
* https://github.com/qupath/qupath-extension-stardist/issues/11
by ensuring that an OpenCV Net wrapped in a DnnModel can be closed without needing a reference to the Net itself.
The StarDist and TensorFlow extensions should be updated to make use of this.