### PR TITLE
Dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## Version 0.3.1-SNAPSHOT
-*In progress*
 
-This is a *minor release* that aims to be fully compatible with v0.3.0 while fixing bugs.
+This is a *minor release* that aims to be fully compatible with v0.3.0 while fixing bugs, updating dependencies and improving performance.
 
-List of bugs fixed:
+### Bugs fixed
 * 'Add intensity features' does not reinitialize options (including channels) when new images are opened (https://github.com/qupath/qupath/issues/836)
 * Reading images with ImageJ is too slow and memory-hungry (https://github.com/qupath/qupath/issues/860)
 * Generating multiple readers with Bio-Formats can be very slow (https://github.com/qupath/qupath/issues/865)
@@ -27,10 +26,18 @@ List of bugs fixed:
   * OMEPyramidWriter logic for bigtiff can fail for image pyramids (https://github.com/qupath/qupath/issues/858)
 
 ### Dependency updates
+* Bio-Formats 6.8.0
+  * See https://www.openmicroscopy.org/2021/12/09/bio-formats-6-8-0.html for details
 * JavaFX 17.0.1
   * Introduced to fix UI bugs, e.g. https://github.com/qupath/qupath/issues/833
+* ImageJ 1.53i
+  * Downgrade to support headless, see https://github.com/imagej/imagej1/issues/140
+* ControlsFX 11.1.1
+* Groovy 3.0.9
+* Gson 2.8.9
 * Logback 1.2.9
-* ImageJ 1.53i - downgrade to support headless, see https://github.com/imagej/imagej1/issues/140
+* Picocli 4.6.2
+* RichTextFX 0.10.7
 
 ## Version 0.3.0
 

--- a/buildSrc/src/main/groovy/qupath.common-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.common-conventions.gradle
@@ -96,14 +96,14 @@ ext {
     // Dependency versions
     commonsMathVersion = '3.6.1'
     commonsTextVersion = '1.9'
-    controlsfxVersion  = '11.1.0'
-    groovyVersion      = '3.0.8'
-    gsonVersion        = '2.8.8'
+    controlsfxVersion  = '11.1.1'
+    groovyVersion      = '3.0.9'
+    gsonVersion        = '2.8.9'
     guavaVersion       = '30.1.1-jre'
     imagejVersion      = '1.53i'
     jfxtrasVersion     = '11-r2'
     jtsVersion         = '1.18.2'
-    picocliVersion     = '4.6.1'
+    picocliVersion     = '4.6.2'
     
     // Note, if OpenCV is a SNAPSHOT version then it must already be installed locally (with Maven)
     if (isAppleSilicon) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/license-unknown.txt
+++ b/license-unknown.txt
@@ -1,6 +1,6 @@
 woolz:JWlz:1.4.0|https://github.com/ma-tech/Woolz|GNU General Public License v2+|https://github.com/ma-tech/Woolz/blob/master/LICENSE
 edu.ucar:cdm:4.6.13|https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm|NetCDF C library license (MIT-style)|https://www.unidata.ucar.edu/software/netcdf/copyright.html
 edu.ucar:httpservices:4.6.13|https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/documentation.htm|NetCDF C library license (MIT-style)|https://www.unidata.ucar.edu/software/netcdf/copyright.html
-cisd:jhdf5:14.12.6|https://wiki-bsse.ethz.ch/display/JHDF5|Apache License 2.0|http://www.apache.org/licenses/LICENSE-2.0.html
-cisd:jhdf5:14.12.6|https://wiki-bsse.ethz.ch/display/JHDF5|Apache License 2.0|http://www.apache.org/licenses/LICENSE-2.0.html
+cisd:jhdf5:19.04.0|https://wiki-bsse.ethz.ch/display/JHDF5|Apache License 2.0|http://www.apache.org/licenses/LICENSE-2.0.html
+cisd:jhdf5:19.04.0|https://wiki-bsse.ethz.ch/display/JHDF5|Apache License 2.0|http://www.apache.org/licenses/LICENSE-2.0.html
 org.json:json:20090211|http://www.json.org|The JSON License|http://www.json.org/license.html

--- a/qupath-app/build.gradle
+++ b/qupath-app/build.gradle
@@ -18,17 +18,17 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.beryx:badass-runtime-plugin:1.12.5"
-    classpath 'com.github.jk1:gradle-license-report:1.16'
+    classpath "org.beryx:badass-runtime-plugin:1.12.7"
+//    classpath 'com.github.jk1:dependency-license-report:2.0'
   }
 }
 
 plugins {
   id 'qupath.common-conventions'
   id 'application'
-  id 'org.beryx.runtime' version '1.12.5'
+  id 'org.beryx.runtime' version '1.12.7'
 //    id 'org.beryx.jlink' version '2.24.0'  // Can use this when QuPath is modular...
-  id 'com.github.jk1.dependency-license-report' version '1.16'
+  id 'com.github.jk1.dependency-license-report' version '2.0'
 }
 
 

--- a/qupath-extension-bioformats/build.gradle
+++ b/qupath-extension-bioformats/build.gradle
@@ -7,7 +7,7 @@ ext.moduleName = 'qupath.extension.bioformats'
 archivesBaseName = 'qupath-extension-bioformats'
 description = "QuPath extension to support image reading and writing using Bio-Formats."
 
-def bioformatsVersion = "6.7.0"
+def bioformatsVersion = "6.8.0"
 
 configurations {
   // Consider using compileOnly for Bio-Formats, and installing bioformats_package.jar separately

--- a/qupath-extension-bioformats/src/main/resources/licenses/Bio-Formats/ReadMe.txt
+++ b/qupath-extension-bioformats/src/main/resources/licenses/Bio-Formats/ReadMe.txt
@@ -1,4 +1,4 @@
-The full list of Bio-Formats dependencies and respective licenses is at https://docs.openmicroscopy.org/bio-formats/6.5.0/developers/java-library.html
+The full list of Bio-Formats dependencies and respective licenses is at https://docs.openmicroscopy.org/bio-formats/6.8.0/developers/java-library.html
 
 Source for this table from https://raw.githubusercontent.com/ome/bio-formats-documentation/master/sphinx/developers/java-library.rst is included below.
 
@@ -86,10 +86,10 @@ Source for this table from https://raw.githubusercontent.com/ome/bio-formats-doc
     * - `Native Library Loader v2.1.4 <https://github.com/scijava/native-lib-loader>`_
       - org.scijava:native-lib-loader:2.1.4
       - `BSD License`_
-    * - `SLF4J API v1.7.4 <https://www.slf4j.org>`_
+    * - `SLF4J API v1.7.4 <http://www.slf4j.org>`_
       - org.slf4j:slf4j-api:1.7.6
       - `MIT License`_
-    * - `SLF4J LOG4J-12 Binding v1.7.6 <https://www.slf4j.org>`_
+    * - `SLF4J LOG4J-12 Binding v1.7.6 <http://www.slf4j.org>`_
       - org.slf4j:slf4j-log4j12:1.7.6
       - `MIT License`_
     * - `TestNG v6.8 <https://testng.org/doc/>`_

--- a/qupath-extension-script-editor/build.gradle
+++ b/qupath-extension-script-editor/build.gradle
@@ -13,5 +13,5 @@ configurations {
 }
 
 dependencies {
-  implementation "org.fxmisc.richtext:richtextfx:0.10.6"
+  implementation "org.fxmisc.richtext:richtextfx:0.10.7"
 }


### PR DESCRIPTION
Full list from changelog (including some updated through previous commits):
* Bio-Formats 6.8.0
  * See https://www.openmicroscopy.org/2021/12/09/bio-formats-6-8-0.html for details
* JavaFX 17.0.1
  * Introduced to fix UI bugs, e.g. https://github.com/qupath/qupath/issues/833
* ImageJ 1.53i
  * Downgrade to support headless, see https://github.com/imagej/imagej1/issues/140
* ControlsFX 11.1.1
* Groovy 3.0.9
* Gson 2.8.9
* Logback 1.2.9
* Picocli 4.6.2
* RichTextFX 0.10.7

Additionally, updated Gradle wrapper to 7.3.3 and both badass-runtime-plugin and dependency-license-report plugins.