### PR TITLE
Make composite classifiers more scriptable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a *minor release* that aims to be fully compatible with v0.3.0 while fix
 * Reading images with ImageJ is too slow and memory-hungry (https://github.com/qupath/qupath/issues/860)
 * Generating multiple readers with Bio-Formats can be very slow (https://github.com/qupath/qupath/issues/865)
 * 'Keep settings' in Brightness/Contrast dialog does not always retain channel colors (https://github.com/qupath/qupath/issues/843)
+* 'Create composite classifier' does not store classifier in the workflow when 'Save & Apply' is selected (https://github.com/qupath/qupath/issues/874)
 * ImageServers can request the same tile in multiple threads simultaneously (https://github.com/qupath/qupath/issues/861)
 * Up arrow can cause viewer to move beyond nSlices for Z-stack (https://github.com/qupath/qupath/issues/821)
 * Location text does not update when navigating with keyboard (https://github.com/qupath/qupath/issues/819)

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifiers.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifiers.java
@@ -130,7 +130,7 @@ public class PixelClassifiers {
 	 */
 	public static void writeClassifier(PixelClassifier classifier, Path path) throws IOException {
 		try (var writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
-			GsonTools.getInstance(true).toJson(classifier, writer);
+			GsonTools.getInstance(true).toJson(classifier, PixelClassifier.class, writer);
 		}
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/classifiers/object/ObjectClassifiers.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/object/ObjectClassifiers.java
@@ -176,7 +176,7 @@ public class ObjectClassifiers {
 	 */
 	public static <T> void writeClassifier(ObjectClassifier<T> classifier, Path path) throws IOException {
 		try (var writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
-			GsonTools.getInstance(true).toJson(classifier, writer);
+			GsonTools.getInstance(true).toJson(classifier, ObjectClassifier.class, writer);
 		}
 	}
 	


### PR DESCRIPTION
Fix for https://github.com/qupath/qupath/issues/874
Meanwhile fix an unnoticed bug when classifiers were saved to files, namely that they were lacking the JSON field required for deserialization.