### PR TITLE
Remove unused imports, give better warning with 'Create objects'

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/imagej/images/writers/AbstractWriterIJ.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/images/writers/AbstractWriterIJ.java
@@ -25,14 +25,7 @@ package qupath.imagej.images.writers;
 
 import ij.IJ;
 import ij.ImagePlus;
-import ij.process.ByteProcessor;
-import ij.process.ColorProcessor;
-import ij.process.FloatProcessor;
-import ij.process.ImageProcessor;
-import ij.process.ShortProcessor;
-
 import java.awt.image.BufferedImage;
-import java.awt.image.DataBuffer;
 import java.io.IOException;
 import java.io.OutputStream;
 

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriter.java
@@ -46,7 +46,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import loci.formats.FormatException;
-import loci.formats.FormatTools;
 import loci.formats.FormatWriter;
 import loci.formats.IFormatWriter;
 import loci.formats.ImageWriter;

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierUI.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierUI.java
@@ -312,10 +312,9 @@ public class PixelClassifierUI {
 				);
 		
 		// To avoid confusing the user unnecessarily, if we *only* have ignored classes then set default for includeIgnored to true
-		boolean includeIgnored = false;
 		var labels = classifier.getMetadata().getClassificationLabels();
-		if (!labels.isEmpty() && labels.values().stream().allMatch(p -> p == null || PathClassTools.isIgnoredClass(p)))
-			includeIgnored = true;
+		boolean allIgnored = !labels.isEmpty() && labels.values().stream().allMatch(p -> p == null || PathClassTools.isIgnoredClass(p));
+		boolean includeIgnored = allIgnored;
 
 		var cal = imageData.getServer().getPixelCalibration();
 		var units = cal.unitsMatch2D() ? cal.getPixelWidthUnit()+"^2" : cal.getPixelWidthUnit() + "x" + cal.getPixelHeightUnit();
@@ -362,6 +361,10 @@ public class PixelClassifierUI {
 			options.add(CreateObjectOptions.DELETE_EXISTING);
 		if (includeIgnored)
 			options.add(CreateObjectOptions.INCLUDE_IGNORED);
+		else if (allIgnored) {
+			Dialogs.showErrorMessage(title, "Cannot create objects - all class names have an asterisk to show they should be 'ignored'!");
+			return false;
+		}
 		if (selectNew)
 			options.add(CreateObjectOptions.SELECT_NEW);
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/extensions/GitHubProject.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/extensions/GitHubProject.java
@@ -1,6 +1,5 @@
 package qupath.lib.gui.extensions;
 
-import java.net.URL;
 import java.util.Objects;
 
 /**


### PR DESCRIPTION
If all classes are 'ignored', yet 'Create objects' with a pixel classifier doesn't want to create ignored objects, give a meaningful error rather than throwing an exception.