### PR TITLE
Downgrade to use Bio-Formats 6.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Version 0.3.2
+
+This is a *minor release* that aims to be fully compatible with v0.3.0 and v0.3.1 while fixing bugs.
+
+### Bugs fixed
+* Fix problems with some svs files introduced in v0.3.1
+  * Discussed at https://forum.image.sc/t/problem-about-opening-some-svs-slides-in-qupath-v0-3-1-bio-formats-6-8-0/61404
+
+
+### Dependency updates
+* Bio-Formats 6.7.0
+  * Downgrade to fix svs issues, see https://github.com/ome/bioformats/issues/3757 for details
+
+
 ## Version 0.3.1
 
 This is a *minor release* that aims to be fully compatible with v0.3.0 while fixing bugs, updating dependencies and improving performance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 This is a *minor release* that aims to be fully compatible with v0.3.0 and v0.3.1 while fixing bugs.
 
 ### Bugs fixed
-* Fix problems with some svs files introduced in v0.3.1
+* Some svs files opened with Bio-Formats are not read correctly in v0.3.1
   * Discussed at https://forum.image.sc/t/problem-about-opening-some-svs-slides-in-qupath-v0-3-1-bio-formats-6-8-0/61404
+* ImageServer pyramid levels are not checked for validity (https://github.com/qupath/qupath/issues/879)
 
 
 ### Dependency updates

--- a/qupath-core/src/main/java/qupath/lib/images/servers/FileFormatInfo.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/FileFormatInfo.java
@@ -223,7 +223,12 @@ public class FileFormatInfo {
 				// If we do have a TIFF, try to get more from the metadata
 				
 				try (ImageInputStream stream = ImageIO.createImageInputStream(file)) {
-					ImageReader reader = ImageIO.getImageReaders(stream).next();
+					var readers = ImageIO.getImageReaders(stream);
+					if (!readers.hasNext()) {
+						logger.debug("ImageIO could not construct reader for {}", file);
+						return;
+					}
+					ImageReader reader = readers.next();
 					reader.setInput(stream);
 
 					TIFFDirectory tiffDir = TIFFDirectory.createFromMetadata(reader.getImageMetadata(0));

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerMetadata.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerMetadata.java
@@ -1086,7 +1086,18 @@ public class ImageServerMetadata {
 			 * @return
 			 */
 			public List<ImageResolutionLevel> build() {
-				return levels;
+				var output = new ArrayList<ImageResolutionLevel>();
+				double lastDownsample = -1;
+				for (var level : levels) {
+					double downsample = level.getDownsample();
+					if (downsample <= lastDownsample) {
+						logger.warn("Resolution levels are out of order! Only {}/{} levels can be used.", output.size(), levels.size());
+						break;
+					}
+					output.add(level);
+					lastDownsample = downsample;
+				}
+				return output;
 			}
 			
 			

--- a/qupath-extension-bioformats/build.gradle
+++ b/qupath-extension-bioformats/build.gradle
@@ -7,7 +7,12 @@ ext.moduleName = 'qupath.extension.bioformats'
 archivesBaseName = 'qupath-extension-bioformats'
 description = "QuPath extension to support image reading and writing using Bio-Formats."
 
-def bioformatsVersion = "6.8.0"
+def bioformatsVersion = "6.7.0"
+def versionOverride = project.properties.getOrDefault('bioformats-version', null)
+if (versionOverride) {
+	println "Using specified Bio-Formats version ${versionOverride}"
+	bioformatsVersion = versionOverride
+}
 
 configurations {
   // Consider using compileOnly for Bio-Formats, and installing bioformats_package.jar separately

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -700,6 +700,26 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 
 			this.args = args;
 			
+			// Build resolutions
+			var resolutions = resolutionBuilder.build();
+			// Unused code to check if resolutions seem to be correct
+//			var iter = resolutions.iterator();
+//			int r = 0;
+//			while (iter.hasNext()) {
+//				var resolution = iter.next();
+//				double widthDifference = Math.abs(resolution.getWidth() - width/resolution.getDownsample());
+//				double heightDifference = Math.abs(resolution.getHeight() - height/resolution.getDownsample());
+//				if (widthDifference > Math.max(2.0, resolution.getWidth()*0.01) || heightDifference > Math.max(2.0, resolution.getHeight()*0.01)) {
+//					logger.warn("Aspect ratio of resolution level {} differs from", r);
+//					iter.remove();
+//					while (iter.hasNext()) {
+//						iter.next();
+//						iter.remove();
+//					}
+//				}
+//				r++;
+//			}
+			
 			// Set metadata
 			path = createID();
 			ImageServerMetadata.Builder builder = new ImageServerMetadata.Builder(
@@ -711,7 +731,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 					channels(channels).
 					sizeZ(nZSlices).
 					sizeT(nTimepoints).
-					levels(resolutionBuilder.build()).
+					levels(resolutions).
 					pixelType(pixelType).
 					rgb(isRGB);
 
@@ -1019,7 +1039,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 				if (newReader != null) {
 					additionalReaders.add(newReader);
 					queue.add(newReader);
-					logger.info("Added new additional reader (total={})", additionalReaders.size());
+					logger.debug("Created new reader (total={})", additionalReaders.size());
 				} else
 					logger.warn("New Bio-Formats reader could not be created (returned null)");
 			} catch (Exception e) {


### PR DESCRIPTION
Add support for building QuPath with a different Bio-Formats version, e.g. with
```
./gradlew jpackage -Pbioformats-version=6.8.0
```
Also perform a check for out-of-order resolution levels across all ImageServers, addressing https://github.com/qupath/qupath/issues/879