### PR TITLE
Sync 'Create single measurement classifier' combo boxes to available classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ This is a *minor release* that aims to be fully compatible with v0.3.0 and v0.3.
 * Some svs files opened with Bio-Formats are not read correctly in v0.3.1
   * Discussed at https://forum.image.sc/t/problem-about-opening-some-svs-slides-in-qupath-v0-3-1-bio-formats-6-8-0/61404
 * ImageServer pyramid levels are not checked for validity (https://github.com/qupath/qupath/issues/879)
+* 'Create single measurement classifier' does not automatically update combo boxes when the available classifications change
 
 
 ### Dependency updates
 * Bio-Formats 6.7.0
   * Downgrade to fix svs issues, see https://github.com/ome/bioformats/issues/3757 for details
+  * Build from source with -Pbioformats-version=6.8.0 option if required
 
 
 ## Version 0.3.1

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SingleMeasurementClassificationCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SingleMeasurementClassificationCommand.java
@@ -140,8 +140,8 @@ public class SingleMeasurementClassificationCommand implements Runnable {
 		private ComboBox<String> comboMeasurements = new ComboBox<>(measurementsFiltered);
 		
 		private Slider sliderThreshold = new Slider();
-		private ComboBox<PathClass> comboAbove = new ComboBox<>();
-		private ComboBox<PathClass> comboBelow = new ComboBox<>();
+		private ComboBox<PathClass> comboAbove;
+		private ComboBox<PathClass> comboBelow;
 		
 		private CheckBox cbLivePreview = new CheckBox("Live preview");
 		
@@ -180,6 +180,11 @@ public class SingleMeasurementClassificationCommand implements Runnable {
 			pane = new GridPane();
 			pane.setHgap(5.0);
 			pane.setVgap(5.0);
+			
+			
+			comboAbove = new ComboBox<>(qupath.getAvailablePathClasses());
+			comboBelow = new ComboBox<>(qupath.getAvailablePathClasses());
+			
 			
 //			comboMeasurements.getEditor().textProperty().addListener((v, o, n) -> {
 //				String text = n == null ? "" : n.toLowerCase().strip();
@@ -432,7 +437,7 @@ public class SingleMeasurementClassificationCommand implements Runnable {
 		void refreshOptions() {
 			refreshTitle();
 			refreshChannels();
-			updateAvailableClasses();
+//			updateAvailableClasses();
 			updateAvailableMeasurements();
 			updateThresholdSlider();
 		}
@@ -459,10 +464,10 @@ public class SingleMeasurementClassificationCommand implements Runnable {
 				comboChannels.getSelectionModel().selectFirst();
 		}
 		
-		void updateAvailableClasses() {
-			comboAbove.getItems().setAll(qupath.getAvailablePathClasses());
-			comboBelow.getItems().setAll(qupath.getAvailablePathClasses());
-		}
+//		void updateAvailableClasses() {
+//			comboAbove.getItems().setAll(qupath.getAvailablePathClasses());
+//			comboBelow.getItems().setAll(qupath.getAvailablePathClasses());
+//		}
 		
 		void resetClassifications(PathObjectHierarchy hierarchy, Map<PathObject, PathClass> mapPrevious) {
 			// Restore classifications if the user cancelled


### PR DESCRIPTION
Adding/removing a class didn't update the dialog until it was relaunched (bug spotted by @lacan)