### PR TITLE
Improved UX in Find command

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -807,6 +807,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 	 * 
 	 * @param tab
 	 * @param script
+	 * @param project 
 	 * @param imageData
 	 */
 	private void executeScript(final ScriptTab tab, final String script, final Project<BufferedImage> project, final ImageData<BufferedImage> imageData) {
@@ -1372,6 +1373,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 	
 	/**
 	 * Request project image entries to run script for.
+	 * @param doSave 
 	 */
 	void handleRunProject(final boolean doSave) {
 		Project<BufferedImage> project = qupath.getProject();
@@ -2055,6 +2057,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 		ScriptFindCommand findCommand = new ScriptFindCommand();
 		Action action = new Action(name, e -> {
 			findCommand.run();
+			e.consume();
 		});
 		action.setAccelerator(new KeyCodeCombination(KeyCode.F, KeyCombination.SHORTCUT_DOWN));
 		return action;
@@ -2473,17 +2476,17 @@ public class DefaultScriptEditor implements ScriptEditor {
 		public void run() {
 			if (dialog == null)
 				createFindDialog();
+			dialog.hide();		// Only way to request focus to dialog when it's not hidden
 			dialog.show();
 			tfFind.requestFocus();
-			
+
 			// If some text is selected in the main text component, use it as search query
 			var selectedText = getCurrentTextComponent().getSelectedText();
-			if (!selectedText.isEmpty())
+			if (!selectedText.isEmpty()) {
 				tfFind.setText(selectedText);
-			
-			// If search is already set, focus on 'Next'
-			if (!tfFind.getText().isEmpty())
-				((Button)dialog.getDialogPane().lookupButton(btNext)).requestFocus();
+				((Button)dialog.getDialogPane().lookupButton(btNext)).requestFocus();				
+			} else
+				tfFind.selectAll();
 		}
 		
 		private void createFindDialog() {
@@ -2525,15 +2528,9 @@ public class DefaultScriptEditor implements ScriptEditor {
 
 			((Button)dialog.getDialogPane().lookupButton(btNext)).addEventFilter(ActionEvent.ACTION, e -> actionNext.handle(e));
 			((Button)dialog.getDialogPane().lookupButton(btPrevious)).addEventFilter(ActionEvent.ACTION, e -> actionPrevious.handle(e));
-			
-//			((Button)dialog.getDialogPane().lookupButton(btClose)).addEventFilter(ActionEvent.ACTION, e -> {
-//				findPrevious(getCurrentTextComponent(), tfFind.getText());
-//				e.consume();
-//			});
 
 			dialog.getDialogPane().setHeader(null);
 			dialog.getDialogPane().setContent(pane);
-			
 		}
 		
 		


### PR DESCRIPTION
This commit exists to fix a few UX problems with the Find command window. These are the intended behaviours:
- Ctrl + F for the first time will show and focus the Find command window
- Ctrl + F not for the first time (e.g. window is already visible) will **also** focus the Find command window (now fixed)
- Ctrl + F with selected text will focus 'Next' button
- Ctrl + F with no selected text will focus the `TextField` and select its content (now fixed)