### PR TITLE
Cache RGB image with BufferedImageOverlay

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/BufferedImageOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/BufferedImageOverlay.java
@@ -231,6 +231,8 @@ public class BufferedImageOverlay extends AbstractImageOverlay implements Change
                 	cacheRGB.put(img, imgRGB);
             	}
             	img = imgRGB;
+            } else {
+            	img = cacheRGB.computeIfAbsent(img, img2 -> convertToDrawable(img2));
             }
         	g2d.drawImage(img, region.getX(), region.getY(), region.getWidth(), region.getHeight(), null);
         }


### PR DESCRIPTION
Resolves some performance issues with non-RGB overlays.