### PR TITLE
Added 'Replace next' and 'Replace all' to Find command in Script Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This is a work-in-progress.
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)
+* Owner of Find window in the script editor is lost when the script editor window is closed (https://github.com/qupath/qupath/issues/893)
+
+### Enhancements
+* Added 'Replace next' and 'Replace all' features to the Find window in the script editor
 
 
 ## Version 0.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This is a work-in-progress.
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)
+* 'Ignore case' in the Find window of the Script editor does not ignore case (https://github.com/qupath/qupath/issues/889)
 * Owner of Find window in the script editor is lost when the script editor window is closed (https://github.com/qupath/qupath/issues/893)
 
 ### Enhancements

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -638,8 +638,8 @@ public class RichScriptEditor extends DefaultScriptEditor {
 		}
 
 		@Override
-		public void selectRange(int anchor, int caretPosition) {
-			textArea.selectRange(anchor, caretPosition);
+		public void selectRange(int startIdx, int endIdx) {
+			textArea.selectRange(startIdx, endIdx);
 		}
 
 		@Override


### PR DESCRIPTION
- Added 'Replace next' and 'Replace all' to Find command
- Fixed 'Previous' button that would search for the next occurrence instead of the previous one
- Improved UX
- Fixed find command window losing its owner whenever the Script Editor is closed