### PR TITLE
Fixed warning message for missing features

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierLoadCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierLoadCommand.java
@@ -368,7 +368,7 @@ public final class ObjectClassifierLoadCommand implements Runnable {
 			for (var entry : missingCounts.entrySet()) {
 				double percent = entry.getValue() * 100.0/n;
 				sb.append("\t").append(entry.getKey()).append(": ")
-					.append(n).append(" objects (")
+					.append(entry.getValue()).append(" objects (")
 					.append(GeneralTools.formatNumber(percent, 2)).append("%)")
 					.append("\n");
 			}


### PR DESCRIPTION
- Fixed the total amount of objects missing the specific feature for the classifier to be applied correctly (it would previously always give the total amount of objects instead). Reported [here](https://forum.image.sc/t/qupath-error-logging-bug/62361).