### PR TITLE
'New line' and 'Find' in Script Editor follow the caret

### DIFF
--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -646,7 +646,11 @@ public class RichScriptEditor extends DefaultScriptEditor {
 		public void setPopup(ContextMenu menu) {
 			textArea.setContextMenu(menu);
 		}
-		
+
+		@Override
+		public void requestFollowCaret() {
+			textArea.requestFollowCaret();
+		}
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -1718,6 +1718,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 		textArea.insertText(caretPos, insertText);
 		int newPos = caretPos + insertText.length();
 		textArea.selectRange(newPos, newPos);
+		textArea.requestFollowCaret();
 	}
 	
 	
@@ -2334,6 +2335,11 @@ public class DefaultScriptEditor implements ScriptEditor {
 		 */
 		public ReadOnlyBooleanProperty focusedProperty();
 
+		/**
+		 * Request that the X and Y scrolls are adjusted to ensure the caret is visible
+		 */
+		public void requestFollowCaret();
+
 	}
 	
 	
@@ -2461,6 +2467,12 @@ public class DefaultScriptEditor implements ScriptEditor {
 		public void setPopup(ContextMenu menu) {
 			textArea.setContextMenu(menu);
 		}
+
+		@Override
+		public void requestFollowCaret() {
+			// TODO: Implement if ever needed
+			return;
+		}
 		
 	}
 	
@@ -2555,6 +2567,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 			else
 				ind = ind + pos;
 			control.selectRange(ind, ind + toFind.length());
+			control.requestFollowCaret();
 		}
 		
 		void findPrevious(final ScriptEditorControl control, final String findText, final boolean ignoreCase) {
@@ -2577,6 +2590,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 			if (ind < 0)
 				ind = text.lastIndexOf(toFind);
 			control.selectRange(ind, ind + toFind.length());
+			control.requestFollowCaret();
 		}
 
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -2336,9 +2336,14 @@ public class DefaultScriptEditor implements ScriptEditor {
 		public ReadOnlyBooleanProperty focusedProperty();
 
 		/**
-		 * Request that the X and Y scrolls are adjusted to ensure the caret is visible
+		 * Request that the X and Y scrolls are adjusted to ensure the caret is visible.
+		 * <p>
+		 * This method does nothing by default. 
+		 * This means that a class extending this interface must specifically implement this method if a different behavior is expected.
 		 */
-		public void requestFollowCaret();
+		public default void requestFollowCaret() {
+			return;
+		}
 
 	}
 	
@@ -2467,13 +2472,6 @@ public class DefaultScriptEditor implements ScriptEditor {
 		public void setPopup(ContextMenu menu) {
 			textArea.setContextMenu(menu);
 		}
-
-		@Override
-		public void requestFollowCaret() {
-			// TODO: Implement if ever needed
-			return;
-		}
-		
 	}
 	
 	


### PR DESCRIPTION
- New lines created at the bottom of the script editor are now visible (scroll is automatically adjusted)
- When searching for a query in the Script Editor (via the 'Find' command), the scroll is automatically adjusted to make the found result visible