### PR TITLE
Added '{}' block handling to Script Editor

### DIFF
--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -647,6 +647,10 @@ public class RichScriptEditor extends DefaultScriptEditor {
 			textArea.setContextMenu(menu);
 		}
 		
+		@Override
+		public void positionCaret(int index) {
+			textArea.moveTo(index);
+		}
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -1733,7 +1733,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 			finalPos = caretPos + 1 + indentation + tabString.length() + lineRemainder.strip().length();
 			
 			// If '{' is not preceded by a space, insert one (this is purely aesthetic)
-			if (trimmedSubString.charAt(trimmedSubString.length() - 2) != ' ')
+			if (trimmedSubString.length() >= 2 && trimmedSubString.charAt(trimmedSubString.length() - 2) != ' ')
 				textArea.insertText(++caretPos - 2, " ");
 
 			textArea.insertText(caretPos, insertText);


### PR DESCRIPTION
- Added the handling of new lines following a '{' character, which works as follows:
1. A block is generally  '{' + new line + indentation + new line + '}'
2. The final caret position is set to inside the block
3. If there originally was some text after '{', the text will be included inside the block. E.g. 
```
forEach{doSomething()
}
```
becomes: 
```
forEach {
    doSomething()
}
```
4. If the amount of '{' and '}' in the text is equal, it will add the new line but won't create a block. This is to avoid cases where there already is a closing bracket. E.g. hitting 'Enter' after the opening bracket in the following example will not add a closing bracket, since one is already present: 
```
forEach { 
    doSomething()
}
```
becomes
```
forEach {
    
    doSomething()
}
```
And not:
```
forEach {
    
    }
    doSomething()
}
```
5. A space is added before '{' if there wasn't one already (purely aesthetic):
```
forEach{...
}
```
and
```
forEach {...
}
```
both become: 
```
forEach {
    ...
}
```

- At this stage, this is quite experimental. However, it could develop into something more advanced in the future.