### PR TITLE
Fixed 'Shift+Tab' in Script Editor

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -1672,18 +1672,20 @@ public class DefaultScriptEditor implements ScriptEditor {
 	 * @param shiftDown
 	 */
 	protected void handleTabPress(final ScriptEditorControl textArea, final boolean shiftDown) {
-		String selected = textArea.getSelectedText();
-		int pos = textArea.getCaretPosition();
-		if (selected == null || selected.length() == 0) {
-			textArea.insertText(pos, tabString);
-			return;
-		}
-
 		String text = textArea.getText();
-		IndexRange range = textArea.getSelection();
+		IndexRange range = textArea.getSelection() == null ? IndexRange.valueOf("0,0") : textArea.getSelection();
 		int startRowPos = getRowStartPosition(text, range.getStart());
 		int endRowPos = getRowEndPosition(text, range.getEnd());
 		String textBetween = text.substring(startRowPos, endRowPos);
+
+		if (range.getLength() == 0) {
+			if (shiftDown && textBetween.indexOf(tabString) == 0)
+				textArea.deleteText(startRowPos, startRowPos + tabString.length());
+			else if (!shiftDown)
+				textArea.insertText(textArea.getCaretPosition(), tabString);
+			return;
+		}
+
 		String replaceText;
 		if (shiftDown) {
 			// Remove tabs at start of selected rows


### PR DESCRIPTION
- Old behaviour:
Shift+Tab with no selection would add a tab (regardless of caret position within line)
- New behaviour:
Shift+Tab with no selection removes a level of indentation at the start of the line if present (regardless of caret position within line)

### Notes:
- Tab with and without selection hasn't changed, regardless of caret position within line
- Shift+Tab with selection hasn't changed, regardless of caret position within line
Shift