### PR TITLE
Added smart parentheses and double quotes

### DIFF
--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -289,10 +289,35 @@ public class RichScriptEditor extends DefaultScriptEditor {
 			
 			
 			codeArea.getStylesheets().add(getClass().getClassLoader().getResource("scripting_styles.css").toExternalForm());
-						
+			
+			// Catch key typed events for special character handling (which should be platform-agnostic)
+			codeArea.addEventFilter(KeyEvent.KEY_TYPED, e -> {
+				if (e.isConsumed())
+					return;
+				
+				if ("(".equals(e.getCharacter())) {
+					handleLeftParenthesis(control);
+					e.consume();
+				} else if (")".equals(e.getCharacter())) {
+					handleRightParenthesis(control);
+					e.consume();
+				} else if ("\"".equals(e.getCharacter())) {
+					handleQuotes(control, true);
+					e.consume();
+				} else if ("\'".equals(e.getCharacter())) {
+					handleQuotes(control, false);
+					e.consume();
+					
+				}
+				if (!e.isConsumed())
+					matchMethodName(control, e);
+			});
+			
+			
 			codeArea.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
 				if (e.isConsumed())
 					return;
+				
 				if (e.getCode() == KeyCode.TAB) {
 					handleTabPress(control, e.isShiftDown());
 					e.consume();
@@ -302,18 +327,10 @@ public class RichScriptEditor extends DefaultScriptEditor {
 				} else if (e.getCode() == KeyCode.ENTER && control.getSelectedText().length() == 0) {
 					handleNewLine(control);
 					e.consume();
-				} else if (new KeyCodeCombination(KeyCode.DIGIT9, KeyCombination.SHIFT_DOWN).match(e) || e.getCode() == KeyCode.LEFT_PARENTHESIS) {
-					// TODO: Check Locale because DIGIT9 + SHIFT_DOWN might not work on all keyboards
-					handleLeftParenthesis(control);
-					e.consume();
-				} else if (new KeyCodeCombination(KeyCode.DIGIT0, KeyCombination.SHIFT_DOWN).match(e) || e.getCode() == KeyCode.RIGHT_PARENTHESIS) {
-					// TODO: Check Locale because DIGIT0 + SHIFT_DOWN might not work on all keyboards
-					handleRightParenthesis(control);
-					e.consume();
-				} else if (new KeyCodeCombination(KeyCode.DIGIT2, KeyCombination.SHIFT_DOWN).match(e) || e.getCode() == KeyCode.QUOTEDBL) {
-					// TODO: Check Locale because DIGIT2 + SHIFT_DOWN might not work on all keyboards
-					handleDoubleQuotes(control);
-					e.consume();
+				} else if (e.getCode() == KeyCode.BACK_SPACE) {
+					if (handleBackspace(control) && !e.isShortcutDown() && !e.isShiftDown())
+						e.consume();
+					
 				}
 				if (!e.isConsumed())
 					matchMethodName(control, e);

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -302,6 +302,18 @@ public class RichScriptEditor extends DefaultScriptEditor {
 				} else if (e.getCode() == KeyCode.ENTER && control.getSelectedText().length() == 0) {
 					handleNewLine(control);
 					e.consume();
+				} else if (new KeyCodeCombination(KeyCode.DIGIT9, KeyCombination.SHIFT_DOWN).match(e) || e.getCode() == KeyCode.LEFT_PARENTHESIS) {
+					// TODO: Check Locale because DIGIT9 + SHIFT_DOWN might not work on all keyboards
+					handleLeftParenthesis(control);
+					e.consume();
+				} else if (new KeyCodeCombination(KeyCode.DIGIT0, KeyCombination.SHIFT_DOWN).match(e) || e.getCode() == KeyCode.RIGHT_PARENTHESIS) {
+					// TODO: Check Locale because DIGIT0 + SHIFT_DOWN might not work on all keyboards
+					handleRightParenthesis(control);
+					e.consume();
+				} else if (new KeyCodeCombination(KeyCode.DIGIT2, KeyCombination.SHIFT_DOWN).match(e) || e.getCode() == KeyCode.QUOTEDBL) {
+					// TODO: Check Locale because DIGIT2 + SHIFT_DOWN might not work on all keyboards
+					handleDoubleQuotes(control);
+					e.consume();
 				}
 				if (!e.isConsumed())
 					matchMethodName(control, e);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -527,7 +527,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 	        } else if (e.getCode() == KeyCode.ENTER && control.getSelectedText().length() == 0) {
 				handleNewLine(control);
 				e.consume();
-			} 
+			}
 	    });
 
 //		editor.getDocument().addUndoableEditListener(new UndoManager());
@@ -1746,6 +1746,30 @@ public class DefaultScriptEditor implements ScriptEditor {
 			finalPos = caretPos + insertText.length();
 		}
 		textArea.positionCaret(finalPos);
+	}
+	
+	protected static void handleLeftParenthesis(final ScriptEditorControl textArea) {
+		textArea.insertText(textArea.getCaretPosition(), ")");
+		textArea.positionCaret(textArea.getCaretPosition()-1);
+	}
+	
+	protected static void handleRightParenthesis(final ScriptEditorControl textArea) {
+		String text = textArea.getText();
+		var caretPos = textArea.getCaretPosition();
+		if (text.length() >= caretPos + 1 && text.charAt(caretPos) == ')') {
+			textArea.deleteText(caretPos, caretPos + 1);
+		}
+	}
+	
+	protected static void handleDoubleQuotes(final ScriptEditorControl textArea) {
+		String text = textArea.getText();
+		var caretPos = textArea.getCaretPosition();
+		if (text.length() >= caretPos + 1 && text.charAt(caretPos) == '"')
+			textArea.deleteText(caretPos, caretPos + 1);
+		else {
+			textArea.insertText(textArea.getCaretPosition(), "\"");
+			textArea.positionCaret(textArea.getCaretPosition()-1);
+		}
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -1750,12 +1750,17 @@ public class DefaultScriptEditor implements ScriptEditor {
 		textArea.positionCaret(finalPos);
 	}
 	
-	protected static void handleLeftParenthesis(final ScriptEditorControl textArea) {
+	protected void handleLeftParenthesis(final ScriptEditorControl textArea) {
+		if (!smartEditing.get())
+			return;
 		textArea.insertText(textArea.getCaretPosition(), ")");
 		textArea.positionCaret(textArea.getCaretPosition()-1);
 	}
 	
-	protected static void handleRightParenthesis(final ScriptEditorControl textArea) {
+	protected void handleRightParenthesis(final ScriptEditorControl textArea) {
+		if (!smartEditing.get())
+			return;
+		
 		String text = textArea.getText();
 		var caretPos = textArea.getCaretPosition();
 		if (text.length() >= caretPos + 1 && text.charAt(caretPos) == ')') {
@@ -1763,7 +1768,10 @@ public class DefaultScriptEditor implements ScriptEditor {
 		}
 	}
 	
-	protected static void handleDoubleQuotes(final ScriptEditorControl textArea) {
+	protected void handleDoubleQuotes(final ScriptEditorControl textArea) {
+		if (!smartEditing.get())
+			return;
+		
 		String text = textArea.getText();
 		var caretPos = textArea.getCaretPosition();
 		if (text.length() >= caretPos + 1 && text.charAt(caretPos) == '"')


### PR DESCRIPTION
- Added smart parentheses '(' and ')'. 
1. Typing an opening parenthesis '(' will automatically add a closing one ')' and move the caret in the middle of both: (`_` is the caret position, not a character here)

_Before_:
```
_
```
_After_:
```
(_)
```
2. Typing a closing parenthesis when the next character is already a closing parenthesis will simply move the caret forward one position:

_Before_:
```
(_)
```
_After_:
```
()_
```
And also, _Before_:
```
doSomething(true_)
```
_After (the closing parenthesis is not repeated)_:
```
doSomething(true)_
```

- Smart double quotes '"'.
1. Typing double quotes '"' will automatically add another following one and move the caret in-between:

_Before_:
```
_
```
_After_:
```
"_"
```
2. Typing double quotes '"' when the next character is already a double quotes will simply move the caret forward one position:

_Before_:
```
"_"
```
_After_:
```
""_
```
And also, _Before_:
```
"Hello World_"
```
_After_:
```
Hello World"_
```

### Note
This PR cannot be merged until these notes are checked manually:
- The smart parentheses behaviour is currently triggered by either typing the left/right parenthesis keys or `Shift` + `9`/`0`, which might not be applicable to all keyboards/locales.
- The smart double quotes behaviour is currently triggered by either typing the double quotes key or `Shift` +  `2`, which might not be applicable to all keyboards/locales.
