### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ This is a work-in-progress.
 * JavaFX 17.0.2
 * Groovy 4.0.0
 * Guava 31.0.1
+* JavaCPP 1.5.7
 * JFreeSVG 5.0.2
+* OpenCV 4.5.5
+* Picocli 4.6.3
 
 
 ## Version 0.3.2

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ task mergedJavadocs(type: Javadoc, description: 'Generate merged javadocs for al
 
 	options.links 'https://docs.oracle.com/en/java/javase/11/docs/api/'
 	options.links 'https://openjfx.io/javadoc/17/'
-	options.links 'https://javadoc.io/doc/org.bytedeco/javacpp/1.5.6/'
-	options.links 'https://javadoc.io/doc/org.bytedeco/opencv/4.5.3-1.5.6/'
+	options.links 'https://javadoc.io/doc/org.bytedeco/javacpp/1.5.7/'
+	options.links 'https://javadoc.io/doc/org.bytedeco/opencv/4.5.5-1.5.7/'
 	options.links 'https://javadoc.io/doc/com.google.code.gson/gson/2.8.9/'
 	options.links 'https://javadoc.io/doc/org.locationtech.jts/jts-core/1.18.2/'
 	options.links 'https://javadoc.io/doc/net.imagej/ij/1.53i/'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -34,5 +34,5 @@ gradlePlugin {
 
 dependencies {
     // Make Gradle plugin available to limit platform jars
-    implementation 'org.bytedeco:gradle-javacpp:1.5.6'
+    implementation 'org.bytedeco:gradle-javacpp:1.5.7'
 }

--- a/buildSrc/src/main/groovy/qupath.common-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.common-conventions.gradle
@@ -103,18 +103,14 @@ ext {
     imagejVersion      = '1.53i'
     jfxtrasVersion     = '11-r2'
     jtsVersion         = '1.18.2'
-    picocliVersion     = '4.6.2'
+    picocliVersion     = '4.6.3'
     
     // Note, if OpenCV is a SNAPSHOT version then it must already be installed locally (with Maven)
-    if (isAppleSilicon) {
-	    javacppVersion     = '1.5.7-SNAPSHOT'
-	    opencvVersion      = "4.5.5-${javacppVersion}"
-	} else {
-		javacppVersion     = '1.5.6'
-	    opencvVersion      = "4.5.3-${javacppVersion}"
-	}
+	javacppVersion     = '1.5.7'
+    opencvVersion      = "4.5.5-${javacppVersion}"
+
 	// Optional, not used by default
-	cudaVersion        = "11.4-8.2-${javacppVersion}"
+	cudaVersion        = "11.6-8.3-${javacppVersion}"
 
     // Additional versions
     logbackVersion     = '1.2.10'

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
@@ -2188,7 +2188,13 @@ public class OpenCVTools {
 	 * @return number of connected components, equal to the value of the highest integer label
 	 */
 	public static int label(Mat matBinary, Mat matLabels, int connectivity) {
-		return opencv_imgproc.connectedComponents(matBinary, matLabels, connectivity, opencv_core.CV_32S) - 1;
+		// See https://github.com/opencv/opencv/pull/21275/files
+		// Error causing segfault introduced in OpenCV 4.5.5, see https://github.com/opencv/opencv/issues/21366
+		// Therefore here we try to revert to the previous default algorithms.
+		// TODO: For OpenCV > 4.5.5 can likely revert back to connectedComponents again, since the bug has been fixed
+		int alg = connectivity == 8 ? opencv_imgproc.CCL_GRANA : opencv_imgproc.CCL_SAUF;
+		return opencv_imgproc.connectedComponentsWithAlgorithm(matBinary, matLabels, connectivity, opencv_core.CV_32S, alg) - 1;
+//		return opencv_imgproc.connectedComponents(matBinary, matLabels, connectivity, opencv_core.CV_32S) - 1;
 	}
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/common/ThreadTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ThreadTools.java
@@ -101,11 +101,7 @@ public class ThreadTools {
 		private int priority;
 	
 		SimpleThreadFactory(final String prefix, final boolean daemon, final int priority) {
-			SecurityManager s = System.getSecurityManager();
-			if (s == null)
-				group = Thread.currentThread().getThreadGroup();
-			else
-				group = s.getThreadGroup();
+			this.group = Thread.currentThread().getThreadGroup();
 			this.prefix = prefix;
 			this.daemon = daemon;
 			this.priority = Math.max(Thread.MIN_PRIORITY, Math.min(Thread.MAX_PRIORITY, priority));


### PR DESCRIPTION
* Update JavaCPP/OpenCV. This includes Apple Silicon support if built with a compatible JDK (but OpenSlide/Bio-Formats still won't work).
* Update Picocli
* Remove `SecurityManager` reference in `ThreadTools`, because it is deprecated for removal in Java 17