### PR TITLE
Improved support for QuPath<->ImageJ object conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is a work-in-progress.
 * Owner of Find window in the script editor is lost when the script editor window is closed (https://github.com/qupath/qupath/issues/893)
 
 ### Enhancements
-* Some general script editor improvements, including:
+* Many script editor improvements, including:
   * Added 'Replace/Next' and 'Replace all' features to Find window (https://github.com/qupath/qupath/pull/898)
   * New lines now trigger caret following (https://github.com/qupath/qupath/pull/900)
   * Proper tab handling (https://github.com/qupath/qupath/pull/902)
@@ -16,6 +16,11 @@ This is a work-in-progress.
     * Brace block handling (https://github.com/qupath/qupath/pull/901)
     * Smart parentheses and (double/single) quotes (https://github.com/qupath/qupath/pull/907)
     * Comment block handling (https://github.com/qupath/qupath/pull/908)
+* Improved support for switching between QuPath objects and ImageJ ROIs
+  * New 'Extensions -> ImageJ -> Import ImageJ ROIs' command
+  * Import .roi and RoiSet.zip files by drag & drop
+  * Built-in ImageJ plugin to send RoiManager ROIs to QuPath (not only overlays)
+  * Retain ROI position information when sending ROIs from ImageJ (hyper)stacks
 
 ### Dependency updates
 * Adoptium OpenJDK 17

--- a/qupath-core/src/main/java/qupath/lib/io/PathIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathIO.java
@@ -911,7 +911,7 @@ public class PathIO {
 	 */
 	public static Set<String> unzippedExtensions(Path path) throws IOException {
 		var content = Files.probeContentType(path);
-		if ("application/zip".equals(content) || "application/java-archive".equals(content)) {
+		if ((content != null && zipContent.contains(content)) || path.toString().toLowerCase().endsWith(".zip")) {
 			// In case we have more than one compressed file, iterate through each entry
 			Set<String> extensions = new LinkedHashSet<>();
 			try (var zipfs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
@@ -932,6 +932,12 @@ public class PathIO {
 		}
 	}
 	
+	private static Set<String> zipContent = Set.of(
+			"application/zip",
+			"application/x-zip-compressed",
+			"application/java-archive"
+			);
+			
 	
 //	private static boolean serializePathObject(File file, PathObject pathObject) {
 //		boolean success = false;

--- a/qupath-core/src/test/java/qupath/lib/io/PathIOTest.java
+++ b/qupath-core/src/test/java/qupath/lib/io/PathIOTest.java
@@ -1,0 +1,74 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
+ * Contact: IP Management (ipmanagement@qub.ac.uk)
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("javadoc")
+public class PathIOTest {
+	
+	@Test
+	public void test_unzippedExtensions() throws IOException {
+		
+		var tmpDir = Files.createTempDirectory("anything");
+		assertTrue(PathIO.unzippedExtensions(tmpDir).isEmpty());
+		Files.deleteIfExists(tmpDir);
+		
+		var tmpFile = Files.createTempFile("anything", ".tmp");
+		assertEquals(
+				Collections.singleton(".tmp"),
+				PathIO.unzippedExtensions(tmpFile));
+		Files.deleteIfExists(tmpFile);
+		
+		for (var zipExtension : Arrays.asList(".zip", ".jar")) {
+			var tmpZipFile = Files.createTempFile("anything", zipExtension);
+			try (var zos = new ZipOutputStream(Files.newOutputStream(tmpZipFile))) {
+				var tmpEntry = new ZipEntry("something.txt");
+				zos.putNextEntry(tmpEntry);
+				var tmpEntry2 = new ZipEntry("something/else.json");
+				zos.putNextEntry(tmpEntry2);
+				var tmpEntry3 = new ZipEntry("something/else-again.json");
+				zos.putNextEntry(tmpEntry3);
+			}
+			assertEquals(
+					Set.of(".txt", ".json"),
+					PathIO.unzippedExtensions(tmpZipFile));
+			Files.deleteIfExists(tmpZipFile);
+		}
+
+	}
+
+	
+}

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
@@ -28,6 +28,7 @@ import ij.ImagePlus;
 import ij.WindowManager;
 import ij.gui.Roi;
 import ij.macro.Interpreter;
+import ij.measure.Calibration;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.scene.Scene;
@@ -317,7 +318,8 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 				}
 				if (params.getBooleanParameterValue("getROI") && impResult.getRoi() != null) {
 					Roi roi = impResult.getRoi();
-					PathObject pathObjectNew = roi == null ? null : IJTools.convertToAnnotation(impResult, imageData.getServer(), roi, downsampleFactor, region.getPlane());
+					Calibration cal = impResult.getCalibration();
+					PathObject pathObjectNew = roi == null ? null : IJTools.convertToAnnotation(roi, cal.xOrigin, cal.yOrigin, downsampleFactor, region.getPlane());
 					if (pathObjectNew != null) {
 						// If necessary, trim any returned annotation
 						if (pathROI != null && !(pathROI instanceof RectangleROI) && pathObjectNew.isAnnotation() && RoiTools.isShapeROI(pathROI) && RoiTools.isShapeROI(pathObjectNew.getROI())) {
@@ -335,7 +337,8 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 				
 				boolean exportAsDetection = ((String) params.getChoiceParameterValue("getOverlayAs")).equals("Detections") ? true : false;
 				if (params.getBooleanParameterValue("getOverlay") && impResult.getOverlay() != null) {
-					List<PathObject> childObjects = QuPath_Send_Overlay_to_QuPath.createPathObjectsFromROIs(imp, impResult.getOverlay().toArray(), imageData.getServer(), downsampleFactor, exportAsDetection, true, region.getPlane());
+					var overlay = impResult.getOverlay();
+					List<PathObject> childObjects = QuPath_Send_Overlay_to_QuPath.createObjectsFromROIs(imp, Arrays.asList(overlay.toArray()), downsampleFactor, exportAsDetection, true, region.getPlane());
 					if (!childObjects.isEmpty()) {
 						pathObject.addPathObjects(childObjects);
 						changes = true;

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImportRoisCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImportRoisCommand.java
@@ -1,0 +1,103 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
+ * Contact: IP Management (ipmanagement@qub.ac.uk)
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.imagej.gui;
+
+import ij.gui.Roi;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import qupath.imagej.tools.IJTools;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.gui.dialogs.Dialogs;
+
+/**
+ * Import ROIs from ImageJ, saved in .roi or .zip format.
+ * 
+ * @author Pete Bankhead
+ *
+ */
+class ImportRoisCommand implements Runnable {
+	
+	private static Logger logger = LoggerFactory.getLogger(ImportRoisCommand.class);
+	
+	private QuPathGUI qupath;
+	
+	/**
+	 * Constructor.
+	 * @param qupath QuPath instance where the command should be installed.
+	 */
+	public ImportRoisCommand(QuPathGUI qupath) {
+		this.qupath = qupath;
+	}
+	
+	/**
+	 * Get the name of the command.
+	 * @return
+	 */
+	public String getName() {
+		return "Import ImageJ ROIs";
+	}
+	
+
+	@Override
+	public void run() {
+		var viewer = qupath.getViewer();
+		var imageData = viewer == null ? null : viewer.getImageData();
+		if (imageData == null) {
+			Dialogs.showNoImageError(getName());
+			return;
+		}
+		
+		var files = Dialogs.promptForMultipleFiles("ImageJ ROIs", null, "ImageJ ROI files", ".roi", ".zip");
+		if (files == null) {
+			logger.info("No ImageJ ROI files selected for import");
+			return;
+		}
+		
+		List<Roi> rois = files.stream()
+				.filter(f -> IJTools.containsImageJRois(f))
+				.flatMap(f -> IJTools.readImageJRois(f).stream())
+				.collect(Collectors.toList());
+		
+		if (rois.isEmpty()) {
+			Dialogs.showInfoNotification(getName(), "No ROIs found in selected files");
+			return;
+		}
+		
+		// TODO: Consider adding options for the import, if needed
+		double downsample = 1.0;
+		double xOrigin = 0.0;
+		double yOrigin = 0.0;
+		var pathObjects = rois.stream().map(r -> IJTools.convertToAnnotation(r, xOrigin, yOrigin, downsample, null)).collect(Collectors.toList());
+
+		var hierarchy = imageData.getHierarchy();
+		hierarchy.addPathObjects(pathObjects);
+		hierarchy.getSelectionModel().selectObjects(pathObjects);
+		
+	}
+	
+	
+}

--- a/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_Overlay_to_QuPath.java
+++ b/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_Overlay_to_QuPath.java
@@ -23,27 +23,30 @@
 
 package qupathj;
 
-import java.awt.image.BufferedImage;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import qupath.imagej.tools.IJTools;
 import qupath.lib.gui.QuPathGUI;
-import qupath.lib.gui.viewer.QuPathViewer;
+import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.PathObject;
-import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.regions.ImagePlane;
 import ij.IJ;
 import ij.ImagePlus;
+import ij.WindowManager;
 import ij.gui.GenericDialog;
 import ij.gui.Overlay;
 import ij.gui.PointRoi;
 import ij.gui.Roi;
+import ij.measure.Calibration;
 import ij.measure.ResultsTable;
 import ij.plugin.PlugIn;
 import ij.plugin.filter.Analyzer;
+import ij.plugin.frame.RoiManager;
 import ij.process.ImageProcessor;
 import ij.process.ImageStatistics;
 import javafx.application.Platform;
@@ -58,79 +61,138 @@ import javafx.application.Platform;
  */
 public class QuPath_Send_Overlay_to_QuPath implements PlugIn {
 	
-	private String typeChoice = "Detection";
+	private String typeChoice = "Annotation";
 	private boolean includeMeasurements = false;
+	private boolean selectObjects = true;
 
 	@Override
 	public void run(String arg) {
-		ImagePlus imp = IJ.getImage();
-		if (imp == null)
+		ImagePlus imp = WindowManager.getCurrentImage();
+		
+		List<Roi> rois = null;
+		if ("manager".equalsIgnoreCase(arg)) {
+			var rm = RoiManager.getInstance();
+			if (rm == null) {
+				IJ.showMessage("No RoiManager found!");
+				return;				
+			}
+			rois = Arrays.asList(rm.getRoisAsArray());
+			if (rois.isEmpty()) {
+				IJ.showMessage("No ROIs found in the RoiManager!");
+				return;								
+			}
+		} else {
+			Overlay overlay = imp == null ? null : imp.getOverlay();
+			if (overlay == null || overlay.size() == 0) {
+				IJ.showMessage("No overlay found!");
+				return;
+			}
+			rois = Arrays.asList(overlay.toArray());
+		}
+		// Shouldn't happen
+		if (rois.isEmpty())
 			return;
 
-		Overlay overlay = imp.getOverlay();
-		if (overlay == null || overlay.size() == 0) {
-			IJ.showMessage("No overlay found!");
+		var gui = QuPathGUI.getInstance();
+		var viewer = gui == null ? null : gui.getViewer();
+		var imageData = viewer == null ? null : viewer.getImageData();
+		if (imageData == null) {
+			IJ.showMessage("No image selected in QuPath!");
 			return;
 		}
+		
+		promptToImportRois(imageData, imp, rois, viewer.getImagePlane());
+	}
 
-		QuPathGUI gui = QuPathGUI.getInstance();
-		if (gui == null) {
-			IJ.showMessage("QuPath viewer not found!");
-			return;
-		}
-
+	private void promptToImportRois(ImageData<?> imageData, ImagePlus imp, Collection<? extends Roi> rois, ImagePlane currentPlane) {
+		
 		GenericDialog gd = new GenericDialog("Send overlay to QuPath");
-		gd.addChoice("Choose_object_type", new String[]{"Annotation", "Detection"}, "Detection");
-		gd.addCheckbox("Include_measurements", false);
+		gd.addChoice("Choose_object_type", new String[]{"Annotation", "Detection"}, typeChoice);
+		if (imp != null)
+			gd.addCheckbox("Include_measurements", false);
+		gd.addCheckbox("Select_objects", selectObjects);
 		gd.showDialog();
 		if (gd.wasCanceled())
 			return;
+		
 		typeChoice = gd.getNextChoice();
 		boolean asDetection = "Detection".equals(typeChoice);
-		includeMeasurements = gd.getNextBoolean();
+		includeMeasurements = imp == null ? false : gd.getNextBoolean();
+		selectObjects = gd.getNextBoolean();
 
-		QuPathViewer viewer = gui.getViewer();
-		ImageServer<BufferedImage> server = viewer.getServer();
-		double downsample = IJTools.estimateDownsampleFactor(imp, server);
-		PathObjectHierarchy hierarchy = gui.getViewer().getHierarchy();
+		var server = imageData.getServer();
+		double downsample = imp == null ? 1.0 : IJTools.estimateDownsampleFactor(imp, server);
+		var hierarchy = imageData.getHierarchy();
 		
-		List<PathObject> pathObjects = createPathObjectsFromROIs(imp, overlay.toArray(), server, downsample, asDetection, includeMeasurements, viewer.getImagePlane());
+		ImagePlane plane = currentPlane;
+		if (imp == null)
+			plane = null;
+		else if (imp != null && server.nZSlices() * server.nTimepoints() > 1) {
+			if (imp.getNSlices() == server.nZSlices() && imp.getNFrames() == server.nTimepoints())
+				plane = null;
+		}
+		
+		List<PathObject> pathObjects = createObjectsFromROIs(imp, rois, downsample, asDetection, includeMeasurements, plane);
 		if (!pathObjects.isEmpty()) {
-			Platform.runLater(() -> hierarchy.addPathObjects(pathObjects));
+			Platform.runLater(() -> {
+				hierarchy.addPathObjects(pathObjects);
+				// Select the objects, e.g. so they can be classified or otherwise updated easily
+				if (selectObjects)
+					hierarchy.getSelectionModel().selectObjects(pathObjects);
+			});
 		}
 	}
 
-	
-	
 	/**
-	 * Turn an array of ImageJ ROIs into a list of QuPath PathObjects, optionally adding measurements as well.
-	 * 
+	 * Legacy method to turn an array of ImageJ ROIs into a list of QuPath PathObjects, optionally adding measurements as well.
 	 * @param imp
 	 * @param rois
 	 * @param server
 	 * @param downsample
 	 * @param asDetection
 	 * @param includeMeasurements
+	 * @param plane
+	 * @return
+	 * @deprecated use instead {@link #createObjectsFromROIs(ImagePlus, Collection, double, boolean, boolean, ImagePlane)}
+	 */
+	@Deprecated
+	public static List<PathObject> createPathObjectsFromROIs(final ImagePlus imp, final Roi[] rois, final ImageServer<?> server, 
+			final double downsample, final boolean asDetection, final boolean includeMeasurements, final ImagePlane plane) {
+		return createObjectsFromROIs(imp, Arrays.asList(rois), downsample, asDetection, includeMeasurements, plane);
+	}
+	
+	/**
+	 * Turn an array of ImageJ ROIs into a list of QuPath PathObjects, optionally adding measurements as well.
+	 * 
+	 * @param imp
+	 * @param rois
+	 * @param downsample
+	 * @param asDetection
+	 * @param includeMeasurements
 	 * @param plane 
 	 * @return
+	 * @since v0.4.0
 	 */
-	public static List<PathObject> createPathObjectsFromROIs(final ImagePlus imp, final Roi[] rois, final ImageServer<?> server, 
+	public static List<PathObject> createObjectsFromROIs(final ImagePlus imp, final Collection<? extends Roi> rois, 
 			final double downsample, final boolean asDetection, final boolean includeMeasurements, final ImagePlane plane) {
 		List<PathObject> pathObjects = new ArrayList<>();
 		ResultsTable rt = new ResultsTable();
-		Analyzer analyzer = new Analyzer(imp, Analyzer.getMeasurements(), rt);
+		Analyzer analyzer = imp == null ? null : new Analyzer(imp, Analyzer.getMeasurements(), rt);
 		String[] headings = null;
+		Calibration cal = imp == null ? null : imp.getCalibration();
+		var xOrigin = cal == null ? 0 : cal.xOrigin;
+		var yOrigin = cal == null ? 0 : cal.yOrigin;
 		for (Roi roi : rois) {
 			PathObject pathObject;
 			if (asDetection && !(roi instanceof PointRoi))
-				pathObject = IJTools.convertToDetection(imp, server, roi, downsample, plane);
+				pathObject = IJTools.convertToDetection(roi, xOrigin, yOrigin, downsample, plane);
 			else
-				pathObject = IJTools.convertToAnnotation(imp, server, roi, downsample, plane);
+				pathObject = IJTools.convertToAnnotation(roi, xOrigin, yOrigin, downsample, plane);
 			if (pathObject == null)
-				IJ.log("Sorry, I could not convert " + roi + " to a value QuPath object");
+				IJ.log("Sorry, I couldn't convert " + roi + " to a valid QuPath object");
 			else {
 				// Make measurements
-				if (includeMeasurements) {
+				if (includeMeasurements && imp != null) {
 					ImageProcessor ip = imp.getProcessor();
 					ip.setRoi(roi);
 					ImageStatistics stats = ImageStatistics.getStatistics(ip, Analyzer.getMeasurements(), imp.getCalibration());

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ImportObjectsCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ImportObjectsCommand.java
@@ -62,7 +62,7 @@ public final class ImportObjectsCommand {
 		if (imageData == null)
 			return false;
 		
-		var file = Dialogs.promptForFile("Choose file to import", null, "QuPath objects", PathIO.getObjectFileExtensions().toArray(String[]::new));
+		var file = Dialogs.promptForFile("Choose file to import", null, "QuPath objects", PathIO.getObjectFileExtensions(true).toArray(String[]::new));
 		
 		// User cancel
 		if (file == null)


### PR DESCRIPTION
* New 'Extensions -> ImageJ -> Import ImageJ ROIs' command
* Import .roi and RoiSet.zip files by drag & drop
* Built-in ImageJ plugin to send RoiManager ROIs to QuPath (not only overlays)
* Retain ROI position information when sending ROIs from ImageJ (hyper)stacks