### PR TITLE
Avoid updating annotation color unnecessarily

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -53,6 +53,7 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.binding.DoubleBinding;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
@@ -806,12 +807,16 @@ public class GuiTools {
 		panel.add(textField, 1, 0);
 
 		boolean promptForColor = true;
-		ColorPicker panelColor = null;
+		ColorPicker colorPicker = null;
+		var originalColor = ColorToolsFX.getDisplayedColor(annotation);
+		var colorChanged = new SimpleBooleanProperty(false); // Track if the user changed anything, so that we don't set the color unnecessarily
 		if (promptForColor) {
-			panelColor = new ColorPicker(ColorToolsFX.getDisplayedColor(annotation));
+			colorPicker = new ColorPicker(originalColor);
+			// If we don't touch the color picker, don't set the color (because it might be the default)
+			colorPicker.valueProperty().addListener((v, o, n) -> colorChanged.set(true));
 			panel.add(new Label("Color "), 0, 1);
-			panel.add(panelColor, 1, 1);
-			panelColor.prefWidthProperty().bind(textField.widthProperty());
+			panel.add(colorPicker, 1, 1);
+			colorPicker.prefWidthProperty().bind(textField.widthProperty());
 		}
 		
 		Label labDescription = new Label("Description");
@@ -857,8 +862,8 @@ public class GuiTools {
 				temp.setName(name);
 			else
 				temp.setName(null);
-			if (promptForColor)
-				temp.setColorRGB(ColorToolsFX.getARGB(panelColor.getValue()));
+			if (promptForColor && colorChanged.get())
+				temp.setColorRGB(ColorToolsFX.getARGB(colorPicker.getValue()));
 	
 			// Set the description only if we have to
 			String description = textAreaDescription.getText();


### PR DESCRIPTION
Avoid setting annotation color in a `PathObject` when setting other properties and keeping the default display color.
Previously, a color property was set even if the user only wanted to add a name or edit the object description through the UI.

(Sidenote: the color is reset when a classification is assigned to an object.)