### PR TITLE
Added one-line if/else statement handling to Script Editor

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/GeneralCodeSyntax.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/GeneralCodeSyntax.java
@@ -123,71 +123,16 @@ abstract class GeneralCodeSyntax implements ScriptSyntax {
 			control.selectRange(startRowPos, startRowPos + replaceText.length());
 	}
 	
-	/**
-	 * Handle adding a new line, by checking current line for appropriate indentation.
-	 * Note: this method should be called <em>instead</em> of simply accepting the newline character,
-	 * i.e. the method itself will add the newline as required.
-	 * <p>
-	 * Additionally, it handles new lines following a '{' character:
-	 * <li> It creates a block of '{' + new line + indentation + new line + '}' </li>
-	 * <li> The caret position is set to inside the block </li>
-	 * <li> If there originally was some text after '{', the text will be included inside the block </li>
-	 * <li> If the amount of '{' and '}' in the text is equal, it will add the new line but won't create a block </li>
-	 * <li> The original indentation is accounted for</li>
-	 * 
-	 * <p>
-	 * 
-	 * As well as new lines which start with  '/*':
-	 * <li> It creates a comment block of '/' + '*' + new line + space + * + space + new line + '/' + '*' </li>
-	 * <li> The caret position is set to inside the block </li>
-	 * <li> The original indentation is accounted for </li>
-	 * 
-	 * <p>
-	 * 
-	 * And new lines which start with  '*':
-	 * <li> The new line will automatically start with '*' + space, as to continue the comment block </li>
-	 * <li> The original indentation is accounted for </li>
-	 */
 	@Override
-	public void handleNewLine(final ScriptEditorControl control, final boolean smartEditing) {
-		int caretPos = control.getCaretPosition();
+	public void handleNewLine(ScriptEditorControl control, final boolean smartEditing) {
 		String text = control.getText();
+		int caretPos = control.getCaretPosition();
 		int startRowPos = getRowStartPosition(text, caretPos);
-		int endRowPos = getRowEndPosition(text, caretPos);
 		String subString = text.substring(startRowPos, caretPos);
-		String trimmedSubString = subString.trim();
-		int indentation = subString.length() - subString.stripLeading().length();
-		int ind = trimmedSubString.length() == 0 ? subString.length() : subString.indexOf(trimmedSubString);
-		int finalPos = caretPos;
-		
-		if (trimmedSubString.startsWith("/*") && !trimmedSubString.contains("*/") && smartEditing) {
-			String insertText = ind == 0 ? "\n" + subString.substring(0, indentation) + " * \n */" : "\n" + subString.substring(0, indentation) + " * \n" + subString.substring(0, indentation) + " */ ";
-			control.insertText(caretPos, insertText);
-			finalPos = caretPos + insertText.length() - (indentation == 0 ? -1 : indentation) - 5;
-		} else if (trimmedSubString.startsWith("*") && !trimmedSubString.contains("*/") && smartEditing) {
-			String insertText = ind == 0 ? "\n* " : "\n" + subString.substring(0, ind) + "* ";
-			control.insertText(caretPos, insertText);
-			finalPos = caretPos + insertText.length();
-		} else if (!trimmedSubString.endsWith("{") || !smartEditing) {
-			String insertText = ind == 0 ? "\n" : "\n" + subString.substring(0, ind);
-			control.insertText(caretPos, insertText);
-			finalPos = caretPos + insertText.length();
-		} else if (smartEditing) {
-			String lineRemainder = text.substring(startRowPos + subString.length(), endRowPos);
-			String insertText =  "\n" + subString.substring(0, indentation) + tabString+ lineRemainder.strip();
-			if (text.replaceAll("[^{]", "").length() != text.replaceAll("[^}]", "").length())
-				insertText += "\n" + subString.substring(0, indentation) + "}";
-			
-			finalPos = caretPos + 1 + indentation + tabString.length() + lineRemainder.strip().length();
-			
-			// If '{' is not preceded by a space, insert one (this is purely aesthetic)
-			if (trimmedSubString.length() >= 2 && trimmedSubString.charAt(trimmedSubString.length() - 2) != ' ')
-				control.insertText(++caretPos - 2, " ");
-			
-			control.insertText(caretPos, insertText);
-			control.deleteText(control.getCaretPosition(), control.getCaretPosition() + lineRemainder.length());
-		}
-		control.positionCaret(finalPos);
+		String indentation = subString.substring(0, subString.length() - subString.stripLeading().length());
+		ScriptSyntax.super.handleNewLine(control, smartEditing);
+		if (smartEditing)
+			control.insertText(control.getCaretPosition(), indentation);
 	}
 
 	/**
@@ -256,11 +201,11 @@ abstract class GeneralCodeSyntax implements ScriptSyntax {
 		textArea.selectRange(startRowPos, startRowPos + replaceText.length());
 	}
 	
-	private static int getRowStartPosition(final String text, final int pos) {
+	static int getRowStartPosition(final String text, final int pos) {
 		return text.substring(0, pos).lastIndexOf("\n") + 1;
 	}
 
-	private static int getRowEndPosition(final String text, final int pos) {
+	static int getRowEndPosition(final String text, final int pos) {
 		int pos2 = text.substring(pos).indexOf("\n");
 		if (pos2 < 0)
 			return text.length();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/GroovySyntax.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/GroovySyntax.java
@@ -30,6 +30,9 @@ package qupath.lib.gui.scripting;
  */
 class GroovySyntax extends GeneralCodeSyntax {
 	
+	private static final String ifStatementPattern = "(else\\s*)?if\\s*\\(.*\\)$";
+	private static final String elseStatementPattern = "\\}?\\s*else$";
+	
 	GroovySyntax() {
 		// Empty constructor
 	}
@@ -37,5 +40,109 @@ class GroovySyntax extends GeneralCodeSyntax {
 	@Override
 	public String getLineCommentString() {
 		return "//";
+	}
+	
+	/**
+	 * Handle adding a new line, by checking current line for appropriate indentation.
+	 * Note: this method should be called <em>instead</em> of simply accepting the newline character,
+	 * i.e. the method itself will add the newline as required.
+	 * <p>
+	 * Additionally, it handles new lines following a '{' character:
+	 * <li> It creates a block of '{' + new line + indentation + new line + '}' </li>
+	 * <li> The caret position is set to inside the block </li>
+	 * <li> If there originally was some text after '{', the text will be included inside the block </li>
+	 * <li> If the amount of '{' and '}' in the text is equal, it will add the new line but won't create a block </li>
+	 * <li> The original indentation is accounted for</li>
+	 * 
+	 * <p>
+	 * 
+	 * And new line as part of a non-braced 'if(/else)' statement:
+	 * <li> It indents the line following an if statement without '{'</li>
+	 * <li> It removes the indentation after the line inside a one-line if statement </li>
+	 * <li> It indents the line following an else statement without '{' </li>
+	 * <li> It removes the indentation after the line inside a one-line else statement </li>
+	 * 
+	 * <p>
+	 * 
+	 * As well as new lines which start with '/*':
+	 * <li> It creates a comment block of '/' + '*' + new line + space + * + space + new line + '/' + '*' </li>
+	 * <li> The caret position is set to inside the block </li>
+	 * <li> The original indentation is accounted for </li>
+	 * 
+	 * <p>
+	 * 
+	 * And new lines which start with  '*':
+	 * <li> The new line will automatically start with '*' + space, as to continue the comment block </li>
+	 * <li> The original indentation is accounted for </li>
+	 */
+	@Override
+	public void handleNewLine(final ScriptEditorControl control, final boolean smartEditing) {
+		int caretPos = control.getCaretPosition();
+		String text = control.getText();
+		int startRowPos = getRowStartPosition(text, caretPos);
+		int endRowPos = getRowEndPosition(text, caretPos);
+		String subString = text.substring(startRowPos, caretPos);
+		String trimmedSubString = subString.trim();
+		int indentation = subString.length() - subString.stripLeading().length();
+		int ind = trimmedSubString.length() == 0 ? subString.length() : subString.indexOf(trimmedSubString);
+		int finalPos = caretPos;
+		String insertText = System.lineSeparator();
+		
+		if (!smartEditing) {
+			super.handleNewLine(control, smartEditing);
+			return;
+		}
+
+		if (trimmedSubString.startsWith("/*") && !trimmedSubString.contains("*/")) {	// Start of a comment block
+			insertText = ind == 0 ? "\n" + subString.substring(0, indentation) + " * \n */" : "\n" + subString.substring(0, indentation) + " * \n" + subString.substring(0, indentation) + " */ ";
+			control.insertText(caretPos, insertText);
+			finalPos += insertText.length() - (indentation == 0 ? -1 : indentation) - 5;
+			return;
+		} else if (trimmedSubString.startsWith("*") && !trimmedSubString.contains("*/")) {	// Inside a comment block
+			insertText = ind == 0 ? "\n* " : "\n" + subString.substring(0, ind) + "* ";
+			control.insertText(caretPos, insertText);
+			finalPos += insertText.length();
+			return;
+		} else if (trimmedSubString.endsWith("{")) {		// Start of a '{'/'}' block
+			String lineRemainder = text.substring(startRowPos + subString.length(), endRowPos);
+			insertText =  "\n" + subString.substring(0, indentation) + tabString + lineRemainder.strip();
+			if (text.replaceAll("[^{]", "").length() != text.replaceAll("[^}]", "").length())
+				insertText += "\n" + subString.substring(0, indentation) + "}";
+			
+			finalPos += 1 + indentation + tabString.length() + lineRemainder.strip().length();
+			
+			// If '{' is not preceded by a space, insert one (this is purely aesthetic)
+			if (trimmedSubString.length() >= 2 && trimmedSubString.charAt(trimmedSubString.length() - 2) != ' ')
+				control.insertText(++caretPos - 2, " ");			
+			control.insertText(caretPos, insertText);
+			control.deleteText(control.getCaretPosition(), control.getCaretPosition() + lineRemainder.length());
+			control.positionCaret(finalPos);
+		} else if (!trimmedSubString.endsWith("{")) {
+			if (trimmedSubString.matches(ifStatementPattern) || trimmedSubString.matches(elseStatementPattern)) {	// Start of a one-line if/else statement
+				insertText = "\n" + subString.substring(0, ind) + tabString;
+				control.insertText(caretPos, insertText);
+				finalPos += insertText.length();
+			} else {	// Normal new line (which keeps indentation, except if part of a one-line if/else statement)
+				if (text.substring(0, startRowPos).contains("\n") && indentation > 0) {
+					int startPrevRowPos = getRowStartPosition(text, startRowPos-1);
+					int endPrevRowPos = getRowEndPosition(text, startPrevRowPos);
+					String prevSubString = text.substring(startPrevRowPos, endPrevRowPos);
+					if (prevSubString.matches(ifStatementPattern) || prevSubString.matches(elseStatementPattern)) {	// If prev line is one-line if/else statement
+						insertText = "\n" + subString.substring(0, ind-tabString.length());
+						control.insertText(caretPos, insertText);
+						finalPos += insertText.length();
+						return;
+					}
+				}
+				
+				// Otherwise treat this new line as normal, and keep the indentation
+				String lineRemainder = text.substring(startRowPos + subString.length(), endRowPos);
+				insertText =  "\n" + subString.substring(0, indentation) + lineRemainder.strip();
+				finalPos += 1 + indentation;
+				control.insertText(caretPos, insertText);
+				control.deleteText(control.getCaretPosition(), control.getCaretPosition() + lineRemainder.length());
+				control.positionCaret(finalPos);
+			}
+		}
 	}
 }


### PR DESCRIPTION
- Handle one-line if/else statement handling in the Script Editor:

Hitting Enter here: (`_` is the caret position)
```
if (true)_
```
will automatically add an indentation for the next line:
```
if (true)
    _
```
and automatically remove the indentation if pressing Enter again:
```
if (true)
    doSomething()_
```
becomes
```
if (true)
    doSomething()
_
```
__________
The same happens with else:
```
if (true)
    doSomething()
else_
```
becomes
```
if (true)
    doSomething()
else
    _
```
and the indentation is automatically removed for the next line:
```
if (true)
    doSomething()
else
    doSomethingElse()
_
```