### PR TITLE
Drag & Drop opens files in Script Editor when import fails

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -348,7 +348,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 
 			// If the toggle is "None", the language could technically still be JSON, so check that first
 			if (n.getUserData().toString().equals(Language.PLAIN.name))
-				currentLanguage.set(selectedScript.get().file == null ? Language.PLAIN : selectedScript.get().file.toString().toLowerCase().endsWith("json") ? Language.JSON : Language.PLAIN);
+				currentLanguage.set((selectedScript.get() == null || selectedScript.get().file == null) ? Language.PLAIN : selectedScript.get().file.toString().toLowerCase().endsWith("json") ? Language.JSON : Language.PLAIN);
 			else
 				currentLanguage.set(Language.fromString((String) n.getUserData()));
 		});

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -319,8 +319,9 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 				Project<BufferedImage> project = ProjectIO.loadProject(file, BufferedImage.class);
 				qupath.setProject(project);
 			} catch (Exception e) {
-				Dialogs.showErrorMessage("Project error", e);
-//					logger.error("Could not open as project file: {}", e);
+//				Dialogs.showErrorMessage("Project error", e);
+				logger.error("Could not open as project file: {}, opening in the Script Editor instead", e);
+				qupath.getScriptEditor().showScript(file);
 			}
 			return;
 		}
@@ -328,7 +329,9 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 		// Check if it is an object file in GeoJSON format (.geojson)
 		if (PathIO.getObjectFileExtensions(false).containsAll(allUnzippedExtensions)) {
 			if (imageData == null || hierarchy == null) {
-				Dialogs.showErrorMessage("Open object file", "Please open an image first to import objects!");
+				qupath.getScriptEditor().showScript(file);
+				logger.info("Opening the dragged file in the Script Editor as there is no currently opened image in the viewer");
+//				Dialogs.showErrorMessage("Open object file", "Please open an image first to import objects!");
 				return;
 			}
 			
@@ -338,7 +341,8 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 				try {
 					var tempObjects = PathIO.readObjects(tempFile);
 					if (tempObjects.isEmpty()) {
-						logger.warn("No objects found in {}", tempFile.getAbsolutePath());
+						logger.warn("No objects found in {}, opening the dragged file in the Script Editor instead", tempFile.getAbsolutePath());
+						qupath.getScriptEditor().showScript(file);
 						return;
 					}
 					pathObjects.addAll(tempObjects);
@@ -383,7 +387,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 		}
 
 
-		// Open Javascript
+		// Open file with an extension supported by the Script Editor
 		ScriptEditor scriptEditor = qupath.getScriptEditor();
 		if (scriptEditor instanceof DefaultScriptEditor && ((DefaultScriptEditor)scriptEditor).supportsFile(file)) {
 			scriptEditor.showScript(file);


### PR DESCRIPTION
Drag & Drop opens files in Script Editor when import fails:
- If the project file couldn't be opened -> open in Script Editor
- If the file is an object file but there is no viewer/hierarchy -> open in Script Editor
- If there is no object found in the object file -> open in Script Editor