### PR TITLE
Support for save file choosers that accept multiple extensions

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
@@ -599,6 +599,20 @@ public class Dialogs {
 	public static File promptToSaveFile(String title, File dirBase, String defaultName, String filterName, String ext) {
 		return getSharedChooser().promptToSaveFile(title, dirBase, defaultName, filterName, ext);
 	}
+	
+	/**
+	 * Prompt user to select a file path to save, providing zero or more file extensions as an option.
+	 * 
+	 * @param title the title to display for the dialog (may be null)
+	 * @param dirBase the base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @param defaultName default file name
+	 * @param filters map of file type descriptions (keys) and file extensions (values); may be empty if an 'all files' filter should be used
+	 * @return the File selected by the user, or null if the dialog was cancelled
+	 * @since v0.4.0
+	 */
+	public static File promptToSaveFile(String title, File dirBase, String defaultName, Map<String, String> filters) {
+		return getSharedChooser().promptToSaveFile(title, dirBase, defaultName, filters);
+	}
 
 	/**
 	 * Prompt user to select a file or input a URL.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/QuPathChooser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/QuPathChooser.java
@@ -25,6 +25,7 @@ package qupath.lib.gui.dialogs;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -99,7 +100,7 @@ public interface QuPathChooser {
 	public File promptForFile(File dirBase);
 	
 	/**
-	 * Prompt user to select a file path to save.
+	 * Prompt user to select a file path to save, using a single file extension as an option.
 	 * 
 	 * @param title the title to display for the dialog (may be null)
 	 * @param dirBase the base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
@@ -109,6 +110,18 @@ public interface QuPathChooser {
 	 * @return the File selected by the user, or null if the dialog was cancelled
 	 */
 	public File promptToSaveFile(String title, File dirBase, String defaultName, String filterDescription, String ext);
+	
+	/**
+	 * Prompt user to select a file path to save, providing zero or more file extensions as an option.
+	 * 
+	 * @param title the title to display for the dialog (may be null)
+	 * @param dirBase the base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @param defaultName default file name
+	 * @param filters map of file type descriptions (keys) and file extensions (values); may be empty if an 'all files' filter should be used
+	 * @return the File selected by the user, or null if the dialog was cancelled
+	 * @since v0.4.0
+	 */
+	public File promptToSaveFile(String title, File dirBase, String defaultName, Map<String, String> filters);
 	
 	/**
 	 * Prompt user to select a file or input a URL.


### PR DESCRIPTION
Previously, only a single file filter could be specified. This meant it wasn't possible, e.g. to provide a single chooser to save from a list of image types. Now a map of filter names to extensions can be provided instead. For JavaFX, this map is converted to an `ExtensionFilter` automatically.

Multi-part file extensions are slightly problematic, at least on macOS, since the chooser will automatically add only the last part of the specified extension. The QuPathChooserFX will attempt to correct for this, but it means that sometimes the file returned is not identical to the one specified in the chooser.

This code can be checked in a script, e.g.
```groovy
def file = Dialogs.promptToSaveFile(
    "My title", null, "default-name",
    ["OME-TIFF": ".ome.tif",
     "TIFF": ".tif",
     "PNG": ".png",
     "Compressed": ".tar.gz"]
)
println "You chose: ${file}"
```