### PR TITLE
Fix exception when removing large numbers of measurements in a script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is a work-in-progress.
 * Owner of Find window in the script editor is lost when the script editor window is closed (https://github.com/qupath/qupath/issues/893)
 * 'Zoom to fit' doesn't handle changes in window size
 * Duplicating images with some names can cause an exception (https://github.com/qupath/qupath/issues/942)
+* Removing >255 measurements throws error when reproducing from workflow script (https://github.com/qupath/qupath/issues/915)
 
 ### Dependency updates
 * Adoptium OpenJDK 17

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -2309,8 +2309,9 @@ public class QP {
 			if (pathObject.getClass() != cls)
 				continue;
 			// Remove the measurements
-			pathObject.getMeasurementList().removeMeasurements(measurementNames);
-			pathObject.getMeasurementList().close();
+			try (var ml = pathObject.getMeasurementList()) {
+				ml.removeMeasurements(measurementNames);
+			}
 		}
 		hierarchy.fireObjectMeasurementsChangedEvent(null, pathObjects);
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementManager.java
@@ -308,6 +308,12 @@ class MeasurementManager {
 		logger.info("Removing measurements: {}", removeString);
 		Class<? extends PathObject> cls = comboBox.getSelectionModel().getSelectedItem();
 		QP.removeMeasurements(imageData.getHierarchy(), cls, selectedItems.toArray(String[]::new));
+		
+		// We need to pass varargs as an array from Groovy if we have too many
+		// See https://github.com/qupath/qupath/issues/915
+		if (selectedItems.size() > 200) {
+			removeString = "[" + removeString + "] as String[]";
+		}
 
 		// Keep for scripting
 		WorkflowStep step = new DefaultScriptableWorkflowStep("Remove measurements",


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/915
Using an array is enough to overcome the problem.

The following script helps quickly add many measurements to a selected object:
```groovy
def pathObject = getSelectedObject()
def measurements = []
try (def ml = pathObject.getMeasurementList()) {
    for (int i = 0; i < 500; i++) {
        def n = "Measurement $i"
        measurements << n
        ml.putMeasurement(n, i*2)
    }
}
```