### PR TITLE
Add support for inverted background visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This is a work-in-progress.
     * Brace block handling (https://github.com/qupath/qupath/pull/901)
     * Smart parentheses and (double/single) quotes (https://github.com/qupath/qupath/pull/907)
     * Comment block handling (https://github.com/qupath/qupath/pull/908)
+* Improved Brightness/Contrast options, including
+  * Switch between dark and light backgrounds (still experimental)
+  * More consistent behavior with 'Show grayscale' option
 * Improved support for switching between QuPath objects and ImageJ ROIs
   * New 'Extensions -> ImageJ -> Import ImageJ ROIs' command
   * Import .roi and RoiSet.zip files by drag & drop

--- a/qupath-core/src/main/java/qupath/lib/color/ColorToolsAwt.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorToolsAwt.java
@@ -121,16 +121,15 @@ public class ColorToolsAwt {
 	 * <p>
 	 * Based on the getLUTFromColorModel ImageJ function (ij.process.LUT)
 	 * 
-	 * @param color
+	 * @param red
+	 * @param green
+	 * @param blue
 	 * @return
 	 */
-	static IndexColorModel createIndexColorModel(Color color) {
+	static IndexColorModel createIndexColorModel(int red, int green, int blue) {
 		byte[] rLut = new byte[256];
 		byte[] gLut = new byte[256];
 		byte[] bLut = new byte[256];
-		int red = color.getRed();
-		int green = color.getGreen();
-		int blue = color.getBlue();
 		double rIncr = ((double)red)/255d;
 		double gIncr = ((double)green)/255d;
 		double bIncr = ((double)blue)/255d;
@@ -143,23 +142,44 @@ public class ColorToolsAwt {
 	}
 
 
-
-	static IndexColorModel getIndexColorModel(final StainVector stain, boolean whiteBackground) {
+	/**
+	 * Get an {@link IndexColorModel} representing a color deconvolution stain.
+	 * The color is just an approximation for visualization purposes, it does not perfectly match the stain itself.
+	 * @param stain the stain to use
+	 * @param whiteBackground if true, the color model will have a white background; if false, it will have a black background
+	 * @return
+	 */
+	public static IndexColorModel getIndexColorModel(final StainVector stain, boolean whiteBackground) {
+		var c = stain.getColor();
+		return createIndexColorModel(
+				ColorTools.red(c), ColorTools.green(c), ColorTools.blue(c), whiteBackground);
+	}
+	
+	/**
+	 * Get an {@link IndexColorModel} representing a linear LUT based on a RGB color.
+	 * @param red the red value of the color for the maximum value
+	 * @param green the green value of the color for the maximum value
+	 * @param blue the blue value of the color for the maximum value
+	 * @param whiteBackground if true, the color model will have a white background; if false, it will have a black background
+	 * @return
+	 */	
+	public static IndexColorModel createIndexColorModel(int red, int green, int blue, boolean whiteBackground) {
 		if (!whiteBackground)
-			return createIndexColorModel(new Color(stain.getColor()));
-		double r = stain.getRed();
-		double g = stain.getGreen();
-		double b = stain.getBlue();
+			return createIndexColorModel(red, green, blue);
+		
+		// Invert the colors
+		red = 255 - red;
+		green = 255 - green;
+		blue = 255 - blue;
+		
+		// Invert again while creating the LUT
 		byte[] r2 = new byte[256];
 		byte[] g2 = new byte[256];
 		byte[] b2 = new byte[256];
 		for (int i = 0; i < 256; i++) {
-			r2[i] = (byte)ColorTools.clip255(255.0 - r * i);
-			g2[i] = (byte)ColorTools.clip255(255.0 - g * i);
-			b2[i] = (byte)ColorTools.clip255(255.0 - b * i);
-			//		r2[i] = (byte)clip255(Math.exp(-r) * (255 - i));
-			//		g2[i] = (byte)clip255(Math.exp(-g) * (255 - i));
-			//		b2[i] = (byte)clip255(Math.exp(-b) * (255 - i));
+			r2[i] = (byte)ColorTools.clip255(255.0 - red / 255.0 * i);
+			g2[i] = (byte)ColorTools.clip255(255.0 - green / 255.0 * i);
+			b2[i] = (byte)ColorTools.clip255(255.0 - blue / 255.0 * i);
 		}
 		return new IndexColorModel(8, 256, r2, g2, b2);		
 	}

--- a/qupath-core/src/main/java/qupath/lib/color/ColorTransformer.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorTransformer.java
@@ -882,9 +882,9 @@ public class ColorTransformer {
 	
 	
 	// Color models
-	final private static IndexColorModel ICM_RED = ColorToolsAwt.createIndexColorModel(Color.RED);
-	final private static IndexColorModel ICM_GREEN = ColorToolsAwt.createIndexColorModel(Color.GREEN);
-	final private static IndexColorModel ICM_BLUE = ColorToolsAwt.createIndexColorModel(Color.BLUE);
+	final private static IndexColorModel ICM_RED = ColorToolsAwt.createIndexColorModel(255, 0, 0);
+	final private static IndexColorModel ICM_GREEN = ColorToolsAwt.createIndexColorModel(0, 255, 0);
+	final private static IndexColorModel ICM_BLUE = ColorToolsAwt.createIndexColorModel(0, 0, 255);
 	final private static IndexColorModel ICM_HUE = ColorToolsAwt.createHueColorModel();
 	final private static IndexColorModel ICM_HEMATOXYLIN;
 	final private static IndexColorModel ICM_EOSIN;

--- a/qupath-core/src/main/java/qupath/lib/common/ColorTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ColorTools.java
@@ -41,7 +41,7 @@ public final class ColorTools {
 	/**
 	 * Packed int representing white.
 	 */
-	final public static int WHITE = packRGB(255, 255, 255);
+	final public static Integer WHITE = packRGB(255, 255, 255);
 
 	/**
 	 * Packed int representing black.

--- a/qupath-core/src/test/java/qupath/lib/color/TestColorsToolsAwt.java
+++ b/qupath-core/src/test/java/qupath/lib/color/TestColorsToolsAwt.java
@@ -1,0 +1,64 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.color;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+import qupath.lib.color.ColorTransformer.ColorTransformMethod;
+import qupath.lib.common.ColorTools;
+
+@SuppressWarnings("javadoc")
+public class TestColorsToolsAwt {
+	
+	@Test
+	public void test_createIndexColorModel() {
+		
+		int[] vals = new int[] {0, 31, 127, 150, 255};
+		
+		// Ensure we have the right start and end colors in our index color models
+		for (int r : vals) {
+			for (int g : vals) {
+				for (int b : vals) {
+					
+					var cmBlack = ColorToolsAwt.createIndexColorModel(r, g, b, false);
+					var cmWhite = ColorToolsAwt.createIndexColorModel(r, g, b, true);
+					
+					assertEquals(ColorTools.BLACK.intValue(), cmBlack.getRGB(0));
+					assertEquals(ColorTools.WHITE.intValue(), cmWhite.getRGB(0));
+					
+					var rgb = ColorTools.packRGB(r, g, b);
+					assertEquals(rgb, cmBlack.getRGB(255));
+					assertEquals(rgb, cmWhite.getRGB(255));
+				}
+			}
+		}
+		
+	}
+	
+}
+

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/AbstractChannelInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/AbstractChannelInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -135,9 +135,9 @@ abstract class AbstractChannelInfo implements ModifiableChannelDisplayInfo {
 	}
 
 	@Override
-	public int updateRGBAdditive(BufferedImage img, int x, int y, int rgb, boolean useColorLUT) {
+	public int updateRGBAdditive(BufferedImage img, int x, int y, int rgb, ChannelDisplayMode mode) {
 		// Just return the (scaled) RGB value for this pixel if we don't have to update anything
-		int rgbNew = getRGB(img, x, y, useColorLUT);
+		int rgbNew = getRGB(img, x, y, mode);
 		if (rgb == 0)
 			return rgbNew;
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ChannelDisplayMode.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ChannelDisplayMode.java
@@ -1,0 +1,66 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.lib.display;
+
+/**
+ * Display mode for an image channel, used in combination with {@link ImageDisplay} and {@link ChannelDisplayInfo}.
+ * 
+ * @author Pete Bankhead
+ * @since v0.4.0
+ * 
+ * @see ImageDisplay
+ * @see ChannelDisplayInfo
+ */
+public enum ChannelDisplayMode {
+	
+	/**
+	 * Show using default color LUT (may be composite)
+	 */
+	COLOR(false),
+	
+	/**
+	 * Show using color LUT with an inverted background
+	 */
+	INVERTED_COLOR(true),
+	
+	/**
+	 * Show using a grayscale LUT (black to white)
+	 */
+	GRAYSCALE(false),
+	
+	/**
+	 * Show using an inverted grayscale LUT (white to black)
+	 */
+	INVERTED_GRAYSCALE(true);
+	
+	private boolean invertColors;
+	
+	private ChannelDisplayMode(boolean invertColors) {
+		this.invertColors = invertColors;
+	}
+	
+	public boolean invertColors() {
+		return invertColors;
+	}
+	
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/DirectServerChannelInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/DirectServerChannelInfo.java
@@ -49,6 +49,7 @@ public class DirectServerChannelInfo extends AbstractSingleChannelInfo {
 	private int channel;
 
 	transient private ColorModel cm;
+	transient private ColorModel cmInverted;
 	transient private int[] rgbLUT;
 	private int rgb;
 	//		private int rgb, r, g, b;
@@ -111,6 +112,10 @@ public class DirectServerChannelInfo extends AbstractSingleChannelInfo {
 		byte[] rb = new byte[256];
 		byte[] gb = new byte[256];
 		byte[] bb = new byte[256];
+		// For inverted
+		byte[] rbi = new byte[256];
+		byte[] gbi = new byte[256];
+		byte[] bbi = new byte[256];
 		for (int i = 0; i < 256; i++) {
 			rgbLUT[i] = ColorTools.packRGB(
 					ColorTools.do8BitRangeCheck(r / 255.0 * i),
@@ -120,9 +125,14 @@ public class DirectServerChannelInfo extends AbstractSingleChannelInfo {
 			rb[i] = (byte)ColorTools.do8BitRangeCheck(r / 255.0 * i);
 			gb[i] = (byte)ColorTools.do8BitRangeCheck(g / 255.0 * i);
 			bb[i] = (byte)ColorTools.do8BitRangeCheck(b / 255.0 * i);
+			
+			rbi[i] = (byte)ColorTools.do8BitRangeCheck((255 - r) / 255.0 * i);
+			gbi[i] = (byte)ColorTools.do8BitRangeCheck((255 - g) / 255.0 * i);
+			bbi[i] = (byte)ColorTools.do8BitRangeCheck((255 - b) / 255.0 * i);
 		}
 
 		cm = new IndexColorModel(8, 256, rb, gb, bb);
+		cmInverted = new IndexColorModel(8, 256, rbi, gbi, bbi);
 
 		this.rgb = ColorTools.packRGB(r, g, b);
 	}
@@ -144,7 +154,10 @@ public class DirectServerChannelInfo extends AbstractSingleChannelInfo {
 
 	@Override
 	public int getRGB(float value, boolean useColorLUT) {
-		return ColorTransformer.makeScaledRGBwithRangeCheck(value, minDisplay, 255.f/(maxDisplay - minDisplay), useColorLUT ? cm : null);
+		// TODO: Restore original line
+//		return ColorTransformer.makeScaledRGBwithRangeCheck(value, minDisplay, 255.f/(maxDisplay - minDisplay), useColorLUT ? cm : null);
+		// For white background
+		return ColorTransformer.makeScaledRGBwithRangeCheck(value, minDisplay, 255.f/(maxDisplay - minDisplay), useColorLUT ? cmInverted : null);
 	}
 
 	@Override

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/DirectServerChannelInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/DirectServerChannelInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -25,7 +25,6 @@ import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.IndexColorModel;
 
-import qupath.lib.color.ColorTransformer;
 import qupath.lib.common.ColorTools;
 import qupath.lib.images.ImageData;
 
@@ -52,7 +51,6 @@ public class DirectServerChannelInfo extends AbstractSingleChannelInfo {
 	transient private ColorModel cmInverted;
 	transient private int[] rgbLUT;
 	private int rgb;
-	//		private int rgb, r, g, b;
 
 	/**
 	 * Constructor.
@@ -98,6 +96,21 @@ public class DirectServerChannelInfo extends AbstractSingleChannelInfo {
 				ColorTools.red(rgb),
 				ColorTools.green(rgb),
 				ColorTools.blue(rgb));
+	}
+	
+	@Override
+	protected ColorModel getColorModel(ChannelDisplayMode mode) {
+		switch (mode) {
+		case INVERTED_GRAYSCALE:
+//			return CM_GRAYSCALE_INVERTED;
+		case GRAYSCALE:
+			return CM_GRAYSCALE;
+		case INVERTED_COLOR:
+			return cmInverted;
+		case COLOR:
+		default:
+			return cm;
+		}
 	}
 
 	/**
@@ -153,14 +166,6 @@ public class DirectServerChannelInfo extends AbstractSingleChannelInfo {
 	}
 
 	@Override
-	public int getRGB(float value, boolean useColorLUT) {
-		// TODO: Restore original line
-//		return ColorTransformer.makeScaledRGBwithRangeCheck(value, minDisplay, 255.f/(maxDisplay - minDisplay), useColorLUT ? cm : null);
-		// For white background
-		return ColorTransformer.makeScaledRGBwithRangeCheck(value, minDisplay, 255.f/(maxDisplay - minDisplay), useColorLUT ? cmInverted : null);
-	}
-
-	@Override
 	public boolean doesSomething() {
 		return true;
 	}
@@ -180,31 +185,5 @@ public class DirectServerChannelInfo extends AbstractSingleChannelInfo {
 		return false;
 	}
 
-	//	@Override
-	//	public int updateRGBAdditive(float value, int rgb) {
-	//		// Just return the (scaled) RGB value for this pixel if we don't have to update anything
-	//		if (rgb == 0)
-	//			return getRGB(value);
-	//		// Don't do anything with an existing pixel if display range is 0, or it is lower than the min display
-	//		if (maxDisplay == minDisplay || value <= minDisplay)
-	//			return rgb;
-	//		//		// Also nothing to do if the pixel is white
-	//		//		if ((rgb & 0xffffff) == 16777215) {
-	//		//			// TODO: REMOVE THIS
-	//		//			System.out.println("I AM SKIPPING A WHITE PIXEL!");
-	//		//			return rgb;
-	//		//		}
-	//		// Figure out how much to scale the pixel's color - zero scale indicates black
-	//		float scale = (value - minDisplay) / (maxDisplay - minDisplay);
-	//		if (scale >= 1)
-	//			scale = 1;
-	//		// Do the scaling & combination
-	//		float r2 = r * scale + ((rgb & ColorTransformer.MASK_RED) >> 16);
-	//		float g2 = g * scale + ((rgb & ColorTransformer.MASK_GREEN) >> 8);
-	//		float b2 = b * scale + (rgb & ColorTransformer.MASK_BLUE);
-	//		return do8BitRangeCheck(r2) << 16 + 
-	//				do8BitRangeCheck(g2) << 8 + 
-	//				do8BitRangeCheck(b2);
-	//	}
 
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -56,6 +56,7 @@ import javafx.collections.ObservableList;
 import qupath.lib.analysis.stats.Histogram;
 import qupath.lib.color.ColorTransformer;
 import qupath.lib.color.ColorTransformer.ColorTransformMethod;
+import qupath.lib.common.ColorTools;
 import qupath.lib.display.ChannelDisplayInfo.ModifiableChannelDisplayInfo;
 import qupath.lib.gui.images.stores.AbstractImageRenderer;
 import qupath.lib.gui.prefs.PathPrefs;
@@ -578,6 +579,15 @@ public class ImageDisplay extends AbstractImageRenderer {
 			}
 		} catch (Exception e) {
 			logger.error("Error extracting pixels for display", e);
+		}
+
+		// TODO: REMOVE COLOR INVERSION IF NOT NEEDED!
+		for (int i = 0; i < pixels.length; i++) {
+			int val = pixels[i];
+			int r = ColorTools.red(val);
+			int g = ColorTools.green(val);
+			int b = ColorTools.blue(val);
+			pixels[i] = ColorTools.packRGB(255 - r, 255 - g, 255 - b);
 		}
 
 		imgOutput.getRaster().setDataElements(0, 0, imgOutput.getWidth(), imgOutput.getHeight(), pixels);

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/RGBDirectChannelInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/RGBDirectChannelInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -30,7 +30,7 @@ import qupath.lib.images.ImageData;
  * Class for displaying RGB image using direct color model, but perhaps with brightness/contrast adjusted.
  * 
  * @author Pete Bankhead
- *
+ * @implNote this currently does not support {@link ChannelDisplayMode}
  */
 class RGBDirectChannelInfo extends AbstractChannelInfo {
 
@@ -45,12 +45,12 @@ class RGBDirectChannelInfo extends AbstractChannelInfo {
 
 	@Override
 	public String getValueAsString(BufferedImage img, int x, int y) {
-		int rgb = getRGB(img, x, y, false);
+		int rgb = getRGB(img, x, y, ChannelDisplayMode.COLOR);
 		return ColorTools.red(rgb) + ", " + ColorTools.green(rgb) + ", " + ColorTools.blue(rgb);
 	}
 
 	@Override
-	public int getRGB(BufferedImage img, int x, int y, boolean useColorLUT) {
+	public int getRGB(BufferedImage img, int x, int y, ChannelDisplayMode mode) {
 		return img.getRGB(x, y);
 	}
 
@@ -71,7 +71,12 @@ class RGBDirectChannelInfo extends AbstractChannelInfo {
 
 
 	@Override
-	public int[] getRGB(BufferedImage img, int[] rgb, boolean useColorLUT) {
+	public int[] getRGB(BufferedImage img, int[] rgb, ChannelDisplayMode mode) {
+		
+		// TODO: Add support for ChannelDisplayMode (if it makes sense!)
+		boolean doInvert = mode == ChannelDisplayMode.INVERTED_COLOR || mode == ChannelDisplayMode.INVERTED_GRAYSCALE;
+		boolean doGrayscale = mode == ChannelDisplayMode.GRAYSCALE || mode == ChannelDisplayMode.INVERTED_GRAYSCALE;
+		
 		// Try to get a data buffer directly, if possible
 		int[] buffer = getRGBIntBuffer(img);
 		if (buffer == null) {
@@ -86,13 +91,44 @@ class RGBDirectChannelInfo extends AbstractChannelInfo {
 		float offset = getOffset();
 		float scale = getScaleToByte();
 		//			ColorTransformer.transformImage(buffer, buffer, ColorTransformMethod.OD_Normalized, offset, scale, false);
-		if (offset != 0 || scale != 1) {
+		if (offset != 0 || scale != 1 || doInvert || doGrayscale) {
 			int ind = 0;
 			for (int v : buffer) {
-				int r = ColorTools.do8BitRangeCheck((ColorTools.red(v) - offset) * scale);
-				int g = ColorTools.do8BitRangeCheck((ColorTools.green(v) - offset) * scale);
-				int b = ColorTools.do8BitRangeCheck((ColorTools.blue(v) - offset) * scale);
-				rgb[ind] = (r << 16) + (g << 8) + b;
+				if (doGrayscale) {
+					// We convert to grayscale using weighted RGB values
+					double r = ((ColorTools.red(v) - offset) * scale);
+					double g = ((ColorTools.green(v) - offset) * scale);
+					double b = ((ColorTools.blue(v) - offset) * scale);
+					// Alternative conversion simply averaging RGB values
+//					int value = ColorTools.do8BitRangeCheck((r + g + b) / 3.0);
+					// Using weighting
+					int value = ColorTools.do8BitRangeCheck((0.299 * r + 0.587 * g + 0.114 * b));
+					rgb[ind] = ColorTools.packRGB(value, value, value);
+				} else if (doInvert) {
+					// Get the original RGB values
+					double r = ((ColorTools.red(v) - offset) * scale);
+					double g = ((ColorTools.green(v) - offset) * scale);
+					double b = ((ColorTools.blue(v) - offset) * scale);
+					
+					// Pragmatic approach... TODO: find a more theoretically justified one!		
+					// Dividing by two here gives a more visually useful result and avoids a very dark image 
+					// (as otherwise each RGB value effectively gets subtracted twice)
+					int r2 = ColorTools.do8BitRangeCheck((g + b)/2);
+					int g2 = ColorTools.do8BitRangeCheck((r + b)/2);
+					int b2 = ColorTools.do8BitRangeCheck((r + g)/2);
+					
+					// Alternative code without the division
+//					int r2 = ColorTools.do8BitRangeCheck((g + b));
+//					int g2 = ColorTools.do8BitRangeCheck((r + b));
+//					int b2 = ColorTools.do8BitRangeCheck((r + g));
+
+					rgb[ind] = (r2 << 16) + (g2 << 8) + b2;
+				} else {
+					int r = ColorTools.do8BitRangeCheck((ColorTools.red(v) - offset) * scale);
+					int g = ColorTools.do8BitRangeCheck((ColorTools.green(v) - offset) * scale);
+					int b = ColorTools.do8BitRangeCheck((ColorTools.blue(v) - offset) * scale);
+					rgb[ind] = (r << 16) + (g << 8) + b;
+				}
 				ind++;
 			}
 		} else if (buffer != rgb) {
@@ -102,7 +138,7 @@ class RGBDirectChannelInfo extends AbstractChannelInfo {
 	}
 
 	@Override
-	public void updateRGBAdditive(BufferedImage img, int[] rgb, boolean useColorLUT) {
+	public void updateRGBAdditive(BufferedImage img, int[] rgb, ChannelDisplayMode mode) {
 		throw new UnsupportedOperationException(this + " does not support additive display");
 
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/RGBNormalizedChannelInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/RGBNormalizedChannelInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -24,15 +24,16 @@ package qupath.lib.display;
 import java.awt.image.BufferedImage;
 
 import qupath.lib.color.ColorTransformer;
+import qupath.lib.common.ColorTools;
 import qupath.lib.images.ImageData;
 
 /**
  * Class for displaying RGB image after normalizing RGB optical densities, and thresholding unstained pixels.
- * 
+ * <p>
  * TODO: Consider if this is generally worthwhile enough to keep.
  * 
  * @author Pete Bankhead
- *
+ * @implNote this currently does not support {@link ChannelDisplayMode}
  */
 class RGBNormalizedChannelInfo extends RGBDirectChannelInfo {
 	
@@ -46,13 +47,13 @@ class RGBNormalizedChannelInfo extends RGBDirectChannelInfo {
 	}
 
 	@Override
-	public int getRGB(BufferedImage img, int x, int y, boolean useColorLUT) {
+	public int getRGB(BufferedImage img, int x, int y, ChannelDisplayMode mode) {
 		return ColorTransformer.getODNormalizedColor(img.getRGB(x, y), 0.1, 0, 1);
 	}
 	
 	
 	@Override
-	public int[] getRGB(BufferedImage img, int[] rgb, boolean useColorLUT) {
+	public int[] getRGB(BufferedImage img, int[] rgb, ChannelDisplayMode mode) {
 		// Try to get a data buffer directly, if possible
 		int[] buffer = getRGBIntBuffer(img);
 		if (buffer == null) {
@@ -66,6 +67,29 @@ class RGBNormalizedChannelInfo extends RGBDirectChannelInfo {
 		float offset = getOffset();
 		float scale = getScaleToByte();
 		ColorTransformer.transformRGB(buffer, rgb, ColorTransformer.ColorTransformMethod.OD_Normalized, offset, scale, false);
+		
+		if (mode.invertColors()) {
+			int ind = 0;
+			int white = ColorTools.WHITE & 0xFFFFFF;
+			int black = ColorTools.BLACK & 0xFFFFFF;
+			// Here, we should just have 'perfectly white' or 'perfectly black', or a normalized color
+			// We let the white & black pixels pass through and we flip the others so they will end up 
+			// ok after being inverted later
+			for (int v : rgb) {
+				if (v == black) {
+//					rgb[ind] = white; // These will already be inverted
+				} else if (v == white) {
+//					rgb[ind] = black;
+				} else {
+					rgb[ind] = ColorTools.packRGB(
+							255 - ColorTools.red(v),
+							255 - ColorTools.green(v),
+							255 - ColorTools.blue(v)
+							);
+				}
+				ind++;
+			}
+		}
 		return rgb;
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/images/servers/ChannelDisplayTransformServer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/images/servers/ChannelDisplayTransformServer.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import qupath.lib.color.ColorModelFactory;
 import qupath.lib.common.ColorTools;
 import qupath.lib.display.ChannelDisplayInfo;
+import qupath.lib.display.ChannelDisplayMode;
 import qupath.lib.display.SingleChannelDisplayInfo;
 import qupath.lib.images.servers.ImageChannel;
 import qupath.lib.images.servers.ImageServer;
@@ -126,7 +127,7 @@ public class ChannelDisplayTransformServer extends TransformingImageServer<Buffe
 					logger.error("Unable to apply color transform " + channel.getName() + " - incompatible with previously-applied transforms");
 				}
 			} else if (channels.size() == 1) {
-				int[] rgb = channel.getRGB(img, null, false);
+				int[] rgb = channel.getRGB(img, null, ChannelDisplayMode.COLOR);
 				img.setRGB(0, 0, width, height, rgb, 0, width);
 				return img;
 			} else {


### PR DESCRIPTION
See original discussion at https://forum.image.sc/t/qupath-white-background/65030

The idea is that sometimes it makes sense for the background to be black, sometimes it makes sense for it to be white. Inverting the RGB image alone isn't enough, since this changes all the colors. However, a combination of RGB inversion plus inverting individual LUTs can achieve the effect of inverting the background but keeping the other colors similar. This avoids any need to define special LUTs.

The end result makes a fluorescence image look a *bit* like a brightfield one. Although does potentially end up saturating more quickly and so is less informative in the end. For that reason, a warning appears.

Inverting RGB images works slightly differently from other multichannel images, in that values are divided by two during the process to avoid most pixels ending up being black. I think this gives a more sensible-looking result when inverting a brightfield image, but the behavior may change based on feedback.

Implementing this involved making substantial changes to `ImageDisplay` and associated classes, including introducing a new `ChannelDisplayMode` class. While doing this, I tried to improve the consistency within the Brightness/Contrast dialog for all combinations of inverted/not-inverted background and grayscale/color LUTs.

### Existing visualization

![inverted screenshot black](https://user-images.githubusercontent.com/4690904/161815495-19db089a-b65a-457d-90d3-473cd15d8dd7.png)

### Inverted visualization

![inverted screenshot](https://user-images.githubusercontent.com/4690904/161815522-10cea11c-4664-4815-ba15-ae65ad907940.png)

