### PR TITLE
Improved sending pixels to ImageJ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This is a work-in-progress.
   * Built-in ImageJ plugin to send RoiManager ROIs to QuPath (not only overlays)
   * Retain ROI position information when sending ROIs from ImageJ (hyper)stacks
 * Updated prompt to set the image type
+* Avoid converting the pixel type to 32-bit unnecessarily when sending image regions to ImageJ
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -55,6 +55,7 @@ import ij.gui.ShapeRoi;
 import ij.gui.Wand;
 import ij.io.FileInfo;
 import ij.measure.Calibration;
+import ij.plugin.CompositeConverter;
 import ij.plugin.frame.RoiManager;
 import ij.process.Blitter;
 import ij.process.ByteProcessor;
@@ -866,7 +867,7 @@ public class IJTools {
 		// Set colors
 		SampleModel sampleModel = img.getSampleModel();
 		if (!server.isRGB() && sampleModel.getNumBands() > 1) {
-			CompositeImage impComp = new CompositeImage(imp, CompositeImage.COMPOSITE);
+			CompositeImage impComp = imp.isRGB() ? (CompositeImage)CompositeConverter.makeComposite(imp) : new CompositeImage(imp, CompositeImage.COMPOSITE);
 			for (int b = 0; b < sampleModel.getNumBands(); b++) {
 				impComp.setChannelLut(
 						LUT.createLutFromColor(

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ScreenshotCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ScreenshotCommand.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -33,6 +33,7 @@ import java.awt.image.BufferedImage;
 
 import javax.swing.SwingUtilities;
 
+import qupath.lib.awt.common.BufferedImageTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.gui.viewer.QuPathViewer;
@@ -74,6 +75,9 @@ class ScreenshotCommand implements Runnable {
 		String name = "QuPath screenshot";
 		if (viewer.getServer() != null)
 			name = WindowManager.getUniqueName("Screenshot - " + ServerTools.getDisplayableImageName(viewer.getServer()));
+		
+		// Ensure we have a 'normal' RGB image, since otherwise ImageJ can handle the alpha channel in an unexpected way
+		img = BufferedImageTools.ensureBufferedImageType(img, BufferedImage.TYPE_INT_RGB);
 		ImagePlus imp = new ImagePlus(name, img);
 		double pixelWidth = getDisplayedPixelWidthMicrons(viewer);
 		double pixelHeight = getDisplayedPixelHeightMicrons(viewer);


### PR DESCRIPTION
* Invert LUTs when sending images to ImageJ
  * This only partially works, because it requires having a non-RGB image.
* Retain the pixel type when sending an image to ImageJ while extracting channels (i.e. don't always convert to 32-bit)
* Fix regression that meant sending a snapshot to ImageJ had an unwelcome alpha channel