### PR TITLE
Warn if training a pixel classifier with too many features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is a work-in-progress.
   * Retain ROI position information when sending ROIs from ImageJ (hyper)stacks
 * Updated prompt to set the image type
 * Avoid converting the pixel type to 32-bit unnecessarily when sending image regions to ImageJ
+* Warn if trying to train a pixel classifier with too many features (https://github.com/qupath/qupath/issues/947)
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -370,9 +370,10 @@ public class OpenCVTools {
 	 * @param channels separate channels
 	 * @param dest optional destination (may be null)
 	 * @return merged {@link Mat}, which will be the same as dest if provided
+	 * @throws IllegalArgumentException if the number of channels in the output would be greater than {@link opencv_core#CV_CN_MAX}
 	 */
 	@SuppressWarnings("unchecked")
-	public static Mat mergeChannels(Collection<? extends Mat> channels, Mat dest) {
+	public static Mat mergeChannels(Collection<? extends Mat> channels, Mat dest) throws IllegalArgumentException {
 		if (dest == null)
 			dest = new Mat();
 				
@@ -400,6 +401,9 @@ public class OpenCVTools {
 
 		// We can only use OpenCV's merge if all Mats are single-channel
 		boolean mixChannels = !allSingleChannel;		
+		if (nChannels > opencv_core.CV_CN_MAX)
+			throw new IllegalArgumentException("Can't merge more than " + opencv_core.CV_CN_MAX + " channels (you requested " + nChannels + ")");
+		
 		try (var scope = new PointerScope()) {
 			if (mixChannels) {
 				dest.create(rows, cols, opencv_core.CV_MAKETYPE(depth, nChannels));

--- a/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.stream.IntStream;
@@ -629,6 +630,27 @@ public class TestOpenCVTools {
 		long endTime = System.currentTimeMillis();
 		logger.debug("Traced {} contours for {} in {} ms with 8-connectivity", objects8.size(), path.getFileName().toString(), endTime - middleTime);
 
+	}
+	
+	
+	@Test
+	void testMerge() {
+		int[] nChannels = {1, 2, opencv_core.CV_CN_MAX, opencv_core.CV_CN_MAX+1};
+		for (int n : nChannels) {
+			try (var scope = new PointerScope()) {
+				var channels = new ArrayList<Mat>();
+				for (int i = 0; i < n; i++) {
+					channels.add(OpenCVTools.scalarMat(i, opencv_core.CV_32F));
+				}
+				if (n > opencv_core.CV_CN_MAX) {
+					assertThrows(IllegalArgumentException.class, () -> OpenCVTools.mergeChannels(channels, null));
+					continue;
+				} else {
+					var merged = OpenCVTools.mergeChannels(channels, null);
+					assertEquals(n, merged.channels());
+				}
+			}
+		}
 	}
 	
 


### PR DESCRIPTION
See https://github.com/qupath/qupath/issues/947
The issue was trying to merge or mix more channels than the value of opencv_core.CV_CN_MAX (i.e. 512)