### PR TITLE
Use version catalog

### DIFF
--- a/buildSrc/src/main/groovy/qupath.common-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.common-conventions.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'qupath.java-conventions'
-    id 'org.bytedeco.gradle-javacpp-platform'
     id 'jacoco'
     id 'io.github.qupath.platform'
+    id 'org.bytedeco.gradle-javacpp-platform'
 }
 
 repositories {
@@ -13,7 +13,7 @@ repositories {
         name 'ImageJ'
         url 'https://maven.imagej.net/content/groups/public' 
     }
-
+    
     // Required for Bio-Formats
     maven {
         name 'Unidata'
@@ -52,14 +52,11 @@ def useCuda = useCudaRedist || project.hasProperty('cuda')
  * Handle OS-specific decisions
  */
 String platform = properties['platform.shortName']
-String jfxPlatform = platform
 if (properties['platform.name'] == null)
     logger.warn('Unknown operating system!')
 if ("32".equals(System.getProperty("sun.arch.data.model"))) {
     logger.warn("You appear to be using a 32-bit JDK - it is very possible some things won't work!")
     logger.warn("You may at least need to replace the OpenSlide dlls with 32-bit versions from https://openslide.org/download/")
-    if (platform == 'win')
-	    jfxPlatform = platform + "-x86"
 }
 
 // Check if we are running using Apple Silicon
@@ -74,9 +71,6 @@ I will try to build anyway, but note that:
 - Parts of the software relying on native libraries are unlikely to work (including OpenSlide)
 If you want to avoid these messages, please use a JDK for x86_64.
 	""".trim())
-	jfxPlatform = "mac-aarch64"
-} else if (platform == 'linux' && osArch == 'aarch64') {
-	jfxPlatform = platform + '-aarch64'
 }
 
 
@@ -86,100 +80,22 @@ If you want to avoid these messages, please use a JDK for x86_64.
 project.file('src/main/resources/VERSION').setText(gradle.ext.qupathVersion, 'UTF-8')
 
 
-/*
- * JavaFX version
- */
-def jfxVersion = '18'
-def jfxModules = ['javafx.base', 'javafx.controls', 'javafx.graphics', 'javafx.media', 'javafx.web', 'javafx.swing']
-
-ext {
-    // Dependency versions
-    commonsMathVersion = '3.6.1'
-    commonsTextVersion = '1.9'
-    controlsfxVersion  = '11.1.1'
-    groovyVersion      = '4.0.1'
-    gsonVersion        = '2.9.0'
-    guavaVersion       = '31.1-jre'
-    imagejVersion      = '1.53q'
-    jfxtrasVersion     = '11-r2'
-    jtsVersion         = '1.18.2'
-    picocliVersion     = '4.6.3'
-    
-    // Note, if OpenCV is a SNAPSHOT version then it must already be installed locally (with Maven)
-	javacppVersion     = '1.5.7'
-    opencvVersion      = "4.5.5-${javacppVersion}"
-
-	// Optional, not used by default
-	cudaVersion        = "11.6-8.3-${javacppVersion}"
-
-    // Additional versions
-    logbackVersion     = '1.2.11'
-    slf4jVersion       = '1.7.36'
-    junitVersion       = '5.8.2'
-}
-
 configurations {
-    jts
-    groovy
-    commonsmath
-    commonstext
-    gson
-    controlsfx
-    jfxtras
     opencv
-    imagej
-    javafx
     guava
-    picocli
-    logback
-
-    // Testing
-    junit
 }
 
 dependencies {
 
-    jts "org.locationtech.jts:jts-core:${jtsVersion}"
-    // Optionally add GeoJSON support (brings in json-simple as sub-dependency)
-    // However, the use of simple-json is troublesome since it brings in an old version of junit
-//   jts "org.locationtech.jts.io:jts-io-common:${jtsVersion}"
-
-    groovy "org.apache.groovy:groovy:${groovyVersion}"
-    groovy "org.apache.groovy:groovy-jsr223:${groovyVersion}"
-    groovy "org.apache.groovy:groovy-xml:${groovyVersion}"
-
-    for (fx in jfxModules.collect{it.replace('.', '-')}) {
-        javafx "org.openjfx:${fx}:${jfxVersion}"
-        javafx "org.openjfx:${fx}:${jfxVersion}:${jfxPlatform}"
-    }
-
-    commonsmath "org.apache.commons:commons-math3:${commonsMathVersion}"
-
-    commonstext "org.apache.commons:commons-text:${commonsTextVersion}"
-
-    gson "com.google.code.gson:gson:${gsonVersion}"
-
-    controlsfx "org.controlsfx:controlsfx:${controlsfxVersion}",  {
-        // ControlsFX 11.0.1 uses a linux classifier to bring in more JavaFX than it may need
-        exclude group: 'org.openjfx'
-    }
-
-    jfxtras "org.jfxtras:jfxtras-menu:${jfxtrasVersion}", {
-        exclude group: 'org.jfxtras', module: 'jfxtras-test-support'
-    }
-
-    if (useCuda) {
-        opencv "org.bytedeco:opencv-platform-gpu:${opencvVersion}"
-        opencv "org.bytedeco:cuda-platform:${cudaVersion}"
-        if (useCudaRedist) {
-	        opencv "org.bytedeco:cuda-platform-redist:${cudaVersion}"
-	    }
+    if (useCudaRedist) {
+        opencv libs.bundles.opencv.cuda
+    } else if (useCuda) {
+        opencv libs.bundles.opencv.gpu
     } else
-        opencv "org.bytedeco:opencv-platform:${opencvVersion}"
+        opencv libs.bundles.opencv
 
-    imagej "net.imagej:ij:${imagejVersion}"
-    
-    guava "com.google.guava:guava:${guavaVersion}", {
+
+    guava libs.guava, {
         exclude group: 'com.google.code.findbugs'
         exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
@@ -187,25 +103,15 @@ dependencies {
         exclude group: 'org.checkerframework', module: 'checker-qual'
     }
 
-    picocli "info.picocli:picocli:${picocliVersion}"
-
-    junit "org.junit.jupiter:junit-jupiter:${junitVersion}"
-//    junit "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
-
-    logback "ch.qos.logback:logback-classic:${logbackVersion}"
-    logback "org.slf4j:slf4j-api:${slf4jVersion}"
-
 }
 
-
-configurations {
-    implementation.extendsFrom logback
-    testImplementation.extendsFrom junit
-}
 
 dependencies {
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation libs.junit
+    testImplementation libs.junit.api
+    testRuntimeOnly    libs.junit.engine
+    
+    implementation libs.bundles.logging
 }
 
 tasks.named('test') {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,63 @@
+[versions]
+groovy        = "4.0.1"
+javafx        = "18"
+ikonli        = "12.3.0"
+junit         = "5.8.2"
+javacpp       = "1.5.7"
+opencv        = "4.5.5-1.5.7"
+cuda          = "11.6-8.3-1.5.7"
+bioformats    = "6.9.0"
+
+[libraries]
+groovy-core   = { module = "org.apache.groovy:groovy", version.ref = "groovy" }
+groovy-jsr223 = { module = "org.apache.groovy:groovy-jsr223", version.ref = "groovy" }
+groovy-xml    = { module = "org.apache.groovy:groovy-xml", version.ref = "groovy" }
+
+gson          = { module = "com.google.code.gson:gson", version = "2.9.0" }
+
+# Optionally add GeoJSON support (brings in json-simple as sub-dependency)
+# However, the use of simple-json is troublesome since it brings in an old version of junit
+jts           = { module = "org.locationtech.jts:jts-core",    version = "1.18.2" }
+
+logback       = { module = "ch.qos.logback:logback-classic",   version = "1.2.11" }
+slf4j         = { module = "org.slf4j:slf4j-api",              version = "1.7.36" }
+
+commons-math  = { module = "org.apache.commons:commons-math3", version = "3.6.1" }
+commons-text  = { module = "org.apache.commons:commons-text",  version = "1.9" }
+controlsfx    = { module = "org.controlsfx:controlsfx",        version = "11.1.1" }
+jfxtras       = { module = "org.jfxtras:jfxtras-menu",         version = "11-r2" }
+guava         = { module = "com.google.guava:guava",           version = "31.1-jre" }
+imagej        = { module = "net.imagej:ij",                    version = "1.53q" }
+picocli       = { module = "info.picocli:picocli",             version = "4.6.3" }
+
+richtextfx    = { module = "org.fxmisc.richtext:richtextfx",   version = "0.10.9" }
+jfreesvg      = { module = "org.jfree:org.jfree.svg",          version = "5.0.2" }
+
+javacpp       = { module = "org.bytedeco:javacpp",              version.ref = "javacpp" }
+opencv        = { module = "org.bytedeco:opencv-platform",      version.ref = "opencv" }
+opencv-gpu    = { module = "org.bytedeco:opencv-platform-gpu",  version.ref = "opencv"}
+cuda          = { module = "org.bytedeco:cuda-platform",        version.ref = "cuda" }
+cuda-redist   = { module = "org.bytedeco:cuda-platform-redist", version.ref = "cuda" }
+
+ikonli-javafx           = { module = "org.kordamp.ikonli:ikonli-javafx",  version.ref = "ikonli" }
+ikonli-ionicons4 = { module = "org.kordamp.ikonli:ikonli-ionicons4-pack", version.ref = "ikonli" }
+
+junit         = { module = "org.junit.jupiter:junit-jupiter",        version.ref = "junit" }
+junit-api     = { module = "org.junit.jupiter:junit-jupiter-api",    version.ref = "junit" }
+junit-engine  = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+
+
+[bundles]
+groovy        = ["groovy-core", "groovy-jsr223", "groovy-xml"]
+ikonli        = ["ikonli-javafx", "ikonli-ionicons4"]
+logging       = ["slf4j", "logback"]
+opencv        = ["javacpp", "opencv"]
+opencv-gpu    = ["javacpp", "opencv-gpu", "cuda"]
+opencv-cuda   = ["javacpp", "opencv-gpu", "cuda", "cuda-redist"]
+
+[plugins]
+# Use the javafx plugin to add modules
+javafx         = { id = 'org.openjfx.javafxplugin', version = '0.0.12' }
+javacpp        = { id = 'org.bytedeco.gradle-javacpp-platform', version = '1.5.7' }
+jpackage       = { id = 'org.beryx.runtime', version = '1.12.7' }
+license-report = { id = 'com.github.jk1.dependency-license-report', version = '2.0' }

--- a/qupath-app/build.gradle
+++ b/qupath-app/build.gradle
@@ -18,7 +18,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.beryx:badass-runtime-plugin:1.12.7"
+//    classpath "org.beryx:badass-runtime-plugin:1.12.7"
 //    classpath 'com.github.jk1:dependency-license-report:2.0'
   }
 }
@@ -26,9 +26,9 @@ buildscript {
 plugins {
   id 'qupath.common-conventions'
   id 'application'
-  id 'org.beryx.runtime' version '1.12.7'
 //    id 'org.beryx.jlink' version '2.24.0'  // Can use this when QuPath is modular...
-  id 'com.github.jk1.dependency-license-report' version '2.0'
+  alias(libs.plugins.license.report)
+  alias(libs.plugins.jpackage)
 }
 
 
@@ -114,16 +114,13 @@ startScripts {
 }
 
 
-configurations {
-  implementation.extendsFrom picocli
-}
-
 // Determine which projects to include/exclude as dependencies
 def excludedProjects = [project.name]
 def includedProjects = rootProject.subprojects.findAll {!excludedProjects.contains(it.name)}
 
 dependencies {
   implementation includedProjects
+  implementation libs.picocli
 }
 
 /**

--- a/qupath-core-processing/build.gradle
+++ b/qupath-core-processing/build.gradle
@@ -9,13 +9,15 @@ archivesBaseName = 'qupath-core-processing'
 description = "Core QuPath module containing the main processing operations."
 
 configurations {
-  implementation.extendsFrom commonsmath
-  implementation.extendsFrom guava
-  api.extendsFrom imagej
   api.extendsFrom opencv
+  implementation.extendsFrom guava
 }
 
 dependencies {
   api project(':qupath-core')
+  
+  api libs.imagej
+  implementation libs.commons.math
+  
   testImplementation project(':qupath-core').sourceSets.test.output
 }

--- a/qupath-core/build.gradle
+++ b/qupath-core/build.gradle
@@ -9,10 +9,17 @@ archivesBaseName = 'qupath-core'
 description = "Core QuPath module containing the main classes and datastructures."
 
 configurations {
-  api.extendsFrom gson
-  api.extendsFrom jts
-  implementation.extendsFrom commonsmath
-  implementation.extendsFrom guava
   implementation.extendsFrom opencv
-  implementation.extendsFrom picocli
+  implementation.extendsFrom guava
+}
+
+dependencies {
+  api libs.gson
+  api libs.jts
+  
+  implementation libs.commons.math
+  implementation libs.picocli
+
+//  implementation libs.bundles.opencv
+  
 }

--- a/qupath-extension-bioformats/build.gradle
+++ b/qupath-extension-bioformats/build.gradle
@@ -7,29 +7,22 @@ ext.moduleName = 'qupath.extension.bioformats'
 archivesBaseName = 'qupath-extension-bioformats'
 description = "QuPath extension to support image reading and writing using Bio-Formats."
 
-def bioformatsVersion = "6.9.0"
+def bioformatsVersion = libs.versions.bioformats.get()
 def versionOverride = project.properties.getOrDefault('bioformats-version', null)
 if (versionOverride) {
 	println "Using specified Bio-Formats version ${versionOverride}"
 	bioformatsVersion = versionOverride
 }
 
-configurations {
-  // Consider using compileOnly for Bio-Formats, and installing bioformats_package.jar separately
-  implementation.extendsFrom bioformats
-  implementation.extendsFrom controlsfx
-  implementation.extendsFrom picocli
-  
-//  testImplementation.extendsFrom bioformats
-//  testImplementation.extendsFrom bioformatsTest
-  testImplementation.extendsFrom imagej
-}
 
 dependencies {
 	// This can be used to include bioformats_package.jar - however it causes warnings with SLF4J
 //  implementation("ome:bioformats_package:${bioformatsVersion}") {
 //  	transitive = false
 //  }
+
+  implementation libs.controlsfx
+  implementation libs.picocli
 
   implementation "ome:formats-gpl:${bioformatsVersion}", {
     exclude group: 'xalan', module: 'serializer'
@@ -44,4 +37,7 @@ dependencies {
 
 //  testImplementation("ome:bioformats_package:${bioformatsVersion}")
   testImplementation "ome:bio-formats_plugins:${bioformatsVersion}"
+  
+  testImplementation libs.imagej
+  
 }

--- a/qupath-extension-processing/build.gradle
+++ b/qupath-extension-processing/build.gradle
@@ -7,6 +7,6 @@ ext.moduleName = 'qupath.extension.processing'
 archivesBaseName = 'qupath-extension-processing'
 description = "QuPath extension to support processing (including many common commands)."
 
-configurations {
-  implementation.extendsFrom commonsmath
+dependencies {
+  implementation libs.commons.math
 }

--- a/qupath-extension-script-editor/build.gradle
+++ b/qupath-extension-script-editor/build.gradle
@@ -7,11 +7,7 @@ ext.moduleName = 'qupath.extension.scripteditor'
 archivesBaseName = 'qupath-extension-script-editor'
 description = "QuPath extension to provide an alternative script editor using RichTextFX."
 
-configurations {
-//  implementation.extendsFrom controlsfx
-  implementation.extendsFrom groovy
-}
-
 dependencies {
-  implementation "org.fxmisc.richtext:richtextfx:0.10.9"
+  implementation libs.bundles.groovy
+  implementation libs.richtextfx
 }

--- a/qupath-extension-svg/build.gradle
+++ b/qupath-extension-svg/build.gradle
@@ -8,5 +8,5 @@ archivesBaseName = 'qupath-extension-svg'
 description = "QuPath extension to write SVG images using JFreeSVG."
 
 dependencies {
-  implementation "org.jfree:org.jfree.svg:5.0.2"
+  implementation libs.jfreesvg
 }

--- a/qupath-gui-fx/build.gradle
+++ b/qupath-gui-fx/build.gradle
@@ -2,6 +2,8 @@ plugins {
   id 'qupath.common-conventions'
   id 'qupath.publishing-conventions'
   id 'java-library'
+  
+  alias(libs.plugins.javafx)
 }
 
 ext.moduleName = 'qupath.gui.fx'
@@ -9,18 +11,29 @@ archivesBaseName = 'qupath-gui-fx'
 description = "Main QuPath user interface."
 
 configurations {
-  api.extendsFrom javafx
-  api.extendsFrom controlsfx
   implementation.extendsFrom guava
-  implementation.extendsFrom jfxtras
-  implementation.extendsFrom commonstext
-  implementation.extendsFrom commonsmath
 }
 
 dependencies {
   api project(':qupath-core')
   api project(':qupath-core-processing')
 
-  implementation 'org.kordamp.ikonli:ikonli-javafx:12.3.0'
-  implementation 'org.kordamp.ikonli:ikonli-ionicons4-pack:12.3.0'
+  api libs.controlsfx
+  
+  implementation libs.jfxtras
+  implementation libs.commons.text
+  implementation libs.commons.math
+
+  implementation libs.bundles.ikonli
+}
+
+javafx {
+	version = libs.versions.javafx.get()
+	modules = ["javafx.base", 
+	           "javafx.controls",
+	           "javafx.graphics",
+	           "javafx.media",
+	           "javafx.web",
+	           "javafx.swing"]
+	configuration = 'api'
 }


### PR DESCRIPTION
See https://docs.gradle.org/current/userguide/platforms.html
This should be a step towards better dependency management. The aim is to make it easier for extension writers to ensure compatibility with any given QuPath version & its dependencies.