### PR TITLE
Bio-Formats-related changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,19 @@ This is a work-in-progress.
 * Duplicating images with some names can cause an exception (https://github.com/qupath/qupath/issues/942)
 * Removing >255 measurements throws error when reproducing from workflow script (https://github.com/qupath/qupath/issues/915)
 
+### Enhancements through Bio-Formats 6.9.1
+* Bio-Formats 6.9.1 brings several important new features to QuPath, including:
+  * Support for reading DICOM whole slide images
+  * Improved handling of brightfield CZI images (i.e. filling unscanned regions in white, not black)
+  * Substantial performance improvements for reading/writing some formats (including OME-TIFF)
+* For details, see https://docs.openmicroscopy.org/bio-formats/6.9.1/about/whats-new.html
+
 ### Known issues
-* Bio-Formats 6.9.0 has problems with a subset of svs files, see https://github.com/ome/bioformats/issues/3757
+* Bio-Formats 6.9.1 may have problems with a subset of svs files, see https://github.com/ome/bioformats/issues/3757
 
 ### Dependency updates
 * Adoptium OpenJDK 17
-* Bio-Formats 6.9.0
+* Bio-Formats 6.9.1
 * JavaFX 17.0.2
 * Groovy 4.0.1
 * Gson 2.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This is a work-in-progress.
 * 'Zoom to fit' doesn't handle changes in window size
 * Duplicating images with some names can cause an exception (https://github.com/qupath/qupath/issues/942)
 * Removing >255 measurements throws error when reproducing from workflow script (https://github.com/qupath/qupath/issues/915)
+* QuPath doesn't support some channel combinations through Bio-Formats (https://github.com/qupath/qupath/issues/956)
 
 ### Enhancements through Bio-Formats 6.9.1
 * Bio-Formats 6.9.1 brings several important new features to QuPath, including:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,15 +36,15 @@ This is a work-in-progress.
 * Removing >255 measurements throws error when reproducing from workflow script (https://github.com/qupath/qupath/issues/915)
 * QuPath doesn't support some channel combinations through Bio-Formats (https://github.com/qupath/qupath/issues/956)
 
-### Enhancements through Bio-Formats 6.9.1
+### Changes through Bio-Formats 6.9.1
 * Bio-Formats 6.9.1 brings several important new features to QuPath, including:
   * Support for reading DICOM whole slide images
   * Improved handling of brightfield CZI images (i.e. filling unscanned regions in white, not black)
   * Substantial performance improvements for reading/writing some formats (including OME-TIFF)
+* Bio-Formats in combination with Java 17 also has some known issues
+  * Unable to properly read a subset of svs files (https://github.com/ome/bioformats/issues/3757)
+  * Memoization is not possible with Java 17, and turned off in QuPath by default (https://github.com/qupath/qupath/issues/957)
 * For details, see https://docs.openmicroscopy.org/bio-formats/6.9.1/about/whats-new.html
-
-### Known issues
-* Bio-Formats 6.9.1 may have problems with a subset of svs files, see https://github.com/ome/bioformats/issues/3757
 
 ### Dependency updates
 * Adoptium OpenJDK 17

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ junit         = "5.8.2"
 javacpp       = "1.5.7"
 opencv        = "4.5.5-1.5.7"
 cuda          = "11.6-8.3-1.5.7"
-bioformats    = "6.9.0"
+bioformats    = "6.9.1"
 
 [libraries]
 groovy-core   = { module = "org.apache.groovy:groovy", version.ref = "groovy" }

--- a/qupath-app/build.gradle
+++ b/qupath-app/build.gradle
@@ -53,13 +53,16 @@ ext {
   qupathAppName = "QuPath-${qupathVersion}"
 }
 
+// Determine java version associated with toolchain
+def toolchainJavaVersion = getToolchainJavaVersion()
+
 // Put the output in the main directory so it is easier to find
 project.buildDir = rootProject.file('build')
 
 application {
   mainClass = "qupath.QuPath"
   applicationName = qupathAppName
-  applicationDefaultJvmArgs = buildDefaultJvmArgs("${project.buildDir}/natives")
+  applicationDefaultJvmArgs = buildDefaultJvmArgs("${project.buildDir}/natives", toolchainJavaVersion)
 }
 
 /*
@@ -364,7 +367,7 @@ JPackageParams buildParameters() {
   params.appVersion = appVersion
   params.imageName = qupathAppName // Will need to be removed for some platforms
   params.installerName = "QuPath"
-  params.jvmArgs += buildDefaultJvmArgs()
+  params.jvmArgs += buildDefaultJvmArgs('$APPDIR', toolchainJavaVersion)
 
   // Configure according to the current platform
   def platform = properties['platform.name']
@@ -515,10 +518,29 @@ def setFileAssociations(JPackageParams params) {
 }
 
 /**
+ * Get the JavaVersion used with the current toolchain.
+ * This is useful for JVM-specific arguments.
+ */ 
+JavaVersion getToolchainJavaVersion() {
+	try {
+		// Certainly feels like there should be a more direct way, but I couldn't find it
+		def toolchain = project.getExtensions().getByType(JavaPluginExtension.class).getToolchain()
+		def service = project.getExtensions().getByType(JavaToolchainService.class)
+		def version = service.compilerFor(toolchain).get().getMetadata().getJvmVersion()
+		return JavaVersion.toVersion(version)
+	} catch (Exception e) {
+		println "Unable to determine Java version from toolchain: ${e.getLocalizedMessage()}"
+		return JavaVersion.current()
+	}
+	if (toolchain == null)
+	return JavaVersion.toVersion(toolchain.getJavaLanguageVersion())
+}
+
+/**
  * Get default JVM arguments (e.g. to set memory, library path)
  * @return
  */
-static List<String> buildDefaultJvmArgs(String libraryPath = '$APPDIR') {
+static List<String> buildDefaultJvmArgs(String libraryPath = '$APPDIR', JavaVersion javaVersion = JavaVersion.current()) {
   // Set up the main Java options
   def javaOptions = []
 
@@ -532,8 +554,12 @@ static List<String> buildDefaultJvmArgs(String libraryPath = '$APPDIR') {
   //   ERROR: QuPath exception: class org.controlsfx.control.textfield.AutoCompletionBinding
   //   (in unnamed module @0x298a5e20) cannot access class com.sun.javafx.event.EventHandlerManager
   //   (in module javafx.base) because module javafx.base does not export com.sun.javafx.event to unnamed module
-  // This Java option will hopefully be temporary, until dependencies are updated to make it unnecessary.
-  javaOptions << '--illegal-access=permit'
+  // This Java option is not supported in Java 17+.
+  // It is useful in Java 16, particularly for Bio-Formats memoization
+  if (javaVersion == JavaVersion.VERSION_16) {
+      println "Setting --illegal-access=permit for pre-Java 16 behavior"
+	  javaOptions << '--illegal-access=permit'
+  }
 
   // Default to using 50% available memory
   javaOptions << '-XX:MaxRAMPercentage=50'

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -1161,7 +1161,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			int memoizationTimeMillis = options.getMemoizationTimeMillis();
 			File dir = null;
 			// We can only use memoization if we don't have an illegal character
-			if (memoizationTimeMillis >= 0 && !id.contains(":")) {
+			if (BioFormatsServerOptions.allowMemoization() && memoizationTimeMillis >= 0 && !id.contains(":")) {
 				// Try to use a specified directory
 				String pathMemoization = options.getPathMemoization();
 				if (pathMemoization != null && !pathMemoization.trim().isEmpty()) {

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -568,15 +568,73 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 				channels.addAll(ImageChannel.getDefaultRGBChannels());
 			}
 			else {
-				for (int c = 0; c < nChannels; c++) {
-					ome.xml.model.primitives.Color color = null;
-					String channelName = null;
-					try {
-						channelName = meta.getChannelName(series, c);
-						color = meta.getChannelColor(series, c);
-					} catch (Exception e) {
-						logger.warn("Unable to parse color", e);
+				// Get channel colors and names
+				var tempColors = new ArrayList<ome.xml.model.primitives.Color>(nChannels);
+				var tempNames = new ArrayList<String>(nChannels);
+				// Be prepared to use default channels if something goes wrong
+				try {
+					int metaChannelCount = meta.getChannelCount(series);
+					// Handle the easy case where the number of channels matches our expectations
+					if (metaChannelCount == nChannels) {
+						for (int c = 0; c < nChannels; c++) {
+							try {
+								// try/catch from old code, before we explicitly checked channel count
+								// No exception should occur now
+								var channelName = meta.getChannelName(series, c);
+								var color = meta.getChannelColor(series, c);
+								tempNames.add(channelName);
+								tempColors.add(color);
+							} catch (Exception e) {
+								logger.warn("Unable to parse name or color for channel {}", c);
+								logger.debug("Unable to parse color", e);
+							}
+						}
+					} else {
+						// Handle the harder case, where we have a different number of channels
+						// I've seen this with a polarized light CZI image, with a channel count of 2 
+						// but in which each of these had 3 samples (resulting in a total of 6 channels)
+						logger.debug("Attempting to parse {} channels with metadata channel count", nChannels, metaChannelCount);
+						int ind = 0;
+						for (int cInd = 0; cInd < metaChannelCount; cInd++) {
+							int nSamples = meta.getChannelSamplesPerPixel(series, cInd).getValue();
+							var baseChannelName = meta.getChannelName(series, cInd);
+							if (baseChannelName != null && baseChannelName.isBlank())
+								baseChannelName = null;
+							// I *expect* this to be null for interleaved channels, in which case it will be filled in later
+							var color = meta.getChannelColor(series, cInd);
+							for (int sampleInd = 0; sampleInd < nSamples; sampleInd++) {
+								String channelName;
+								if (baseChannelName == null)
+									channelName = "Channel " + (ind + 1);
+								else
+									channelName = baseChannelName.strip() + " " + (sampleInd + 1);
+								
+								tempNames.add(channelName);
+								tempColors.add(color);
+								
+								ind++;
+							}
+						}
 					}
+				} catch (Exception e) {
+					logger.warn("Exception parsing channels " + e.getLocalizedMessage(), e);
+				}
+				if (nChannels != tempNames.size() || tempNames.size() != tempColors.size()) {
+					logger.warn("The channel names and colors read from the metadata don't match the expected number of channels!");
+					logger.warn("Be very cautious working with channels, since the names and colors may be misaligned, incorrect or default values.");
+					long nNames = tempNames.stream().filter(n -> n != null && !n.isBlank()).count();
+					long nColors = tempColors.stream().filter(n -> n != null).count();
+					logger.warn("(I expected {} channels, but found {} names and {} colors)", nChannels, nNames, nColors);
+					// Could reset them, but may help to use what we can
+//					tempNames.clear();
+//					tempColors.clear();
+				}
+				
+					
+				// Now loop through whatever we could parse and add QuPath ImageChannel objects
+				for (int c = 0; c < nChannels; c++) {
+					String channelName = c < tempNames.size() ? tempNames.get(c) : null;
+					var color = c < tempColors.size() ? tempColors.get(c) : null; 
 					Integer channelColor = null;
 					if (color != null)
 						channelColor = ColorTools.packARGB(color.getAlpha(), color.getRed(), color.getGreen(), color.getBlue());
@@ -591,6 +649,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 						channelName = "Channel " + (c + 1);
 					channels.add(ImageChannel.getInstance(channelName, channelColor));
 				}
+				assert nChannels == channels.size();
 				// Update RGB status if needed - sometimes we might really have an RGB image, but the Bio-Formats flag doesn't show this - 
 				// and we want to take advantage of the optimizations where we can
 				if (nChannels == 3 && 
@@ -631,7 +690,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 					int lastTimepoint = -1;
 					int count = 0;
 					timepoints = new double[nTimepoints];
-					logger.debug("PLANE COUNT: " + meta.getPlaneCount(series));
+					logger.debug("Plane count: " + meta.getPlaneCount(series));
 					for (int plane = 0; plane < meta.getPlaneCount(series); plane++) {
 						int timePoint = meta.getPlaneTheT(series, plane).getValue();
 						logger.debug("Checking " + timePoint);
@@ -1362,6 +1421,33 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 						offsets[b] = b * tileWidth * tileHeight;
 					sampleModel = new ComponentSampleModel(dataBuffer.getDataType(), tileWidth, tileHeight, 1, tileWidth, offsets);
 				}
+			} else if (sizeC > effectiveC) {
+				// Handle multiple bands, but still interleaved
+				// See https://forum.image.sc/t/qupath-cant-open-polarized-light-scans/65951
+				int[] offsets = new int[sizeC];
+				int[] bandInds = new int[sizeC];
+				int ind = 0;
+				
+				int channelCount = metadata.getChannelCount(series);
+				for (int cInd = 0; cInd < channelCount; cInd++) {
+					int nSamples = metadata.getChannelSamplesPerPixel(series, cInd).getValue();
+					for (int s = 0; s < nSamples; s++) {
+						bandInds[ind] = cInd;
+						if (interleaved) {
+							offsets[ind] = s;
+						} else {
+							offsets[ind] = s * tileWidth * tileHeight;							
+						}
+						ind++;
+					}
+				}
+				// TODO: Check this! It works for the only test image I have... (2 channels with 3 samples each)
+				// I would guess it fails if pixelStride does not equal nSamples, and if nSamples is different for different 'channels' - 
+				// but I don't know if this occurs in practice.
+				// If it does, I don't see a way to use a ComponentSampleModel... which could complicate things quite a bit
+				int pixelStride = sizeC / effectiveC;
+				int scanlineStride = pixelStride*tileWidth;
+				sampleModel = new ComponentSampleModel(dataBuffer.getDataType(), tileWidth, tileHeight, pixelStride, scanlineStride, bandInds, offsets);
 			} else {
 				// Merge channels on different planes
 				sampleModel = new BandedSampleModel(dataBuffer.getDataType(), tileWidth, tileHeight, sizeC);

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsOptionsExtension.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsOptionsExtension.java
@@ -125,10 +125,14 @@ public class BioFormatsOptionsExtension implements QuPathExtension {
 		prefs.addPropertyPreference(useParallelization, Boolean.class, "Enable Bio-Formats tile parallelization", "Bio-Formats", "Enable reading image tiles in parallel when using Bio-Formats");
 //		prefs.addPropertyPreference(parallelizeMultichannel, Boolean.class, "Enable Bio-Formats channel parallelization (experimental)", "Bio-Formats", "Request multiple image channels in parallel, even if parallelization of tiles is turned off - "
 //				+ "only relevant for multichannel images, and may fail for some image formats");
-		prefs.addPropertyPreference(memoizationTimeMillis, Integer.class, "Bio-Formats memoization time (ms)", "Bio-Formats", "Specify how long a file requires to open before Bio-Formats will create a .bfmemo file to improve performance (set < 0 to never use memoization)");
 		
-		prefs.addDirectoryPropertyPreference(pathMemoization, "Bio-Formats memoization directory", "Bio-Formats",
-				"Choose directory where Bio-Formats should write cache files for memoization; by default the directory where the image is stored will be used");
+		if (BioFormatsServerOptions.allowMemoization()) {
+			prefs.addPropertyPreference(memoizationTimeMillis, Integer.class, "Bio-Formats memoization time (ms)", "Bio-Formats", "Specify how long a file requires to open before Bio-Formats will create a .bfmemo file to improve performance (set < 0 to never use memoization)");
+			
+			prefs.addDirectoryPropertyPreference(pathMemoization, "Bio-Formats memoization directory", "Bio-Formats",
+					"Choose directory where Bio-Formats should write cache files for memoization; by default the directory where the image is stored will be used");
+		}
+		
 		prefs.addPropertyPreference(useExtensions, String.class, "Always use Bio-Formats for specified image extensions", "Bio-Formats", 
 				"Request that Bio-Formats is always the file reader used for images with specific extensions; enter as a list with spaces between each entry");
 		prefs.addPropertyPreference(skipExtensions, String.class, "Never use Bio-Formats for specified image extensions", "Bio-Formats", 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -1164,7 +1164,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 										objectCell = objectTemp;
 										tree.refresh();
 									} catch (Exception ex) {
-										logger.warn("Error opening ImageServer (thumbnail generation): " + ex.getLocalizedMessage());
+										logger.warn("Error opening ImageServer (thumbnail generation): " + ex.getLocalizedMessage(), ex);
 										Platform.runLater(() -> setGraphic(IconFactory.createNode(15, 15, PathIcons.INACTIVE_SERVER)));
 										serversFailed.add(item);
 									}


### PR DESCRIPTION
* Update to Bio-Formats 6.9.1
* Fix https://github.com/qupath/qupath/issues/956
* Work around https://github.com/qupath/qupath/issues/957

Memoization will need to be revisited in the future. Here, it is disabled when using using Java 17+ because it doesn't work and logs many errors (somehow related to JEP 403). This behavior can be overridden by adding
```
  java-options=-Dqupath.bioformats.allow.memoization=true
```
to the QuPath.cfg file (i.e. set the system property), but it likely won't help until there is a new Bio-Formats release.

Relatedly, the qupath-app build.gradle now only adds `--illegal-access=permit` for Java 16, since it's the only version where it makes a difference.

The easiest way to get QuPath with memoization is therefore to use
```
gradlew jpackage -Ptoolchain=16
```