### PR TITLE
Add a UUID to each PathObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This is a work-in-progress.
 
 ### Enhancements
 
+* Objects now have IDs
+  * This aims to make it much easier to match up objects whenever some further analysis is done elsewhere (e.g. classification or clustering in Python or R)
+  * See https://github.com/qupath/qupath/pull/959
+* Completely rewritten 'View -> Show view tracker' command
 * Improved measurement tables
   * Include thumbnail images for each object (can be turned off with 'Include image column in measurement tables' preference)
   * Center viewer on an object by selecting it & pressing the 'spacebar'
@@ -24,6 +28,7 @@ This is a work-in-progress.
   * Built-in ImageJ plugin to send RoiManager ROIs to QuPath (not only overlays)
   * Retain ROI position information when sending ROIs from ImageJ (hyper)stacks
 * Updated prompt to set the image type
+* Missing thumbnails are automatically regenerated when a project is opened
 * Avoid converting the pixel type to 32-bit unnecessarily when sending image regions to ImageJ
 * Warn if trying to train a pixel classifier with too many features (https://github.com/qupath/qupath/issues/947)
 

--- a/qupath-core/src/main/java/qupath/lib/io/PathIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathIO.java
@@ -48,7 +48,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -99,11 +98,56 @@ public class PathIO {
 	 * Version 1.0 was the first...
 	 * Version 2 switched to integers, and includes Locale information
 	 * Version 3 stores JSON instead of a server path
+	 * Version 4 stores PathObject UUIDs as a separate field
 	 */
 	private final static int DATA_FILE_VERSION = 3;
 	
 	private PathIO() {}
 	
+	private static int requestedDataFileVersion = DATA_FILE_VERSION - 1;
+	
+	/**
+	 * Get the requested version for .qpdata files.
+	 * 
+	 * @return
+	 * @see #setRequestedDataFileVersion(int version)
+	 * @see #getCurrentDataFileVersion()
+	 */
+	public static int getRequestedDataFileVersion() {
+		return requestedDataFileVersion;
+	}
+	
+	/**
+	 * Get the current preferred data file version.
+	 * @return
+	 * @see #setRequestedDataFileVersion(int version)
+	 * @see #getCurrentDataFileVersion()
+	 */
+	public static int getCurrentDataFileVersion() {
+		return DATA_FILE_VERSION;
+	}
+	
+	/**
+	 * Set the requested version for .qpdata files.
+	 * 
+	 * <ul>
+	 * <li><b>1.0</b> Initial version stored in very early .qpdata files (no longer supported)</li>
+	 * <li><b>2</b> Switched versions to use integers, added Locale information (used in QuPath v0.1.2)</li>
+	 * <li><b>3</b> Switched {@link ImageServer} paths to be a JSON representation rather than a single path/URL</li>
+	 * <li><b>4</b> Added support for UUID to be stored in each {@link PathObject} (introducted QuPath v0.4.0)</li>
+	 * </ul>
+	 * 
+	 * @param version integer representation of the requested version
+	 * @see #getRequestedDataFileVersion()
+	 * @see #getCurrentDataFileVersion()
+	 * @since v0.4.0
+	 * @throws IllegalArgumentException if the requested version is less than 2 or greater than {@link #getCurrentDataFileVersion()}
+	 */
+	public static void setRequestedDataFileVersion(int version) throws IllegalArgumentException {
+		if (version < 2 || version > DATA_FILE_VERSION)
+			throw new IllegalArgumentException("Requested data file version must be between 2 and " + DATA_FILE_VERSION);
+		requestedDataFileVersion = version;
+	}
 	
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
@@ -228,7 +228,7 @@ class PathObjectTypeAdapters {
 //			out.value(value.getClass().getSimpleName());		
 	
 			// Since v0.4.0
-			var id = value.getID();
+			var id = value.getId();
 			if (id != null) {
 				out.name("id");
 				out.value(id.toString());		
@@ -450,7 +450,7 @@ class PathObjectTypeAdapters {
 				pathObject = PathObjects.createAnnotationObject(roi);
 			}
 			if (uuid != null)
-				pathObject.setID(uuid);
+				pathObject.setId(uuid);
 			
 			if (measurementList != null && !measurementList.isEmpty()) {
 				try (var ml = pathObject.getMeasurementList()) {

--- a/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -225,6 +227,13 @@ class PathObjectTypeAdapters {
 //			out.name("id");
 //			out.value(value.getClass().getSimpleName());		
 	
+			// Since v0.4.0
+			var id = value.getID();
+			if (id != null) {
+				out.name("id");
+				out.value(id.toString());		
+			}
+
 			// TODO: Write cell objects as a Geometry collection to include the nucleus as well
 			out.name("geometry");
 			ROITypeAdapters.ROI_ADAPTER_INSTANCE.write(out, value.getROI());
@@ -332,11 +341,21 @@ class PathObjectTypeAdapters {
 			
 			// Get an ID
 			String id = null;
+			UUID uuid = null;
 			if (obj.has("id")) {
 				id = obj.get("id").getAsString();
 				// In v0.2, we (unwisely...) stored the type in an ID
 				if (LEGACY_TYPE_IDS.contains(id))
 					type = id;
+				else {
+					// From v0.4, we use UUID
+					try {
+						uuid = UUID.fromString(id);
+						id = null;
+					} catch (Exception e) {
+						logger.debug("Invalid ID found in GeoJSON");
+					}
+				}
 			}
 			
 			ROI roi = ROITypeAdapters.ROI_ADAPTER_INSTANCE.fromJsonTree(obj.get("geometry"));
@@ -430,6 +449,9 @@ class PathObjectTypeAdapters {
 				logger.warn("Unknown object type {}, I will create an annotation", type);
 				pathObject = PathObjects.createAnnotationObject(roi);
 			}
+			if (uuid != null)
+				pathObject.setID(uuid);
+			
 			if (measurementList != null && !measurementList.isEmpty()) {
 				try (var ml = pathObject.getMeasurementList()) {
 					for (int i = 0; i < measurementList.size(); i++)

--- a/qupath-core/src/main/java/qupath/lib/objects/DefaultPathObjectComparator.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/DefaultPathObjectComparator.java
@@ -103,7 +103,7 @@ public class DefaultPathObjectComparator implements Comparator<PathObject> {
 			return 1;
 		
 		// Shouldn't end up here much...
-		return o1.getID().compareTo(o2.getID());
+		return o1.getId().compareTo(o2.getId());
 	}
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/objects/DefaultPathObjectComparator.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/DefaultPathObjectComparator.java
@@ -103,7 +103,7 @@ public class DefaultPathObjectComparator implements Comparator<PathObject> {
 			return 1;
 		
 		// Shouldn't end up here much...
-		return 0;
+		return o1.getID().compareTo(o2.getID());
 	}
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/objects/MetadataMap.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/MetadataMap.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -35,12 +35,9 @@ import java.util.Set;
 /**
  * Helper class for storing metadata key/value pairs.
  * <p>
- * Currently wraps a LinkedHashMap, but this implementation may change.
+ * Currently wraps a {@link LinkedHashMap}, but this implementation may change.
  * <p>
- * Serializes itself efficiently by using Object arrays.
- * <p>
- * Warning: everything that goes into the map should be serializable, or bad things may happen...
- * in practice, only Strings and Numbers should be used.  As such, this class isn't exposed publicly to the world.
+ * Serializes itself reasonably efficiently by using Object arrays.
  * 
  * @author Pete Bankhead
  *

--- a/qupath-core/src/main/java/qupath/lib/objects/MetadataStore.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/MetadataStore.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Interface that may be used to indicate that a PathObject (or other object) can store metadata.
+ * Interface that may be used to indicate that a {@link PathObject} (or other object) can store metadata.
  * <p>
  * Implementing classes should ensure that entries are stored in insertion order.
  * 

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -36,7 +36,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import qupath.lib.io.PathIO;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.measurements.MeasurementListFactory;
 import qupath.lib.objects.classes.PathClass;
@@ -54,6 +59,12 @@ import qupath.lib.roi.interfaces.ROI;
 public abstract class PathObject implements Externalizable {
 	
 	private static final long serialVersionUID = 1L;
+		
+	private final static Logger logger = LoggerFactory.getLogger(PathObject.class);
+	
+	private final static String METADATA_KEY_ID = "Object ID";
+	
+	private UUID id = UUID.randomUUID();
 	
 	private PathObject parent = null;
 	private Collection<PathObject> childList = null; // Collections.synchronizedList(new ArrayList<>(0));
@@ -76,13 +87,16 @@ public abstract class PathObject implements Externalizable {
 	 * @param measurements
 	 */
 	public PathObject(MeasurementList measurements) {
+		this();
 		this.measurements = measurements;
 	}
 
 	/**
 	 * Default constructor. Used for Externalizable support, not intended to be used by other consumers.
 	 */
-	public PathObject() {}
+	public PathObject() {
+		id = UUID.randomUUID();
+	}
 	
 	/**
 	 * Request the parent object. Each PathObject may have only one parent.
@@ -739,6 +753,46 @@ public abstract class PathObject implements Externalizable {
 		this.color = color;
 	}
 	
+	/**
+	 * Get the ID for this object.
+	 * @return
+	 * @see #setID(UUID)
+	 * @see #updateID()
+	 */
+	public UUID getID() {
+		return id;
+	}
+	
+	/**
+	 * Set the ID for this object.
+	 * <p>
+	 * <b>Important!</b> Use this with caution or, even better, not at all!
+	 * <p>
+	 * In general, the ID for an object should be unique.
+	 * This is best achieved by allowing the ID to be generated randomly when the object 
+	 * is created, and never changing it to anything else.
+	 * <p>
+	 * However, there are times when it is necessary to transfer the ID from an existing object, 
+	 * such as whenever the ROI of an object is being transformed and the original object deleted.
+	 * <p>
+	 * For that reason, it is possible (although discouraged) to set an ID explicitly.
+	 * 
+	 * @param id the ID to use
+	 * @throws IllegalArgumentException if the specified ID is null
+	 */
+	public void setID(UUID id) throws IllegalArgumentException {
+		if (id == null)
+			throw new IllegalArgumentException("ID of an object cannot be null!");
+		this.id = id;
+	}
+	
+	/**
+	 * Regenerate a new random ID.
+	 * @see #setID(UUID)
+	 */
+	public void updateID() {
+		setID(UUID.randomUUID());
+	}
 	
 	/**
 	 * Ensure that we have a child list with a minimum capacity.
@@ -835,10 +889,43 @@ public abstract class PathObject implements Externalizable {
 		out.writeObject(name);
 		out.writeObject(color);
 		
-		if (metadata != null)
-			out.writeObject(metadata);
+		// Write the ID, and an int representing the number of fields to include in the file
+		// This is not currently used, but exists in case future QuPath versions need 
+		// improved flexibility while wanting v0.4.0 to still be able to open the data files.
+		if (PathIO.getRequestedDataFileVersion() >= 4) {
+			out.writeObject(id);
+			// Number of additional fields to write as objects
+			int nFields = 1;
+			if (metadata != null) {
+				nFields++;
+			}
+			out.writeInt(nFields);
+			if (metadata != null)
+				out.writeObject(metadata);
+			out.writeObject(measurements);
+		} else {
+			// v3 method way of writing output - enhanced to write the ID into the metadata map
+			// This isn't as efficient as it could be, but means files can be reopened with earlier QuPath versions
+			var tempMetadata = new MetadataMap();
+			if (metadata != null) {
+				tempMetadata.putAll(metadata);
+			}
+			if (id != null && !tempMetadata.containsKey(METADATA_KEY_ID))
+				tempMetadata.put(METADATA_KEY_ID, id.toString());
+			
+			// We always have metadata now
+			out.writeObject(tempMetadata);
+			
+			// Write measurements as well
+			out.writeObject(measurements);		
+						
+//			// Previous way of writing output
+//			if (metadata != null)
+//				out.writeObject(metadata);
+//			out.writeObject(measurements);			
+		}
 
-		out.writeObject(measurements);
+		// Write number of child objects, followed by those objects
 		int n = nChildObjects();
 		out.writeInt(n);
 		if (n > 0) {
@@ -854,7 +941,7 @@ public abstract class PathObject implements Externalizable {
 	public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
 		
 		name = (String)in.readObject();
-		
+				
 		// Integer check so that legacy (pre-release) data that use Java's AWT Color objects doesn't immediately break
 		// (Could try parsing from Java's AWT Color... but shouldn't need to - it hasn't been used for a long time)
 		Object colorObject = in.readObject();
@@ -864,18 +951,63 @@ public abstract class PathObject implements Externalizable {
 		// Read the next object carefully, to help deal with changes in object specifications
 		Object nextObject = in.readObject();
 		
-		// Read metadata, if we have it
-		if (nextObject instanceof MetadataMap) {
-			metadata = (MetadataMap)nextObject;
-			nextObject = in.readObject();
+		// If we have a UUID, then we're working with a data file version of at least 4
+		if (nextObject instanceof UUID) {
+			id = (UUID)nextObject;
+			// Here we've stored the number of object fields (for future expansion)
+			int nFields = in.readInt();
+			for (int i = 0; i < nFields; i++) {
+				nextObject = in.readObject();
+				if (nextObject instanceof MetadataMap) {
+					// Read metadata, if we have it
+					metadata = (MetadataMap)nextObject;
+				} else if (nextObject instanceof MeasurementList) {
+					// Read a measurement list, if we have one
+					// This is rather hack-ish... but re-closing a list can prompt it to be stored more efficiently
+					measurements = (MeasurementList)nextObject;
+					measurements.close();
+				} else if (nextObject != null) {
+					logger.debug("Unsupported field during deserialization {}", nextObject);
+				} else {
+					logger.debug("Null field during deserialization");					
+				}
+			}
+		} else {
+			// Handle legacy data file version
+			// Here, we maybe have a metadata map and maybe have a measurement list - in that order - but nothing else
+			// before reaching child objects
+		
+			// Read metadata, if we have it
+			if (nextObject instanceof MetadataMap) {
+				metadata = (MetadataMap)nextObject;
+				String idString = metadata.getOrDefault(METADATA_KEY_ID, null);
+				
+				// Try to parse UUID from metadata map if we can
+				if (idString != null && idString.length() <= 36 && idString.contains("-")) {
+					try {
+						id = UUID.fromString(idString);
+						if (metadata.size() == 1)
+							metadata = null;
+						else
+							metadata.remove(METADATA_KEY_ID);
+					} catch (Exception e) {
+						logger.debug("Unable to parse UUID from metadata ID");
+					}
+				}			
+				nextObject = in.readObject();
+			}
+			
+			// Read a measurement list, if we have one
+			// This is rather hack-ish... but re-closing a list can prompt it to be stored more efficiently
+			if (nextObject instanceof MeasurementList) {
+				measurements = (MeasurementList)nextObject;
+				measurements.close();
+			}
 		}
 		
-		// Read a measurement list, if we have one
-		// This is rather hack-ish... but re-closing a list can prompt it to be stored more efficiently
-		if (nextObject instanceof MeasurementList) {
-			measurements = (MeasurementList)nextObject;
-			measurements.close();
-		}
+		// Ensure we have an ID
+		if (id == null)
+			id = UUID.randomUUID();
 		
 		// Read child objects
 		int nChildObjects = in.readInt();

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -756,10 +756,10 @@ public abstract class PathObject implements Externalizable {
 	/**
 	 * Get the ID for this object.
 	 * @return
-	 * @see #setID(UUID)
-	 * @see #updateID()
+	 * @see #setId(UUID)
+	 * @see #updateId()
 	 */
-	public UUID getID() {
+	public UUID getId() {
 		return id;
 	}
 	
@@ -780,7 +780,7 @@ public abstract class PathObject implements Externalizable {
 	 * @param id the ID to use
 	 * @throws IllegalArgumentException if the specified ID is null
 	 */
-	public void setID(UUID id) throws IllegalArgumentException {
+	public void setId(UUID id) throws IllegalArgumentException {
 		if (id == null)
 			throw new IllegalArgumentException("ID of an object cannot be null!");
 		this.id = id;
@@ -788,10 +788,10 @@ public abstract class PathObject implements Externalizable {
 	
 	/**
 	 * Regenerate a new random ID.
-	 * @see #setID(UUID)
+	 * @see #setId(UUID)
 	 */
-	public void updateID() {
-		setID(UUID.randomUUID());
+	public void updateId() {
+		setId(UUID.randomUUID());
 	}
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -947,9 +948,9 @@ public class PathObjectTools {
 		return nChanges > 0;		
 	}
 	
-	
 	/**
-	 * Create a(n optionally) transformed version of a {@link PathObject}.
+	 * Create a transformed version of a {@link PathObject} with a new ID.
+	 * If the transform is null or the identity transform, then a duplicate object is generated instead.
 	 * <p>
 	 * Note: only detections (including tiles and cells) and annotations are fully supported by this method.
 	 * Root objects are duplicated.
@@ -962,8 +963,31 @@ public class PathObjectTools {
 	 * @param copyMeasurements if true, the measurement list of the new object will be populated with the measurements of pathObject
 	 * 
 	 * @return a duplicate of pathObject, with affine transform applied to the object's ROI(s) if required
+	 * @see #transformObject(PathObject, AffineTransform, boolean, boolean)
 	 */
 	public static PathObject transformObject(PathObject pathObject, AffineTransform transform, boolean copyMeasurements) {
+		return transformObject(pathObject, transform, copyMeasurements, false);
+	}
+	
+	/**
+	 * Create a transformed version of a {@link PathObject}, optionally with a new ID.
+	 * If the transform is null or the identity transform, then a duplicate object is generated instead.
+	 * <p>
+	 * Note: only detections (including tiles and cells) and annotations are fully supported by this method.
+	 * Root objects are duplicated.
+	 * TMA core objects are transformed only if the resulting transform creates an ellipse ROI, since this is 
+	 * currently the only ROI type supported for a TMA core (this behavior may change).
+	 * Any other object types result in an {@link UnsupportedOperationException} being thrown.
+	 * 
+	 * @param pathObject the object to transform; this will be unchanged
+	 * @param transform optional affine transform; if {@code null}, this effectively acts to duplicate the object
+	 * @param copyMeasurements if true, the measurement list of the new object will be populated with the measurements of pathObject
+	 * @param createNewIDs if true, create new IDs for each copied object; otherwise, retain the same ID.
+	 * 
+	 * @return a duplicate of pathObject, with affine transform applied to the object's ROI(s) if required
+	 * @since v0.4.0
+	 */
+	public static PathObject transformObject(PathObject pathObject, AffineTransform transform, boolean copyMeasurements, boolean createNewIDs) {
 		ROI roi = maybeTransformROI(pathObject.getROI(), transform);
 		PathClass pathClass = pathObject.getPathClass();
 		PathObject newObject;
@@ -992,23 +1016,44 @@ public class PathObjectTools {
 			}
 			newObject.getMeasurementList().close();
 		}
+		// Retain the ID, if needed
+		if (!createNewIDs)
+			newObject.setID(pathObject.getID());
 		return newObject;
 	}
 	
 	/**
-	 * Create (optionally) transformed versions of the {@link PathObject} and all its descendants, recursively. 
+	 * Create (optionally) transformed versions of the {@link PathObject} and all its descendants, recursively.
+	 * This method can be applied to all objects in a hierarchy by supplying its root object. The parent-children 
+	 * relationships are kept after transformation.
+	 * Measurements are copied to the new object, and new IDs are created.
+	 * 
+	 * @param pathObject the object to transform; this will be unchanged
+	 * @param transform optional affine transform; if {@code null}, this effectively acts to duplicate the object
+	 * @param copyMeasurements if true, the measurement list of the new object will be populated with the measurements of pathObject
+	 * @return the new object, including all child objects
+	 */
+	public static PathObject transformObjectRecursive(PathObject pathObject, AffineTransform transform, boolean copyMeasurements) {
+		return transformObjectRecursive(pathObject, transform, true, true);
+	}
+
+	/**
+	 * Create (optionally) transformed versions of the {@link PathObject} and all its descendants, recursively, optionally assigning
+	 * new IDs to the created objects. 
 	 * This method can be applied to all objects in a hierarchy by supplying its root object. The parent-children 
 	 * relationships are kept after transformation.
 	 * 
-	 * @param pathObject
-	 * @param transform
-	 * @param copyMeasurements
-	 * @return
+	 * @param pathObject the object to transform; this will be unchanged
+	 * @param transform optional affine transform; if {@code null}, this effectively acts to duplicate the object
+	 * @param copyMeasurements if true, the measurement list of the new object will be populated with the measurements of pathObject
+	 * @param createNewIDs if true, create new IDs for each copied object; otherwise, retain the same ID.
+	 * @return the new object, including all child objects
+	 * @since v0.4.0
 	 */
-	public static PathObject transformObjectRecursive(PathObject pathObject, AffineTransform transform, boolean copyMeasurements) {
-		var newObj = transformObject(pathObject, transform, copyMeasurements);
+	public static PathObject transformObjectRecursive(PathObject pathObject, AffineTransform transform, boolean copyMeasurements, boolean createNewIDs) {
+		var newObj = transformObject(pathObject, transform, copyMeasurements, createNewIDs);
 		for (var child: pathObject.getChildObjects()) {
-			newObj.addPathObject(transformObjectRecursive(child, transform, copyMeasurements));
+			newObj.addPathObject(transformObjectRecursive(child, transform, copyMeasurements, createNewIDs));
 		}
 		return newObj;
 	}
@@ -1018,6 +1063,64 @@ public class PathObjectTools {
 			return roi;
 		return RoiTools.transformROI(roi, transform);
 	}
+	
+	/**
+	 * Find objects based on a String representation of their IDs.
+	 * @param ids IDs to match; each will correspond to a key in the output map
+	 * @param pathObjects the objects that may contain corresponding IDs
+	 * @return a map between ids and any matched objects (or null if no matched object was found)
+	 * 
+	 * @see #findByUUID(Collection, Collection)
+	 * @see #matchByID(Collection, Collection)
+	 * @since v0.4.0
+	 */
+	public static Map<String, PathObject> findByStringID(Collection<String> ids, Collection<? extends PathObject> pathObjects) {
+		var map = pathObjects.stream().collect(Collectors.toMap(p -> p.getID().toString(), p -> p));
+		var output = new HashMap<String, PathObject>();
+		for (var id : ids) {
+			output.put(id, map.getOrDefault(id, null));
+		}
+		return output;
+	}
+	
+	/**
+	 * Find objects based on their IDs.
+	 * @param ids IDs to match; each will correspond to a key in the output map
+	 * @param pathObjects the objects that may contain corresponding IDs
+	 * @return a map between ids and any matched objects (or null if no matched object was found)
+	 * 
+	 * @see #findByStringID(Collection, Collection)
+	 * @see #matchByID(Collection, Collection)
+	 * @since v0.4.0
+	 */
+	public static Map<UUID, PathObject> findByUUID(Collection<UUID> ids, Collection<? extends PathObject> pathObjects) {
+		var map = pathObjects.stream().collect(Collectors.toMap(p -> p.getID(), p -> p));
+		var output = new HashMap<UUID, PathObject>();
+		for (var id : ids) {
+			output.put(id, map.getOrDefault(id, null));
+		}
+		return output;
+	}
+
+	/**
+	 * Match objects according to their IDs.
+	 * @param sourceObjects source objects; each will correspond to a key in the output map
+	 * @param targetObjects target objects; each will correspond to a value in the output map provided it has a match in sourceObjects
+	 * @return a map between sourceObjects and any matched target objects (or null if no matched object was found)
+	 * 
+	 * @see #findByUUID(Collection, Collection)
+	 * @see #findByStringID(Collection, Collection)
+	 * @since v0.4.0
+	 */
+	public static Map<PathObject, PathObject> matchByID(Collection<? extends PathObject> sourceObjects, Collection<? extends PathObject> targetObjects) {
+		var map = targetObjects.stream().collect(Collectors.toMap(p -> p.getID(), p -> p));
+		var output = new HashMap<PathObject, PathObject>();
+		for (var sourceObject : sourceObjects) {
+			output.put(sourceObject, map.getOrDefault(sourceObject.getID(), null));
+		}
+		return output;
+	}
+	
 	
 	/**
 	 * Duplicate all the selected objects in a hierarchy.
@@ -1057,16 +1160,31 @@ public class PathObjectTools {
 	}
 	
 	/**
-	 * Duplicate the specified objects.
+	 * Duplicate the specified objects, assigning new IDs for each object.
+	 * 
 	 * @param hierarchy hierarchy containing the objects to duplicate
 	 * @param pathObjects objects that should be duplicated
 	 * @return true if the hierarchy is changed, false otherwise
+	 * @see #duplicateObjects(PathObjectHierarchy, Collection, boolean)
 	 */
 	public static boolean duplicateObjects(PathObjectHierarchy hierarchy, Collection<PathObject> pathObjects) {
+		return duplicateObjects(hierarchy, pathObjects, true);
+	}
+	
+	/**
+	 * Duplicate the specified objects, optionally creating new IDs.
+	 * 
+	 * @param hierarchy hierarchy containing the objects to duplicate
+	 * @param pathObjects objects that should be duplicated
+	 * @return true if the hierarchy is changed, false otherwise
+	 * 
+	 * @since v0.4.0
+	 */
+	public static boolean duplicateObjects(PathObjectHierarchy hierarchy, Collection<PathObject> pathObjects, boolean createNewIDs) {
 		var map = pathObjects
 				.stream()
 				.collect(Collectors.toMap(p -> p,
-						p -> PathObjectTools.transformObject(p, null, true)));
+						p -> PathObjectTools.transformObject(p, null, true, createNewIDs)));
 		if (map.isEmpty()) {
 			logger.error("No selected objects to duplicate!");
 			return false;

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -1018,7 +1018,7 @@ public class PathObjectTools {
 		}
 		// Retain the ID, if needed
 		if (!createNewIDs)
-			newObject.setID(pathObject.getID());
+			newObject.setId(pathObject.getId());
 		return newObject;
 	}
 	
@@ -1075,7 +1075,7 @@ public class PathObjectTools {
 	 * @since v0.4.0
 	 */
 	public static Map<String, PathObject> findByStringID(Collection<String> ids, Collection<? extends PathObject> pathObjects) {
-		var map = pathObjects.stream().collect(Collectors.toMap(p -> p.getID().toString(), p -> p));
+		var map = pathObjects.stream().collect(Collectors.toMap(p -> p.getId().toString(), p -> p));
 		var output = new HashMap<String, PathObject>();
 		for (var id : ids) {
 			output.put(id, map.getOrDefault(id, null));
@@ -1094,7 +1094,7 @@ public class PathObjectTools {
 	 * @since v0.4.0
 	 */
 	public static Map<UUID, PathObject> findByUUID(Collection<UUID> ids, Collection<? extends PathObject> pathObjects) {
-		var map = pathObjects.stream().collect(Collectors.toMap(p -> p.getID(), p -> p));
+		var map = pathObjects.stream().collect(Collectors.toMap(p -> p.getId(), p -> p));
 		var output = new HashMap<UUID, PathObject>();
 		for (var id : ids) {
 			output.put(id, map.getOrDefault(id, null));
@@ -1113,10 +1113,10 @@ public class PathObjectTools {
 	 * @since v0.4.0
 	 */
 	public static Map<PathObject, PathObject> matchByID(Collection<? extends PathObject> sourceObjects, Collection<? extends PathObject> targetObjects) {
-		var map = targetObjects.stream().collect(Collectors.toMap(p -> p.getID(), p -> p));
+		var map = targetObjects.stream().collect(Collectors.toMap(p -> p.getId(), p -> p));
 		var output = new HashMap<PathObject, PathObject>();
 		for (var sourceObject : sourceObjects) {
-			output.put(sourceObject, map.getOrDefault(sourceObject.getID(), null));
+			output.put(sourceObject, map.getOrDefault(sourceObject.getId(), null));
 		}
 		return output;
 	}

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjects.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjects.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/qupath-core/src/test/java/qupath/lib/io/PathObjectIOTest.java
+++ b/qupath-core/src/test/java/qupath/lib/io/PathObjectIOTest.java
@@ -26,6 +26,7 @@ package qupath.lib.io;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -115,13 +116,18 @@ public class PathObjectIOTest {
 			// Test whether po has a ROI
 			assertTrue(po.hasROI());
 			
+			assertNotNull(po.getROI());
+			assertNotNull(po.getID());
+			
 			if (po.isTile()) {
 				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest2", ColorTools.GREEN));
+				assertEquals(po.getID(), myPTO.getID());
 				assertSameROIs(po.getROI(), roiTile);
 				assertFalse(po.hasMeasurements());
 				countCheck[0]++;
 			} else if (po.isCell()) {
 				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest2", ColorTools.GREEN));
+				assertEquals(po.getID(), myPCO.getID());
 				assertSameROIs(po.getROI(), roiCell1);
 				assertSameROIs(((PathCellObject)po).getNucleusROI(), roiCell2);
 				if (keepMeasurements) {
@@ -132,6 +138,7 @@ public class PathObjectIOTest {
 				countCheck[1]++;
 			} else if (po.isDetection()) {
 				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest1", ColorTools.BLACK));
+				assertEquals(po.getID(), myPDO.getID());
 				assertSameROIs(po.getROI(), roiDetection);
 				if (keepMeasurements) {
 					assertTrue(po.hasMeasurements());
@@ -141,10 +148,12 @@ public class PathObjectIOTest {
 				countCheck[2]++;
 			} else if (po.isAnnotation()) {
 				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest1", ColorTools.BLACK));
+				assertEquals(po.getID(), myPAO.getID());
 				assertSameROIs(po.getROI(), roiAnnotation);
 				assertFalse(po.hasMeasurements());
 				countCheck[3]++;
 			} else if (po.isTMACore()) {
+				assertEquals(po.getID(), myTMA.getID());
 				assertFalse(po.hasMeasurements());
 				assertSameROIs(po.getROI(), myTMA.getROI());
 				countCheck[4]++;

--- a/qupath-core/src/test/java/qupath/lib/io/PathObjectIOTest.java
+++ b/qupath-core/src/test/java/qupath/lib/io/PathObjectIOTest.java
@@ -117,17 +117,17 @@ public class PathObjectIOTest {
 			assertTrue(po.hasROI());
 			
 			assertNotNull(po.getROI());
-			assertNotNull(po.getID());
+			assertNotNull(po.getId());
 			
 			if (po.isTile()) {
 				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest2", ColorTools.GREEN));
-				assertEquals(po.getID(), myPTO.getID());
+				assertEquals(po.getId(), myPTO.getId());
 				assertSameROIs(po.getROI(), roiTile);
 				assertFalse(po.hasMeasurements());
 				countCheck[0]++;
 			} else if (po.isCell()) {
 				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest2", ColorTools.GREEN));
-				assertEquals(po.getID(), myPCO.getID());
+				assertEquals(po.getId(), myPCO.getId());
 				assertSameROIs(po.getROI(), roiCell1);
 				assertSameROIs(((PathCellObject)po).getNucleusROI(), roiCell2);
 				if (keepMeasurements) {
@@ -138,7 +138,7 @@ public class PathObjectIOTest {
 				countCheck[1]++;
 			} else if (po.isDetection()) {
 				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest1", ColorTools.BLACK));
-				assertEquals(po.getID(), myPDO.getID());
+				assertEquals(po.getId(), myPDO.getId());
 				assertSameROIs(po.getROI(), roiDetection);
 				if (keepMeasurements) {
 					assertTrue(po.hasMeasurements());
@@ -148,12 +148,12 @@ public class PathObjectIOTest {
 				countCheck[2]++;
 			} else if (po.isAnnotation()) {
 				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest1", ColorTools.BLACK));
-				assertEquals(po.getID(), myPAO.getID());
+				assertEquals(po.getId(), myPAO.getId());
 				assertSameROIs(po.getROI(), roiAnnotation);
 				assertFalse(po.hasMeasurements());
 				countCheck[3]++;
 			} else if (po.isTMACore()) {
-				assertEquals(po.getID(), myTMA.getID());
+				assertEquals(po.getId(), myTMA.getId());
 				assertFalse(po.hasMeasurements());
 				assertSameROIs(po.getROI(), myTMA.getROI());
 				countCheck[4]++;

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
@@ -39,7 +39,7 @@ import qupath.lib.roi.ROIs;
 import qupath.lib.roi.interfaces.ROI;
 
 @SuppressWarnings("javadoc")
-public class TestPathAnnotationObject extends PathObjectTestWrapper { 
+public class TestPathAnnotationObject extends TestPathObject { 
 	private final Integer nPO = 10; // number of (child) objects to be added
 	private final Double classprobability = 0.5;
 	private final Double line_x = 0.0;

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathDetectionObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathDetectionObject.java
@@ -26,7 +26,7 @@ package qupath.lib.objects;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("javadoc")
-public class TestPathDetectionObject extends PathObjectTestWrapper {
+public class TestPathDetectionObject extends TestPathObject {
 	PathDetectionObject myPO = new PathDetectionObject();
 	
 	// leaving only those tests that should perform different from Annotations

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2021 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -34,7 +34,7 @@ import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.roi.interfaces.ROI;
 
-class PathObjectTestWrapper {
+class TestPathObject {
 	private final Double epsilon = 1e-15; // error for double comparison
 	
 	//@Test

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools.java
@@ -83,11 +83,11 @@ public class TestPathObjectTools extends TestPathObject {
 		assertEquals(pathObjects.size(), mapNewIds.size());
 		assertEquals(0L, mapNewIds.values().stream().filter(p -> p != null).count());
 
-		var mapNewIds2 = PathObjectTools.findByUUID(pathObjects.stream().map(p -> p.getID()).collect(Collectors.toList()), duplicateObjectsNewIds);
+		var mapNewIds2 = PathObjectTools.findByUUID(pathObjects.stream().map(p -> p.getId()).collect(Collectors.toList()), duplicateObjectsNewIds);
 		assertEquals(pathObjects.size(), mapNewIds2.size());
 		assertEquals(0L, mapNewIds2.values().stream().filter(p -> p != null).count());
 
-		var mapNewIds3 = PathObjectTools.findByStringID(pathObjects.stream().map(p -> p.getID().toString()).collect(Collectors.toList()), duplicateObjectsNewIds);
+		var mapNewIds3 = PathObjectTools.findByStringID(pathObjects.stream().map(p -> p.getId().toString()).collect(Collectors.toList()), duplicateObjectsNewIds);
 		assertEquals(pathObjects.size(), mapNewIds3.size());
 		assertEquals(0L, mapNewIds3.values().stream().filter(p -> p != null).count());
 
@@ -95,11 +95,11 @@ public class TestPathObjectTools extends TestPathObject {
 		assertEquals(pathObjects.size(), mapSameIds.size());
 		assertEquals(pathObjects.size(), mapSameIds.values().stream().filter(p -> p != null).count());
 		
-		var mapSameIds2 = PathObjectTools.findByUUID(pathObjects.stream().map(p -> p.getID()).collect(Collectors.toList()), duplicateObjectsSameIds);
+		var mapSameIds2 = PathObjectTools.findByUUID(pathObjects.stream().map(p -> p.getId()).collect(Collectors.toList()), duplicateObjectsSameIds);
 		assertEquals(pathObjects.size(), mapSameIds2.size());
 		assertEquals(pathObjects.size(), mapSameIds2.values().stream().filter(p -> p != null).count());
 
-		var mapSameIds3 = PathObjectTools.findByStringID(pathObjects.stream().map(p -> p.getID().toString()).collect(Collectors.toList()), duplicateObjectsSameIds);
+		var mapSameIds3 = PathObjectTools.findByStringID(pathObjects.stream().map(p -> p.getId().toString()).collect(Collectors.toList()), duplicateObjectsSameIds);
 		assertEquals(pathObjects.size(), mapSameIds3.size());
 		assertEquals(pathObjects.size(), mapSameIds3.values().stream().filter(p -> p != null).count());
 	}
@@ -110,9 +110,9 @@ public class TestPathObjectTools extends TestPathObject {
 		assertEquals(p1.getROI(), p2.getROI());
 		assertEquals(p1.getPathClass(), p2.getPathClass());
 		if (sameIDs) {
-			assertEquals(p1.getID(), p2.getID());			
+			assertEquals(p1.getId(), p2.getId());			
 		} else {
-			assertNotEquals(p1.getID(), p2.getID());			
+			assertNotEquals(p1.getId(), p2.getId());			
 		}
 	}
 	

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools.java
@@ -1,0 +1,121 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.regions.ImagePlane;
+import qupath.lib.roi.ROIs;
+
+@SuppressWarnings("javadoc")
+public class TestPathObjectTools extends TestPathObject { 
+	
+	@Test
+	public void test_BasicPO() {
+		
+		// Check that duplicating objects works
+		var rois = Arrays.asList(
+				ROIs.createRectangleROI(1, 2, 100, 200, ImagePlane.getDefaultPlane()),
+				ROIs.createRectangleROI(1, 2, 100, 200, ImagePlane.getPlane(1, 2))
+				);
+		
+		var pathClasses = Arrays.asList(
+				PathClassFactory.getPathClass("First"),
+				PathClassFactory.getPathClass("Second"),
+				PathClassFactory.getPathClass("Third: Fourth"),
+				null
+				);
+		
+		var pathObjects = new ArrayList<PathObject>();
+		for (var r : rois) {
+			for (var pc : pathClasses) {
+				pathObjects.add(PathObjects.createAnnotationObject(r, pc));
+				pathObjects.add(PathObjects.createDetectionObject(r, pc));
+				pathObjects.add(PathObjects.createTileObject(r, pc, null));
+			}
+		}
+		
+		var duplicateObjectsNewIds = pathObjects.stream().map(p -> PathObjectTools.transformObject(p, null, true, true)).collect(Collectors.toList());
+		var duplicateObjectsSameIds = pathObjects.stream().map(p -> PathObjectTools.transformObject(p, null, true, false)).collect(Collectors.toList());
+		
+		for (int i = 0; i < pathObjects.size(); i++) {
+			
+			var pathObject = pathObjects.get(i);
+			var sameID = duplicateObjectsSameIds.get(i);
+			var newID = duplicateObjectsNewIds.get(i);
+			
+			assertSame(pathObject, sameID, true);
+			assertSame(pathObject, newID, false);
+
+		}
+		
+		// Check the matching functions work as well
+		Collections.shuffle(pathObjects);
+		var mapNewIds = PathObjectTools.matchByID(pathObjects, duplicateObjectsNewIds);
+		assertEquals(pathObjects.size(), mapNewIds.size());
+		assertEquals(0L, mapNewIds.values().stream().filter(p -> p != null).count());
+
+		var mapNewIds2 = PathObjectTools.findByUUID(pathObjects.stream().map(p -> p.getID()).collect(Collectors.toList()), duplicateObjectsNewIds);
+		assertEquals(pathObjects.size(), mapNewIds2.size());
+		assertEquals(0L, mapNewIds2.values().stream().filter(p -> p != null).count());
+
+		var mapNewIds3 = PathObjectTools.findByStringID(pathObjects.stream().map(p -> p.getID().toString()).collect(Collectors.toList()), duplicateObjectsNewIds);
+		assertEquals(pathObjects.size(), mapNewIds3.size());
+		assertEquals(0L, mapNewIds3.values().stream().filter(p -> p != null).count());
+
+		var mapSameIds = PathObjectTools.matchByID(pathObjects, duplicateObjectsSameIds);
+		assertEquals(pathObjects.size(), mapSameIds.size());
+		assertEquals(pathObjects.size(), mapSameIds.values().stream().filter(p -> p != null).count());
+		
+		var mapSameIds2 = PathObjectTools.findByUUID(pathObjects.stream().map(p -> p.getID()).collect(Collectors.toList()), duplicateObjectsSameIds);
+		assertEquals(pathObjects.size(), mapSameIds2.size());
+		assertEquals(pathObjects.size(), mapSameIds2.values().stream().filter(p -> p != null).count());
+
+		var mapSameIds3 = PathObjectTools.findByStringID(pathObjects.stream().map(p -> p.getID().toString()).collect(Collectors.toList()), duplicateObjectsSameIds);
+		assertEquals(pathObjects.size(), mapSameIds3.size());
+		assertEquals(pathObjects.size(), mapSameIds3.values().stream().filter(p -> p != null).count());
+	}
+	
+	
+	private static void assertSame(PathObject p1, PathObject p2, boolean sameIDs) {
+		assertEquals(p1.getClass(), p2.getClass());
+		assertEquals(p1.getROI(), p2.getROI());
+		assertEquals(p1.getPathClass(), p2.getPathClass());
+		if (sameIDs) {
+			assertEquals(p1.getID(), p2.getID());			
+		} else {
+			assertNotEquals(p1.getID(), p2.getID());			
+		}
+	}
+	
+	
+	
+}

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathRootObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathRootObject.java
@@ -37,7 +37,7 @@ import qupath.lib.objects.classes.PathClassFactory;
 
 
 @SuppressWarnings("javadoc")
-public class TestPathRootObject extends PathObjectTestWrapper {
+public class TestPathRootObject extends TestPathObject {
 	private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
 	private final Integer nPO = 10;
 	PathRootObject myPO = new PathRootObject();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -1165,7 +1165,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 
 		@Override
 		protected String getMeasurementValue(PathObject pathObject) {
-			var id = pathObject.getID(); // Shouldn't be null!
+			var id = pathObject.getId(); // Shouldn't be null!
 			if (id == null) {
 				logger.warn("ID null for {}", pathObject);
 				return null;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -191,7 +191,11 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 				containsRoot = true;
 		}
 		boolean detectionsAnywhere = imageData == null ? containsDetections : !imageData.getHierarchy().getDetectionObjects().isEmpty();
-		
+
+		// Include object ID if we have anything other than root objects
+		if (containsAnnotations || containsDetections || containsTMACores)
+			builderMap.put("Object ID", new ObjectIdMeasurementBuilder());
+
 		// Include the object displayed name
 //		if (containsDetections || containsAnnotations || containsTMACores)
 		builderMap.put("Name", new ObjectNameMeasurementBuilder());
@@ -523,8 +527,6 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		}
 		
 	}
-	
-	
 	
 	class ObjectTypeCountMeasurement extends IntegerBinding {
 		
@@ -1154,6 +1156,24 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	}
 	
 	
+	static class ObjectIdMeasurementBuilder extends StringMeasurementBuilder {
+		
+		@Override
+		public String getName() {
+			return "Object ID";
+		}
+
+		@Override
+		protected String getMeasurementValue(PathObject pathObject) {
+			var id = pathObject.getID(); // Shouldn't be null!
+			if (id == null) {
+				logger.warn("ID null for {}", pathObject);
+				return null;
+			}
+			return id.toString();
+		}
+		
+	}
 	
 	
 	static class ObjectNameMeasurementBuilder extends StringMeasurementBuilder {


### PR DESCRIPTION
This is a fairly major change to incorporate IDs for objects.

The purpose is to make it much easier to match up objects whenever some further analysis is done elsewhere (e.g. classification or clustering in Python).

I've attempted to ensure both forwards and backwards compatibility by storing the ID in the metadata map. This is somewhat inefficient, but means that data files can be reopened in earlier QuPath versions. A future QuPath release might change this to a more efficient representation.