### PR TITLE
BUG FIX: turn off inter-value interpolation for labelmaps

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
+++ b/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
@@ -22,6 +22,7 @@
 package qupath.lib.images.writers;
 
 import java.awt.image.BufferedImage;
+import java.awt.image.IndexColorModel;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -867,7 +868,12 @@ public class TileExporter  {
 			}
 			img = cropOrPad(img, width, height, xProp, yProp);
 		}
-		return BufferedImageTools.resize(img, width, height, true);
+		// if image is a label map, use nearest neighbors interpolation to ensure that no new values (outside the labels) are created
+		boolean smoothInterpolate = true;
+		if ((img.getColorModel() instanceof IndexColorModel) || (server instanceof LabeledImageServer)) {
+			smoothInterpolate = false;
+		}
+		return BufferedImageTools.resize(img, width, height, smoothInterpolate);
 	}
 	
 	


### PR DESCRIPTION
For a labelmap or any image where pixel values mean something specific (e.g. gray values in a CT) using any interpolation that creates values outside the range that already exists is invalid, so labelmap images should use nearest-neighbours interpolation when resampling instead of OpenCV's INTER_AREA, which is the current default for interpolation. This change implements this. 
338890