### PR TITLE
Improve PathPrefs, Locale support & available PathClasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,8 @@ This is a work-in-progress.
 ### Dependency updates
 * Adoptium OpenJDK 17
 * Bio-Formats 6.9.1
-* JavaFX 17.0.2
-* Groovy 4.0.1
+* JavaFX 18.0.1
+* Groovy 4.0.2
 * Gson 2.9.0
 * Guava 31.1
 * JavaCPP 1.5.7

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ task mergedJavadocs(type: Javadoc,
 	options.links 'https://javadoc.io/doc/org.bytedeco/opencv/4.5.5-1.5.7/'
 	options.links 'https://javadoc.io/doc/com.google.code.gson/gson/2.9.0/'
 	options.links 'https://javadoc.io/doc/org.locationtech.jts/jts-core/1.18.2/'
-	options.links 'https://javadoc.io/doc/net.imagej/ij/1.53q/'
+	options.links 'https://javadoc.io/doc/net.imagej/ij/1.53s/'
 	options.links 'https://javadoc.scijava.org/Bio-Formats/'
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-groovy        = "4.0.1"
-javafx        = "18"
+groovy        = "4.0.2"
+javafx        = "18.0.1"
 ikonli        = "12.3.0"
 junit         = "5.8.2"
 javacpp       = "1.5.7"
@@ -27,7 +27,7 @@ commons-text  = { module = "org.apache.commons:commons-text",  version = "1.9" }
 controlsfx    = { module = "org.controlsfx:controlsfx",        version = "11.1.1" }
 jfxtras       = { module = "org.jfxtras:jfxtras-menu",         version = "11-r2" }
 guava         = { module = "com.google.guava:guava",           version = "31.1-jre" }
-imagej        = { module = "net.imagej:ij",                    version = "1.53q" }
+imagej        = { module = "net.imagej:ij",                    version = "1.53s" }
 picocli       = { module = "info.picocli:picocli",             version = "4.6.3" }
 
 richtextfx    = { module = "org.fxmisc.richtext:richtextfx",   version = "0.10.9" }

--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -82,8 +82,8 @@ import qupath.lib.scripting.QP;
 @Command(name = "QuPath", subcommands = {HelpCommand.class, ScriptCommand.class, GenerateCompletion.class},
 	footer = {"",
 			"Copyright(c) The Queen's University Belfast (2014-2016)",
-			"Copyright(c) QuPath developers (2017-2021)",
-			"Copyright(c) The University of Edinburgh (2018-2021)"
+			"Copyright(c) QuPath developers (2017-2022)",
+			"Copyright(c) The University of Edinburgh (2018-2022)"
 			}, mixinStandardHelpOptions = true, versionProvider = QuPath.VersionProvider.class)
 public class QuPath {
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/CommandFinderTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/CommandFinderTools.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -133,23 +133,13 @@ public class CommandFinderTools {
 	
 
 	
-	private static ObjectProperty<CommandBarDisplay> commandBarDisplay;
+	private static ObjectProperty<CommandBarDisplay> commandBarDisplay = PathPrefs.createPersistentPreference("commandFinderDisplayMode", CommandBarDisplay.NEVER, CommandBarDisplay.class);
 	
 	/**
 	 * Property specifying where the command bar should be displayed relative to the main viewer window.
 	 * @return
 	 */
-	public synchronized static ObjectProperty<CommandBarDisplay> commandBarDisplayProperty() {
-		if (commandBarDisplay == null) {
-			String name = PathPrefs.getUserPreferences().get("commandFinderDisplayMode", CommandBarDisplay.NEVER.name());
-			CommandBarDisplay display = CommandBarDisplay.valueOf(name);
-			if (display == null)
-				display = CommandBarDisplay.HOVER;
-			commandBarDisplay = new SimpleObjectProperty<>(display);
-			commandBarDisplay.addListener((v, o, n) -> {
-				PathPrefs.getUserPreferences().put("commandFinderDisplayMode", n.name());
-			});			
-		}
+	public static ObjectProperty<CommandBarDisplay> commandBarDisplayProperty() {
 		return commandBarDisplay;
 	}
 	


### PR DESCRIPTION
* Support better serialization/deserialization of objects to Strings via PathPrefs - including with JSON.
* Add PathPrefs.dumpPreferences() and PathPreds.importPreferences(String) methods
* Move locale to preferences & away from startup dialog (aim being to replace startup dialog entirely)
* Support setting different locale categories, and try to automatically update the UI (lists, tables) accordingly
* Better protect QuPathGUI.getAvailablePathClasses() from invalid modifications (via a ChangeListener that removes duplicates/nulls quickly)