### PR TITLE
Remove OpenCV as a qupath-core dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ This is a work-in-progress.
   * Import .roi and RoiSet.zip files by drag & drop
   * Built-in ImageJ plugin to send RoiManager ROIs to QuPath (not only overlays)
   * Retain ROI position information when sending ROIs from ImageJ (hyper)stacks
+* OpenCV is no longer a dependency of qupath-core (https://github.com/qupath/qupath/issues/961)
+  * Moved `OpenCVTypeAdapters` to qupath-core-processing
+  * Switched `BufferedImageTools.resize` to use ImageJ internally
 * Updated prompt to set the image type
 * Missing thumbnails are automatically regenerated when a project is opened
 * Avoid converting the pixel type to 32-bit unnecessarily when sending image regions to ImageJ
@@ -38,6 +41,7 @@ This is a work-in-progress.
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)
+* Image resizing bug affecting labeled image export (https://github.com/qupath/qupath/issues/974)
 * 'Ignore case' in the Find window of the Script editor does not ignore case (https://github.com/qupath/qupath/issues/889)
 * Owner of Find window in the script editor is lost when the script editor window is closed (https://github.com/qupath/qupath/issues/893)
 * 'Zoom to fit' doesn't handle changes in window size

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -129,6 +129,7 @@ import qupath.lib.roi.ROIs;
 import qupath.lib.roi.RoiTools;
 import qupath.lib.roi.interfaces.ROI;
 import qupath.opencv.dnn.DnnTools;
+import qupath.opencv.io.OpenCVTypeAdapters;
 import qupath.opencv.ml.objects.OpenCVMLClassifier;
 import qupath.opencv.ml.objects.features.FeatureExtractors;
 import qupath.opencv.ml.pixel.PixelClassifierTools;
@@ -216,6 +217,7 @@ public class QP {
 			.registerTypeAdapterFactory(PixelClassifiers.getTypeAdapterFactory())
 			.registerTypeAdapterFactory(FeatureExtractors.getTypeAdapterFactory())
 			.registerTypeAdapterFactory(ObjectClassifiers.getTypeAdapterFactory())
+			.registerTypeAdapterFactory(OpenCVTypeAdapters.getOpenCVTypeAdaptorFactory())
 			.registerTypeAdapter(ColorTransforms.ColorTransform.class, new ColorTransforms.ColorTransformTypeAdapter());
 		
 		// Currently, the type adapters are registered within the class... so we need to initialize the class

--- a/qupath-core-processing/src/main/java/qupath/opencv/io/OpenCVTypeAdapters.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/io/OpenCVTypeAdapters.java
@@ -19,7 +19,7 @@
  * #L%
  */
 
-package qupath.lib.io;
+package qupath.opencv.io;
 
 import java.io.IOException;
 import java.util.Map;

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/OpenCVClassifiers.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/OpenCVClassifiers.java
@@ -44,8 +44,8 @@ import com.google.gson.stream.JsonWriter;
 
 import qupath.lib.common.GeneralTools;
 import qupath.lib.io.GsonTools;
-import qupath.lib.io.OpenCVTypeAdapters;
 import qupath.lib.plugins.parameters.ParameterList;
+import qupath.opencv.io.OpenCVTypeAdapters;
 import qupath.opencv.tools.OpenCVTools;
 
 /**

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/features/Preprocessing.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/features/Preprocessing.java
@@ -34,7 +34,7 @@ import com.google.gson.annotations.JsonAdapter;
 
 import qupath.lib.analysis.stats.RunningStatistics;
 import qupath.lib.classifiers.Normalization;
-import qupath.lib.io.OpenCVTypeAdapters;
+import qupath.opencv.io.OpenCVTypeAdapters;
 
 /**
  * Helper class for preprocessing input for machine learning algorithms using OpenCV Mats.

--- a/qupath-core-processing/src/test/java/qupath/opencv/io/TypeAdaptersCVTest.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/io/TypeAdaptersCVTest.java
@@ -19,7 +19,7 @@
  * #L%
  */
 
-package qupath.lib.io;
+package qupath.opencv.io;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.Test;
 import org.bytedeco.opencv.opencv_core.TermCriteria;
 
 import com.google.gson.GsonBuilder;
+
+import qupath.opencv.io.OpenCVTypeAdapters;
 
 
 @SuppressWarnings("javadoc")

--- a/qupath-core/build.gradle
+++ b/qupath-core/build.gradle
@@ -9,8 +9,8 @@ archivesBaseName = 'qupath-core'
 description = "Core QuPath module containing the main classes and datastructures."
 
 configurations {
-  implementation.extendsFrom opencv
   implementation.extendsFrom guava
+  implementation.extendsFrom opencv
 }
 
 dependencies {
@@ -19,7 +19,6 @@ dependencies {
   
   implementation libs.commons.math
   implementation libs.picocli
-
-//  implementation libs.bundles.opencv
+  implementation libs.imagej
   
 }

--- a/qupath-core/build.gradle
+++ b/qupath-core/build.gradle
@@ -10,7 +10,6 @@ description = "Core QuPath module containing the main classes and datastructures
 
 configurations {
   implementation.extendsFrom guava
-  implementation.extendsFrom opencv
 }
 
 dependencies {

--- a/qupath-core/src/main/java/qupath/lib/awt/common/BufferedImageTools.java
+++ b/qupath-core/src/main/java/qupath/lib/awt/common/BufferedImageTools.java
@@ -32,14 +32,11 @@ import java.awt.image.DataBuffer;
 import java.awt.image.WritableRaster;
 import java.util.Hashtable;
 
-import org.bytedeco.javacpp.indexer.FloatIndexer;
-import org.bytedeco.opencv.global.opencv_core;
-import org.bytedeco.opencv.global.opencv_imgproc;
-import org.bytedeco.opencv.opencv_core.Mat;
-import org.bytedeco.opencv.opencv_core.Size;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ij.process.FloatProcessor;
+import ij.process.ImageProcessor;
 import qupath.lib.common.ColorTools;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.images.servers.AbstractTileableImageServer;
@@ -422,8 +419,11 @@ public final class BufferedImageTools {
 	 * @param img input image to be resized
 	 * @param finalWidth target output width
 	 * @param finalHeight target output height
-	 * @param smoothInterpolate if true, the resize method is permitted to use a smooth interpolation method. If false, nearest-neighbor interpolation is used.
+	 * @param smoothInterpolate if true, the resize method is permitted to use a smooth interpolation method.
+	 *           If false, nearest-neighbor interpolation is used.
 	 * @return resized image
+	 * @implNote the method of smooth interpolation is not currently specified or adjustable.
+	 *           Since v0.4.0, it uses ImageJ's bilinear interpolation with area averaging - however this may change.
 	 */
 	public static BufferedImage resize(final BufferedImage img, final int finalWidth, final int finalHeight, boolean smoothInterpolate) {
 
@@ -444,42 +444,32 @@ public final class BufferedImageTools {
 		WritableRaster raster = img.getRaster();
 		WritableRaster raster2 = raster.createCompatibleWritableRaster(finalWidth, finalHeight);
 
+		boolean isIntType = isIntType(raster.getTransferType());
 		int w = img.getWidth();
 		int h = img.getHeight();
 		
-		int cvType = opencv_core.CV_32F;
-		boolean isIntType = isIntType(img.getRaster().getTransferType());
+		boolean areaAveraging;
+
+		var fp = new FloatProcessor(w, h);
+		if (smoothInterpolate) {
+			fp.setInterpolationMethod(ImageProcessor.BILINEAR);
+			areaAveraging = true;
+		} else {
+			fp.setInterpolationMethod(ImageProcessor.NEAREST_NEIGHBOR);
+			areaAveraging = false;
+		}
 		
-		Mat matInput = new Mat(h, w, cvType);
-		Size sizeOutput = new Size(finalWidth, finalHeight);
-		Mat matOutput = new Mat(sizeOutput, cvType);
-		FloatIndexer idxInput = matInput.createIndexer(true);
-		FloatIndexer idxOutput = matOutput.createIndexer(true);
-		float[] pixels = new float[w*h];
-		float[] pixelsOut = new float[finalWidth*finalHeight];
-		
-		int interp = smoothInterpolate ? opencv_imgproc.INTER_AREA : opencv_imgproc.INTER_NEAREST;
 		for (int b = 0; b < raster.getNumBands(); b++) {
+			float[] pixels = (float[])fp.getPixels();
 			raster.getSamples(0, 0, w, h, b, pixels);
-			idxInput.put(0L, pixels);
-			opencv_imgproc.resize(matInput, matOutput, sizeOutput, 0, 0, interp);
-			idxOutput.get(0, pixelsOut);
-			// If we have integer input, make sure we have integer output
-			// Fixes bug in QuPath v0.3 (and probably v0.2) where resizing a constant 
-			// region could result in new values due to subtle precision errors and 
-			// strict rounding down within raster.setSamples.
+			var fp2 = fp.resize(finalWidth, finalHeight, areaAveraging);
+			float[] pixelsOut = (float[])fp2.getPixels();
 			if (isIntType) {
 				for (int i = 0; i < pixelsOut.length; i++)
 					pixelsOut[i] = Math.round(pixelsOut[i]);
 			}
 			raster2.setSamples(0, 0, finalWidth, finalHeight, b, pixelsOut);
 		}
-		
-		idxInput.close();
-		idxOutput.close();
-		matInput.close();
-		matOutput.close();
-		sizeOutput.close();
 		
 //		System.err.println(String.format("Resizing from %d x %d to %d x %d", w, h, finalWidth, finalHeight));
 

--- a/qupath-core/src/main/java/qupath/lib/io/GsonTools.java
+++ b/qupath-core/src/main/java/qupath/lib/io/GsonTools.java
@@ -76,7 +76,6 @@ public class GsonTools {
 			.serializeSpecialFloatingPointValues()
 			.setLenient()
 			.registerTypeAdapterFactory(new QuPathTypeAdapterFactory())
-			.registerTypeAdapterFactory(OpenCVTypeAdapters.getOpenCVTypeAdaptorFactory())
 			.registerTypeAdapter(AffineTransform.class, AffineTransformTypeAdapter.INSTANCE);
 			//.create();
 	


### PR DESCRIPTION
Addresses https://github.com/qupath/qupath/issues/961

Involves using ImageJ internally for `BufferedImageTools.resize`, therefore some differences in resize output may be expected. However, it seems a good time to make this change since the previous behavior was broken anyway, i.e. see https://github.com/qupath/qupath/issues/974