### PR TITLE
Improved gamma support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This is a work-in-progress.
 * Objects now have IDs
   * This aims to make it much easier to match up objects whenever some further analysis is done elsewhere (e.g. classification or clustering in Python or R)
   * See https://github.com/qupath/qupath/pull/959
+* Improved Brightness/Contrast options, including
+  * Switch between dark and light backgrounds (still experimental)
+  * More consistent behavior with 'Show grayscale' option
+  * Show RGB histograms
+* Improved gamma support
+  * Adjust gamma with a slider in Brightness/Contrast window (no longer in preferences)
+  * Apply gamma to mini/channel viewers
 * Completely rewritten 'View -> Show view tracker' command
 * Improved channel viewer
   * Show only the visible/most relevant channels by default, based on image type
@@ -25,9 +32,6 @@ This is a work-in-progress.
     * Brace block handling (https://github.com/qupath/qupath/pull/901)
     * Smart parentheses and (double/single) quotes (https://github.com/qupath/qupath/pull/907)
     * Comment block handling (https://github.com/qupath/qupath/pull/908)
-* Improved Brightness/Contrast options, including
-  * Switch between dark and light backgrounds (still experimental)
-  * More consistent behavior with 'Show grayscale' option
 * Improved support for switching between QuPath objects and ImageJ ROIs
   * New 'Extensions -> ImageJ -> Import ImageJ ROIs' command
   * Import .roi and RoiSet.zip files by drag & drop

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ExtractRegionCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ExtractRegionCommand.java
@@ -164,6 +164,13 @@ class ExtractRegionCommand implements Runnable {
 		List<ChannelDisplayInfo> channels = doTransforms && !selectedChannels.isEmpty() ? selectedChannels : null;
 		if (channels != null)
 			server = ChannelDisplayTransformServer.createColorTransformServer(server, channels);
+		
+		// We don't support applying gamma for now
+		if (doTransforms) {
+			var gamma = viewer.getGammaOp();
+			if (gamma != null)
+				logger.warn("Gamma transform not supported when sending image to ImageJ");
+		}
 
 		// Loop through all selected objects
 		Collection<PathObject> pathObjects = viewer.getHierarchy().getSelectionModel().getSelectedObjects();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MiniViewers.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MiniViewers.java
@@ -716,6 +716,10 @@ public class MiniViewers {
 						null,
 						renderer);
 				
+				var gammaOp = mainViewer.getGammaOp();
+				if (gammaOp != null)
+					gammaOp.filter(img.getRaster(), img.getRaster());
+				
 				float opacity = mainViewer.getOverlayOptions().getOpacity();
 				if (showOverlays.get() && opacity > 0) {
 					if (opacity < 1f)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -284,9 +284,9 @@ public class PreferencePane {
 				"Auto Brightness/Contrast saturation %", category, 
 				"Set % bright and % dark pixels that should be saturated when applying 'Auto' brightness/contrast settings");
 		
-		addPropertyPreference(PathPrefs.viewerGammaProperty(), Double.class,
-				"Gamma value (display only)", category, 
-				"Set the gamma value applied to the image in the viewer for display - recommended to leave at default value of 1");
+//		addPropertyPreference(PathPrefs.viewerGammaProperty(), Double.class,
+//				"Gamma value (display only)", category, 
+//				"Set the gamma value applied to the image in the viewer for display - recommended to leave at default value of 1");
 		
 		addPropertyPreference(PathPrefs.invertZSliderProperty(), Boolean.class,
 				"Invert z-position slider",


### PR DESCRIPTION
This addresses https://github.com/qupath/qupath/issues/981

Main changes:
* Adjust gamma in Brightness/Contrast window (no longer in preferences)
* Apply gamma to mini/channel viewers
* Make gamma accessible via public methods on the viewer
* Warn in the Brightness/Contrast window when the gamma is anything other than 1
* Support unbinding the gamma property for a viewer and setting it manually via scripting (although discouraged)

One concern is that this means that the gamma slider in the brightness/contrast dialog controls a global preference, whereas the min/max sliders operate per-viewer. This may need to revised if it causes confusion.

Bonus:
* Show RGB histograms in Brightness/Contrast window