### PR TITLE
Improve CellTools robustness

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVDnn.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVDnn.java
@@ -652,6 +652,8 @@ public class OpenCVDnn implements UriResource, DnnModel<Mat> {
 		private transient StringVector outputLayerNamesVector;
 		
 		// Experimental code - can use a ThreadLocal Net, but doesn't seem to improve performance overall
+		// and can even slightly reduce it
+		// (tested 06/22 using StarDist on an Apple M1 Max with 32 GB RAM)
 //		private transient ThreadLocal<Net> localNet = ThreadLocal.withInitial(() -> {
 //			ensureInitialized();
 //			if (net != null) {


### PR DESCRIPTION
- Reduce instances of TopologyException (currently in StarDist) by fixing geometries produced by estimateCellBoundary if needed.
- Improve detectionsToCells to avoid losing all cells if one throws an exception.