### PR TITLE
JTS update & related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ This is a work-in-progress.
 * OpenCV is no longer a dependency of qupath-core (https://github.com/qupath/qupath/issues/961)
   * Moved `OpenCVTypeAdapters` to qupath-core-processing
   * Switched `BufferedImageTools.resize` to use ImageJ internally
+* Use `-Djts.overlay=ng` system property by default with Java Topology Suite
+  * This should resolve many occurrences of the dreaded `TopologyException` when manipulating ROIs & geometries
 * Updated prompt to set the image type
 * Missing thumbnails are automatically regenerated when a project is opened
 * Avoid converting the pixel type to 32-bit unnecessarily when sending image regions to ImageJ
@@ -74,6 +76,7 @@ This is a work-in-progress.
 * Adoptium OpenJDK 17
 * Bio-Formats 6.10.0
 * JavaFX 18.0.1
+* Java Topology Suite 1.19.0
 * Groovy 4.0.2
 * Gson 2.9.0
 * Guava 31.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ gson          = { module = "com.google.code.gson:gson", version = "2.9.0" }
 
 # Optionally add GeoJSON support (brings in json-simple as sub-dependency)
 # However, the use of simple-json is troublesome since it brings in an old version of junit
-jts           = { module = "org.locationtech.jts:jts-core",    version = "1.18.2" }
+jts           = { module = "org.locationtech.jts:jts-core",    version = "1.19.0" }
 
 logback       = { module = "ch.qos.logback:logback-classic",   version = "1.2.11" }
 slf4j         = { module = "org.slf4j:slf4j-api",              version = "1.7.36" }

--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -59,7 +59,6 @@ import qupath.lib.gui.logging.LogManager;
 import qupath.lib.gui.logging.LogManager.LogLevel;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.scripting.DefaultScriptEditor;
-import qupath.lib.gui.scripting.languages.GroovyLanguage;
 import qupath.lib.gui.scripting.languages.RunnableLanguage;
 import qupath.lib.gui.scripting.languages.ScriptLanguage;
 import qupath.lib.gui.scripting.languages.ScriptLanguageProvider;
@@ -193,6 +192,25 @@ public class QuPath {
 		}
 	
 		return;
+	}
+	
+	
+	static void initializeProperties() {
+		initializeJTS();
+	}
+	
+	
+	/**
+	 * Use OverlayNG with Java Topology Suite by default.
+	 * This can greatly reduce TopologyExceptions.
+	 * Use -Djts.overlay=old to turn off this behavior.
+	 */
+	static void initializeJTS() {
+		var prop = System.getProperty("jts.overlay");
+		if (prop == null) {
+			logger.debug("Setting -Djts.overlay=ng");
+			System.setProperty("jts.overlay", "ng");
+		}
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -234,7 +234,7 @@ public class RoiTools {
 				// Compute the intersection
 				g = geom.intersection(g);
 				// If we have a collection, we need to ensure homogeneity - intersections between two areas can result in lines occurring
-				g = GeometryTools.homogenizeGeometryCollection(geom.intersection(g));
+				g = GeometryTools.homogenizeGeometryCollection(g);
 				// Return the intersection if it is non-null, and also avoids any 'collapse', e.g. an area becoming a line
 				if (!g.isEmpty()) {
 					var r2 = GeometryTools.geometryToROI(g, r.getImagePlane());


### PR DESCRIPTION
Update to use JTS 1.19.0.

Introduce `-Djts.overlay=ng` by default.
Lots of evidence on the forum that this resolves thorny TopologyExceptions.
See https://forum.image.sc/t/stardist-error-message-topologyexception/67708/7 for more info.

Avoid calling `geom.intersection(g)` twice in `RoiTools.clipToROI(ROI, Collection)`, which caused problems with OverlayNG.
This should fix https://github.com/qupath/qupath/issues/996