### PR TITLE
Warn when unable to serialize a property in qpdata

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/io/PathIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathIO.java
@@ -592,7 +592,7 @@ public class PathIO {
 				if (entry.getValue() instanceof Serializable)
 					map.put(entry.getKey(), entry.getValue());
 				else
-					logger.error("Property not serializable and will not be saved!  Key: " + entry.getKey() + ", Value: " + entry.getValue());
+					logger.warn("Property not serializable and will not be saved!  Key: " + entry.getKey() + ", Value: " + entry.getValue());
 			}
 			if (map != null)
 				outStream.writeObject(map);


### PR DESCRIPTION
This is as opposed to reporting it as an error.
See https://forum.image.sc/t/how-to-measure-the-staining-intensity-without-positive-cell-detection/66847/12