### PR TITLE
Improve performance writing planar ome-tiffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ This is a work-in-progress.
 * Avoid converting the pixel type to 32-bit unnecessarily when sending image regions to ImageJ
 * Warn if trying to train a pixel classifier with too many features (https://github.com/qupath/qupath/issues/947)
 * Directory choosers can now have titles (https://github.com/qupath/qupath/issues/940)
+* Improved performance writing large, multi-channel OME-TIFF images
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)


### PR DESCRIPTION
* Support specifying threads for parallel writing
* Reverse tiles when writing each plane of a multi-channel output

The second of these makes it possible to reuse cached tiles much more effectively. In one test example using LuCa-7color_Scan1.qptiff it decreased export time from 270s to 188s (although differences may vary considerably depending upon available memory and how expensive tile reading is).

Inspiration from this discussion: https://forum.image.sc/t/saving-to-ome-tiff-slow-warpy-and-qupath/69153/50