### PR TITLE
Further OME-TIFF writing improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ This is a work-in-progress.
 * Improved gamma support
   * Adjust gamma with a slider in Brightness/Contrast window (no longer in preferences)
   * Apply gamma to mini/channel viewers
+* Improved OME-TIFF export
+  * Better performance when writing large & multi-channel images
+  * Optionally cast to a different pixel type, via `OMEPyramidWriter.Builder.pixelType(type)`
 * Completely rewritten 'View -> Show view tracker' command
 * Improved channel viewer
   * Show only the visible/most relevant channels by default, based on image type
@@ -60,7 +63,6 @@ This is a work-in-progress.
 * Avoid converting the pixel type to 32-bit unnecessarily when sending image regions to ImageJ
 * Warn if trying to train a pixel classifier with too many features (https://github.com/qupath/qupath/issues/947)
 * Directory choosers can now have titles (https://github.com/qupath/qupath/issues/940)
-* Improved performance writing large, multi-channel OME-TIFF images
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)

--- a/qupath-core/src/main/java/qupath/lib/images/servers/TileRequest.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/TileRequest.java
@@ -92,20 +92,47 @@ public class TileRequest {
 	}
 	
 	/**
-	 * Create a new tile request for a specified region and resolution level.
+	 * Create a new tile request for a specified region and resolution level of an image.
+	 * <p>
+	 * Most of the time this should not be needed: use {@link ImageServer#getTileRequestManager()} instead 
+	 * to get the tiles that are actually available for an image.
+	 * 
 	 * @param server
 	 * @param level
 	 * @param tileRegion
 	 * @return
+	 * @see #createInstance(ImageServer, int, ImageRegion)
 	 */
-	private static TileRequest createInstance(ImageServer<?> server, int level, ImageRegion tileRegion) {
-		double downsample = server.getDownsampleForResolution(level);
+	public static TileRequest createInstance(ImageServer<?> server, int level, ImageRegion tileRegion) {
+		return createInstance(server.getPath(), level, server.getDownsampleForResolution(level), tileRegion);
+	}
+	
+	
+	/**
+	 * Create a new tile request for a specified region, downsample and resolution level.
+	 * <p>
+	 * Most of the time this should not be needed: use {@link ImageServer#getTileRequestManager()} instead.
+	 * <p>
+	 * In cases where a new {@link TileRequest} is necessary, it is better to use {@link #createInstance(ImageServer, int, ImageRegion)}
+	 * where possible.
+	 * The current method exists for cases where a {@link TileRequest} is a useful data structure but it isn't 
+	 * associated with a specific image.
+	 * 
+	 * @param path
+	 * @param level
+	 * @param downsample
+	 * @param tileRegion
+	 * @return
+	 * @see #createInstance(ImageServer, int, ImageRegion)
+	 */
+	public static TileRequest createInstance(String path, int level, double downsample, ImageRegion tileRegion) {
 		return new TileRequest(
-				getRegionRequest(server.getPath(), downsample, tileRegion),
+				getRegionRequest(path, downsample, tileRegion),
 				level,
 				tileRegion
 				);
 	}
+	
 
 	private static RegionRequest getRegionRequest(String path, double downsample, ImageRegion tileRegion) {
 		double x1 = tileRegion.getX() * downsample;

--- a/qupath-core/src/main/java/qupath/lib/regions/RegionRequest.java
+++ b/qupath-core/src/main/java/qupath/lib/regions/RegionRequest.java
@@ -315,6 +315,18 @@ public class RegionRequest extends ImageRegion {
 	}
 	
 	/**
+	 * Create a {@link RegionRequest} equivalent to this one with the x and y coordinates updated by translation.
+	 * @param dx value to add to the x coordinate
+	 * @param dy value to add to the y coordinate
+	 * @return {@link RegionRequest} with the specified path value (may be this object unchanged).
+	 */
+	public RegionRequest translate(int dx, int dy) {
+		if (dx == 0 && dy == 0)
+			return this;
+		return RegionRequest.createInstance(path, getDownsample(), getX()+dx, getY()+dy, getWidth(), getHeight(), getZ(), getT());
+	}
+	
+	/**
 	 * Add symmetric padding to the x and y dimensions of a request.
 	 * @param xPad padding to add along the x dimension; the width will be adjusted by {@code xPad * 2}
 	 * @param yPad padding to add along the y dimension; the height will be adjusted by {@code yPad * 2}

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriter.java
@@ -59,7 +59,6 @@ import loci.formats.tiff.IFD;
 import ome.units.UNITS;
 import ome.units.quantity.Length;
 import ome.xml.model.enums.DimensionOrder;
-import ome.xml.model.enums.PixelType;
 import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.PositiveInteger;
 import qupath.lib.color.ColorModelFactory;
@@ -68,8 +67,10 @@ import qupath.lib.images.servers.ImageChannel;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerMetadata;
 import qupath.lib.images.servers.PixelCalibration;
+import qupath.lib.images.servers.PixelType;
 import qupath.lib.images.servers.ServerTools;
 import qupath.lib.images.servers.ImageServerMetadata.ChannelType;
+import qupath.lib.images.servers.ImageServers;
 import qupath.lib.regions.ImageRegion;
 import qupath.lib.regions.RegionRequest;
 
@@ -166,15 +167,28 @@ public class OMEPyramidWriter {
 		 * @return
 		 */
 		public boolean supportsImage(ImageServer<?> server) {
+			return supportsImage(server.getPixelType(), server.nChannels(), server.isRGB());
+		}
+		
+		/**
+		 * Returns true if the compression type supports a specific {@link PixelType} output 
+		 * with the given number of channels - and (optionally) RGB status.
+		 * 
+		 * @param pixelType
+		 * @param nChannels
+		 * @param isRGB
+		 * @return
+		 */
+		public boolean supportsImage(PixelType pixelType, int nChannels, boolean isRGB) {
 			switch(this) {
 			case JPEG:
-				return server.isRGB() || 
+				return isRGB || 
 						//@phaub JPEG support for nChannels>1
-						(server.nChannels() >= 1 && server.getPixelType() == qupath.lib.images.servers.PixelType.UINT8);
+						(nChannels >= 1 && pixelType == PixelType.UINT8);
 			case J2K:
 			case J2K_LOSSY:
 				// It seems OME-TIFF can only write 8-bit or 16-bit J2K?
-				return server.getPixelType().getBytesPerPixel() <= 2;
+				return pixelType.getBytesPerPixel() <= 2;
 			case LZW:
 			case DEFAULT:
 			case UNCOMPRESSED:
@@ -294,7 +308,7 @@ public class OMEPyramidWriter {
 				for (double d : temp.downsamples) {
 					nPixelBytes += ((long)Math.ceil(temp.width / d) * Math.ceil(temp.height / d) 
 							* temp.channels.length 
-							* temp.server.getPixelType().getBytesPerPixel() 
+							* temp.getExportPixelType().getBytesPerPixel() 
 							* (temp.tEnd - temp.tStart)
 							* (temp.zEnd - temp.zStart));
 				}
@@ -330,7 +344,7 @@ public class OMEPyramidWriter {
 			writer.setId(path);
 			for (int s = 0; s < series.size(); s++) {
 				var temp = series.get(s);
-				logger.info("Writing {} to {} (series {}/{})", ServerTools.getDisplayableImageName(temp.server), path, s+1, series.size());
+				logger.info("Writing {} to {} (series {}/{})", ServerTools.getDisplayableImageName(temp.getOriginalServer()), path, s+1, series.size());
 				temp.writeSeries(writer.getWriter(), meta, s);
 			}
 		}
@@ -345,7 +359,10 @@ public class OMEPyramidWriter {
 		
 		private OMEPyramidSeries() {}
 		
-		private ImageServer<BufferedImage> server;
+		private ImageServer<BufferedImage> serverOriginal;
+		private ImageServer<BufferedImage> serverPyramidalized;
+		
+		private PixelType exportPixelType;
 		
 		private String name; // Series name
 	
@@ -368,6 +385,8 @@ public class OMEPyramidWriter {
 	
 		private CompressionType compression = CompressionType.DEFAULT;
 		
+		private static int[] RGB_CHANNEL_ARRAY = new int[] {0, 1, 2};
+		
 		void initializeMetadata(IMetadata meta, int series) throws IOException {
 			
 			meta.setImageID("Image:"+series, series);
@@ -378,33 +397,34 @@ public class OMEPyramidWriter {
 			meta.setPixelsBigEndian(ByteOrder.BIG_ENDIAN.equals(endian), series);
 			
 			meta.setPixelsDimensionOrder(DimensionOrder.XYCZT, series);
-			switch (server.getPixelType()) {
+			var pixelType = getExportPixelType();
+			switch (pixelType) {
 			case INT8:
-				meta.setPixelsType(PixelType.INT8, series);
+				meta.setPixelsType(ome.xml.model.enums.PixelType.INT8, series);
 				break;
 			case UINT8:
-				meta.setPixelsType(PixelType.UINT8, series);
+				meta.setPixelsType(ome.xml.model.enums.PixelType.UINT8, series);
 				break;
 			case INT16:
-				meta.setPixelsType(PixelType.INT16, series);
+				meta.setPixelsType(ome.xml.model.enums.PixelType.INT16, series);
 				break;
 			case UINT16:
-				meta.setPixelsType(PixelType.UINT16, series);
+				meta.setPixelsType(ome.xml.model.enums.PixelType.UINT16, series);
 				break;
 			case INT32:
-				meta.setPixelsType(PixelType.INT32, series);
+				meta.setPixelsType(ome.xml.model.enums.PixelType.INT32, series);
 				break;
 			case UINT32:
-				meta.setPixelsType(PixelType.UINT32, series);
+				meta.setPixelsType(ome.xml.model.enums.PixelType.UINT32, series);
 				break;
 			case FLOAT32:
-				meta.setPixelsType(PixelType.FLOAT, series);
+				meta.setPixelsType(ome.xml.model.enums.PixelType.FLOAT, series);
 				break;
 			case FLOAT64:
-				meta.setPixelsType(PixelType.DOUBLE, series);
+				meta.setPixelsType(ome.xml.model.enums.PixelType.DOUBLE, series);
 				break;
 			default:
-				throw new IOException("Cannot convert pixel type value of " + server.getPixelType() + " into a valid OME PixelType");
+				throw new IOException("Cannot convert pixel type value of " + pixelType + " into a valid OME PixelType");
 			}
 			meta.setPixelsSizeX(new PositiveInteger((int)(width / downsamples[0])), series);
 			meta.setPixelsSizeY(new PositiveInteger((int)(height / downsamples[0])), series);
@@ -421,7 +441,7 @@ public class OMEPyramidWriter {
 			
 			int nSamples = 1;
 			int nChannels = this.channels.length;
-			boolean isRGB = server.isRGB() && Arrays.equals(channels, new int[] {0, 1, 2});
+			boolean isRGB = doExportRGB();
 			boolean isInterleaved = false;
 			if (channelExportType == ChannelExportType.DEFAULT) {
 				if (isRGB)
@@ -451,6 +471,7 @@ public class OMEPyramidWriter {
 			//		nChannels = 2;
 	
 			// Set channel colors
+			var serverOriginal = getOriginalServer();
 			meta.setPixelsSizeC(new PositiveInteger(nChannels), series);
 			if (isRGB) {
 				meta.setChannelID("Channel:0", series, 0);			
@@ -463,7 +484,7 @@ public class OMEPyramidWriter {
 					meta.setChannelID("Channel:0:" + c, series, c);			
 	//				meta.setChannelSamplesPerPixel(new PositiveInteger(nSamples), series, c);
 	//				Integer color = server.getChannels().get(c).getColor();
-					ImageChannel channel = server.getChannel(c);
+					ImageChannel channel = serverOriginal.getChannel(c);
 					Integer color = channel.getColor();
 					meta.setChannelColor(new Color(
 							ColorTools.red(color),
@@ -476,13 +497,17 @@ public class OMEPyramidWriter {
 			}
 	
 			// Set physical units, if we have them
-			PixelCalibration cal = server.getPixelCalibration();
+			PixelCalibration cal = serverOriginal.getPixelCalibration();
 			if (cal.hasPixelSizeMicrons()) {
 				meta.setPixelsPhysicalSizeX(new Length(cal.getPixelWidthMicrons() * downsamples[0], UNITS.MICROMETER), series);
 				meta.setPixelsPhysicalSizeY(new Length(cal.getPixelHeightMicrons() * downsamples[0], UNITS.MICROMETER), series);
 			}
 			if (!Double.isNaN(cal.getZSpacingMicrons()))
 				meta.setPixelsPhysicalSizeZ(new Length(cal.getZSpacingMicrons(), UNITS.MICROMETER), series);
+			
+			// TOD: Consider time increments
+			if (tEnd - tStart > 1)
+				logger.warn("I can't currently export time series calibration information, sorry");
 	
 			// TODO: Consider setting the magnification
 	
@@ -495,6 +520,14 @@ public class OMEPyramidWriter {
 				((IPyramidStore)meta).setResolutionSizeY(new PositiveInteger(h), series, level);
 			}
 	
+		}
+		
+		PixelType getExportPixelType() {
+			return exportPixelType == null ? serverOriginal.getPixelType() : exportPixelType;
+		}
+		
+		boolean doExportRGB() {
+			return serverOriginal.isRGB() && getExportPixelType() == PixelType.UINT8 && Arrays.equals(channels, RGB_CHANNEL_ARRAY);
 		}
 		
 		/**
@@ -568,7 +601,7 @@ public class OMEPyramidWriter {
 			while (writer instanceof ImageWriter)
 				writer = ((ImageWriter)writer).getWriter();
 			
-			boolean isRGB = server.isRGB() && Arrays.equals(channels, new int[] {0, 1, 2});
+			boolean isRGB = doExportRGB();
 			int nChannels = meta.getPixelsSizeC(series).getValue();
 			int nSamples = meta.getChannelSamplesPerPixel(series, 0).getValue();
 			int sizeZ = meta.getPixelsSizeZ(series).getValue();
@@ -576,6 +609,8 @@ public class OMEPyramidWriter {
 			int width = meta.getPixelsSizeX(series).getValue();
 			int height = meta.getPixelsSizeY(series).getValue();
 			int nPlanes = (nChannels / nSamples) * sizeZ * sizeT;
+			
+			var server = getExportServer();
 			
 			// Try to choose a sensible default for compression
 			// For TIFFs, this has multiple options - but other writers (e.g. JP2K) might just have one
@@ -675,6 +710,28 @@ public class OMEPyramidWriter {
 							}
 						}
 						
+//						int levelTemp = ServerTools.getPreferredResolutionLevel(server, d);
+//						// Use tiles directly if we aren't cropping and they exist as the requested resolution level
+//						if (d == server.getDownsampleForResolution(levelTemp) && 
+//								x == 0 && y == 0 && this.width == server.getWidth() && this.height == server.getHeight() &&
+//								tileWidth == server.getMetadata().getPreferredTileWidth() && tileHeight == server.getMetadata().getPreferredTileHeight()) {
+//							logger.info("USING TILES DIRECTLY FOR REGIONS");
+//							server.getTileRequestManager()
+//								.getTileRequestsForLevel(levelTemp)
+//								.stream()
+//								.map(tile -> tile.getRegionRequest())
+//								.forEachOrdered(regions::add);
+//						} else {
+//							// Legacy code to generate regions, possibly involving cropping
+//							for (int yy = 0; yy < h; yy += tileHeight) {
+//								int hh = Math.min(h - yy, tileHeight);
+//								for (int xx = 0; xx < w; xx += tileWidth) {
+//									int ww = Math.min(w - xx, tileWidth);
+//									regions.add(ImageRegion.createInstance(xx, yy, ww, hh, z, t));
+//								}
+//							}
+//						}
+						
 						int total = regions.size() * (tEnd - tStart) * (zEnd - zStart);
 						if (z == zStart && t == tStart)
 							logger.info("Writing resolution {} of {} (downsample={}, {} tiles)", level+1, downsamples.length, d, total);
@@ -703,11 +760,13 @@ public class OMEPyramidWriter {
 							logger.info("Writing plane {}/{}", plane+1, nPlanes);
 								
 							// We *must* write the first region first
-							writeRegion(writer, plane, ifd, firstRegion, d, isRGB, localChannels);
+							writeRegion(writer, plane, ifd, server, firstRegion, d, isRGB, localChannels);
 							if (!regions.isEmpty()) {
 								
 								// Reversing the regions means that for a large image we can still get some tiles from the cache
-								if (ci > 0) {
+								// Do this for channels and levels, since we sometimes need to request the same tiles when exporting 
+								// at a lower resolution
+								if (ci > 0 || level > 0) {
 									logger.trace("Reversing list if {} regions", regions.size());
 									Collections.reverse(regions);
 								}
@@ -719,7 +778,7 @@ public class OMEPyramidWriter {
 										try {
 											if (Thread.currentThread().isInterrupted())
 												return;
-											writeRegion(localWriter, plane, ifd, region, d, isRGB, localChannels);
+											writeRegion(localWriter, plane, ifd, server, region, d, isRGB, localChannels);
 										} catch (Exception e) {
 											logger.error(String.format(
 													"Error writing %s (downsample=%.2f)",
@@ -780,9 +839,11 @@ public class OMEPyramidWriter {
 		 * @param downsample 
 		 * @return
 		 */
-		RegionRequest downsampledRegionToRequest(ImageRegion region, double downsample) {
+		RegionRequest downsampledRegionToRequest(String path, ImageRegion region, double downsample) {
+//			if (region instanceof RegionRequest && ((RegionRequest) region).getDownsample() == downsample)
+//				return ((RegionRequest)region).updatePath(path);
 			return RegionRequest.createInstance(
-					server.getPath(), downsample, 
+					path, downsample, 
 					(int)(region.getX() * downsample) + x, 
 					(int)(region.getY() * downsample) + y, 
 					(int)(region.getWidth() * downsample), 
@@ -791,6 +852,26 @@ public class OMEPyramidWriter {
 					region.getT());
 		}
 		
+		/**
+		 * Get the original {@link ImageServer} for the image that should be export.
+		 * @return
+		 */
+		private ImageServer<BufferedImage> getOriginalServer() {
+			return serverOriginal;
+		}
+		
+		/**
+		 * Get the {@link ImageServer} to actually use for export.
+		 * This is often the same as {@link #getOriginalServer()}, but can be different if the server has been wrapped 
+		 * up for pyramidalization.
+		 * <p>
+		 * Note that there should be no other sneaky transforms applied, e.g. we assume the channels, dimensions and 
+		 * pixel type are unchanged. The purpose of the wrapping is only to make pixel access more efficient.
+		 * @return
+		 */
+		private ImageServer<BufferedImage> getExportServer() {
+			return serverPyramidalized == null ? getOriginalServer() : serverPyramidalized;
+		}
 		
 		/**
 		 * Write a region. The ifd is only used if writer is an instance of TiffWriter.
@@ -798,18 +879,21 @@ public class OMEPyramidWriter {
 		 * @param writer
 		 * @param plane
 		 * @param ifd
+		 * @param server the image to export
 		 * @param region
 		 * @param downsample
-		 * @param isRGB
+		 * @param isRGB export as RGB; this assumes both the input and export images are RGB (i.e. no extra conversions, channel reordering etc.)
 		 * @param channels
 		 * @throws FormatException
 		 * @throws IOException
 		 */
-		private void writeRegion(IFormatWriter writer, int plane, IFD ifd, ImageRegion region, double downsample, boolean isRGB, int[] channels) throws FormatException, IOException {
-			RegionRequest request = downsampledRegionToRequest(region, downsample);
+		private void writeRegion(IFormatWriter writer, int plane, IFD ifd, ImageServer<BufferedImage> server, ImageRegion region, double downsample, boolean isRGB, int[] channels) throws FormatException, IOException {
+			
+			RegionRequest request = downsampledRegionToRequest(server.getPath(), region, downsample);
 			BufferedImage img = server.readBufferedImage(request);
 			
-			int bytesPerPixel = server.getPixelType().getBytesPerPixel();
+			var pixelType = getExportPixelType();
+			int bytesPerPixel = pixelType.getBytesPerPixel();
 			int nChannels = channels.length;
 			if (img == null) {
 				byte[] zeros = new byte[region.getWidth() * region.getHeight() * bytesPerPixel * nChannels];
@@ -826,7 +910,7 @@ public class OMEPyramidWriter {
 					.order(endian);
 			
 			if (isRGB) {
-				Object pixelBuffer = getPixelBuffer(ww*hh);
+				Object pixelBuffer = getPixelBuffer(ww*hh, pixelType);
 				if (!(pixelBuffer instanceof int[]))
 					pixelBuffer = null;
 				int[] rgba = img.getRGB(0, 0, ww, hh, (int[])pixelBuffer, 0, ww);
@@ -839,7 +923,7 @@ public class OMEPyramidWriter {
 				for (int ci = 0; ci < channels.length; ci++) {
 					int c = channels[ci];
 					int ind = ci * bytesPerPixel;
-					channelToBuffer(img.getRaster(), c, buf, ind, channels.length * bytesPerPixel);
+					channelToBuffer(img.getRaster(), c, buf, ind, channels.length * bytesPerPixel, pixelType);
 				}
 			}
 			if (writer instanceof TiffWriter)
@@ -856,15 +940,16 @@ public class OMEPyramidWriter {
 		 * @param buf the buffer to which the pixels should be extracted
 		 * @param startInd the starting index in the buffer, where the first pixel should be written
 		 * @param inc the increment (in bytes) between each pixel that is written
+		 * @param pixelType the pixel type that the buffer should support
 		 * @return 
 		 */
-		boolean channelToBuffer(WritableRaster raster, int c, ByteBuffer buf, int startInd, int inc) {
+		boolean channelToBuffer(WritableRaster raster, int c, ByteBuffer buf, int startInd, int inc, PixelType pixelType) {
 			int ind = startInd;
 			int ww = raster.getWidth();
 			int hh = raster.getHeight();
 			int n = ww*hh;
-			Object pixelBuffer = getPixelBuffer(n);
-			switch (server.getPixelType()) {
+			Object pixelBuffer = getPixelBuffer(n, pixelType);
+			switch (pixelType) {
 			case INT8:
 			case UINT8:
 			case INT16:
@@ -874,18 +959,19 @@ public class OMEPyramidWriter {
 				int[] pixelsInt = pixelBuffer instanceof int[] ? (int[])pixelBuffer : null;
 				if (pixelsInt == null || pixelsInt.length < n)
 					pixelsInt = new int[n];
+				// TODO: Note that this will (I think) cast float/double values to int, i.e. it won't round
 				pixelsInt = raster.getSamples(0, 0, ww, hh, c, pixelsInt);
-				if (server.getPixelType().getBitsPerPixel() == 8) {
+				if (pixelType.getBitsPerPixel() == 8) {
 					for (int i = 0; i < n; i++) {
 						buf.put(ind, (byte)pixelsInt[i]);
 						ind += inc;
 					}
-				} else if (server.getPixelType().getBitsPerPixel() == 16) {
+				} else if (pixelType.getBitsPerPixel() == 16) {
 					for (int i = 0; i < n; i++) {
 						buf.putShort(ind, (short)pixelsInt[i]);
 						ind += inc;
 					}
-				} else if (server.getPixelType().getBitsPerPixel() == 32) {
+				} else if (pixelType.getBitsPerPixel() == 32) {
 					for (int i = 0; i < n; i++) {
 						buf.putInt(ind, (int)pixelsInt[i]);
 						ind += inc;
@@ -913,7 +999,7 @@ public class OMEPyramidWriter {
 				}
 				return true;
 			default:
-				logger.warn("Cannot convert to buffer - unknown pixel type {}", server.getPixelType());
+				logger.warn("Cannot convert to buffer - unknown pixel type {}", pixelType);
 				return false;
 			}
 		}
@@ -923,13 +1009,14 @@ public class OMEPyramidWriter {
 		/**
 		 * Get a primitive array of the specified length for extracting pixels from the current server.
 		 * 
-		 * @param length
+		 * @param length the length of the buffer (number of pixels)
+		 * @param pixelType the type that should be supported by the buffer
 		 * @return
 		 */
-		Object getPixelBuffer(int length) {
+		Object getPixelBuffer(int length, PixelType pixelType) {
 			Object originalBuffer = this.pixelBuffer.get();
 			Object updatedBuffer = null;
-			switch (server.getPixelType()) {
+			switch (pixelType) {
 			case FLOAT32:
 				updatedBuffer = ensureFloatArray(originalBuffer, length);
 				break;
@@ -1010,8 +1097,7 @@ public class OMEPyramidWriter {
 		 * @param server the ImageServer from which pixels will be requested and written to the OME-TIFF.
 		 */
 		public Builder(ImageServer<BufferedImage> server) {
-			series.server = server;
-			series.server = server;
+			series.serverOriginal = server;
 			series.x = 0;
 			series.y = 0;
 			series.width = server.getWidth();
@@ -1106,7 +1192,7 @@ public class OMEPyramidWriter {
 		 * @return this builder
 		 */
 		public Builder lossyCompression() {
-			series.compression = getDefaultLossyCompressionType(series.server);
+			series.compression = getDefaultLossyCompressionType(series.serverOriginal);
 			return this;
 		}
 		
@@ -1115,7 +1201,7 @@ public class OMEPyramidWriter {
 		 * @return
 		 */
 		public Builder losslessCompression() {
-			series.compression = getDefaultLosslessCompressionType(series.server);
+			series.compression = getDefaultLosslessCompressionType(series.serverOriginal);
 			return this;
 		}
 		
@@ -1164,13 +1250,41 @@ public class OMEPyramidWriter {
 			series.parallelThreads = nThreads;
 			return this;
 		}
+		
+		/**
+		 * Specify the output {@link PixelType}.
+		 * @param exportPixelType
+		 * @return
+		 * @implNote this will cast the pixel values if necessary (it will not round values).
+		 */
+		public Builder pixelType(PixelType exportPixelType) {
+			series.exportPixelType = exportPixelType;
+			return this;
+		}
+
+		/**
+		 * Specify the output {@link PixelType} as a String, e.g. "UINT8", "FLOAT32" etc.
+		 * @param exportPixelType
+		 * @return
+		 * @implNote this will cast the pixel values if necessary (it will not round values).
+		 */
+		public Builder pixelType(String exportPixelType) {
+			if (exportPixelType == null)
+				return pixelType((PixelType)null);
+			try {
+				series.exportPixelType = PixelType.valueOf(exportPixelType.toUpperCase());
+			} catch (Exception e) {
+				logger.warn("{} is not a valid pixel type! Supported values are {}", exportPixelType, Arrays.asList(PixelType.values()));
+			}
+			return this;
+		}
 
 		/**
 		 * Request that all z-slices are exported.
 		 * @return this builder
 		 */
 		public Builder allZSlices() {
-			return this.zSlices(0, series.server.nZSlices());
+			return this.zSlices(0, series.serverOriginal.nZSlices());
 		}
 
 		/**
@@ -1193,9 +1307,9 @@ public class OMEPyramidWriter {
 				logger.warn("First z-slice (" + zStart + ") is out of bounds. Will use " + 0 + " instead.");
 				zStart = 0;
 			}
-			if (zEnd > series.server.nZSlices()) {
-				logger.warn("Last z-slice (" + zEnd + ") is out of bounds. Will use " + series.server.nZSlices() + " instead.");
-				zEnd = series.server.nZSlices();
+			if (zEnd > series.serverOriginal.nZSlices()) {
+				logger.warn("Last z-slice (" + zEnd + ") is out of bounds. Will use " + series.serverOriginal.nZSlices() + " instead.");
+				zEnd = series.serverOriginal.nZSlices();
 			}
 			series.zStart = zStart;
 			series.zEnd = zEnd;
@@ -1216,7 +1330,7 @@ public class OMEPyramidWriter {
 		 * @return this builder
 		 */
 		public Builder allTimePoints() {
-			return this.timePoints(0, series.server.nTimepoints());
+			return this.timePoints(0, series.serverOriginal.nTimepoints());
 		}
 
 		/**
@@ -1230,9 +1344,9 @@ public class OMEPyramidWriter {
 				logger.warn("First timepoint (" + tStart + ") is out of bounds. Will use " + 0 + " instead.");
 				tStart = 0;
 			}
-			if (tEnd > series.server.nTimepoints()) {
-				logger.warn("Last timepoint (" + tEnd + ") is out of bounds. Will use " + series.server.nTimepoints() + " instead.");
-				tEnd = series.server.nTimepoints();
+			if (tEnd > series.serverOriginal.nTimepoints()) {
+				logger.warn("Last timepoint (" + tEnd + ") is out of bounds. Will use " + series.serverOriginal.nTimepoints() + " instead.");
+				tEnd = series.serverOriginal.nTimepoints();
 			}
 			series.tStart = tStart;
 			series.tEnd = tEnd;
@@ -1390,7 +1504,7 @@ public class OMEPyramidWriter {
 		 */
 		public OMEPyramidSeries build() {
 			//@phaub Sanity check (JPEG support for nChannels>1)
-			int nChannels = series.server.nChannels();
+			int nChannels = series.serverOriginal.nChannels();
 			if ( ( nChannels == 2 || nChannels > 3) 
 				 && (series.channelExportType == ChannelExportType.INTERLEAVED)
 				 && (series.compression == CompressionType.JPEG) ){
@@ -1410,6 +1524,20 @@ public class OMEPyramidWriter {
 			}
 			if (lastDownsample < series.downsamples.length)
 				series.downsamples = Arrays.copyOf(series.downsamples, lastDownsample);
+			
+			// Pyramidalize if we need to - this should help improve export efficiency and eliminate some potential 
+			// memory errors for large, non-pyramidal images
+			if (series.downsamples.length > 1) {
+				if (series.serverOriginal.nResolutions() == 1 || 
+						series.serverOriginal.getDownsampleForResolution(0) < series.downsamples[0]) {
+					logger.info("Creating pyramidal server");
+					series.serverPyramidalized = ImageServers.pyramidalizeTiled(
+							series.serverOriginal,
+							series.tileWidth,
+							series.tileHeight,
+							series.downsamples);
+				}
+			}
 			
 			return series;
 		}


### PR DESCRIPTION
* Optionally cast to a different pixel type, via `OMEPyramidWriter.Builder.pixelType(type)`
* Automatically pyramidalize images where required; this should fix https://github.com/qupath/qupath/issues/984