### PR TITLE
Ensure project refreshed when adding image

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -714,6 +714,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 					logger.error("Unable to save ImageData: " + e.getLocalizedMessage(), e);
 				}
 			}
+			qupath.refreshProject();
 		}
 	}
 


### PR DESCRIPTION
Relevant when using `QuPathViewer.setImageData(imageData)`, which has the side effect of adding the image to a project if it isn't already there.

Previously, the image wasn't visible in the project browser until the project was otherwise reloaded. This bug was new to v0.4.0-SNAPSHOT, spotted by @iwbh15