### PR TITLE
Deprecate old classes, add serialization filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ This is a work-in-progress.
   * Import .roi and RoiSet.zip files by drag & drop
   * Built-in ImageJ plugin to send RoiManager ROIs to QuPath (not only overlays)
   * Retain ROI position information when sending ROIs from ImageJ (hyper)stacks
+* Reduced use of Java serialization
+  * Serialization filters now used to better control deserialized classes
 * OpenCV is no longer a dependency of qupath-core (https://github.com/qupath/qupath/issues/961)
   * Moved `OpenCVTypeAdapters` to qupath-core-processing
   * Switched `BufferedImageTools.resize` to use ImageJ internally

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -1429,6 +1429,8 @@ public class QP {
 	 * Run an detection object classifier for the specified image data
 	 * @param imageData
 	 * @param classifier
+	 * @deprecated this refers to old-style (&leq; v.1.2) object classifiers, which have been replaced by {@link ObjectClassifier}.
+	 *             See instead {@link #runObjectClassifier(ImageData, String...)}.
 	 */
 	@Deprecated
 	public static void runClassifier(final ImageData<?> imageData, final PathObjectClassifier classifier) {
@@ -1440,6 +1442,8 @@ public class QP {
 	 * Run a detection object classifier for the specified image hierarchy
 	 * @param hierarchy
 	 * @param classifier
+	 * @deprecated this refers to old-style (&leq; v.1.2) object classifiers, which have been replaced by {@link ObjectClassifier}.
+	 *             See instead {@link #runObjectClassifier(ImageData, String...)}.
 	 */
 	@Deprecated
 	public static void runClassifier(final PathObjectHierarchy hierarchy, final PathObjectClassifier classifier) {
@@ -1450,6 +1454,8 @@ public class QP {
 	/**
 	 * Run a detection object classifier for the current image data, reading the classifier from a specified path
 	 * @param path
+	 * @deprecated this refers to old-style (&leq; v.1.2) object classifiers, which have been replaced by {@link ObjectClassifier}.
+	 *             See instead {@link #runObjectClassifier(String...)}.
 	 */
 	@Deprecated
 	public static void runClassifier(final String path) {

--- a/qupath-core-processing/src/main/java/qupath/opencv/classify/OpenCvClassifier.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/classify/OpenCvClassifier.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import qupath.lib.analysis.stats.RunningStatistics;
 import qupath.lib.classifiers.Normalization;
 import qupath.lib.classifiers.PathObjectClassifier;
+import qupath.lib.classifiers.object.ObjectClassifier;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.classes.PathClass;
@@ -62,19 +63,23 @@ import org.slf4j.LoggerFactory;
 /**
  * Abstract base class for OpenCV classifiers.
  * <p>
- * Note: We cannot directly serialize an OpenCV classifier, so instead the training data is serialized and the classifier
- * rebuilt as required.  This means that potentially if a classifier is reloaded with a different version of the OpenCV library,
- * if the training algorithm has changed then there may be a different result.
+ * @implNote At the time this was written, we could not directly serialize an OpenCV classifier, so instead the training data
+ * was serialized and the classifier rebuilt as required.
+ * This means that potentially if a classifier is reloaded with a different version of the OpenCV library,
+ * there could be a different result if the training algorithm had changed.
  * 
  * @author Pete Bankhead
  * @param <T> 
  *
+ * @deprecated This was based on the deprecated {@link PathObjectClassifier}, replaced by {@link ObjectClassifier}. 
+ *             This class is scheduled for removal in the next QuPath release.
  */
+@Deprecated
 public abstract class OpenCvClassifier<T extends StatModel> implements PathObjectClassifier, Externalizable {
 	
 	private static final long serialVersionUID = -7974734731360344083L;
 
-	final private static Logger logger = LoggerFactory.getLogger(OpenCvClassifier.class);
+	private final static Logger logger = LoggerFactory.getLogger(OpenCvClassifier.class);
 	
 	private long timestamp = System.currentTimeMillis();
 	private Normalization normalization = Normalization.NONE;

--- a/qupath-core/src/main/java/qupath/lib/classifiers/CompositeClassifier.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/CompositeClassifier.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import qupath.lib.classifiers.object.ObjectClassifier;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.classes.PathClass;
 
@@ -42,8 +43,10 @@ import qupath.lib.objects.classes.PathClass;
  * 
  * @author Pete Bankhead
  *
+ * @deprecated Replaced by {@link ObjectClassifier} and {@link qupath.lib.classifiers.object.CompositeClassifier}.
+ *             This class is scheduled for removal in the next QuPath release.
  */
-// TODO: Guarding more against invalid classifiers
+@Deprecated
 class CompositeClassifier implements PathObjectClassifier, Serializable {
 	
 	private static final long serialVersionUID = 1L;

--- a/qupath-core/src/main/java/qupath/lib/classifiers/PathClassifierTools.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/PathClassifierTools.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import qupath.lib.classifiers.object.ObjectClassifier;
 import qupath.lib.images.servers.ImageChannel;
+import qupath.lib.io.PathIO;
 import qupath.lib.objects.PathDetectionObject;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
@@ -188,7 +189,7 @@ public final class PathClassifierTools {
 		PathObjectClassifier classifier = null;
 		ObjectInputStream inStream = null;
 		try {
-			inStream = new ObjectInputStream(new FileInputStream(file));
+			inStream = PathIO.createObjectInputStream(new FileInputStream(file));
 			classifier = (PathObjectClassifier)inStream.readObject();
 			inStream.close();
 			logger.info(String.format("Reading classifier %s complete!", classifier.toString()));

--- a/qupath-core/src/main/java/qupath/lib/classifiers/PathClassifierTools.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/PathClassifierTools.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import qupath.lib.classifiers.object.ObjectClassifier;
 import qupath.lib.images.servers.ImageChannel;
 import qupath.lib.objects.PathDetectionObject;
 import qupath.lib.objects.PathObject;
@@ -55,11 +56,15 @@ import qupath.lib.objects.hierarchy.TMAGrid;
  * Static methods to load &amp; run a detection object classifier.
  * 
  * @author Pete Bankhead
- *
+ * 
+ * @deprecated These methods were associated with the legacy {@link PathObjectClassifier}, which 
+ *             has been replaced by {@link ObjectClassifier}.
+ *             This class is scheduled for removal in the next QuPath release.
  */
+@Deprecated
 public final class PathClassifierTools {
 	
-	final private static Logger logger = LoggerFactory.getLogger(PathClassifierTools.class);
+	private final static Logger logger = LoggerFactory.getLogger(PathClassifierTools.class);
 
 	// Suppress default constructor for non-instantiability
 	private PathClassifierTools() {
@@ -70,7 +75,9 @@ public final class PathClassifierTools {
 	 * Apply a classifier to the detection objects in a hierarchy.
 	 * @param hierarchy
 	 * @param classifier
+	 * @deprecated
 	 */
+	@Deprecated
 	public static void runClassifier(final PathObjectHierarchy hierarchy, final PathObjectClassifier classifier) {
 		// Apply classifier to everything
 		// If we have a TMA grid, do one core at a time
@@ -108,7 +115,9 @@ public final class PathClassifierTools {
 	 * @param pathObjects the objects containing classifications
 	 * @return a mapping between objects and their current classifications
 	 * @see #restoreClassificationsFromMap(Map)
+	 * @deprecated
 	 */
+	@Deprecated
 	public static Map<PathObject, PathClass> createClassificationMap(Collection<? extends PathObject> pathObjects) {
 		Map<PathObject, PathClass> mapPrevious = new HashMap<>();
 		for (var pathObject : pathObjects) {
@@ -123,7 +132,9 @@ public final class PathClassifierTools {
 	 * @param classificationMap the map containing objects and the classifications that should be applied
 	 * @return a collection containing all objects with classifications that were changed. This can be used to fire update events.
 	 * @see #createClassificationMap(Collection)
+	 * @deprecated
 	 */
+	@Deprecated
 	public static Collection<PathObject> restoreClassificationsFromMap(Map<PathObject, PathClass> classificationMap) {
 		var changed = new ArrayList<PathObject>();
 		for (var entry : classificationMap.entrySet()) {
@@ -169,7 +180,9 @@ public final class PathClassifierTools {
 	 * Load a classifier that has previously been serialized to a file.
 	 * @param file
 	 * @return
+	 * @deprecated
 	 */
+	@Deprecated
 	public static PathObjectClassifier loadClassifier(File file) {
 		// TODO: Put this into another method
 		PathObjectClassifier classifier = null;

--- a/qupath-core/src/main/java/qupath/lib/classifiers/PathIntensityClassifier.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/PathIntensityClassifier.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import qupath.lib.classifiers.object.ObjectClassifier;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.classes.PathClassFactory;
@@ -43,8 +44,11 @@ import qupath.lib.objects.PathObject;
  * after applying another classifier to distinguish cell types.
  * 
  * @author Pete Bankhead
- *
+ * 
+ * @deprecated Superinterface replaced by {@link ObjectClassifier}, which has different behavior regarding intensity (sub)classes.
+ *             This class is scheduled for removal in the next QuPath release.
  */
+@Deprecated
 class PathIntensityClassifier implements Serializable, PathObjectClassifier {
 	
 	private static final long serialVersionUID = 1L;

--- a/qupath-core/src/main/java/qupath/lib/classifiers/PathObjectClassifier.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/PathObjectClassifier.java
@@ -27,15 +27,18 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import qupath.lib.classifiers.object.ObjectClassifier;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.classes.PathClass;
 
 /**
- * Interface to define a basic object classifier.
+ * Legacy interface to define a basic object classifier.
  * 
  * @author Pete Bankhead
- *
+ * @deprecated Replaced by {@link ObjectClassifier}.
+ *             This class is scheduled for removal in the next QuPath release.
  */
+@Deprecated
 public interface PathObjectClassifier {
 
 	/**

--- a/qupath-core/src/main/java/qupath/lib/classifiers/package-info.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/package-info.java
@@ -1,7 +1,10 @@
 /**
  * Classes and interfaces to support machine learning classifiers.
  * <p>
- * The aim is to help  support new, custom implementations for (almost) any kind of 
- * classifier in QuPath - possibly backed by different machine learning libraries.
+ * Most classes directly in this package are scheduled for removal in the next QuPath release, 
+ * this these refer to specific object classifier implementations that are no longer the default since 
+ * QuPath v0.2.
+ * Most of their functionality has been replaced by the {@link qupath.lib.classifiers.object} subpackage.
+ * <p>
  */
 package qupath.lib.classifiers;

--- a/qupath-core/src/main/java/qupath/lib/io/PathIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathIO.java
@@ -1048,8 +1048,9 @@ public class PathIO {
 
 			// Accept from QuPath lib packages
 			// TODO: Perform stricter check (and/or update for modularization)
+			// Can increase to qupath.lib after PathObjectClassifier deprecated
 			String packageName = serialClass.getPackageName();
-			if (packageName != null && packageName.startsWith("qupath.lib"))
+			if (packageName != null && packageName.startsWith("qupath."))
 				return true;
 		}
 		System.err.println(serialClass);

--- a/qupath-core/src/main/java/qupath/lib/io/PathIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathIO.java
@@ -33,6 +33,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.ObjectInputFilter;
+import java.io.ObjectInputFilter.FilterInfo;
+import java.io.ObjectInputFilter.Status;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
@@ -91,7 +94,7 @@ import qupath.lib.roi.GeometryTools;
  */
 public class PathIO {
 	
-	final private static Logger logger = LoggerFactory.getLogger(PathIO.class);
+	private final static Logger logger = LoggerFactory.getLogger(PathIO.class);
 	
 	/**
 	 * Data file version identifier, written within the .qpdata file.
@@ -101,6 +104,21 @@ public class PathIO {
 	 * Version 4 stores PathObject UUIDs as a separate field
 	 */
 	private final static int DATA_FILE_VERSION = 3;
+	
+	/**
+	 * Input filter for deserialization that is limited to QuPath-related classes.
+	 */
+	private final static ObjectInputFilter QUPATH_INPUT_FILTER = PathIO::qupathInputFilter;
+	// Less restrictive ObjectInputFilter
+//	private final static ObjectInputFilter CLASS_LOADER_INPUT_FILTER = PathIO::classLoaderInputFilter;
+	
+//	static {
+//		/**
+//		 * TODO: Consider setting global filter.
+//		 * However note that this then impacts scripts and extensions, so could become restrictive.
+//		 */
+//		ObjectInputFilter.Config.setSerialFilter(OBJECT_INPUT_FILTER);
+//	}
 	
 	private PathIO() {}
 	
@@ -166,7 +184,8 @@ public class PathIO {
 	public static String readSerializedServerPath(final File file) throws FileNotFoundException, IOException, ClassNotFoundException {
 		String serverPath = null;
 		try (FileInputStream fileIn = new FileInputStream(file)) {
-			ObjectInputStream inStream = new ObjectInputStream(new BufferedInputStream(fileIn));
+			ObjectInputStream inStream = createObjectInputStream(new BufferedInputStream(fileIn));
+			
 			// Check the first line, then read the server path if it is valid
 			String firstLine = inStream.readUTF();
 			if (firstLine.startsWith("Data file version")) {
@@ -187,7 +206,8 @@ public class PathIO {
 	 */
 	public static <T> ServerBuilder<T> extractServerBuilder(Path file) throws IOException {
 		try (InputStream fileIn = Files.newInputStream(file)) {
-			ObjectInputStream inStream = new ObjectInputStream(new BufferedInputStream(fileIn));
+			ObjectInputStream inStream = createObjectInputStream(new BufferedInputStream(fileIn));
+			
 			// Check the first line, then read the server path if it is valid
 			String firstLine = inStream.readUTF();
 			if (firstLine.startsWith("Data file version")) {
@@ -200,6 +220,20 @@ public class PathIO {
 		} catch (IOException e) {
 			throw e;
 		}
+	}
+	
+	
+	/**
+	 * Create a new {@link ObjectInputStream}, setting the default {@link ObjectInputFilter} for QuPath-related 
+	 * and core Java classes only.
+	 * @param stream
+	 * @return
+	 * @throws IOException
+	 */
+	public final static ObjectInputStream createObjectInputStream(InputStream stream) throws IOException {
+		ObjectInputStream inStream = new ObjectInputStream(stream);
+		inStream.setObjectInputFilter(QUPATH_INPUT_FILTER);
+		return inStream;
 	}
 	
 	
@@ -281,7 +315,8 @@ public class PathIO {
 		Locale locale = Locale.getDefault(Category.FORMAT);
 		boolean localeChanged = false;
 
-		try (ObjectInputStream inStream = new ObjectInputStream(new BufferedInputStream(stream))) {
+		try (ObjectInputStream inStream = createObjectInputStream(new BufferedInputStream(stream))) {
+			
 			ServerBuilder<T> serverBuilder = null;
 			PathObjectHierarchy hierarchy = null;
 			ImageData.ImageType imageType = null;
@@ -589,7 +624,7 @@ public class PathIO {
 			// Write any remaining (serializable) properties
 			Map<String, Object> map = new HashMap<>();
 			for (Entry<String, Object> entry : imageData.getProperties().entrySet()) {
-				if (entry.getValue() instanceof Serializable)
+				if (serializableObject(entry.getValue()))
 					map.put(entry.getKey(), entry.getValue());
 				else
 					logger.warn("Property not serializable and will not be saved!  Key: " + entry.getKey() + ", Value: " + entry.getValue());
@@ -647,7 +682,8 @@ public class PathIO {
 		Locale locale = Locale.getDefault(Category.FORMAT);
 		boolean localeChanged = false;
 
-		try (ObjectInputStream inStream = new ObjectInputStream(new BufferedInputStream(fileIn))) {
+		try (ObjectInputStream inStream = createObjectInputStream(new BufferedInputStream(fileIn))) {
+			
 			if (!inStream.readUTF().startsWith("Data file version")) {
 				logger.error("Input stream is not from a valid QuPath data file!");
 			}
@@ -985,34 +1021,60 @@ public class PathIO {
 			return Collections.singleton(ext);
 		}
 	}
-			
 	
-//	private static boolean serializePathObject(File file, PathObject pathObject) {
-//		boolean success = false;
-//		if (file == null)
-//			return false;
-//		BufferedOutputStream outputStream = null;
-//		try {
-//			logger.info("Writing {}", pathObject);
-//			FileOutputStream fileOutMain = new FileOutputStream(file);
-//			outputStream = new BufferedOutputStream(fileOutMain);
-//			ObjectOutputStream outStream = new ObjectOutputStream(outputStream);
-//			outStream.writeObject(pathObject);
-//			outStream.close();
-//			success = true;
-//		} catch (IOException e) {
-//			e.printStackTrace();
-//		} finally {
-//			if (outputStream != null)
-//				try {
-//					outputStream.close();
-//				} catch (IOException e) {
-//					// TODO Auto-generated catch block
-//					e.printStackTrace();
-//				}
-//		}
-//		return success;
-//	}
+	private final static boolean serializableObject(Object obj) {
+		return obj == null ? true : checkQuPathSerializableClass(obj.getClass());
+	}
+	
+	/**
+	 * Check if a class is part of java.base or qupath.lib.
+	 * @param serialClass
+	 * @return
+	 */
+	private final static boolean checkQuPathSerializableClass(Class<?> serialClass) {
+		if (serialClass == null)
+			return true;
+		
+		if (!(serialClass instanceof Serializable))
+			return false;
+		
+		// Require 
+		if (checkClassLoader(serialClass)) {
+		
+			// Accept from java.base module
+			var module = serialClass.getModule();
+			if (module != null && Objects.equals(module.getName(), "java.base"))
+				return true;
+
+			// Accept from QuPath lib packages
+			// TODO: Perform stricter check (and/or update for modularization)
+			String packageName = serialClass.getPackageName();
+			if (packageName != null && packageName.startsWith("qupath.lib"))
+				return true;
+		}
+		System.err.println(serialClass);
+		return false;
+	}
+	
+	/**
+	 * Check if a class was loaded by the bootstrap, platform or system classloader.
+	 * @param serialClass
+	 * @return
+	 */
+	private final static boolean checkClassLoader(Class<?> serialClass) {
+		if (serialClass == null)
+			return true;
+		var classloader = serialClass.getClassLoader();
+		return classloader == null || classloader == ClassLoader.getPlatformClassLoader() || classloader == ClassLoader.getSystemClassLoader();
+	}
+	
+	private final static Status classLoaderInputFilter(FilterInfo filterInfo) {
+		return checkClassLoader(filterInfo.serialClass()) ? Status.ALLOWED : Status.REJECTED;
+	}
+	
+	private final static Status qupathInputFilter(FilterInfo filterInfo) {
+		return checkQuPathSerializableClass(filterInfo.serialClass()) ? Status.ALLOWED : Status.REJECTED;
+	}
 	
 	
 }

--- a/qupath-core/src/main/java/qupath/lib/projects/ResourceManager.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/ResourceManager.java
@@ -21,12 +21,7 @@
 
 package qupath.lib.projects;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -293,32 +288,34 @@ public class ResourceManager {
 	}
 
 
-	static class SerializableFileResourceManager<T extends Serializable> extends FileResourceManager<T> {
-
-		private Class<T> cls;
-		
-		SerializableFileResourceManager(Path dir, Class<T> cls) {
-			super(dir, ".serialized");
-			this.cls = cls;
-		}
-
-		@Override
-		protected T readFromFile(Path path) throws IOException {
-			try (var stream = Files.newInputStream(path)) {
-				return cls.cast(new ObjectInputStream(new BufferedInputStream(stream)).readObject());
-			} catch (ClassNotFoundException e) {
-				throw new IOException(e);
-			}
-		}
-
-		@Override
-		protected void writeToFile(Path path, T resource) throws IOException {
-			try (var stream = Files.newOutputStream(path)) {
-				new ObjectOutputStream(new BufferedOutputStream(stream)).writeObject(resource);
-			}
-		}
-		
-	}
+	// Removed v0.4.0 because unused... and don't really want to encourage further use of serialization
+	// May be reinstated if it has a proper use.
+//	static class SerializableFileResourceManager<T extends Serializable> extends FileResourceManager<T> {
+//
+//		private Class<T> cls;
+//		
+//		SerializableFileResourceManager(Path dir, Class<T> cls) {
+//			super(dir, ".serialized");
+//			this.cls = cls;
+//		}
+//
+//		@Override
+//		protected T readFromFile(Path path) throws IOException {
+//			try (var stream = Files.newInputStream(path)) {
+//				return cls.cast(new ObjectInputStream(new BufferedInputStream(stream)).readObject());
+//			} catch (ClassNotFoundException e) {
+//				throw new IOException(e);
+//			}
+//		}
+//
+//		@Override
+//		protected void writeToFile(Path path, T resource) throws IOException {
+//			try (var stream = Files.newOutputStream(path)) {
+//				new ObjectOutputStream(new BufferedOutputStream(stream)).writeObject(resource);
+//			}
+//		}
+//		
+//	}
 
 
 	static class JsonFileResourceManager<T> extends FileResourceManager<T> {

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/ClassifierBuilderPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/ClassifierBuilderPane.java
@@ -92,6 +92,7 @@ import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.dialogs.Dialogs;
 import qupath.lib.gui.dialogs.ParameterPanelFX;
 import qupath.lib.images.ImageData;
+import qupath.lib.io.PathIO;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
@@ -335,7 +336,7 @@ public class ClassifierBuilderPane<T extends PathObjectClassifier> implements Pa
 
 
 	private boolean loadRetainedObjects(final File file) {
-		try (ObjectInputStream inStream = new ObjectInputStream(new BufferedInputStream(new FileInputStream(file)))) {
+		try (ObjectInputStream inStream = PathIO.createObjectInputStream(new BufferedInputStream(new FileInputStream(file)))) {
 			Object input = inStream.readObject();
 			if (input instanceof RetainedTrainingObjects) {
 				this.retainedObjectsMap = (RetainedTrainingObjects)input;

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/ClassifierBuilderPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/ClassifierBuilderPane.java
@@ -119,7 +119,9 @@ import qupath.process.gui.ml.legacy.PathClassificationLabellingHelper.SplitType;
  * @author Pete Bankhead
  *
  * @param <T>
+ * @deprecated
  */
+@Deprecated
 public class ClassifierBuilderPane<T extends PathObjectClassifier> implements PathObjectHierarchyListener, ChangeListener<ImageData<BufferedImage>> {
 
 	private final static Logger logger = LoggerFactory.getLogger(ClassifierBuilderPane.class);

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/ConfusionMatrix.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/ConfusionMatrix.java
@@ -34,7 +34,9 @@ import java.util.function.Function;
  * @author Pete Bankhead
  * @param <T> 
  *
+ * @deprecated This class is scheduled for removal in the next QuPath release (unless it finds a new use).
  */
+@Deprecated
 class ConfusionMatrix<T> {
 
 	private List<T> classes = new ArrayList<>();

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/FeatureSelectionPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/FeatureSelectionPane.java
@@ -68,8 +68,9 @@ import qupath.lib.objects.PathObject;
  * 
  * 
  * @author Pete Bankhead
- *
+ * @deprecated This class is scheduled for removal in the next QuPath release.
  */
+@Deprecated
 class FeatureSelectionPane {
 
 	private QuPathGUI qupath;

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/LegacyDetectionClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/LegacyDetectionClassifierCommand.java
@@ -49,8 +49,9 @@ import qupath.opencv.classify.SVMClassifier;
  * Command used to create and show a suitable dialog box for interactive display of OpenCV classifiers.
  * 
  * @author Pete Bankhead
- *
+ * @deprecated This class is scheduled for removal in the next QuPath release.
  */
+@Deprecated
 public class LegacyDetectionClassifierCommand implements Runnable {
 	
 	final private static String name = "Create detection classifier";

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/PathClassificationLabellingHelper.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/PathClassificationLabellingHelper.java
@@ -53,7 +53,7 @@ import qupath.lib.roi.PointsROI;
  * 
  * @author Pete Bankhead
  *
- * @Deprecated
+ * @deprecated This class is scheduled for removal in the next QuPath release.
  */
 class PathClassificationLabellingHelper {
 	

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/PathClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/PathClassifierPane.java
@@ -54,6 +54,7 @@ import qupath.lib.plugins.workflow.RunSavedClassifierWorkflowStep;
  * 
  * @author Pete Bankhead
  *
+ * @deprecated This class is scheduled for removal in the next QuPath release.
  */
 @Deprecated
 public class PathClassifierPane {

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/PathIntensityClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/PathIntensityClassifierPane.java
@@ -74,8 +74,9 @@ import qupath.lib.plugins.parameters.ParameterList;
  * In the future, it is (tentatively) planned to address this and support ParameterChangeListeners instead.
  * 
  * @author Pete Bankhead
- *
+ * @deprecated
  */
+@Deprecated
 class PathIntensityClassifierPane implements PathObjectSelectionListener {
 	
 	final private static Logger logger = LoggerFactory.getLogger(PathIntensityClassifierPane.class);

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/RetainedTrainingObjects.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ml/legacy/RetainedTrainingObjects.java
@@ -52,8 +52,10 @@ import qupath.lib.objects.classes.PathClassFactory;
  * Within this map, objects are further separated by 'ground truth' PathClass.
  * 
  * @author Pete Bankhead
- *
+ * 
+ * @deprecated This class is scheduled for removal in the next QuPath release.
  */
+@Deprecated
 class RetainedTrainingObjects implements Externalizable {
 	
 	private static final long serialVersionUID = 1L;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -1923,7 +1923,7 @@ public class QuPathGUI {
 		if (bytes == null || bytes.length == 0)
 			return Collections.emptyList();
 		ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
-		try (ObjectInputStream in = new ObjectInputStream(stream)) {
+		try (ObjectInputStream in = PathIO.createObjectInputStream(stream)) {
 			List<PathClass> pathClassesOriginal = (List<PathClass>)in.readObject();
 			List<PathClass> pathClasses = new ArrayList<>();
 			for (PathClass pathClass : pathClassesOriginal) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/UndoRedoManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/UndoRedoManager.java
@@ -49,6 +49,7 @@ import qupath.lib.gui.viewer.QuPathViewer;
 import qupath.lib.gui.viewer.QuPathViewerListener;
 import qupath.lib.gui.viewer.QuPathViewerPlus;
 import qupath.lib.images.ImageData;
+import qupath.lib.io.PathIO;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.objects.hierarchy.events.PathObjectHierarchyEvent;
@@ -421,7 +422,7 @@ public class UndoRedoManager implements ChangeListener<QuPathViewerPlus>, QuPath
 		@SuppressWarnings("unchecked")
 		private T deserialize(byte[] bytes) {
 			try (ByteArrayInputStream stream = new ByteArrayInputStream(bytes)) {
-				ObjectInputStream in = new ObjectInputStream(stream);
+				ObjectInputStream in = PathIO.createObjectInputStream(stream);
 				return (T)in.readObject();
 			} catch (ClassNotFoundException | IOException e) {
 				logger.error("Error deserializing object", e);


### PR DESCRIPTION
* Make more PathObjectClassifier-related classes as deprecated.
* Reduce the use of Java serialization, and introduce serialization filters