### PR TITLE
Add xml support to script editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ This is a work-in-progress.
   * Added 'Replace/Next' and 'Replace all' features to Find window (https://github.com/qupath/qupath/pull/898)
   * New lines now trigger caret following (https://github.com/qupath/qupath/pull/900)
   * Proper tab handling (https://github.com/qupath/qupath/pull/902)
-  * Introduction of 'Smart Editing' (enabled through the corresponding persistent preference under 'Edit'), which supports the following features:
+  * Introduction of 'Smart Editing' (enabled through the corresponding preference under 'Edit'), which supports the following features:
     * Brace block handling (https://github.com/qupath/qupath/pull/901)
     * Smart parentheses and (double/single) quotes (https://github.com/qupath/qupath/pull/907)
     * Comment block handling (https://github.com/qupath/qupath/pull/908)
+  * New 'Edit -> Wrap lines' option
 * Improved Brightness/Contrast options, including
   * Switch between dark and light backgrounds (still experimental)
   * More consistent behavior with 'Show grayscale' option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This is a work-in-progress.
     * Brace block handling (https://github.com/qupath/qupath/pull/901)
     * Smart parentheses and (double/single) quotes (https://github.com/qupath/qupath/pull/907)
     * Comment block handling (https://github.com/qupath/qupath/pull/908)
-  * New 'Edit -> Wrap lines' option
+  * New 'Edit -> Wrap lines', 'Edit -> Replace curly quotes' and 'Edit -> Zap gremlins' options
 * Improved Brightness/Contrast options, including
   * Switch between dark and light backgrounds (still experimental)
   * More consistent behavior with 'Show grayscale' option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is a work-in-progress.
     * This aims to make it much easier to match up objects whenever some further analysis is done elsewhere (e.g. classification or clustering in Python or R)
     * See https://github.com/qupath/qupath/pull/959
 * Many script editor improvements, including:
-  * Support for writing Markdown documents
+  * Syntax highlighting for Markdown, JSON and XML documents
   * Added 'Replace/Next' and 'Replace all' features to Find window (https://github.com/qupath/qupath/pull/898)
   * New lines now trigger caret following (https://github.com/qupath/qupath/pull/900)
   * Proper tab handling (https://github.com/qupath/qupath/pull/902)

--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -862,6 +862,70 @@ public final class GeneralTools {
 	}
 	
 	/**
+	 * Remove non-printable characters from a String.
+	 * @param text
+	 * @return the modified String, or the original if no changes were made
+	 */
+	public static String zapGremlins(String text) {
+		return replaceGremlins(text, null);
+	}
+	
+	/**
+	 * Replace non-printable characters from a String with a specified replacement (may be null).
+	 * @param text
+	 * @return the modified String, or the original if no changes were made
+	 */
+	public static String replaceGremlins(String text, CharSequence replacement) {
+		var sb = new StringBuilder();
+		int skipCount = 0;
+		for (var c : text.toCharArray()) {
+			if (c != '\n' && c != '\t' && (c < 32 || c > 127)) {
+				skipCount++;
+				if (replacement != null)
+					sb.append(replacement);
+			} else
+				sb.append(c);
+		}
+		if (skipCount == 1)
+			logger.info("Zapped 1 gremlin");
+		else
+			logger.info("Zapped {} gremlins", skipCount);
+		if (skipCount > 0)
+			return sb.toString();
+		return text;
+	}
+	
+	/**
+	 * Replace different kinds of 'curly quote' in a String with straight quotes.
+	 * This is particularly useful when working with a script editor.
+	 * 
+	 * @param text
+	 * @return the modified String, or the original if no changes were made
+	 */
+	public static String replaceCurlyQuotes(String text) {
+		var sb = new StringBuilder();
+		int replacedCount = 0;
+		for (var c : text.toCharArray()) {
+			if (c == '\u2018' || c == '\u2019' || c == '\u201B' || c == '\u275B' || c == '\u275C') {
+				sb.append("'");
+				replacedCount++;
+			} else if (c == '\u201C' || c == '\u201D' || c == '\u201F' || c == '\u275D' || c == '\u275E' || c == '\u301D' || c == '\u301E') {
+				sb.append("\"");
+				replacedCount++;				
+			} else
+				sb.append(c);
+		}
+		if (replacedCount == 1)
+			logger.warn("Replaced 1 quotes");
+		else
+			logger.info("Replaced {} quotes", replacedCount);
+		if (replacedCount > 0)
+			return sb.toString();
+		return text;
+	}
+	
+	
+	/**
 	 * Helper class for smart-sorting.
 	 * @param <T>
 	 */

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/MarkdownHighlighter.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/MarkdownHighlighter.java
@@ -100,7 +100,7 @@ public class MarkdownHighlighter implements ScriptHighlighter {
 	 */
 	@Override
 	public String getBaseStyle() {
-		return "-fx-font-family: sans-serif";
+		return "-fx-font-family: sans-serif;";
 	}
 	
 	private static Parser parser = Parser.builder()

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/XmlHighlighter.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/XmlHighlighter.java
@@ -1,0 +1,179 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.scripting.highlighters;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.fxmisc.richtext.CodeArea;
+import org.fxmisc.richtext.model.StyleSpans;
+import org.fxmisc.richtext.model.StyleSpansBuilder;
+
+/**
+ * Highlighting to apply to a {@link CodeArea} for XML.
+ * <p>
+ * This is based on {@code XMLEditorDemo.java} from RichTextFX, available at 
+ * https://github.com/FXMisc/RichTextFX/blob/master/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/XMLEditorDemo.java
+ * and adapted for use in QuPath.
+ * <p>
+ * The license for RichTextFX is given below:
+ * <p><blockquote><pre>
+ *   Copyright (c) 2013-2017, Tomas Mikula and contributors
+ *   
+ *   All rights reserved.
+ *   
+ *   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *   
+ *   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *   
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *   
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+ *   IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ *   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
+ *   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
+ *   IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * </pre></blockquote>
+ * 
+ * 
+ * @author Pete Bankhead
+ * @since v0.4.0
+ */
+public class XmlHighlighter implements ScriptHighlighter {
+	
+	/**
+	 * Instance of this highlighter. Can't be final because of {@link ServiceLoader}.
+	 */
+	private static XmlHighlighter INSTANCE;
+
+	private static final Pattern XML_TAG = Pattern.compile("(?<ELEMENT>(</?\\h*)(\\w+)([^<>]*)(\\h*/?>))"
+    		+"|(?<COMMENT><!--(.|\\v)+?-->)");
+    
+    private static final Pattern ATTRIBUTES = Pattern.compile("(\\w+\\h*)(=)(\\h*\"[^\"]+\")");
+    
+    private static final int GROUP_OPEN_BRACKET = 2;
+    private static final int GROUP_ELEMENT_NAME = 3;
+    private static final int GROUP_ATTRIBUTES_SECTION = 4;
+    private static final int GROUP_CLOSE_BRACKET = 5;
+    private static final int GROUP_ATTRIBUTE_NAME = 1;
+    private static final int GROUP_EQUAL_SYMBOL = 2;
+    private static final int GROUP_ATTRIBUTE_VALUE = 3;
+    
+	
+	/**
+	 * Get the static instance of this class.
+	 * @return instance
+	 */
+	public static ScriptHighlighter getInstance() {
+		return INSTANCE;
+	}
+	
+	/**
+	 * Constructor for a JSON Highlighter. This constructor should never be 
+	 * called. Instead, use the static {@link #getInstance()} method.
+	 * <p>
+	 * Note: this has to be public for the {@link ServiceLoader} to work.
+	 */
+	public XmlHighlighter() {
+		if (INSTANCE != null)
+			throw new UnsupportedOperationException("Highlighter classes cannot be instantiated more than once!");
+		
+		// Because of ServiceLoader, have to assign INSTANCE here.
+		XmlHighlighter.INSTANCE = this;
+	}
+	
+	@Override
+	public String getLanguageName() {
+		return "XML";
+	}
+
+	@Override
+	public StyleSpans<Collection<String>> computeEditorHighlighting(String text) {
+		return computeHighlighting(text);
+	}
+
+	@Override
+	public StyleSpans<Collection<String>> computeConsoleHighlighting(String text) {
+		return ScriptHighlighter.getPlainStyling(text);
+	}
+	
+	
+	private static StyleSpans<Collection<String>> computeHighlighting(String text) {
+    	
+        Matcher matcher = XML_TAG.matcher(text);
+        int lastKwEnd = 0;
+        StyleSpansBuilder<Collection<String>> spansBuilder = new StyleSpansBuilder<>();
+        while (matcher.find()) {
+        	
+        	appendSpan(spansBuilder, null, matcher.start() - lastKwEnd);
+        	if (matcher.group("COMMENT") != null) {
+        		appendSpan(spansBuilder, "comment", matcher.end() - matcher.start());
+        	}
+        	else {
+        		if (matcher.group("ELEMENT") != null) {
+        			String attributesText = matcher.group(GROUP_ATTRIBUTES_SECTION);
+        			
+        			appendSpan(spansBuilder, "tagmark", matcher.end(GROUP_OPEN_BRACKET) - matcher.start(GROUP_OPEN_BRACKET));
+        			appendSpan(spansBuilder, "anytag", matcher.end(GROUP_ELEMENT_NAME) - matcher.end(GROUP_OPEN_BRACKET));
+
+        			if(!attributesText.isEmpty()) {
+        				
+        				lastKwEnd = 0;
+        				
+        				Matcher amatcher = ATTRIBUTES.matcher(attributesText);
+        				while (amatcher.find()) {
+        					appendSpan(spansBuilder, null, amatcher.start() - lastKwEnd);
+        					appendSpan(spansBuilder, "attribute", amatcher.end(GROUP_ATTRIBUTE_NAME) - amatcher.start(GROUP_ATTRIBUTE_NAME));
+        					appendSpan(spansBuilder, "tagmark", amatcher.end(GROUP_EQUAL_SYMBOL) - amatcher.end(GROUP_ATTRIBUTE_NAME));
+        					appendSpan(spansBuilder, "avalue", amatcher.end(GROUP_ATTRIBUTE_VALUE) - amatcher.end(GROUP_EQUAL_SYMBOL));
+        					lastKwEnd = amatcher.end();
+        				}
+        				if(attributesText.length() > lastKwEnd)
+        					appendSpan(spansBuilder, null, attributesText.length() - lastKwEnd);
+        			}
+
+        			lastKwEnd = matcher.end(GROUP_ATTRIBUTES_SECTION);
+        			
+        			appendSpan(spansBuilder, "tagmark", matcher.end(GROUP_CLOSE_BRACKET) - lastKwEnd);
+        		}
+        	}
+            lastKwEnd = matcher.end();
+        }
+        appendSpan(spansBuilder, null, text.length() - lastKwEnd);
+        return spansBuilder.create();
+    }
+	
+	private final static Collection<String> BASE_STYLE = Collections.singletonList("xml");
+	
+	private static void appendSpan(StyleSpansBuilder<Collection<String>> spansBuilder, String style, int length) {
+		if (style == null || style.isEmpty())
+			spansBuilder.add(BASE_STYLE, length);
+		else
+			spansBuilder.add(List.of("xml", style), length);
+	}
+
+}

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/CodeAreaControl.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/CodeAreaControl.java
@@ -26,6 +26,7 @@ package qupath.lib.gui.scripting.richtextfx;
 import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.CodeArea;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -172,6 +173,11 @@ public class CodeAreaControl implements ScriptEditorControl {
 	@Override
 	public void setPopup(ContextMenu menu) {
 		textArea.setContextMenu(menu);
+	}
+	
+	@Override
+	public BooleanProperty wrapTextProperty() {
+		return textArea.wrapTextProperty();
 	}
 
 	@Override

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -126,7 +126,6 @@ public class RichScriptEditor extends DefaultScriptEditor {
 	protected ScriptEditorControl getNewEditor() {
 		try {
 			CodeArea codeArea = new CustomCodeArea();
-			codeArea.setWrapText(true);
 			CodeAreaControl control = new CodeAreaControl(codeArea);
 			
 			/*

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -126,6 +126,7 @@ public class RichScriptEditor extends DefaultScriptEditor {
 	protected ScriptEditorControl getNewEditor() {
 		try {
 			CodeArea codeArea = new CustomCodeArea();
+			codeArea.setWrapText(true);
 			CodeAreaControl control = new CodeAreaControl(codeArea);
 			
 			/*
@@ -223,9 +224,6 @@ public class RichScriptEditor extends DefaultScriptEditor {
 					} else if (e.getCode() == KeyCode.BACK_SPACE) {
 						if (scriptSyntax.handleBackspace(control, smartEditing.get()) && !e.isShortcutDown() && !e.isShiftDown())
 							e.consume();
-					} else if (beautifierCodeCombination.match(e)) {
-						getCurrentTextComponent().setText(scriptSyntax.beautify(getCurrentText()));
-						e.isConsumed();
 					}
 				}
 				

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -293,11 +293,14 @@ public class RichScriptEditor extends DefaultScriptEditor {
 			// Triggered whenever the script styling changes (e.g. change of language)
 			scriptHighlighter.addListener((v, o, n) -> {
 				if (n == null) {
-					codeArea.setStyle(null);
+					codeArea.setStyle(styleBackground);
 					return;
 				}
 				String baseStyle = n.getBaseStyle();
-				codeArea.setStyle(baseStyle);
+				if (baseStyle == null || baseStyle.isBlank())
+					codeArea.setStyle(styleBackground);
+				else
+					codeArea.setStyle(styleBackground + " " + baseStyle);
 				StyleSpans<Collection<String>> changes = n.computeEditorHighlighting(codeArea.getText());
 				codeArea.setStyleSpans(0, changes);
 				codeArea.requestFocus(); // Seems necessary to trigger the update when switching between scripts
@@ -311,11 +314,14 @@ public class RichScriptEditor extends DefaultScriptEditor {
 		}
 	}
 	
+	private static String styleBackground = "-fx-background-color: -fx-control-inner-background;";
+	
+	
 	@Override
 	protected ScriptEditorControl getNewConsole() {
 		try {
 			CodeArea codeArea = new CodeArea();
-			codeArea.setStyle("-fx-background-color: -fx-control-inner-background;");
+			codeArea.setStyle(styleBackground);
 			
 			codeArea.richChanges()
 			.successionEnds(Duration.ofMillis(delayMillis))

--- a/qupath-extension-script-editor/src/main/resources/META-INF/services/qupath.lib.gui.scripting.highlighters.ScriptHighlighter
+++ b/qupath-extension-script-editor/src/main/resources/META-INF/services/qupath.lib.gui.scripting.highlighters.ScriptHighlighter
@@ -2,3 +2,4 @@ qupath.lib.gui.scripting.highlighters.PlainHighlighter
 qupath.lib.gui.scripting.highlighters.GroovyHighlighter
 qupath.lib.gui.scripting.highlighters.JsonHighlighter
 qupath.lib.gui.scripting.highlighters.MarkdownHighlighter
+qupath.lib.gui.scripting.highlighters.XmlHighlighter

--- a/qupath-extension-script-editor/src/main/resources/scripting_styles.css
+++ b/qupath-extension-script-editor/src/main/resources/scripting_styles.css
@@ -95,3 +95,22 @@
 	-fx-font-family: monospace;
 	-fx-fill: red;
 }
+
+.xml.body {
+	-fx-fill: -fx-text-inner-color;
+}
+.xml.attribute {
+	-fx-fill: royalblue;
+}
+.xml.tagmark {
+	-fx-fill: -fx-text-inner-color;
+}
+.xml.anytag {
+	-fx-fill: darkorange;
+}
+.xml.avalue {
+	-fx-fill: seagreen;
+}
+.xml.comment {
+    -fx-fill: rgb(128, 128, 128);
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -65,6 +65,7 @@ import javafx.geometry.Orientation;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
@@ -146,7 +147,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 	private ObjectProperty<ScriptTab> selectedScript = new SimpleObjectProperty<>();
 	
 	private ObjectProperty<ScriptLanguage> currentLanguage = new SimpleObjectProperty<>();
-	
+		
 	// Binding to indicate it shouldn't be possible to 'Run' any script right now
 	private BooleanBinding disableRun = runningTask.isNotNull().or(Bindings.createBooleanBinding(() -> !(currentLanguage.getValue() instanceof RunnableLanguage), currentLanguage));
 	
@@ -234,6 +235,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 	private BooleanProperty autoClearConsole = PathPrefs.createPersistentPreference("scriptingAutoClearConsole", true);
 	private BooleanProperty clearCache = PathPrefs.createPersistentPreference("scriptingClearCache", false);
 	protected BooleanProperty smartEditing = PathPrefs.createPersistentPreference("scriptingSmartEditing", true);
+	private BooleanProperty wrapTextProperty = PathPrefs.createPersistentPreference("scriptingWrapText", false);
 	
 
 	// Regex pattern used to identify whether a script should be run in the JavaFX Platform thread
@@ -366,6 +368,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 	 */
 	public void addNewScript(final String script, final ScriptLanguage language, final boolean doSelect) {
 		ScriptEditorControl editor = getNewEditor();
+		editor.wrapTextProperty().bindBidirectional(wrapTextProperty);
 		ScriptTab tab = new ScriptTab(editor, getNewConsole(), script, language);
 		
 		// Attach all listeners
@@ -403,6 +406,8 @@ public class DefaultScriptEditor implements ScriptEditor {
 		}
 		
 		ScriptEditorControl editor = getNewEditor();
+		editor.wrapTextProperty().bindBidirectional(wrapTextProperty);
+		
 		ScriptTab tab = new ScriptTab(editor, getNewConsole(), file);
 		
 		// Attach all listeners
@@ -469,7 +474,6 @@ public class DefaultScriptEditor implements ScriptEditor {
 
 	protected ScriptEditorControl getNewEditor() {
 		TextArea editor = new CustomTextArea();
-		editor.setWrapText(false);
 		editor.setFont(fontMain);
 		
 		TextAreaControl control = new TextAreaControl(editor);
@@ -532,6 +536,8 @@ public class DefaultScriptEditor implements ScriptEditor {
 		
 		menubar.getMenus().add(menuFile);
 		
+		var miWrapLines = new CheckMenuItem("Wrap lines");
+		miWrapLines.selectedProperty().bindBidirectional(wrapTextProperty);
 
 		// Edit menu
 		Menu menuEdit = new Menu("Edit");
@@ -550,7 +556,8 @@ public class DefaultScriptEditor implements ScriptEditor {
 				beautifySourceAction,
 				compressSourceAction,
 				null,
-				smartEditingAction
+				smartEditingAction,
+				miWrapLines
 				);
 //		menuEdit.setMnemonic(KeyEvent.VK_E);
 //
@@ -1351,6 +1358,9 @@ public class DefaultScriptEditor implements ScriptEditor {
 		var text = getClipboardText(escapeCharacters);
 		if (text == null)
 			return false;
+		
+		
+		
 		control.paste(text);
 		return true;
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -1619,6 +1619,11 @@ public class DefaultScriptEditor implements ScriptEditor {
 
 	@Override
 	public void showEditor() {
+		if (!Platform.isFxApplicationThread()) {
+			Platform.runLater(this::showEditor);
+			return;
+		}
+
 		if (dialog == null)
 			createDialog();
 		else {
@@ -1637,6 +1642,10 @@ public class DefaultScriptEditor implements ScriptEditor {
 
 	@Override
 	public void showScript(String name, String script) {
+		if (!Platform.isFxApplicationThread()) {
+			Platform.runLater(() -> showScript(name, script));
+			return;
+		}
 		if (dialog == null)
 			createDialog();
 		addNewScript(script, getDefaultLanguage(name), true);
@@ -1665,6 +1674,10 @@ public class DefaultScriptEditor implements ScriptEditor {
 
 	@Override
 	public void showScript(File file) {
+		if (!Platform.isFxApplicationThread()) {
+			Platform.runLater(() -> showScript(file));
+			return;
+		}
 		try {
 			if (dialog == null)
 				createDialog();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptEditorControl.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptEditorControl.java
@@ -23,6 +23,7 @@
 
 package qupath.lib.gui.scripting;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableValue;
@@ -179,6 +180,12 @@ public interface ScriptEditorControl extends TextAppendable {
 	 * @param index
 	 */
 	public void positionCaret(int index);
+	
+	/**
+	 * Request wordwrap.
+	 * @return
+	 */
+	public BooleanProperty wrapTextProperty();
 
 	/**
 	 * Request that the X and Y scrolls are adjusted to ensure the caret is visible.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/TextAreaControl.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/TextAreaControl.java
@@ -23,6 +23,7 @@
 
 package qupath.lib.gui.scripting;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableValue;
@@ -154,6 +155,11 @@ class TextAreaControl implements ScriptEditorControl {
 	@Override
 	public void selectRange(int startIdx, int endIdx) {
 		textArea.selectRange(startIdx, endIdx);
+	}
+	
+	@Override
+	public BooleanProperty wrapTextProperty() {
+		return textArea.wrapTextProperty();
 	}
 
 	@Override

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/DefaultScriptLanguage.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/DefaultScriptLanguage.java
@@ -60,7 +60,7 @@ import qupath.lib.scripting.QP;
  */
 public class DefaultScriptLanguage extends ScriptLanguage implements RunnableLanguage {
 	
-	final static private Logger logger = LoggerFactory.getLogger(DefaultScriptLanguage.class);
+	private final static Logger logger = LoggerFactory.getLogger(DefaultScriptLanguage.class);
 	
 	private ScriptSyntax syntax;
 	private ScriptAutoCompletor completor;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/GeneralCodeSyntax.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/GeneralCodeSyntax.java
@@ -75,17 +75,54 @@ abstract class GeneralCodeSyntax implements ScriptSyntax {
 	@Override
 	public void handleQuotes(final ScriptEditorControl control, boolean isDoubleQuote, final boolean smartEditing) {
 		String quotes = isDoubleQuote ? "\"" : "\'";
-		control.insertText(control.getCaretPosition(), quotes);
+		if (control.getSelection().getLength() == 0)
+			control.insertText(control.getCaretPosition(), quotes);
+		else
+			control.paste(quotes);
 		if (!smartEditing)
 			return;
 		
 		String text = control.getText();
 		var caretPos = control.getCaretPosition();
-		if (text.length() >= caretPos + 1 && text.charAt(caretPos) == quotes.charAt(0))
-			control.deleteText(caretPos, caretPos + 1);
-		else {
-			control.insertText(control.getCaretPosition(), quotes);
-			control.positionCaret(control.getCaretPosition()-1);
+		
+		// Check for triple quotes
+		if (caretPos >= 3 && text.substring(caretPos-3, caretPos).equals("\"\"\"")) {
+			// Triple quotes are awkward... the following works well for opening them, but not for closing them
+			// For now, we don't try to handle them in a smarter way
+//			int followingQuotes = 0;
+//			for (int i = caretPos; i < text.length(); i++) {
+//				if (text.charAt(i) == '"')
+//					followingQuotes++;
+//				else
+//					break;
+//			}
+//			String toInsert = null;
+//			switch (followingQuotes) {
+//			case 0:
+//				toInsert = "\"\"\"";
+//				break;
+//			case 1:
+//				toInsert = "\"\"";
+//				break;
+//			case 2:
+//				toInsert = "\"";
+//				break;
+//			case 3:
+//			default:
+//				break;
+//			}
+//			if (toInsert != null) {
+//				control.insertText(control.getCaretPosition(), toInsert);
+//				control.positionCaret(control.getCaretPosition()-toInsert.length());
+//			}
+		} else {
+			// Handle closing if we don't have triple quotes
+			if (text.length() >= caretPos + 1 && text.charAt(caretPos) == quotes.charAt(0))
+				control.deleteText(caretPos, caretPos + 1);
+			else {
+				control.insertText(control.getCaretPosition(), quotes);
+				control.positionCaret(control.getCaretPosition()-1);
+			}
 		}
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/GeneralCodeSyntax.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/GeneralCodeSyntax.java
@@ -41,7 +41,15 @@ abstract class GeneralCodeSyntax implements ScriptSyntax {
 		control.insertText(control.getCaretPosition(), "(");
 		if (!smartEditing)
 			return;
-		control.insertText(control.getCaretPosition(), ")");
+		String text = control.getText();
+		var pos = control.getCaretPosition();
+		// If the next character is a letter or digit, we don't want to close the parentheses
+		if (pos < text.length()) {
+			char nextChar = text.charAt(pos);
+			if (Character.isLetterOrDigit(nextChar))
+				return;
+		}
+		control.insertText(pos, ")");
 		control.positionCaret(control.getCaretPosition()-1);
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/JsonSyntax.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/JsonSyntax.java
@@ -42,7 +42,9 @@ class JsonSyntax extends GeneralCodeSyntax {
 	
 	private static final JsonSyntax INSTANCE = new JsonSyntax();
 	private static final Logger logger = LoggerFactory.getLogger(JsonSyntax.class);
+	
 	private static final Gson gson = GsonTools.getInstance(true);
+	private static final Gson gsonCompress = GsonTools.getInstance(false);
 	
 	// Empty constructor
 	private JsonSyntax() {}
@@ -68,4 +70,25 @@ class JsonSyntax extends GeneralCodeSyntax {
 			return text;
 		}
 	}
+	
+	@Override
+	public boolean canBeautify() {
+		return true;
+	}
+
+	@Override
+	public boolean canCompress() {
+		return true;
+	}
+	
+	@Override
+	public String compress(String text) {
+		try {
+			return gsonCompress.toJson(gsonCompress.fromJson(text, JsonElement.class));
+		} catch (JsonSyntaxException ex) {
+			logger.warn("Could not compress this JSON text", ex.getLocalizedMessage());
+			return text;
+		}
+	}
+	
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/ScriptSyntax.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/ScriptSyntax.java
@@ -119,4 +119,30 @@ public interface ScriptSyntax {
 	public default String beautify(String text) {
 		return text;
 	}
+	
+	/**
+	 * Returns {@code true} if {@link #beautify(String)} is capable of beautifying the text, {@code false} otherwise.
+	 * @return
+	 */
+	public default boolean canBeautify() {
+		return false;
+	}
+	
+	/**
+	 * Compresses the specified text by removing extra space, according to the syntax.
+	 * @param text the text to compress
+	 * @return beautified text
+	 */
+	public default String compress(String text) {
+		return text;
+	}
+	
+	/**
+	 * Returns {@code true} if {@link #compress(String)} is capable of compressing the text, {@code false} otherwise.
+	 * @return
+	 */
+	public default boolean canCompress() {
+		return false;
+	}
+	
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/XmlLanguage.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/XmlLanguage.java
@@ -1,0 +1,73 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.scripting.languages;
+
+import java.util.ServiceLoader;
+
+/**
+ * Class for representing XML in QuPath.
+ * 
+ * @author Pete Bankhead
+ * @since v0.4.0
+ */
+public class XmlLanguage extends ScriptLanguage {
+	
+	/**
+	 * Instance of this language. Can't be final because of {@link ServiceLoader}.
+	 */
+	private static XmlLanguage INSTANCE;
+	
+	/**
+	 * Constructor for XML Language. This constructor should never be 
+	 * called. Instead, use the static {@link #getInstance()} method.
+	 * <p>
+	 * Note: this has to be public for the {@link ServiceLoader} to work.
+	 */
+	public XmlLanguage() {
+		super("XML", new String[] {".xml"});
+		
+		if (INSTANCE != null)
+			throw new UnsupportedOperationException("Language classes cannot be instantiated more than once!");
+		
+		// Because of ServiceLoader, have to assign INSTANCE here.
+		XmlLanguage.INSTANCE = this;
+	}
+	
+	/**
+	 * Get the static instance of this class.
+	 * @return instance
+	 */
+	public static XmlLanguage getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	public ScriptSyntax getSyntax() {
+		return XmlSyntax.getInstance();
+	}
+
+	@Override
+	public ScriptAutoCompletor getAutoCompletor() {
+		return null;
+	}
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/XmlSyntax.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/XmlSyntax.java
@@ -1,0 +1,120 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.scripting.languages;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javafx.scene.control.IndexRange;
+import qupath.lib.gui.scripting.ScriptEditorControl;
+
+/**
+ * Class that takes care of XML syntax.
+ * 
+ * @author Pete Bankhead
+ * @since v0.4.0
+ */
+class XmlSyntax extends GeneralCodeSyntax {
+	
+	private static final XmlSyntax INSTANCE = new XmlSyntax();
+	private static final Logger logger = LoggerFactory.getLogger(XmlSyntax.class);
+	
+	// Empty constructor
+	private XmlSyntax() {}
+	
+	static XmlSyntax getInstance() {
+		return INSTANCE;
+	}
+	
+	/**
+	 * XML does not easily support line comments comments. Therefore this method does nothing.
+	 */
+	@Override
+	public void handleLineComment(final ScriptEditorControl control) {
+		// Do nothing
+		
+		String text = control.getText();
+		IndexRange range = control.getSelection();
+		boolean hasSelection = range.getLength() > 0;
+		boolean hasMultilineSelection = hasSelection && control.getSelectedText().contains("\n");
+		String textBetween = control.getSelectedText();
+		if (hasSelection && !hasMultilineSelection && !textBetween.startsWith("<!--") && !textBetween.startsWith("-->")) {
+			String newText = "<!--" + textBetween + "-->";
+			control.paste(newText);
+			control.selectRange(range.getStart(), range.getStart() + newText.length());
+		} else {
+			int startRowPos = getRowStartPosition(text, range.getStart());
+			int endRowPos = getRowEndPosition(text, range.getEnd());
+			textBetween = text.substring(startRowPos, endRowPos);
+			if (textBetween.trim().startsWith("<!--") && textBetween.trim().endsWith("-->")) {
+				// Remove comment
+				int indStart2 = textBetween.indexOf("<!--");
+				int indEnd2 = textBetween.lastIndexOf("-->");
+				endRowPos = startRowPos + indEnd2 + 3;
+				startRowPos += indStart2;
+				if (indEnd2 > indStart2 + 4) {
+					control.selectRange(startRowPos, endRowPos);
+					String newText = textBetween.substring(indStart2+4, indEnd2);
+					control.paste(newText);
+					control.selectRange(startRowPos, startRowPos + newText.length());
+				}
+			} else {
+				// Add comment
+				String newText = "<!--" + textBetween + "-->";
+				control.selectRange(startRowPos, endRowPos);
+				control.paste(newText);
+				control.selectRange(startRowPos, startRowPos + newText.length());
+//				control.positionCaret(pos + 4);
+			}
+		}	
+	}
+	
+	@Override
+	public String beautify(String text) {
+		try {
+			var transformer = TransformerFactory.newInstance().newTransformer();
+			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+			transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+			
+			var source = new StreamSource(new StringReader(text));
+			var writer = new StringWriter();
+			var result = new StreamResult(writer);
+			
+			transformer.transform(source, result);
+			
+			return result.getWriter().toString();
+		} catch (TransformerException ex) {
+			logger.warn("Could not beautify this XML", ex.getLocalizedMessage());
+			return text;
+		}
+	}
+}

--- a/qupath-gui-fx/src/main/resources/META-INF/services/qupath.lib.gui.scripting.languages.ScriptLanguage
+++ b/qupath-gui-fx/src/main/resources/META-INF/services/qupath.lib.gui.scripting.languages.ScriptLanguage
@@ -2,3 +2,4 @@ qupath.lib.gui.scripting.languages.PlainLanguage
 qupath.lib.gui.scripting.languages.GroovyLanguage
 qupath.lib.gui.scripting.languages.JsonLanguage
 qupath.lib.gui.scripting.languages.MarkdownLanguage
+qupath.lib.gui.scripting.languages.XmlLanguage


### PR DESCRIPTION
Assuming a Bio-Formats image is open, then a script like this should extract the XML for visualization in a script editor:
```groovy
def xml = getCurrentServer().dumpMetadata()
getQuPath().getScriptEditor().showScript("metadata.xml", xml)
```