### PR TITLE
Support passing arguments via a map to runPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ This is a work-in-progress.
 * Added `getCurrentImageName()` method to `QP` for scripting (https://github.com/qupath/qupath/issues/1009)
 * Code cleaned up and simplified, with older (previously deprecated) detection classifiers removed
   * `PathClassifierTools` methods have been moved to `PathObjectTools` and `ServerTools`
+* Support passing arguments via a map to `runPlugin`, rather than only a JSON-encoded String
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -1220,8 +1220,8 @@ public class QP {
 	/**
 	 * Run the specified plugin on the current {@code ImageData}.
 	 * 
-	 * @param className
-	 * @param args
+	 * @param className the full Java class name for the plugin
+	 * @param args any arguments required by the plugin (usually a JSON-encoded map)
 	 * @return
 	 * @throws InterruptedException
 	 * 
@@ -1238,9 +1238,9 @@ public class QP {
 	/**
 	 * Run the specified plugin on the specified {@code ImageData}.
 	 * 
-	 * @param className
-	 * @param imageData
-	 * @param args
+	 * @param className the full Java class name for the plugin
+	 * @param imageData the ImageData to which the plugin should be applied
+	 * @param args any arguments required by the plugin (usually a JSON-encoded map)
 	 * @return
 	 * @throws InterruptedException
 	 */
@@ -1258,6 +1258,87 @@ public class QP {
 			logger.error("Unable to run plugin " + className, e);
 			return false;
 		}
+	}
+	
+	/**
+	 * Run the specified plugin on the current {@code ImageData}, using a map for arguments.
+	 * 
+	 * @param className the full Java class name for the plugin
+	 * @param args the arguments
+	 * @return
+	 * @throws InterruptedException
+	 * 
+	 * @see #getCurrentImageData
+	 * 
+	 * @since v0.4.0
+	 * @implNote this is currently a convenience method that converts the arguments to a JSON-encoded string and calls 
+	 *           {@link #runPlugin(String, String)}
+	 */
+	public static boolean runPlugin(final String className, final Map<String, ?> args) throws InterruptedException {
+		var json = args == null ? "" : GsonTools.getInstance().toJson(args);
+		return runPlugin(className, json);
+	}
+	
+	/**
+	 * Run the specified plugin on the specified {@code ImageData}, using a map for arguments.
+	 * 
+	 * @param className the full Java class name for the plugin
+	 * @param imageData the ImageData to which the plugin should be applied
+	 * @param args the arguments
+	 * @return
+	 * @throws InterruptedException
+	 * 
+	 * @since v0.4.0
+	 * @implNote this is currently a convenience method that converts the arguments to a JSON-encoded string and calls 
+	 *           {@link #runPlugin(String, ImageData, String)}
+	 */
+	public static boolean runPlugin(final String className, final ImageData<?> imageData, final Map<String, ?> args) throws InterruptedException {
+		var json = args == null ? "" : GsonTools.getInstance().toJson(args);
+		return runPlugin(className, imageData, json);
+	}
+	
+	/**
+	 * Run the specified plugin on the current {@code ImageData}, with Groovy keyword argument support.
+	 * <p>
+	 * This reason is that this Groovy supports keyword arguments, but only if a {@link Map} is the first argument to a method.
+	 * This therefore makes it possible to change only non-default arguments with a call like this:
+	 * <pre><code>
+	 * runPlugin('qupath.imagej.detect.cells.WatershedCellDetection', cellExpansionMicrons: 3, detectionImage: "DAPI", threshold: 1.0)
+	 * </code></pre>
+	 * It is not even essential to provide the required {@code className} in the first position.
+	 * 
+	 * @param className the full Java class name for the plugin
+	 * @param args the arguments
+	 * @return
+	 * @throws InterruptedException
+	 * 
+	 * @since v0.4.0
+	 * @implNote this calls {@link #runPlugin(String, Map)}
+	 */
+	public static boolean runPlugin(final Map<String, ?> args, final String className) throws InterruptedException {
+		return runPlugin(className, args);
+	}
+
+	/**
+	 * Run the specified plugin on the specified {@code ImageData}, with Groovy keyword argument support.
+	 * <p>
+	 * This reason is that this Groovy supports keyword arguments, but only if a {@link Map} is the first argument to a method.
+	 * This therefore makes it possible to change only non-default arguments with a call like this:
+	 * <pre><code>
+	 * runPlugin('qupath.imagej.detect.cells.WatershedCellDetection', imageData, cellExpansionMicrons: 3, detectionImage: "DAPI", threshold: 1.0)
+	 * </code></pre>
+	 * It is not even essential to provide the required {@code className} in the first position.
+	 * 
+	 * @param className the full Java class name for the plugin
+	 * @param args the arguments
+	 * @return
+	 * @throws InterruptedException
+	 * 
+	 * @since v0.4.0
+	 * @implNote this calls {@link #runPlugin(String, ImageData, Map)}
+	 */
+	public static boolean runPlugin(final Map<String, ?> args, final String className, final ImageData<?> imageData) throws InterruptedException {
+		return runPlugin(className, imageData, args);
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/plugins/workflow/DefaultScriptableWorkflowStep.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/workflow/DefaultScriptableWorkflowStep.java
@@ -43,7 +43,7 @@ public class DefaultScriptableWorkflowStep implements ScriptableWorkflowStep {
 
 	/**
 	 * Constructor that takes a parameter map for display.
-	 * 
+	 * <p>
 	 * The parameter map isn't embedded in the script by default - this script that is passed should be complete.
 	 * 
 	 * @param name

--- a/qupath-core/src/main/java/qupath/lib/plugins/workflow/RunSavedClassifierWorkflowStep.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/workflow/RunSavedClassifierWorkflowStep.java
@@ -80,7 +80,7 @@ public class RunSavedClassifierWorkflowStep implements ScriptableWorkflowStep {
 	
 	@Override
 	public String getScript() {
-		return "runClassifier('" + classifierPath + "');";
+		return "runClassifier('" + classifierPath + "')";
 	}
 	
 	


### PR DESCRIPTION
This provides an alternative to needing to do awkward string concatenation when changing arguments within a script.

Instead use:
```groovy
runPlugin(className, ["someArg": value])
```

Also add runPlugin methods that take a Map as first input, which makes it possible to use Groovy keyword  arguments, e.g.

```groovy
runPlugin(className, someArg: value)
runPlugin(someArg: value, className)
```

Also remove semi-colons from the end of lines for auto-generated scripts (since they were added inconsistently), and add (private, experimental) system property within SimplePluginWorkflowStep to explore using Maps rather than Strings in auto-generated scripts.