### PR TITLE
fixed RoiTools.computeTiledROIs

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -742,7 +742,7 @@ public class RoiTools {
 													x,
 													envelope.getMinY(),
 													w + overlap*2,
-													envelope.getMaxX());
+													envelope.getMaxY());
 											if (!prepared2.intersects(col))
 												return empty;
 											else if (prepared2.covers(col))
@@ -765,13 +765,13 @@ public class RoiTools {
 
 			double y = yMin + yi * h - overlap;
 			if (rowParents != null)
-				geometryLocal = rowParents.getOrDefault(y, geometry);
+				geometryLocal = rowParents.getOrDefault(yi, geometry);
 
 			for (int xi = 0; xi < nx; xi++) {
 
 				double x = xMin + xi * w - overlap;
 				if (columnParents != null)
-					geometryLocal = columnParents.getOrDefault(x, geometry);
+					geometryLocal = columnParents.getOrDefault(xi, geometry);
 				
 				if (geometryLocal.isEmpty())
 					continue;


### PR DESCRIPTION
Noticed that byColumn option did not work (the bottom tiles would never be generated when only using prepared geometries) and that the geometryLocal was not different from geometry (because of typo in the index for row/columnParents).

Made some changes, hope they work.