### PR TITLE
Add 'Signed distances to annotations 2D'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is a work-in-progress.
     * Smart parentheses and (double/single) quotes (https://github.com/qupath/qupath/pull/907)
     * Comment block handling (https://github.com/qupath/qupath/pull/908)
   * New 'Edit -> Wrap lines', 'Edit -> Replace curly quotes' and 'Edit -> Zap gremlins' options
+* New 'Analyze -> Spatial analysis -> Signed distance to annotations 2D' command (https://github.com/qupath/qupath/issues/1032)
 * Better support for opening/importing from files containing multiple images
   * New 'Show image selector' option when adding images to a project
   * Image selector dialog has a filter to find images more easily

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -2808,9 +2808,11 @@ public class QP {
 	/**
 	 * Compute the distance for all detection object centroids to the closest annotation with each valid, not-ignored classification and add 
 	 * the result to the detection measurement list.
+	 * If the centroid falls inside an annotation, the distance is zero.
 	 * @param imageData
 	 * @param splitClassNames 
 	 * @see DistanceTools#detectionToAnnotationDistances(ImageData, boolean)
+	 * @see QP#detectionToAnnotationDistancesSigned(ImageData, boolean)
 	 */
 	public static void detectionToAnnotationDistances(ImageData<?> imageData, boolean splitClassNames) {
 		DistanceTools.detectionToAnnotationDistances(imageData, splitClassNames);
@@ -2831,11 +2833,40 @@ public class QP {
 	/**
 	 * Compute the distance for all detection object centroids to the closest annotation with each valid, not-ignored classification and add 
 	 * the result to the detection measurement list for the current ImageData.
+	 * If the centroid falls inside an annotation, the distance is zero.
 	 * @param splitClassNames 
 	 * @see DistanceTools#detectionToAnnotationDistances(ImageData, boolean)
+	 * @see QP#detectionToAnnotationDistancesSigned(boolean)
 	 */
 	public static void detectionToAnnotationDistances(boolean splitClassNames) {
 		detectionToAnnotationDistances(getCurrentImageData(), splitClassNames);
+	}
+	
+	/**
+	 * Compute the signed distance for all detection object centroids to the closest annotation with each valid, not-ignored classification and add 
+	 * the result to the detection measurement list.
+	 * If the centroid falls inside an annotation, the negative distance to the annotation boundary is used.
+	 * @param imageData
+	 * @param splitClassNames 
+	 * @see DistanceTools#detectionToAnnotationDistancesSigned(ImageData, boolean)
+	 * @see QP#detectionToAnnotationDistances(ImageData, boolean)
+	 * @since v0.4.0
+	 */
+	public static void detectionToAnnotationDistancesSigned(ImageData<?> imageData, boolean splitClassNames) {
+		DistanceTools.detectionToAnnotationDistancesSigned(imageData, splitClassNames);
+	}
+	
+	/**
+	 * Compute the signed distance for all detection object centroids to the closest annotation with each valid, not-ignored classification and add 
+	 * the result to the detection measurement list for the current ImageData.
+	 * If the centroid falls inside an annotation, the negative distance to the annotation boundary is used.
+	 * @param splitClassNames 
+	 * @see DistanceTools#detectionToAnnotationDistancesSigned(ImageData, boolean)
+	 * @see QP#detectionToAnnotationDistances(boolean)
+	 * @since v0.4.0
+	 */
+	public static void detectionToAnnotationDistancesSigned(boolean splitClassNames) {
+		detectionToAnnotationDistancesSigned(getCurrentImageData(), splitClassNames);
 	}
 
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
@@ -251,10 +251,16 @@ class Menus {
 //		@Deprecated
 //		public final Action SHAPE_FEATURES = qupath.createPluginAction("Add shape features", ShapeFeaturesPlugin.class, null);
 
-		@ActionDescription("Calculate distances between detection centroids and the closest annotation for each classification. " +
+		@ActionDescription("Calculate distances between detection centroids and the closest annotation for each classification, using zero if the centroid is inside the annotation. " +
 				"For example, this may be used to identify the distance of every cell from 'bigger' region that has been annotated (e.g. an area of tumor, a blood vessel).")
 		@ActionMenu("Spatial analysis>Distance to annotations 2D")
-		public final Action DISTANCE_TO_ANNOTATIONS = qupath.createImageDataAction(imageData -> Commands.distanceToAnnotations2D(imageData));
+		public final Action DISTANCE_TO_ANNOTATIONS = qupath.createImageDataAction(imageData -> Commands.distanceToAnnotations2D(imageData, false));
+		
+		@ActionDescription("Calculate distances between detection centroids and the closest annotation for each classification, using the negative distance to the boundary if the centroid is inside the annotation. " +
+				"For example, this may be used to identify the distance of every cell from 'bigger' region that has been annotated (e.g. an area of tumor, a blood vessel).")
+		@ActionMenu("Spatial analysis>Signed distance to annotations 2D")
+		public final Action SIGNED_DISTANCE_TO_ANNOTATIONS = qupath.createImageDataAction(imageData -> Commands.distanceToAnnotations2D(imageData, true));
+		
 		@ActionDescription("Calculate distances between detection centroids for each classification. " +
 				"For example, this may be used to identify the closest cell of a specified type.")
 		@ActionMenu("Spatial analysis>Detect centroid distances 2D")

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -1190,9 +1190,10 @@ public class Commands {
 	/**
 	 * Compute the distance between all detections and the closest annotation, for all annotation classifications.
 	 * @param imageData the image data to process
+	 * @param signedDistances if true, use signed distances
 	 */
-	public static void distanceToAnnotations2D(ImageData<?> imageData) {
-		String title = "Distance to annotations 2D";
+	public static void distanceToAnnotations2D(ImageData<?> imageData, boolean signedDistances) {
+		String title = signedDistances ? "Signed distance to annotations 2D" : "Distance to annotations 2D";
 		if (imageData == null) {
 			Dialogs.showNoImageError(title);
 			return;
@@ -1206,6 +1207,7 @@ public class Commands {
 				return;
 			}
 		}
+		
 		var result = Dialogs.showYesNoCancelDialog(title, "Split multi-part classifications?\nIf yes, each component of classifications such as \"Class1: Class2\" will be treated separately.");
 		boolean doSplit = false;
 		if (result == DialogButton.YES)
@@ -1213,11 +1215,17 @@ public class Commands {
 		else if (result != DialogButton.NO)
 			return;
 
-		
-		DistanceTools.detectionToAnnotationDistances(imageData, doSplit);
-		imageData.getHistoryWorkflow().addStep(new DefaultScriptableWorkflowStep(
-				"Distance to annotations 2D",
-				doSplit ? "detectionToAnnotationDistances(true)" : "detectionToAnnotationDistances(false)"));
+		if (signedDistances) {
+			DistanceTools.detectionToAnnotationDistancesSigned(imageData, doSplit);
+			imageData.getHistoryWorkflow().addStep(new DefaultScriptableWorkflowStep(
+					"Signed distance to annotations 2D",
+					doSplit ? "detectionToAnnotationDistancesSigned(true)" : "detectionToAnnotationDistancesSigned(false)"));
+		} else {
+			DistanceTools.detectionToAnnotationDistances(imageData, doSplit);
+			imageData.getHistoryWorkflow().addStep(new DefaultScriptableWorkflowStep(
+					"Distance to annotations 2D",
+					doSplit ? "detectionToAnnotationDistances(true)" : "detectionToAnnotationDistances(false)"));
+		}
 	}
 	
 	/**


### PR DESCRIPTION
Addresses this (frequent) feature request:
* https://github.com/qupath/qupath/issues/1032

Adds a new *Signed distances to annotations 2D* command, which should be scriptable via `QP` and `DistanceTools`.

![distances](https://user-images.githubusercontent.com/4690904/185462509-7fb60798-5bbd-4590-8ea6-fca54b40f91c.jpg)

![distances-signed](https://user-images.githubusercontent.com/4690904/185462522-878d8793-4456-4931-aa9b-9ac44f6428b1.jpg)

