### PR TITLE
Fix RoiTools.computeTiledROIs()

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -717,7 +717,7 @@ public class RoiTools {
 											var row = GeometryTools.createRectangle(
 													envelope.getMinX(),
 													y,
-													envelope.getMaxX(),
+													envelope.getMaxX() - envelope.getMinX(),
 													h + overlap*2);
 											if (!prepared2.intersects(row))
 												return empty;
@@ -742,7 +742,7 @@ public class RoiTools {
 													x,
 													envelope.getMinY(),
 													w + overlap*2,
-													envelope.getMaxX());
+													envelope.getMaxY() - envelope.getMinY());
 											if (!prepared2.intersects(col))
 												return empty;
 											else if (prepared2.covers(col))
@@ -765,16 +765,19 @@ public class RoiTools {
 
 			double y = yMin + yi * h - overlap;
 			if (rowParents != null)
-				geometryLocal = rowParents.getOrDefault(y, geometry);
+				geometryLocal = rowParents.getOrDefault(yi, geometry);
 
 			for (int xi = 0; xi < nx; xi++) {
 
 				double x = xMin + xi * w - overlap;
 				if (columnParents != null)
-					geometryLocal = columnParents.getOrDefault(x, geometry);
+					geometryLocal = columnParents.getOrDefault(xi, geometry);
 				
 				if (geometryLocal.isEmpty())
 					continue;
+				
+//				if (geometry != geometryLocal)
+//					System.err.println("Using row or column geometry!");
 				
 				// Create the tile
 				var rect = GeometryTools.createRectangle(x, y, w + overlap*2, h + overlap*2);


### PR DESCRIPTION
Thanks to @crobbins327 for pointing out the problem and solution.

Slightly modified from proposed code at https://github.com/qupath/qupath/pull/1039

Testing is somewhat convoluted. I originally (wrongly thought) that the *Create tiles* command used this method, but it doesn't. However it's used internally for plugin commands (like cell detection) - so is potentially quite important.

Testing is difficult, but a script like this can help:
```groovy
def annotation = getSelectedObject()
int s = 64
def size = qupath.lib.geom.ImmutableDimension.getInstance(s, s)
def rois = RoiTools.computeTiledROIs(annotation.getROI(), size, size, true, 0)
def newAnnotations = rois.collect {r -> PathObjects.createAnnotationObject(r)}
annotation.clearPathObjects()
annotation.addPathObjects(newAnnotations)
fireHierarchyUpdate()
```

Using a rather convoluted example, and reducing the `geometry.getNumPoints() > 1000` threshold in `RoiTools` to trigger the code, tiles were previously missing:

![wrong](https://user-images.githubusercontent.com/4690904/185470614-92ab1d77-e1d4-47da-b53a-af569900469b.png)

With the adapted code they are included:

![right](https://user-images.githubusercontent.com/4690904/185470631-3f9a4c95-cb18-49b0-ae3b-f0250cc03cfd.png)

The problem hadn't surfaced before, probably because (as @crobbins327 pointed out) the wrong key was used with the map, and so the 'optimization' of handling row/column geometries didn't do anything.

With that in mind, if this turns out to cause problems then the whole method could just be simplified and the unnecessary attempt at optimization from https://github.com/qupath/qupath/commit/a3366633851740e0d675b118b48133ce61211101 removed.

@crobbins327 could you check if the fix looks ok to you as well?