### PR TITLE
Introduce code style checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ gradle.properties
 .settings/
 .project
 .classpath
+.checkstyle
 
 # Mac
 .DS_Store

--- a/buildSrc/src/main/groovy/qupath.common-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.common-conventions.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'jacoco'
     id 'io.github.qupath.platform'
     id 'org.bytedeco.gradle-javacpp-platform'
+    id 'checkstyle'
 }
 
 repositories {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    This configuration file was written by the eclipse-cs plugin configuration editor
+-->
+<!--
+    Checkstyle-Configuration: QuPath style
+    Description: none
+-->
+<module name="Checker">
+  <property name="severity" value="warning"/>
+  <module name="TreeWalker">
+    <module name="ModifierOrder">
+      <property name="severity" value="error"/>
+    </module>
+    <module name="RedundantImport">
+      <property name="severity" value="error"/>
+    </module>
+    <module name="UnusedImports">
+      <property name="severity" value="warning"/>
+    </module>
+    <module name="IllegalImport">
+      <property name="severity" value="warning"/>
+    </module>
+  </module>
+  <module name="JavadocPackage">
+    <property name="severity" value="warning"/>
+  </module>
+</module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -27,4 +27,11 @@
   <module name="JavadocPackage">
     <property name="severity" value="warning"/>
   </module>
+  <module name="RegexpOnFilename">
+    <property name="severity" value="error"/>
+    <property name="folderPattern" value="src/test/java"/>
+    <property name="fileNamePattern" value="^Test.*"/>
+    <property name="match" value="false"/>
+    <property name="fileExtensions" value=".java"/>
+  </module>
 </module>

--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -86,7 +86,7 @@ import qupath.lib.scripting.QP;
 			}, mixinStandardHelpOptions = true, versionProvider = QuPath.VersionProvider.class)
 public class QuPath {
 	
-	private final static Logger logger = LoggerFactory.getLogger(QuPath.class);
+	private static final Logger logger = LoggerFactory.getLogger(QuPath.class);
 	
 	@Parameters(arity = "0..1", description = {"Path to image or project to open"}, hidden = true)
 	private String path;
@@ -269,12 +269,12 @@ public class QuPath {
 		"By default, this will not save changes to any data files."})
 class ScriptCommand implements Runnable {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ScriptCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(ScriptCommand.class);
 	
 	/**
 	 * Default extension for scripting (when not specified)
 	 */
-	private final static String DEFAULT_SCRIPT_EXTENSION = ".groovy";
+	private static final String DEFAULT_SCRIPT_EXTENSION = ".groovy";
 	
 	@Parameters(index = "0", description = "Path to the script file (.groovy).", arity = "0..1", paramLabel = "script")
 	private String scriptFile;

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
@@ -91,7 +91,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImage> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(SubcellularDetection.class);
+	private static final Logger logger = LoggerFactory.getLogger(SubcellularDetection.class);
 	
 	
 	@Override
@@ -491,7 +491,7 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 	@Deprecated
 	static class SubcellularObject extends PathDetectionObject {
 		
-		final private static long serialVersionUID = 1L;
+		private static final long serialVersionUID = 1L;
 		
 		static Integer color = ColorTools.packRGB(200, 200, 50);
 		

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
@@ -137,9 +137,9 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 			"maxBackground"
 	};
 
-	transient private CellDetector detector;
+	private transient CellDetector detector;
 	
-	private final static Logger logger = LoggerFactory.getLogger(WatershedCellDetection.class);
+	private static final Logger logger = LoggerFactory.getLogger(WatershedCellDetection.class);
 	
 	static String IMAGE_OPTICAL_DENSITY = "Optical density sum";
 	static String IMAGE_HEMATOXYLIN = "Hematoxylin OD";

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellMembraneDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellMembraneDetection.java
@@ -118,7 +118,7 @@ public class WatershedCellMembraneDetection extends AbstractTileableDetectionPlu
 		"cellExpansion",
 		};
 	
-	transient private CellDetector detector;
+	private transient CellDetector detector;
 	
 	static String IMAGE_OPTICAL_DENSITY = "Optical density sum";
 	static String IMAGE_HEMATOXYLIN = "Hematoxylin";
@@ -389,7 +389,7 @@ public class WatershedCellMembraneDetection extends AbstractTileableDetectionPlu
 	
 	static class WatershedCellDetector {
 		
-		final private static Logger logger = LoggerFactory.getLogger(WatershedCellDetector.class);
+		private static final Logger logger = LoggerFactory.getLogger(WatershedCellDetector.class);
 		
 		private boolean refineBoundary = true; // TODO: Consider making this variable accessible
 		

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/dearray/TMADearrayer.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/dearray/TMADearrayer.java
@@ -178,9 +178,9 @@ public class TMADearrayer {
 	
 	static class TMAGridShape {
 		
-		final public int nVertical;
-		final public int nHorizontal;
-		final public Polygon polyGrid;
+		public final int nVertical;
+		public final int nHorizontal;
+		public final Polygon polyGrid;
 		
 		private TMAGridShape(final Polygon polyGrid, final int nVertical, final int nHorizontal) {
 			this.polyGrid = polyGrid;

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/dearray/TMADearrayerPluginIJ.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/dearray/TMADearrayerPluginIJ.java
@@ -72,11 +72,11 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class TMADearrayerPluginIJ extends AbstractInteractivePlugin<BufferedImage> {
 	
-	final private static Logger logger = LoggerFactory.getLogger(TMADearrayerPluginIJ.class);
+	private static final Logger logger = LoggerFactory.getLogger(TMADearrayerPluginIJ.class);
 	
 	private ParameterList params;
 	
-	transient private Dearrayer dearrayer;
+	private transient Dearrayer dearrayer;
 	
 	/**
 	 * Default constructor.
@@ -163,7 +163,7 @@ public class TMADearrayerPluginIJ extends AbstractInteractivePlugin<BufferedImag
 	
 	static class Dearrayer implements ObjectDetector<BufferedImage> {
 		
-		final private static Logger logger = LoggerFactory.getLogger(Dearrayer.class);
+		private static final Logger logger = LoggerFactory.getLogger(Dearrayer.class);
 		
 		private ImageProcessor ip;
 		

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/PositivePixelCounterIJ.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/PositivePixelCounterIJ.java
@@ -72,9 +72,9 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class PositivePixelCounterIJ extends AbstractDetectionPlugin<BufferedImage> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(PositivePixelCounterIJ.class);
+	private static final Logger logger = LoggerFactory.getLogger(PositivePixelCounterIJ.class);
 	
-	transient private PositivePixelDetector detector;
+	private transient PositivePixelDetector detector;
 	
 	
 	static class PositivePixelDetector implements ObjectDetector<BufferedImage> {

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/SimpleTissueDetection2.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/SimpleTissueDetection2.java
@@ -89,7 +89,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class SimpleTissueDetection2 extends AbstractDetectionPlugin<BufferedImage> {
 	
-	final private static Logger logger = LoggerFactory.getLogger(SimpleTissueDetection2.class);
+	private static final Logger logger = LoggerFactory.getLogger(SimpleTissueDetection2.class);
 	
 	private ParameterList params;
 

--- a/qupath-core-processing/src/main/java/qupath/imagej/images/servers/ImageJServer.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/images/servers/ImageJServer.java
@@ -83,7 +83,7 @@ import qupath.lib.regions.RegionRequest;
  */
 public class ImageJServer extends AbstractImageServer<BufferedImage> implements PathObjectReader {
 	
-	final private static Logger logger = LoggerFactory.getLogger(ImageJServer.class);
+	private static final Logger logger = LoggerFactory.getLogger(ImageJServer.class);
 	
 	private ImageServerMetadata originalMetadata;
 	

--- a/qupath-core-processing/src/main/java/qupath/imagej/processing/MorphologicalReconstruction.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/processing/MorphologicalReconstruction.java
@@ -518,7 +518,7 @@ public class MorphologicalReconstruction {
 	
 	private static class IntDequeue {
 		
-		final private static int MAX_EXPANSION = 1024*10;
+		private static final int MAX_EXPANSION = 1024*10;
 		
 		private int[] array;
 		private int head = 0; // Points to location of first element in queue

--- a/qupath-core-processing/src/main/java/qupath/imagej/processing/Watershed.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/processing/Watershed.java
@@ -199,15 +199,15 @@ public class Watershed {
 	
 	static class WatershedQueueWrapper {
 
-		final private PriorityQueue<PixelWithValue> queue = new PriorityQueue<>();
-		final private boolean[] queued;
-		final private int width, height;
-		final private ImageProcessor ip;
+		private final PriorityQueue<PixelWithValue> queue = new PriorityQueue<>();
+		private final boolean[] queued;
+		private final int width, height;
+		private final ImageProcessor ip;
 		
 		private long counter = 0;//Long.MIN_VALUE;
 		
 		// Keep a pool of objects so they can be reused... not normally worth the effort, but we are likely to have *a lot*
-		final private ArrayDeque<PixelWithValue> dequePool;
+		private final ArrayDeque<PixelWithValue> dequePool;
 		
 		
 		public WatershedQueueWrapper(final ImageProcessor ip, final ImageProcessor ipLabels, final double minThreshold) {
@@ -302,9 +302,9 @@ public class Watershed {
 		public float value;
 		public long count;
 		
-//		final public int x, y;
-//		final public float value;
-//		final public long count;
+//		public final int x, y;
+//		public final float value;
+//		public final long count;
 		
 		public PixelWithValue(final int x, final int y, final float value, final long count) {
 			this.x = x;

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
@@ -105,7 +105,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class IJTools {
 	
-	final private static Logger logger = LoggerFactory.getLogger(IJTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(IJTools.class);
 	
 	private static List<String> micronList = Arrays.asList("micron", "microns", "um", GeneralTools.micrometerSymbol());
 	

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/PathImagePlus.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/PathImagePlus.java
@@ -42,9 +42,9 @@ import qupath.lib.regions.RegionRequest;
  */
 class PathImagePlus implements PathImage<ImagePlus> {
 	
-	final private static Logger logger = LoggerFactory.getLogger(PathImagePlus.class);
+	private static final Logger logger = LoggerFactory.getLogger(PathImagePlus.class);
 	
-	transient private ImagePlus imp = null;
+	private transient ImagePlus imp = null;
 	private RegionRequest request;
 	
 	private PixelCalibration calibration;

--- a/qupath-core-processing/src/main/java/qupath/lib/algorithms/HaralickFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/algorithms/HaralickFeaturesPlugin.java
@@ -75,7 +75,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class HaralickFeaturesPlugin extends AbstractInteractivePlugin<BufferedImage> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(HaralickFeaturesPlugin.class);
+	private static final Logger logger = LoggerFactory.getLogger(HaralickFeaturesPlugin.class);
 	
 	private ParameterList params;
 	

--- a/qupath-core-processing/src/main/java/qupath/lib/algorithms/IntensityFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/algorithms/IntensityFeaturesPlugin.java
@@ -83,7 +83,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class IntensityFeaturesPlugin extends AbstractInteractivePlugin<BufferedImage> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(IntensityFeaturesPlugin.class);
+	private static final Logger logger = LoggerFactory.getLogger(IntensityFeaturesPlugin.class);
 	
 	private boolean parametersInitialized = false;
 	

--- a/qupath-core-processing/src/main/java/qupath/lib/analysis/algorithms/EstimateStainVectors.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/analysis/algorithms/EstimateStainVectors.java
@@ -54,7 +54,7 @@ import qupath.lib.common.ColorTools;
  */
 public class EstimateStainVectors {
 	
-	final private static Logger logger = LoggerFactory.getLogger(EstimateStainVectors.class);
+	private static final Logger logger = LoggerFactory.getLogger(EstimateStainVectors.class);
 	
 	/**
 	 * Estimate two stains from a BufferedImage, with default parameter settings.

--- a/qupath-core-processing/src/main/java/qupath/lib/analysis/algorithms/Watershed.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/analysis/algorithms/Watershed.java
@@ -41,7 +41,7 @@ import qupath.lib.analysis.images.SimpleModifiableImage;
  */
 public class Watershed {
 	
-	final private static Logger logger = LoggerFactory.getLogger(Watershed.class);
+	private static final Logger logger = LoggerFactory.getLogger(Watershed.class);
 	
 	/**
 	 * Apply a 2D watershed transform.
@@ -177,7 +177,7 @@ public class Watershed {
 		queue.add(x+1, y+1);
 	}
 	
-	private final static class WatershedQueueWrapper {
+	private static final class WatershedQueueWrapper {
 
 		private PriorityQueue<PixelWithValue> queue = new PriorityQueue<>();
 		private boolean[] queued = null;
@@ -252,7 +252,7 @@ public class Watershed {
 	}
 
 
-	private final static class PixelWithValue implements Comparable<PixelWithValue> {
+	private static final class PixelWithValue implements Comparable<PixelWithValue> {
 		
 		public int x, y;
 		public float value;

--- a/qupath-core-processing/src/main/java/qupath/lib/analysis/features/HaralickFeatures.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/analysis/features/HaralickFeatures.java
@@ -36,15 +36,15 @@ public class HaralickFeatures {
 	/**
 	 * Value of {@code Math.log(2)} (natural logarithm).
 	 */
-	private final static double LOG2 = Math.log(2);
+	private static final double LOG2 = Math.log(2);
 	// Add a small constant to avoid log of zero
-//	public final static double eps = 0.0000001;
+//	public static final double eps = 0.0000001;
 	
 	private CoocMatrix matrix;
 	
 	private double[] f = new double[13];
 	
-	private final static String[] FEATURE_NAMES = new String[]{
+	private static final String[] FEATURE_NAMES = new String[]{
 		"Angular second moment",
 		"Contrast",
 		"Correlation",

--- a/qupath-core-processing/src/main/java/qupath/lib/analysis/features/ObjectMeasurements.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/analysis/features/ObjectMeasurements.java
@@ -73,7 +73,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class ObjectMeasurements {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ObjectMeasurements.class);
+	private static final Logger logger = LoggerFactory.getLogger(ObjectMeasurements.class);
 	
 	/**
 	 * Cell compartments.
@@ -170,7 +170,7 @@ public class ObjectMeasurements {
 	}
 	
 	
-	private final static Collection<ShapeFeatures> ALL_SHAPE_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ShapeFeatures.values())));
+	private static final Collection<ShapeFeatures> ALL_SHAPE_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ShapeFeatures.values())));
 	
 	/**
 	 * Add shape measurements for one object. If this is a cell, measurements will be made for both the 

--- a/qupath-core-processing/src/main/java/qupath/lib/analysis/heatmaps/DensityMaps.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/analysis/heatmaps/DensityMaps.java
@@ -90,12 +90,12 @@ import qupath.opencv.ml.pixel.PixelClassifierTools.CreateObjectOptions;
  */
 public class DensityMaps {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DensityMaps.class);
+	private static final Logger logger = LoggerFactory.getLogger(DensityMaps.class);
 	
 	/**
 	 * Channel name for the channel with all object counts (not always present).
 	 */
-	public final static String CHANNEL_ALL_OBJECTS = "Counts";
+	public static final String CHANNEL_ALL_OBJECTS = "Counts";
 	
 	private static int preferredTileSize = 2048;
 	

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/FindConvexHullDetectionsPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/FindConvexHullDetectionsPlugin.java
@@ -57,7 +57,7 @@ import qupath.lib.roi.ConvexHull;
  */
 public class FindConvexHullDetectionsPlugin<T> extends AbstractInteractivePlugin<T> {
 	
-	private final static String commandName = "Find convex hull detections (TMA)";
+	private static final String commandName = "Find convex hull detections (TMA)";
 	
 	private transient AtomicInteger nObjectsRemoved = new AtomicInteger();
 	

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/ShapeFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/ShapeFeaturesPlugin.java
@@ -55,7 +55,7 @@ public class ShapeFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 	
 	private ParameterList params;
 	
-	final private static Logger logger = LoggerFactory.getLogger(ShapeFeaturesPlugin.class);
+	private static final Logger logger = LoggerFactory.getLogger(ShapeFeaturesPlugin.class);
 	
 	/**
 	 * Constructor.

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
@@ -65,7 +65,7 @@ public class SmoothFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 	
 	private ParameterList params;
 	
-	final private static Logger logger = LoggerFactory.getLogger(SmoothFeaturesPlugin.class);
+	private static final Logger logger = LoggerFactory.getLogger(SmoothFeaturesPlugin.class);
 	
 	/**
 	 * Default constructor.

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -154,7 +154,7 @@ import qupath.opencv.tools.OpenCVTools;
  */
 public class QP {
 	
-	final private static Logger logger = LoggerFactory.getLogger(QP.class);
+	private static final Logger logger = LoggerFactory.getLogger(QP.class);
 	
 	/**
 	 * Brightfield image type with hematoxylin and DAB staining
@@ -232,7 +232,7 @@ public class QP {
 	}
 
 	
-	private final static Set<Class<?>> CORE_CLASSES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+	private static final Set<Class<?>> CORE_CLASSES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
 			// Core datastructures
 			ImageData.class,
 			ImageServer.class,

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -159,27 +159,27 @@ public class QP {
 	/**
 	 * Brightfield image type with hematoxylin and DAB staining
 	 */
-	final public static ImageData.ImageType BRIGHTFIELD_H_DAB = ImageData.ImageType.BRIGHTFIELD_H_DAB;
+	public static final ImageData.ImageType BRIGHTFIELD_H_DAB = ImageData.ImageType.BRIGHTFIELD_H_DAB;
 	
 	/**
 	 * Brightfield image type with hematoxylin and eosin staining
 	 */
-	final public static ImageData.ImageType BRIGHTFIELD_H_E = ImageData.ImageType.BRIGHTFIELD_H_E;
+	public static final ImageData.ImageType BRIGHTFIELD_H_E = ImageData.ImageType.BRIGHTFIELD_H_E;
 	
 	/**
 	 * Brightfield image type
 	 */
-	final public static ImageData.ImageType BRIGHTFIELD_OTHER = ImageData.ImageType.BRIGHTFIELD_OTHER;
+	public static final ImageData.ImageType BRIGHTFIELD_OTHER = ImageData.ImageType.BRIGHTFIELD_OTHER;
 	
 	/**
 	 * Fluorescence image type
 	 */
-	final public static ImageData.ImageType FLUORESCENCE = ImageData.ImageType.FLUORESCENCE;
+	public static final ImageData.ImageType FLUORESCENCE = ImageData.ImageType.FLUORESCENCE;
 	
 	/**
 	 * Any other image type (neither brightfield nor fluorescence)
 	 */
-	final public static ImageData.ImageType OTHER = ImageData.ImageType.OTHER;
+	public static final ImageData.ImageType OTHER = ImageData.ImageType.OTHER;
 	
 	/**
 	 * Store ImageData accessible to the script thread
@@ -198,7 +198,7 @@ public class QP {
 	 *   var path = buildFilePath(PROJECT_BASE_DIR, 'subdir', 'name.txt')
 	 * </pre>
 	 */
-	final public static String PROJECT_BASE_DIR = "{%PROJECT}";
+	public static final String PROJECT_BASE_DIR = "{%PROJECT}";
 	
 	
 	/**

--- a/qupath-core-processing/src/main/java/qupath/opencv/DetectCytokeratinCV.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/DetectCytokeratinCV.java
@@ -74,9 +74,9 @@ import qupath.opencv.tools.OpenCVTools;
  */
 public class DetectCytokeratinCV extends AbstractDetectionPlugin<BufferedImage> {
 
-	private final static Logger logger = LoggerFactory.getLogger(DetectCytokeratinCV.class);
+	private static final Logger logger = LoggerFactory.getLogger(DetectCytokeratinCV.class);
 
-	transient private CytokeratinDetector detector;
+	private transient CytokeratinDetector detector;
 
 
 	static class CytokeratinDetector implements ObjectDetector<BufferedImage> {
@@ -84,8 +84,8 @@ public class DetectCytokeratinCV extends AbstractDetectionPlugin<BufferedImage> 
 		// TODO: REQUEST DOWNSAMPLE IN PLUGINS
 		private List< PathObject> pathObjects = new ArrayList<>();
 
-		transient private RegionRequest lastRequest = null;
-		transient private BufferedImage img = null;
+		private transient RegionRequest lastRequest = null;
+		private transient BufferedImage img = null;
 		
 		private String lastResultsDescription = null;
 

--- a/qupath-core-processing/src/main/java/qupath/opencv/WatershedNucleiCV.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/WatershedNucleiCV.java
@@ -86,7 +86,7 @@ public class WatershedNucleiCV extends AbstractTileableDetectionPlugin<BufferedI
 
 	private static Logger logger = LoggerFactory.getLogger(WatershedNucleiCV.class);
 
-	transient private WatershedNuclei detector;
+	private transient WatershedNuclei detector;
 
 
 	class WatershedNuclei implements ObjectDetector<BufferedImage> {

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DefaultDnnModel.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DefaultDnnModel.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 class DefaultDnnModel<T> implements DnnModel<T> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DefaultDnnModel.class);
+	private static final Logger logger = LoggerFactory.getLogger(DefaultDnnModel.class);
 	
 	private static final Set<String> DEFAULT_NAMES = Set.of(DEFAULT_INPUT_NAME, DEFAULT_OUTPUT_NAME);
 	

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnObjectClassifier.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnObjectClassifier.java
@@ -62,7 +62,7 @@ import qupath.lib.objects.classes.PathClass;
  */
 public class DnnObjectClassifier<T> extends AbstractObjectClassifier<BufferedImage> implements UriResource {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DnnObjectClassifier.class);
+	private static final Logger logger = LoggerFactory.getLogger(DnnObjectClassifier.class);
 	
 	private DnnModel<T> model;
 	private List<PathClass> pathClasses;

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnTools.java
@@ -81,16 +81,16 @@ import qupath.opencv.tools.OpenCVTools;
  */
 public class DnnTools {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DnnTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(DnnTools.class);
 	
 	@SuppressWarnings("rawtypes")
-	private final static SubTypeAdapterFactory<DnnModel> dnnAdapter;
+	private static final SubTypeAdapterFactory<DnnModel> dnnAdapter;
 	
 	@SuppressWarnings("rawtypes")
-	private final static SubTypeAdapterFactory<BlobFunction> blobAdapter;
+	private static final SubTypeAdapterFactory<BlobFunction> blobAdapter;
 	
 	@SuppressWarnings("rawtypes")
-	private final static SubTypeAdapterFactory<PredictionFunction> predictionAdapter;
+	private static final SubTypeAdapterFactory<PredictionFunction> predictionAdapter;
 	
 	static {
 		

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVModelObjectClassifier.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVModelObjectClassifier.java
@@ -56,7 +56,7 @@ import qupath.opencv.dnn.OpenCVDnn.ModelType;
  */
 public class OpenCVModelObjectClassifier extends AbstractObjectClassifier<BufferedImage> implements UriResource {
 	
-	private final static Logger logger = LoggerFactory.getLogger(OpenCVModelObjectClassifier.class);
+	private static final Logger logger = LoggerFactory.getLogger(OpenCVModelObjectClassifier.class);
 	
 	private OpenCVDnn model;
 	private List<PathClass> pathClasses;

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/PredictionFunction.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/PredictionFunction.java
@@ -47,12 +47,12 @@ public interface PredictionFunction<T> {
 	/**
 	 * Default name to use for single input.
 	 */
-	public final static String DEFAULT_INPUT_NAME = "input";
+	public static final String DEFAULT_INPUT_NAME = "input";
 	
 	/**
 	 * Default name to use for single output.
 	 */
-	public final static String DEFAULT_OUTPUT_NAME = "output";
+	public static final String DEFAULT_OUTPUT_NAME = "output";
 	
 	/**
 	 * Call a function that takes one or more inputs to produce zero or more outputs.

--- a/qupath-core-processing/src/main/java/qupath/opencv/features/DelaunayClusteringPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/features/DelaunayClusteringPlugin.java
@@ -62,7 +62,7 @@ import qupath.lib.plugins.parameters.ParameterList;
  */
 public class DelaunayClusteringPlugin<T> extends AbstractInteractivePlugin<T> {
 
-	private final static Logger logger = LoggerFactory.getLogger(DelaunayClusteringPlugin.class);
+	private static final Logger logger = LoggerFactory.getLogger(DelaunayClusteringPlugin.class);
 	
 	/**
 	 * Constructor.

--- a/qupath-core-processing/src/main/java/qupath/opencv/features/DelaunayTriangulation.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/features/DelaunayTriangulation.java
@@ -62,7 +62,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class DelaunayTriangulation implements PathObjectConnectionGroup {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DelaunayTriangulation.class);
+	private static final Logger logger = LoggerFactory.getLogger(DelaunayTriangulation.class);
 	
 	private double distanceThreshold = Double.NaN;
 	private boolean limitByClass = false;

--- a/qupath-core-processing/src/main/java/qupath/opencv/io/OpenCVTypeAdapters.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/io/OpenCVTypeAdapters.java
@@ -182,7 +182,7 @@ public class OpenCVTypeAdapters {
 	 * TypeAdapter that helps include OpenCV-based objects within a Java object being serialized to JSON.
 	 * @param <T> 
 	 */
-	public static abstract class OpenCVTypeAdapter<T> extends TypeAdapter<T> {
+	public abstract static class OpenCVTypeAdapter<T> extends TypeAdapter<T> {
 		
 		Gson gson = new GsonBuilder().setLenient().create();
 

--- a/qupath-core-processing/src/main/java/qupath/opencv/io/package-info.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/io/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Support for serializing and deserializing OpenCV objects.
+ */
+package qupath.opencv.io;

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/OpenCVClassifiers.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/OpenCVClassifiers.java
@@ -164,7 +164,7 @@ public class OpenCVClassifiers {
 	 * parameters can be set.
 	 */
 	@JsonAdapter(OpenCVClassifierTypeAdapter.class)
-	public static abstract class OpenCVStatModel {
+	public abstract static class OpenCVStatModel {
 		
 		/**
 		 * Classifier can handle missing (NaN) values
@@ -276,7 +276,7 @@ public class OpenCVClassifiers {
 	
 	
 	
-	static abstract class AbstractOpenCVClassifierML<T extends StatModel> extends OpenCVStatModel {
+	abstract static class AbstractOpenCVClassifierML<T extends StatModel> extends OpenCVStatModel {
 
 		@JsonAdapter(OpenCVTypeAdapters.OpenCVTypeAdaptorFactory.class)
 		private T model;
@@ -586,7 +586,7 @@ public class OpenCVClassifiers {
 		
 	}
 	
-	static abstract class AbstractTreeClassifier<T extends DTrees> extends AbstractOpenCVClassifierML<T> {
+	abstract static class AbstractTreeClassifier<T extends DTrees> extends AbstractOpenCVClassifierML<T> {
 
 		AbstractTreeClassifier() {
 			super();

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/OpenCVMLClassifier.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/OpenCVMLClassifier.java
@@ -60,7 +60,7 @@ import qupath.opencv.ml.OpenCVClassifiers.OpenCVStatModel;
  */
 public class OpenCVMLClassifier<T> extends AbstractObjectClassifier<T> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(OpenCVMLClassifier.class);
+	private static final Logger logger = LoggerFactory.getLogger(OpenCVMLClassifier.class);
 	
 	/**
 	 * Extract features from objects

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/features/FeatureExtractors.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/features/FeatureExtractors.java
@@ -49,7 +49,7 @@ public class FeatureExtractors {
 		
 		private static String typeName = "feature_extractor_type";
 		
-		private final static SubTypeAdapterFactory<FeatureExtractor> featureCalculatorTypeAdapter = 
+		private static final SubTypeAdapterFactory<FeatureExtractor> featureCalculatorTypeAdapter = 
 				GsonTools.createSubTypeAdapterFactory(FeatureExtractor.class, typeName)
 					.registerSubtype(DefaultFeatureExtractor.class)
 					.registerSubtype(NormalizedFeatureExtractor.class)
@@ -66,7 +66,7 @@ public class FeatureExtractors {
 		
 	}
 	
-	private final static TypeAdapterFactory factory = new FeatureExtractorTypeAdapterFactory();
+	private static final TypeAdapterFactory factory = new FeatureExtractorTypeAdapterFactory();
 	
 	/**
 	 * Get the {@link TypeAdapterFactory} default used for {@link FeatureExtractor} objects.

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifiers.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifiers.java
@@ -69,12 +69,12 @@ public class PixelClassifiers {
 		
 		private static String typeName = "pixel_classifier_type";
 		
-		private final static SubTypeAdapterFactory<PixelClassifier> pixelClassifierTypeAdapter = 
+		private static final SubTypeAdapterFactory<PixelClassifier> pixelClassifierTypeAdapter = 
 				GsonTools.createSubTypeAdapterFactory(PixelClassifier.class, typeName)
 				.registerSubtype(OpenCVPixelClassifier.class)
 				.registerSubtype(ThresholdPixelClassifier.class);
 		
-		private final static TypeAdapterFactory classifierFunctionTypeAdapter = GsonTools.createSubTypeAdapterFactory(ClassifierFunction.class, "classifier_function")
+		private static final TypeAdapterFactory classifierFunctionTypeAdapter = GsonTools.createSubTypeAdapterFactory(ClassifierFunction.class, "classifier_function")
 				.registerSubtype(ClassifierGreaterEquals.class)
 				.registerSubtype(ClassifierGreater.class)
 				.registerSubtype(MultiThresholdClassifierFunction.class);
@@ -99,7 +99,7 @@ public class PixelClassifiers {
 		
 	}
 	
-	private final static TypeAdapterFactory factory = new PixelClassifierTypeAdapterFactory();
+	private static final TypeAdapterFactory factory = new PixelClassifierTypeAdapterFactory();
 		
 	/**
 	 * Get the {@link TypeAdapterFactory} default used for {@link PixelClassifier} objects.

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifiers.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifiers.java
@@ -220,7 +220,7 @@ static class ThresholdClassifierBuilder {
 		
 	}
 	
-	static abstract class SingleThresholdClassifierFunction implements ClassifierFunction {
+	abstract static class SingleThresholdClassifierFunction implements ClassifierFunction {
 		
 		private int band;
 		protected float threshold;

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOpServer.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOpServer.java
@@ -46,7 +46,7 @@ import qupath.opencv.tools.OpenCVTools;
  */
 class ImageOpServer extends AbstractTileableImageServer implements ImageDataServer<BufferedImage> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ImageOpServer.class);
+	private static final Logger logger = LoggerFactory.getLogger(ImageOpServer.class);
 	
 	private ImageData<BufferedImage> imageData;
 	private ImageDataOp dataOp;

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -1078,7 +1078,7 @@ public class ImageOps {
 			
 		}
 		
-		static abstract class MorphOp extends PaddedOp {
+		abstract static class MorphOp extends PaddedOp {
 			
 			private int radius;
 			private transient Mat kernel;
@@ -1577,7 +1577,7 @@ public class ImageOps {
 			
 		}
 		
-		static abstract class ReduceChannelsOp implements ImageOp {
+		abstract static class ReduceChannelsOp implements ImageOp {
 
 			@Override
 			public Mat apply(Mat input) {
@@ -1701,7 +1701,7 @@ public class ImageOps {
 			return new MedianAbsDevThresholdOp(k);
 		}
 		
-		static abstract class AbstractThresholdOp implements ImageOp {
+		abstract static class AbstractThresholdOp implements ImageOp {
 			
 			@Override
 			public Mat apply(Mat input) {
@@ -3027,7 +3027,7 @@ public class ImageOps {
 	/**
 	 * Abstract {@link ImageOp} to simplify the process of handling padding.
 	 */
-	public static abstract class PaddedOp implements ImageOp {
+	public abstract static class PaddedOp implements ImageOp {
 		
 		private transient Padding padding;
 		

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -91,7 +91,7 @@ import qupath.opencv.tools.OpenCVTools;
  */
 public class ImageOps {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ImageOps.class);
+	private static final Logger logger = LoggerFactory.getLogger(ImageOps.class);
 	
 	
 	@Target(ElementType.TYPE)
@@ -2373,7 +2373,7 @@ public class ImageOps {
 		@OpType("sequential")
 		static class SequentialMultiOp extends PaddedOp {
 			
-			private final static Logger logger = LoggerFactory.getLogger(SequentialMultiOp.class);
+			private static final Logger logger = LoggerFactory.getLogger(SequentialMultiOp.class);
 			
 			private List<ImageOp> ops;
 			
@@ -2749,7 +2749,7 @@ public class ImageOps {
 		@OpType("opencv-dnn")
 		static class DnnOp<T> extends PaddedOp {
 			
-			private final static Logger logger = LoggerFactory.getLogger(DnnOp.class);
+			private static final Logger logger = LoggerFactory.getLogger(DnnOp.class);
 
 			private DnnModel<T> model;
 			private int inputWidth;

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/LocalNormalization.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/LocalNormalization.java
@@ -68,13 +68,13 @@ public class LocalNormalization {
 		/**
 		 * Smoothing scale for Gaussian subtraction.
 		 */
-		final public SmoothingScale scale;
+		public final SmoothingScale scale;
 		/**
 		 * Smoothing scale for Gaussian-weighted standard deviation estimate.
 		 */
-		final public SmoothingScale scaleVariance;
+		public final SmoothingScale scaleVariance;
 		
-//		final private boolean subtractOnly;
+//		private final boolean subtractOnly;
 
 		private LocalNormalizationType(SmoothingScale scale, SmoothingScale scaleVariance) {
 			this.scale = scale;
@@ -133,8 +133,8 @@ public class LocalNormalization {
 	 */
 	public static class SmoothingScale {
 		
-		final private double sigma;
-		final private ScaleType scaleType;
+		private final double sigma;
+		private final ScaleType scaleType;
 		
 		private SmoothingScale(ScaleType scaleType, double sigma) {
 			this.sigma = sigma;

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/Thinning.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/Thinning.java
@@ -59,7 +59,7 @@ import qupath.lib.common.GeneralTools;
  */
 public class Thinning {
 	
-	private final static Logger logger = LoggerFactory.getLogger(Thinning.class);
+	private static final Logger logger = LoggerFactory.getLogger(Thinning.class);
 	
 	private static final AdjacencyTree adjacencyTree = new AdjacencyTree();
 	

--- a/qupath-core-processing/src/test/java/qupath/opencv/io/TestOpenCVTypeAdapters.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/io/TestOpenCVTypeAdapters.java
@@ -40,7 +40,7 @@ import com.google.gson.GsonBuilder;
 
 
 @SuppressWarnings("javadoc")
-public class TypeAdaptersCVTest {
+public class TestOpenCVTypeAdapters {
 
 	@SuppressWarnings("unchecked")
 	@Test

--- a/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
@@ -58,7 +58,7 @@ import qupath.lib.images.servers.PixelType;
 public class TestOpenCVTools {
 	
 	@SuppressWarnings("unused")
-	private final static Logger logger = LoggerFactory.getLogger(TestOpenCVTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(TestOpenCVTools.class);
 
 	/**
 	 * Test creation of BufferedImages of different types, and conversions between BufferedImage, Mat and ImagePlus.

--- a/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
@@ -77,7 +77,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class DelaunayTools {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DelaunayTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(DelaunayTools.class);
 	
 	private static boolean calibrated(PixelCalibration cal) {
 		return cal != null && (cal.getPixelHeight().doubleValue() != 1 || cal.getPixelWidth().doubleValue() != 1);
@@ -592,7 +592,7 @@ public class DelaunayTools {
 	 */
 	public static class Subdivision {
 		
-		private final static Logger logger = LoggerFactory.getLogger(Subdivision.class);
+		private static final Logger logger = LoggerFactory.getLogger(Subdivision.class);
 		
 		private Set<PathObject> pathObjects = new LinkedHashSet<>();
 		private Map<Coordinate, PathObject> coordinateMap = new HashMap<>();

--- a/qupath-core/src/main/java/qupath/lib/analysis/DistanceTools.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/DistanceTools.java
@@ -62,7 +62,7 @@ import qupath.lib.roi.GeometryTools;
  */
 public class DistanceTools {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DistanceTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(DistanceTools.class);
 	
 	/**
 	 * Compute the distance for all detection object centroids to the closest annotation with each valid, not-ignored classification and add 

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
@@ -85,7 +85,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class ContourTracing {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ContourTracing.class);
+	private static final Logger logger = LoggerFactory.getLogger(ContourTracing.class);
 	
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/analysis/stats/ArrayWrappers.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/stats/ArrayWrappers.java
@@ -116,7 +116,7 @@ public class ArrayWrappers {
 	
 	static class UnsignedByteArrayWrapper implements ArrayWrapper {
 		
-		final private byte[] array;
+		private final byte[] array;
 		
 		public UnsignedByteArrayWrapper(byte[] array) {
 			this.array = array;
@@ -142,7 +142,7 @@ public class ArrayWrappers {
 	
 	static class UnsignedShortArrayWrapper implements ArrayWrapper {
 		
-		final private short[] array;
+		private final short[] array;
 		
 		public UnsignedShortArrayWrapper(short[] array) {
 			this.array = array;
@@ -168,7 +168,7 @@ public class ArrayWrappers {
 	
 	static class IntArrayWrapper implements ArrayWrapper {
 		
-		final private int[] array;
+		private final int[] array;
 		
 		public IntArrayWrapper(int[] array) {
 			this.array = array;
@@ -194,7 +194,7 @@ public class ArrayWrappers {
 	
 	static class FloatArrayWrapper implements ArrayWrapper  {
 		
-		final private float[] array;
+		private final float[] array;
 		
 		public FloatArrayWrapper(float[] array) {
 			this.array = array;
@@ -220,7 +220,7 @@ public class ArrayWrappers {
 	
 	static class DoubleArrayWrapper implements ArrayWrapper  {
 		
-		final private double[] array;
+		private final double[] array;
 		
 		public DoubleArrayWrapper(double[] array) {
 			this.array = array;

--- a/qupath-core/src/main/java/qupath/lib/analysis/stats/survival/LogRankTest.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/stats/survival/LogRankTest.java
@@ -37,7 +37,7 @@ import qupath.lib.common.GeneralTools;
  */
 public class LogRankTest {
 
-	final private static Logger logger = LoggerFactory.getLogger(LogRankTest.class);
+	private static final Logger logger = LoggerFactory.getLogger(LogRankTest.class);
 
 	private static ChiSquaredDistribution chi2 = new ChiSquaredDistribution(1);
 

--- a/qupath-core/src/main/java/qupath/lib/classifiers/object/ObjectClassifiers.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/object/ObjectClassifiers.java
@@ -60,14 +60,14 @@ public class ObjectClassifiers {
 		
 		private static String typeName = "object_classifier_type";
 		
-		private final static SubTypeAdapterFactory<ObjectClassifier> objectClassifierTypeAdapter = 
+		private static final SubTypeAdapterFactory<ObjectClassifier> objectClassifierTypeAdapter = 
 				GsonTools.createSubTypeAdapterFactory(ObjectClassifier.class, typeName)
 //					.registerSubtype(OpenCVMLClassifier.class)
 					.registerSubtype(CompositeClassifier.class)
 					.registerSubtype(SimpleClassifier.class);
 //					.registerSubtype(ResetClassifier.class);
 		
-		private final static SubTypeAdapterFactory<Function> classifierFunTypeAdapter = 
+		private static final SubTypeAdapterFactory<Function> classifierFunTypeAdapter = 
 				GsonTools.createSubTypeAdapterFactory(Function.class, "classifier_fun")
 					.registerSubtype(ClassifyByMeasurementFunction.class);
 		
@@ -89,7 +89,7 @@ public class ObjectClassifiers {
 		
 	}
 	
-	private final static TypeAdapterFactory factory = new ObjectClassifierTypeAdapterFactory();
+	private static final TypeAdapterFactory factory = new ObjectClassifierTypeAdapterFactory();
 	
 	/**
 	 * Get a {@link TypeAdapterFactory} to handle {@link ObjectClassifier} instances.

--- a/qupath-core/src/main/java/qupath/lib/color/ColorDeconvolutionHelper.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorDeconvolutionHelper.java
@@ -39,7 +39,7 @@ import qupath.lib.common.ColorTools;
  */
 public class ColorDeconvolutionHelper {
 	
-	final private static Logger logger = LoggerFactory.getLogger(ColorDeconvolutionHelper.class);
+	private static final Logger logger = LoggerFactory.getLogger(ColorDeconvolutionHelper.class);
 
 	/**
 	 * Convert a single pixel value to an optical density as {@code max(0, -log10(val/max)}. where {@code val} is clipped to be &gt;= 1.

--- a/qupath-core/src/main/java/qupath/lib/color/ColorDeconvolutionStains.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorDeconvolutionStains.java
@@ -55,7 +55,7 @@ public class ColorDeconvolutionStains implements Externalizable {
 	
 	private static final long serialVersionUID = 1L;
 	
-	final private static Logger logger = LoggerFactory.getLogger(ColorDeconvolutionStains.class);
+	private static final Logger logger = LoggerFactory.getLogger(ColorDeconvolutionStains.class);
 
 	private static int version = 1;
 	
@@ -112,7 +112,7 @@ public class ColorDeconvolutionStains implements Externalizable {
 	private StainVector stain1, stain2, stain3;
 	private double maxRed, maxGreen, maxBlue;
 	
-	transient private double[][] matInverse = null;
+	private transient double[][] matInverse = null;
 	
 	/**
 	 * Create a ColorDeconvolutionStains for a default stain combination, and default max values (255 for all channels).

--- a/qupath-core/src/main/java/qupath/lib/color/ColorMaps.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorMaps.java
@@ -57,7 +57,7 @@ import qupath.lib.common.GeneralTools;
  */
 public class ColorMaps {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ColorMaps.class);
+	private static final Logger logger = LoggerFactory.getLogger(ColorMaps.class);
 	
 	private static ColorMap LEGACY_COLOR_MAP = new PseudoColorMap();
 	

--- a/qupath-core/src/main/java/qupath/lib/color/ColorModelFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorModelFactory.java
@@ -59,7 +59,7 @@ import qupath.lib.objects.classes.PathClassTools;
  */
 public final class ColorModelFactory {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ColorModelFactory.class);
+	private static final Logger logger = LoggerFactory.getLogger(ColorModelFactory.class);
 	
 //	private static Map<Map<Integer, PathClass>, IndexColorModel> classificationModels = Collections.synchronizedMap(new HashMap<>());
 

--- a/qupath-core/src/main/java/qupath/lib/color/ColorModelFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorModelFactory.java
@@ -517,7 +517,7 @@ public final class ColorModelFactory {
 	/**
 	 * Abstract color model that handles all types of transfer.
 	 */
-	static abstract class DefaultAbstractColorModel extends ColorModel {
+	abstract static class DefaultAbstractColorModel extends ColorModel {
 		
 		private PixelType pixelType;
 		private int nBands;

--- a/qupath-core/src/main/java/qupath/lib/color/ColorTransformer.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorTransformer.java
@@ -192,13 +192,13 @@ public class ColorTransformer {
 	
 	
 	// LUT for faster optical density computations (assuming white value of 255)
-	private final static double[] od_lut;
+	private static final double[] od_lut;
 	
 	/**
 	 * Inverse of default H-DAB color deconvolution matrix.
 	 */
-	private final static double[][] inv_H_DAB;
-	private final static double[][] inv_H_E;
+	private static final double[][] inv_H_DAB;
+	private static final double[][] inv_H_E;
 
 	static {
 		od_lut = ColorDeconvolutionHelper.makeODLUT(255, 256);
@@ -882,15 +882,15 @@ public class ColorTransformer {
 	
 	
 	// Color models
-	final private static IndexColorModel ICM_RED = ColorToolsAwt.createIndexColorModel(255, 0, 0);
-	final private static IndexColorModel ICM_GREEN = ColorToolsAwt.createIndexColorModel(0, 255, 0);
-	final private static IndexColorModel ICM_BLUE = ColorToolsAwt.createIndexColorModel(0, 0, 255);
-	final private static IndexColorModel ICM_HUE = ColorToolsAwt.createHueColorModel();
-	final private static IndexColorModel ICM_HEMATOXYLIN;
-	final private static IndexColorModel ICM_EOSIN;
-	final private static IndexColorModel ICM_DAB;
+	private static final IndexColorModel ICM_RED = ColorToolsAwt.createIndexColorModel(255, 0, 0);
+	private static final IndexColorModel ICM_GREEN = ColorToolsAwt.createIndexColorModel(0, 255, 0);
+	private static final IndexColorModel ICM_BLUE = ColorToolsAwt.createIndexColorModel(0, 0, 255);
+	private static final IndexColorModel ICM_HUE = ColorToolsAwt.createHueColorModel();
+	private static final IndexColorModel ICM_HEMATOXYLIN;
+	private static final IndexColorModel ICM_EOSIN;
+	private static final IndexColorModel ICM_DAB;
 
-	final private static Map<ColorTransformer.ColorTransformMethod, ColorModel> COLOR_MODEL_MAP;
+	private static final Map<ColorTransformer.ColorTransformMethod, ColorModel> COLOR_MODEL_MAP;
 	
 	
 	static {
@@ -1079,9 +1079,9 @@ public class ColorTransformer {
 	
 	
 	
-	private final static double POW_10_INC = 0.0015;
-	private final static double[] POW_10_TABLE = new double[2500];
-	private final static double LOG_10 = Math.log(10);
+	private static final double POW_10_INC = 0.0015;
+	private static final double[] POW_10_TABLE = new double[2500];
+	private static final double LOG_10 = Math.log(10);
 	
 	static {
 		

--- a/qupath-core/src/main/java/qupath/lib/color/DefaultColorModel.java
+++ b/qupath-core/src/main/java/qupath/lib/color/DefaultColorModel.java
@@ -46,7 +46,7 @@ import qupath.lib.images.servers.PixelType;
  */
 class DefaultColorModel extends ColorModel {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DefaultColorModel.class);
+	private static final Logger logger = LoggerFactory.getLogger(DefaultColorModel.class);
 		
 	public static final int BACKGROUND_COLOR = ColorTools.packARGB(0, 255, 253, 254); // TODO: See PixelClassifierOutputChannel.TRANSPARENT;
 

--- a/qupath-core/src/main/java/qupath/lib/color/StainVector.java
+++ b/qupath-core/src/main/java/qupath/lib/color/StainVector.java
@@ -46,7 +46,7 @@ public class StainVector implements Externalizable {
 	
 	private static final long serialVersionUID = 1L;
 	
-	final private static Logger logger = LoggerFactory.getLogger(StainVector.class);
+	private static final Logger logger = LoggerFactory.getLogger(StainVector.class);
 	
 	/**
 	 * Enum representing default stains.

--- a/qupath-core/src/main/java/qupath/lib/common/ColorTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ColorTools.java
@@ -41,62 +41,62 @@ public final class ColorTools {
 	/**
 	 * Packed int representing white.
 	 */
-	final public static Integer WHITE = packRGB(255, 255, 255);
+	public static final Integer WHITE = packRGB(255, 255, 255);
 
 	/**
 	 * Packed int representing black.
 	 */
-	final public static Integer BLACK = packRGB(0, 0, 0);
+	public static final Integer BLACK = packRGB(0, 0, 0);
 
 	/**
 	 * Packed int representing red.
 	 */
-	final public static Integer RED = packRGB(255, 0, 0);
+	public static final Integer RED = packRGB(255, 0, 0);
 
 	/**
 	 * Packed int representing green.
 	 */
-	final public static Integer GREEN = packRGB(0, 255, 0);
+	public static final Integer GREEN = packRGB(0, 255, 0);
 
 	/**
 	 * Packed int representing blue.
 	 */
-	final public static Integer BLUE = packRGB(0, 0, 255);
+	public static final Integer BLUE = packRGB(0, 0, 255);
 
 	/**
 	 * Packed int representing magenta.
 	 */
-	final public static Integer MAGENTA = packRGB(255, 0, 255);
+	public static final Integer MAGENTA = packRGB(255, 0, 255);
 
 	/**
 	 * Packed int representing cyan.
 	 */
-	final public static Integer CYAN = packRGB(0, 255, 255);
+	public static final Integer CYAN = packRGB(0, 255, 255);
 
 	/**
 	 * Packed int representing yellow.
 	 */
-	final public static Integer YELLOW = packRGB(255, 255, 0);
+	public static final Integer YELLOW = packRGB(255, 255, 0);
 
 	/**
 	 * Mask for use when extracting the alpha component from a packed ARGB int value.
 	 */
-	final public static Integer MASK_ALPHA = 0xff000000;
+	public static final Integer MASK_ALPHA = 0xff000000;
 	
 	/**
 	 * Mask for use when extracting the red component from a packed (A)RGB int value.
 	 */
-	final public static Integer MASK_RED = 0xff0000;
+	public static final Integer MASK_RED = 0xff0000;
 	
 	/**
 	 * Mask for use when extracting the green component from a packed (A)RGB int value.
 	 */
-	final public static Integer MASK_GREEN = 0xff00;
+	public static final Integer MASK_GREEN = 0xff00;
 	
 	/**
 	 * Mask for use when extracting the blue component from a packed (A)RGB int value.
 	 */
-	final public static Integer MASK_BLUE = 0xff;
+	public static final Integer MASK_BLUE = 0xff;
 
 	/**
 	 * Make a packed RGB value from specified input values.

--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -521,7 +521,7 @@ public final class GeneralTools {
 	 * @param maxDecimalPlaces
 	 * @return
 	 */
-	public synchronized static String formatNumber(final double value, final int maxDecimalPlaces) {
+	public static synchronized String formatNumber(final double value, final int maxDecimalPlaces) {
 		return formatNumber(Locale.getDefault(Category.FORMAT), value, maxDecimalPlaces);
 	}
 	
@@ -533,7 +533,7 @@ public final class GeneralTools {
 	 * @param maxDecimalPlaces
 	 * @return
 	 */
-	public synchronized static String formatNumber(Locale locale, final double value, final int maxDecimalPlaces) {
+	public static synchronized String formatNumber(Locale locale, final double value, final int maxDecimalPlaces) {
 		if (locale == null)
 			locale = Locale.getDefault(Category.FORMAT);
 		NumberFormat nf = formatters.get(locale);

--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -77,10 +77,10 @@ import com.google.gson.reflect.TypeToken;
  */
 public final class GeneralTools {
 	
-	final private static Logger logger = LoggerFactory.getLogger(GeneralTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(GeneralTools.class);
 	
 	
-	private final static String LATEST_VERSION = getCurrentVersion();
+	private static final String LATEST_VERSION = getCurrentVersion();
 	
 	/**
 	 * Request the version of QuPath.
@@ -571,24 +571,24 @@ public final class GeneralTools {
 	 * 
 	 * @return
 	 */
-	public final static String micrometerSymbol() {
+	public static final String micrometerSymbol() {
 		return SYMBOL_MICROMETER;
 	}
 	
 	/**
 	 * Small Green mu (useful for micrometers)
 	 */
-	public final static char SYMBOL_MU = '\u00B5';
+	public static final char SYMBOL_MU = '\u00B5';
 
 	/**
 	 * Small Greek sigma (useful for Gaussian filter sizes, standard deviations)
 	 */
-	public final static char SYMBOL_SIGMA = '\u03C3';
+	public static final char SYMBOL_SIGMA = '\u03C3';
 
 	/**
 	 * String to represent um (but with the proper 'mu' symbol)
 	 */
-	public final static String SYMBOL_MICROMETER = '\u00B5' + "m";
+	public static final String SYMBOL_MICROMETER = '\u00B5' + "m";
 	
 	
 	/**
@@ -932,7 +932,7 @@ public final class GeneralTools {
 	 */
 	private static class StringPartsSorter<T> implements Comparable<StringPartsSorter<T>> {
 		
-		private final static Pattern PATTERN = Pattern.compile("(\\d+)");
+		private static final Pattern PATTERN = Pattern.compile("(\\d+)");
 		
 		private T obj;
 		private List<Object> parts;

--- a/qupath-core/src/main/java/qupath/lib/common/ThreadTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ThreadTools.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ThreadTools {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ThreadTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(ThreadTools.class);
 	
 	private static int requestedThreads = ForkJoinPool.getCommonPoolParallelism();
 	

--- a/qupath-core/src/main/java/qupath/lib/common/Version.java
+++ b/qupath-core/src/main/java/qupath/lib/common/Version.java
@@ -46,27 +46,27 @@ public class Version implements Comparable<Version> {
 	/**
 	 * Compare major versions only.
 	 */
-	public final static Comparator<Version> COMPARATOR_MAJOR = Comparator.comparingInt(Version::getMajor);
+	public static final Comparator<Version> COMPARATOR_MAJOR = Comparator.comparingInt(Version::getMajor);
 
 	/**
 	 * Compare major then minor versions.
 	 */
-	public final static Comparator<Version> COMPARATOR_MAJOR_MINOR = COMPARATOR_MAJOR
+	public static final Comparator<Version> COMPARATOR_MAJOR_MINOR = COMPARATOR_MAJOR
 																			.thenComparing(Version::getMinor);
 
 	/**
 	 * Compare major then minor then patch versions (ignoring suffixes).
 	 */
-	public final static Comparator<Version> COMPARATOR_MAJOR_MINOR_PATCH = COMPARATOR_MAJOR_MINOR
+	public static final Comparator<Version> COMPARATOR_MAJOR_MINOR_PATCH = COMPARATOR_MAJOR_MINOR
 																			.thenComparing(Version::getPatch);
 
 	/**
 	 * Compare full version, including any suffixes.
 	 */
-	public final static Comparator<Version> COMPARATOR_FULL = COMPARATOR_MAJOR_MINOR_PATCH
+	public static final Comparator<Version> COMPARATOR_FULL = COMPARATOR_MAJOR_MINOR_PATCH
 																		.thenComparing(Version::getSuffix, (s1, s2) -> compareSuffixes(s1, s2));
 
-	private final static Comparator<String> COMPARATOR_SUFFIX = GeneralTools.smartStringComparator();
+	private static final Comparator<String> COMPARATOR_SUFFIX = GeneralTools.smartStringComparator();
 	
 	private int major;
 	private int minor;

--- a/qupath-core/src/main/java/qupath/lib/geom/ImmutableDimension.java
+++ b/qupath-core/src/main/java/qupath/lib/geom/ImmutableDimension.java
@@ -34,12 +34,12 @@ public class ImmutableDimension {
 	/**
 	 * Width of the ImmutableDimension.
 	 */
-	final public int width;
+	public final int width;
 	
 	/**
 	 * Height of the ImmutableDimension.
 	 */
-	final public int height;
+	public final int height;
 	
 	/**
 	 * Constructor for a new ImmutableDimension.

--- a/qupath-core/src/main/java/qupath/lib/images/ImageData.java
+++ b/qupath-core/src/main/java/qupath/lib/images/ImageData.java
@@ -106,11 +106,11 @@ public class ImageData<T> implements WorkflowListener, PathObjectHierarchyListen
 		
 	}
 
-	final private static Logger logger = LoggerFactory.getLogger(ImageData.class);
+	private static final Logger logger = LoggerFactory.getLogger(ImageData.class);
 
-	transient private PropertyChangeSupport pcs;
+	private transient PropertyChangeSupport pcs;
 	
-	transient private ImageServer<T> server;
+	private transient ImageServer<T> server;
 	
 	private String lastSavedPath = null;
 	

--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractImageServer.java
@@ -53,7 +53,7 @@ import qupath.lib.regions.RegionRequest;
  */
 public abstract class AbstractImageServer<T> implements ImageServer<T> {
 	
-	final private static Logger logger = LoggerFactory.getLogger(AbstractImageServer.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractImageServer.class);
 	
 	/**
 	 * User-defined metadata (e.g. if pixel sizes needed to be set explicitly).

--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -66,7 +66,7 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 	
 	private transient Set<TileRequest> emptyTiles = new HashSet<>();
 	
-	private final static Long ZERO = Long.valueOf(0L);
+	private static final Long ZERO = Long.valueOf(0L);
 	
 	// Maintain a record of tiles that could not be cached, so we warn for each only once
 	private transient Set<RegionRequest> failedCacheTiles = new HashSet<>();

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ChannelTransformFeatureServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ChannelTransformFeatureServer.java
@@ -51,7 +51,7 @@ import qupath.lib.regions.RegionRequest;
  */
 public class ChannelTransformFeatureServer extends TransformingImageServer<BufferedImage> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ChannelTransformFeatureServer.class);
+	private static final Logger logger = LoggerFactory.getLogger(ChannelTransformFeatureServer.class);
 	
 	private List<ColorTransforms.ColorTransform> transforms;
 	private ImageServerMetadata metadata;

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ColorDeconvolutionImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ColorDeconvolutionImageServer.java
@@ -56,7 +56,7 @@ import qupath.lib.regions.RegionRequest;
  */
 class ColorDeconvolutionImageServer extends TransformingImageServer<BufferedImage> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ColorDeconvolutionImageServer.class);
+	private static final Logger logger = LoggerFactory.getLogger(ColorDeconvolutionImageServer.class);
 	
 	private ColorDeconvolutionStains stains;
 	private List<ColorTransformMethod> methods;

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
@@ -404,7 +404,7 @@ public class ColorTransforms {
 	}
 	
 	
-	static abstract class CombineChannels implements ColorTransform {
+	abstract static class CombineChannels implements ColorTransform {
 				
 		@Override
 		public float[] extractChannel(ImageServer<BufferedImage> server, BufferedImage img, float[] pixels) {

--- a/qupath-core/src/main/java/qupath/lib/images/servers/FileFormatInfo.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/FileFormatInfo.java
@@ -58,7 +58,7 @@ import qupath.lib.common.GeneralTools;
  */
 public class FileFormatInfo {
 	
-	final private static Logger logger = LoggerFactory.getLogger(FileFormatInfo.class);
+	private static final Logger logger = LoggerFactory.getLogger(FileFormatInfo.class);
 	
 	private static Map<URI, ImageCheckType> cache = new HashMap<>();
 	

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageChannel.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageChannel.java
@@ -72,7 +72,7 @@ public class ImageChannel {
 	 * @param color Color as a packed (A)RGB value.
 	 * @return
 	 */
-	public synchronized static ImageChannel getInstance(String name, Integer color) {
+	public static synchronized ImageChannel getInstance(String name, Integer color) {
 		name = Objects.requireNonNull(name);
 		var key = name + "::" + color;
 		var channel = cache.get(key);
@@ -88,7 +88,7 @@ public class ImageChannel {
 	 * @param names the names of the channels
 	 * @return a list of {@link ImageChannel}, where channel names are taken from the input array
 	 */
-	public synchronized static List<ImageChannel> getChannelList(String... names) {
+	public static synchronized List<ImageChannel> getChannelList(String... names) {
 		var list = new ArrayList<ImageChannel>();
 		int i = 0;
 		for (String name : names)

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageChannel.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageChannel.java
@@ -53,17 +53,17 @@ public class ImageChannel {
 	/**
 	 * Default red channel for RGB images.
 	 */
-	public final static ImageChannel RED   = getInstance("Red", ColorTools.packRGB(255, 0, 0));
+	public static final ImageChannel RED   = getInstance("Red", ColorTools.packRGB(255, 0, 0));
 	
 	/**
 	 * Default green channel for RGB images.
 	 */
-	public final static ImageChannel GREEN = getInstance("Green", ColorTools.packRGB(0, 255, 0));
+	public static final ImageChannel GREEN = getInstance("Green", ColorTools.packRGB(0, 255, 0));
 	
 	/**
 	 * Default blue channel for RGB images.
 	 */
-	public final static ImageChannel BLUE  = getInstance("Blue", ColorTools.packRGB(0, 0, 255));
+	public static final ImageChannel BLUE  = getInstance("Blue", ColorTools.packRGB(0, 0, 255));
 	
 	/**
 	 * Get a channel instance with the specified name and color.

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
@@ -153,7 +153,7 @@ public interface ImageServerBuilder<T> {
 	 *
 	 * @param <T>
 	 */
-	static abstract class AbstractServerBuilder<T> implements ServerBuilder<T> {
+	abstract static class AbstractServerBuilder<T> implements ServerBuilder<T> {
 		
 		private ImageServerMetadata metadata;
 		

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
@@ -54,7 +54,7 @@ import qupath.lib.regions.RegionRequest;
  */
 public class ImageServerProvider {
 	
-	final private static Logger logger = LoggerFactory.getLogger(ImageServerProvider.class);
+	private static final Logger logger = LoggerFactory.getLogger(ImageServerProvider.class);
 	
 	private static Map<Class<?>, Map<RegionRequest, ?>> cacheMap = new HashMap<>();
 	

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
@@ -78,7 +78,7 @@ import qupath.lib.regions.ImageRegion;
  */
 public class ImageServers {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ImageServers.class);
+	private static final Logger logger = LoggerFactory.getLogger(ImageServers.class);
 	
 	private static SubTypeAdapterFactory<ServerBuilder> serverBuilderFactory = 
 			GsonTools.createSubTypeAdapterFactory(ServerBuilder.class, "builderType")

--- a/qupath-core/src/main/java/qupath/lib/images/servers/LabeledImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/LabeledImageServer.java
@@ -82,13 +82,13 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class LabeledImageServer extends AbstractTileableImageServer implements GeneratingImageServer<BufferedImage> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(LabeledImageServer.class);
+	private static final Logger logger = LoggerFactory.getLogger(LabeledImageServer.class);
 	
 	private ImageServerMetadata originalMetadata;
 	
 	// Easy way to get the default color models...
-	private final static ColorModel COLOR_MODEL_GRAY_UINT8 = new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_GRAY).getColorModel();
-	private final static ColorModel COLOR_MODEL_GRAY_UINT16 = new BufferedImage(1, 1, BufferedImage.TYPE_USHORT_GRAY).getColorModel();
+	private static final ColorModel COLOR_MODEL_GRAY_UINT8 = new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_GRAY).getColorModel();
+	private static final ColorModel COLOR_MODEL_GRAY_UINT16 = new BufferedImage(1, 1, BufferedImage.TYPE_USHORT_GRAY).getColorModel();
 	
 	private PathObjectHierarchy hierarchy;
 		

--- a/qupath-core/src/main/java/qupath/lib/images/servers/PixelCalibration.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/PixelCalibration.java
@@ -42,17 +42,17 @@ public class PixelCalibration {
 	/**
 	 * String to represent 'pixel' units. This is the default when no pixel size calibration is known.
 	 */
-	public final static String PIXEL = "px";
+	public static final String PIXEL = "px";
 
 	/**
 	 * String to represent 'micrometer' units.
 	 */
-	public final static String MICROMETER = GeneralTools.micrometerSymbol();
+	public static final String MICROMETER = GeneralTools.micrometerSymbol();
 
 	/**
 	 * String to represent 'z-slice' units.
 	 */
-	public final static String Z_SLICE = "z-slice";
+	public static final String Z_SLICE = "z-slice";
 	
 	private SimpleQuantity pixelWidth = SimpleQuantity.DEFAULT_PIXEL_SIZE;
 	private SimpleQuantity pixelHeight = SimpleQuantity.DEFAULT_PIXEL_SIZE;

--- a/qupath-core/src/main/java/qupath/lib/images/servers/SparseImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/SparseImageServer.java
@@ -60,7 +60,7 @@ import qupath.lib.roi.GeometryTools;
  */
 public class SparseImageServer extends AbstractTileableImageServer {
 	
-	private final static Logger logger = LoggerFactory.getLogger(SparseImageServer.class);
+	private static final Logger logger = LoggerFactory.getLogger(SparseImageServer.class);
 	
 	private final ImageServerMetadata metadata;
 	

--- a/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
+++ b/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
@@ -70,7 +70,7 @@ import qupath.lib.roi.RoiTools;
  */
 public class TileExporter  {
 
-	private final static Logger logger = LoggerFactory.getLogger(TileExporter.class);
+	private static final Logger logger = LoggerFactory.getLogger(TileExporter.class);
 
 	private ImageData<BufferedImage> imageData;
 	private ImageServer<BufferedImage> server;

--- a/qupath-core/src/main/java/qupath/lib/io/GsonTools.java
+++ b/qupath-core/src/main/java/qupath/lib/io/GsonTools.java
@@ -70,7 +70,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class GsonTools {
 	
-	private final static Logger logger = LoggerFactory.getLogger(GsonTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(GsonTools.class);
 	
 	private static GsonBuilder builder = new GsonBuilder()
 			.serializeSpecialFloatingPointValues()
@@ -167,7 +167,7 @@ public class GsonTools {
 	 */
 	public static class SubTypeAdapterFactory<T> implements TypeAdapterFactory {
 		
-		private final static Logger logger = LoggerFactory.getLogger(SubTypeAdapterFactory.class);
+		private static final Logger logger = LoggerFactory.getLogger(SubTypeAdapterFactory.class);
 		
 		private final Class<?> baseType;
 		private final String typeFieldName;

--- a/qupath-core/src/main/java/qupath/lib/io/PathIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathIO.java
@@ -94,7 +94,7 @@ import qupath.lib.roi.GeometryTools;
  */
 public class PathIO {
 	
-	private final static Logger logger = LoggerFactory.getLogger(PathIO.class);
+	private static final Logger logger = LoggerFactory.getLogger(PathIO.class);
 	
 	/**
 	 * Data file version identifier, written within the .qpdata file.
@@ -103,14 +103,14 @@ public class PathIO {
 	 * Version 3 stores JSON instead of a server path
 	 * Version 4 stores PathObject UUIDs as a separate field
 	 */
-	private final static int DATA_FILE_VERSION = 3;
+	private static final int DATA_FILE_VERSION = 3;
 	
 	/**
 	 * Input filter for deserialization that is limited to QuPath-related classes.
 	 */
-	private final static ObjectInputFilter QUPATH_INPUT_FILTER = PathIO::qupathInputFilter;
+	private static final ObjectInputFilter QUPATH_INPUT_FILTER = PathIO::qupathInputFilter;
 	// Less restrictive ObjectInputFilter
-//	private final static ObjectInputFilter CLASS_LOADER_INPUT_FILTER = PathIO::classLoaderInputFilter;
+//	private static final ObjectInputFilter CLASS_LOADER_INPUT_FILTER = PathIO::classLoaderInputFilter;
 	
 //	static {
 //		/**
@@ -230,7 +230,7 @@ public class PathIO {
 	 * @return
 	 * @throws IOException
 	 */
-	public final static ObjectInputStream createObjectInputStream(InputStream stream) throws IOException {
+	public static final ObjectInputStream createObjectInputStream(InputStream stream) throws IOException {
 		ObjectInputStream inStream = new ObjectInputStream(stream);
 		inStream.setObjectInputFilter(QUPATH_INPUT_FILTER);
 		return inStream;
@@ -1022,7 +1022,7 @@ public class PathIO {
 		}
 	}
 	
-	private final static boolean serializableObject(Object obj) {
+	private static final boolean serializableObject(Object obj) {
 		return obj == null ? true : checkQuPathSerializableClass(obj.getClass());
 	}
 	
@@ -1031,7 +1031,7 @@ public class PathIO {
 	 * @param serialClass
 	 * @return
 	 */
-	private final static boolean checkQuPathSerializableClass(Class<?> serialClass) {
+	private static final boolean checkQuPathSerializableClass(Class<?> serialClass) {
 		if (serialClass == null)
 			return true;
 		
@@ -1061,18 +1061,18 @@ public class PathIO {
 	 * @param serialClass
 	 * @return
 	 */
-	private final static boolean checkClassLoader(Class<?> serialClass) {
+	private static final boolean checkClassLoader(Class<?> serialClass) {
 		if (serialClass == null)
 			return true;
 		var classloader = serialClass.getClassLoader();
 		return classloader == null || classloader == ClassLoader.getPlatformClassLoader() || classloader == ClassLoader.getSystemClassLoader();
 	}
 	
-	private final static Status classLoaderInputFilter(FilterInfo filterInfo) {
+	private static final Status classLoaderInputFilter(FilterInfo filterInfo) {
 		return checkClassLoader(filterInfo.serialClass()) ? Status.ALLOWED : Status.REJECTED;
 	}
 	
-	private final static Status qupathInputFilter(FilterInfo filterInfo) {
+	private static final Status qupathInputFilter(FilterInfo filterInfo) {
 		return checkQuPathSerializableClass(filterInfo.serialClass()) ? Status.ALLOWED : Status.REJECTED;
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
@@ -187,7 +187,7 @@ class PathObjectTypeAdapters {
 	
 	static class PathObjectTypeAdapter extends TypeAdapter<PathObject> {
 		
-		private final static Logger logger = LoggerFactory.getLogger(PathObjectTypeAdapter.class);
+		private static final Logger logger = LoggerFactory.getLogger(PathObjectTypeAdapter.class);
 		
 		static PathObjectTypeAdapter INSTANCE = new PathObjectTypeAdapter();
 		

--- a/qupath-core/src/main/java/qupath/lib/io/PointIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PointIO.java
@@ -69,7 +69,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class PointIO {
 	
-	final private static Logger logger = LoggerFactory.getLogger(PointIO.class);
+	private static final Logger logger = LoggerFactory.getLogger(PointIO.class);
 	
 	/**
 	 * Read a list of point annotations from a stream.

--- a/qupath-core/src/main/java/qupath/lib/io/TMAScoreImporter.java
+++ b/qupath-core/src/main/java/qupath/lib/io/TMAScoreImporter.java
@@ -59,7 +59,7 @@ import qupath.lib.objects.hierarchy.TMAGrid;
  */
 public class TMAScoreImporter {
 	
-	final private static Logger logger = LoggerFactory.getLogger(TMAScoreImporter.class);
+	private static final Logger logger = LoggerFactory.getLogger(TMAScoreImporter.class);
 	
 	/**
 	 * Import TMA scores from a file into the TMAGrid of an object hierarchy.

--- a/qupath-core/src/main/java/qupath/lib/io/UriUpdater.java
+++ b/qupath-core/src/main/java/qupath/lib/io/UriUpdater.java
@@ -55,7 +55,7 @@ import qupath.lib.projects.Project;
  */
 public class UriUpdater<T extends UriResource> {
 
-	private final static Logger logger = LoggerFactory.getLogger(UriUpdater.class);
+	private static final Logger logger = LoggerFactory.getLogger(UriUpdater.class);
 
 	private Collection<T> resources;
 	private Collection<SingleUriItem> items;

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementFactory.java
@@ -62,8 +62,8 @@ class DoubleMeasurement implements Measurement {
 	
 	private static final long serialVersionUID = 1L;
 	
-	final private String name;
-	final private double value;
+	private final String name;
+	private final double value;
 	
 	DoubleMeasurement(String name, double value) {
 		// There may be many measurements... so interning the names can help considerably
@@ -99,8 +99,8 @@ class FloatMeasurement implements Measurement {
 	
 	private static final long serialVersionUID = 1L;
 	
-	final private String name;
-	final private float value;
+	private final String name;
+	private final float value;
 	
 	FloatMeasurement(String name, double value) {
 		// There may be many measurements... so interning the names can help considerably

--- a/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
@@ -93,7 +93,7 @@ class NumericMeasurementList {
 	
 	
 	
-	private static abstract class AbstractNumericMeasurementList implements MeasurementList {
+	private abstract static class AbstractNumericMeasurementList implements MeasurementList {
 		
 		private static final long serialVersionUID = 1L;
 		
@@ -177,7 +177,7 @@ class NumericMeasurementList {
 	    }
 		
 		@Override
-		final public int size() {
+		public final int size() {
 			return names.size();
 		}
 

--- a/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
  */
 class NumericMeasurementList {
 	
-	final private static Logger logger = LoggerFactory.getLogger(NumericMeasurementList.class);
+	private static final Logger logger = LoggerFactory.getLogger(NumericMeasurementList.class);
 	
 	private static Map<List<String>, NameMap> namesPool = Collections.synchronizedMap(new WeakHashMap<>());
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/PathAnnotationObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathAnnotationObject.java
@@ -45,7 +45,7 @@ public class PathAnnotationObject extends PathROIObject {
 	
 	private static final long serialVersionUID = 1L;
 	
-	private final static String KEY_ANNOTATION_TEXT = "ANNOTATION_DESCRIPTION";
+	private static final String KEY_ANNOTATION_TEXT = "ANNOTATION_DESCRIPTION";
 	
 	/**
 	 * Default constructor. Should not be used directly, instead use {@link PathObjects#createAnnotationObject(ROI)}.

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -60,9 +60,9 @@ public abstract class PathObject implements Externalizable {
 	
 	private static final long serialVersionUID = 1L;
 		
-	private final static Logger logger = LoggerFactory.getLogger(PathObject.class);
+	private static final Logger logger = LoggerFactory.getLogger(PathObject.class);
 	
-	private final static String METADATA_KEY_ID = "Object ID";
+	private static final String METADATA_KEY_ID = "Object ID";
 	
 	private UUID id = UUID.randomUUID();
 	
@@ -75,7 +75,7 @@ public abstract class PathObject implements Externalizable {
 	private String name = null;
 	private Integer color;
 
-	transient private Collection<PathObject> cachedUnmodifiableChildren = null;
+	private transient Collection<PathObject> cachedUnmodifiableChildren = null;
 	
 
 	/**

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectPredicates.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectPredicates.java
@@ -104,7 +104,7 @@ public class PathObjectPredicates {
 		
 	}
 	
-	static abstract class AbstractPathObjectPredicate implements PathObjectPredicate {
+	abstract static class AbstractPathObjectPredicate implements PathObjectPredicate {
 		
 		@Override
 		public PathObjectPredicate and(PathObjectPredicate p) {

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -74,7 +74,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class PathObjectTools {
 	
-	private final static Logger logger = LoggerFactory.getLogger(PathObjectTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(PathObjectTools.class);
 
 	/**
 	 * Remove objects with PointsROI from a collection.

--- a/qupath-core/src/main/java/qupath/lib/objects/PathRootObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathRootObject.java
@@ -42,7 +42,7 @@ public class PathRootObject extends PathObject {
 
 	private static final long serialVersionUID = 1L;
 	
-	final private static Logger logger = LoggerFactory.getLogger(PathRootObject.class);
+	private static final Logger logger = LoggerFactory.getLogger(PathRootObject.class);
 	
 	@Override
 	public boolean isRootObject() {

--- a/qupath-core/src/main/java/qupath/lib/objects/TMACoreObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/TMACoreObject.java
@@ -46,27 +46,27 @@ public class TMACoreObject extends PathROIObject implements MetadataStore {
 	/**
 	 * Metadata key for the TMA core unique patient ID;
 	 */
-	final public static String KEY_UNIQUE_ID = "Unique ID";
+	public static final String KEY_UNIQUE_ID = "Unique ID";
 	
 	/**
 	 * Metadata key for an overall survival (temporal) value.
 	 */
-	final public static String KEY_OVERALL_SURVIVAL = "Overall survival";
+	public static final String KEY_OVERALL_SURVIVAL = "Overall survival";
 	
 	/**
 	 * Metadata key for an recurrence-free survival (temporal) value.
 	 */
-	final public static String KEY_RECURRENCE_FREE_SURVIVAL = "Recurrence-free survival";
+	public static final String KEY_RECURRENCE_FREE_SURVIVAL = "Recurrence-free survival";
 	
 	/**
 	 * Metadata key for an overall survival censored flag.
 	 */
-	final public static String KEY_OS_CENSORED = "OS censored";
+	public static final String KEY_OS_CENSORED = "OS censored";
 	
 	/**
 	 * Metadata key for an recurrence-free survival censored flag.
 	 */
-	final public static String KEY_RFS_CENSORED = "RFS censored";
+	public static final String KEY_RFS_CENSORED = "RFS censored";
 	
 	private boolean isMissing = false;
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
@@ -56,7 +56,7 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 	private final String name;
 	private Integer colorRGB;
 	
-	private final static UUID secret = UUID.randomUUID();
+	private static final UUID secret = UUID.randomUUID();
 	
 	/**
 	 * Cached String representation

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
@@ -128,11 +128,11 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 		return true;
 	}
 	
-	synchronized static PathClass getNullClass() {
+	static synchronized PathClass getNullClass() {
 		return NULL_CLASS;
 	}
 	
-	synchronized static PathClass getInstance(PathClass parent, String name, Integer colorRGB) {
+	static synchronized PathClass getInstance(PathClass parent, String name, Integer colorRGB) {
 		if (parent == getNullClass())
 			parent = null;
 		

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassFactory.java
@@ -126,13 +126,13 @@ public final class PathClassFactory {
 
 	private static Map<String, PathClass> mapPathClasses = new HashMap<>();
 
-	private final static PathClass NULL_CLASS = PathClass.getNullClass();
+	private static final PathClass NULL_CLASS = PathClass.getNullClass();
 	
-	final static String POSITIVE = "Positive";
-	final static String NEGATIVE = "Negative";
-	final static String ONE_PLUS = "1+";
-	final static String TWO_PLUS = "2+";
-	final static String THREE_PLUS = "3+";
+	static final String POSITIVE = "Positive";
+	static final String NEGATIVE = "Negative";
+	static final String ONE_PLUS = "1+";
+	static final String TWO_PLUS = "2+";
+	static final String THREE_PLUS = "3+";
 	static List<String> intensityClassNames = Arrays.asList(ONE_PLUS, TWO_PLUS, THREE_PLUS);
 	
 	private static final Integer COLOR_POSITIVE = ColorTools.packRGB(200, 50, 50);

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/DefaultTMAGrid.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/DefaultTMAGrid.java
@@ -40,7 +40,7 @@ public class DefaultTMAGrid implements TMAGrid {
 	
 	private static final long serialVersionUID = 1L;
 	
-	private final static Logger logger = LoggerFactory.getLogger(DefaultTMAGrid.class);
+	private static final Logger logger = LoggerFactory.getLogger(DefaultTMAGrid.class);
 	
 	private List<TMACoreObject> cores = new ArrayList<>();
 	private int gridWidth = -1;

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
@@ -75,7 +75,7 @@ public final class PathObjectHierarchy implements Serializable {
 	
 	private static final long serialVersionUID = 1L;
 	
-	final private static Logger logger = LoggerFactory.getLogger(PathObjectHierarchy.class);
+	private static final Logger logger = LoggerFactory.getLogger(PathObjectHierarchy.class);
 			
 	// TODO: Make this a choice - currently a cell object is considered 'inside' if its nucleus is fully contained (as cell boundaries themselves are a little more questionable)
 	/*
@@ -100,11 +100,11 @@ public final class PathObjectHierarchy implements Serializable {
 	private TMAGrid tmaGrid = null;
 	private PathObject rootObject = new PathRootObject();
 	
-	transient private PathObjectSelectionModel selectionModel = new PathObjectSelectionModel();
-	transient private List<PathObjectHierarchyListener> listeners = new ArrayList<>();
+	private transient PathObjectSelectionModel selectionModel = new PathObjectSelectionModel();
+	private transient List<PathObjectHierarchyListener> listeners = new ArrayList<>();
 
 	// Cache enabling faster access of objects according to location
-	transient private PathObjectTileCache tileCache = new PathObjectTileCache(this);
+	private transient PathObjectTileCache tileCache = new PathObjectTileCache(this);
 
 	/**
 	 * Default constructor, creates an empty hierarchy.

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
@@ -75,12 +75,12 @@ class PathObjectTileCache implements PathObjectHierarchyListener {
 	
 	public static int DEFAULT_TILE_SIZE = 1024;
 	
-	final private static Logger logger = LoggerFactory.getLogger(PathObjectTileCache.class);
+	private static final Logger logger = LoggerFactory.getLogger(PathObjectTileCache.class);
 	
 	/**
 	 * Largest positive envelope, used when all objects are requested.
 	 */
-	private final static Envelope MAX_ENVELOPE = new Envelope(-Double.MAX_VALUE, Double.MAX_VALUE, -Double.MAX_VALUE, Double.MAX_VALUE);
+	private static final Envelope MAX_ENVELOPE = new Envelope(-Double.MAX_VALUE, Double.MAX_VALUE, -Double.MAX_VALUE, Double.MAX_VALUE);
 	
 	/**
 	 * Keep a map of envelopes per ROI; ROIs should be immutable.
@@ -100,9 +100,9 @@ class PathObjectTileCache implements PathObjectHierarchyListener {
 	/**
 	 * Map to cache Geometries, specifically for annotations.
 	 */
-	final private static Map<ROI, Geometry> geometryMap = Collections.synchronizedMap(new WeakHashMap<>());
-	final private static Map<ROI, PointOnGeometryLocator> locatorMap = Collections.synchronizedMap(new WeakHashMap<>());
-//	final private static Map<ROI, Coordinate> centroidMap = Collections.synchronizedMap(new WeakHashMap<>());
+	private static final Map<ROI, Geometry> geometryMap = Collections.synchronizedMap(new WeakHashMap<>());
+	private static final Map<ROI, PointOnGeometryLocator> locatorMap = Collections.synchronizedMap(new WeakHashMap<>());
+//	private static final Map<ROI, Coordinate> centroidMap = Collections.synchronizedMap(new WeakHashMap<>());
 
 	private PathObjectHierarchy hierarchy;
 	private boolean isActive = false;

--- a/qupath-core/src/main/java/qupath/lib/plugins/AbstractInteractivePlugin.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/AbstractInteractivePlugin.java
@@ -42,9 +42,9 @@ import qupath.lib.plugins.parameters.ParameterList;
  */
 public abstract class AbstractInteractivePlugin<T> extends AbstractPlugin<T> implements PathInteractivePlugin<T> {
 	
-	transient protected ParameterList params;
+	protected transient ParameterList params;
 	
-	private final static Logger logger = LoggerFactory.getLogger(AbstractInteractivePlugin.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractInteractivePlugin.class);
 	
 	/**
 	 * This should return a default ParameterList containing any information that is needed to repeat the task exactly.

--- a/qupath-core/src/main/java/qupath/lib/plugins/AbstractPlugin.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/AbstractPlugin.java
@@ -48,7 +48,7 @@ import qupath.lib.plugins.workflow.WorkflowStep;
  */
 public abstract class AbstractPlugin<T> implements PathPlugin<T> {
 	
-	final private static Logger logger = LoggerFactory.getLogger(AbstractPlugin.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractPlugin.class);
 	
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/plugins/AbstractPluginRunner.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/AbstractPluginRunner.java
@@ -53,7 +53,7 @@ import qupath.lib.images.ImageData;
  */
 public abstract class AbstractPluginRunner<T> implements PluginRunner<T> {
 	
-	final private static Logger logger = LoggerFactory.getLogger(AbstractPluginRunner.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractPluginRunner.class);
 
 	private static int counter = 0;
 

--- a/qupath-core/src/main/java/qupath/lib/plugins/CommandLinePluginRunner.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/CommandLinePluginRunner.java
@@ -72,7 +72,7 @@ public class CommandLinePluginRunner<T> extends AbstractPluginRunner<T> {
 	 */
 	public static class CommandLineProgressMonitor implements SimpleProgressMonitor {
 		
-		final private static Logger logger = LoggerFactory.getLogger(CommandLineProgressMonitor.class);
+		private static final Logger logger = LoggerFactory.getLogger(CommandLineProgressMonitor.class);
 		
 		private long startTime;
 		private AtomicInteger progress = new AtomicInteger(0);

--- a/qupath-core/src/main/java/qupath/lib/plugins/DetectionPluginTools.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/DetectionPluginTools.java
@@ -70,7 +70,7 @@ public class DetectionPluginTools {
 
 	static class DetectionRunnable<T> implements PathTask {
 
-		final private static Logger logger = LoggerFactory.getLogger(DetectionPluginTools.class);
+		private static final Logger logger = LoggerFactory.getLogger(DetectionPluginTools.class);
 
 		ObjectDetector<T> detector;
 		private ParameterList params;

--- a/qupath-core/src/main/java/qupath/lib/plugins/ParallelTileObject.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/ParallelTileObject.java
@@ -65,7 +65,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class ParallelTileObject extends PathTileObject implements TemporaryObject {
 
-	final private static Logger logger = LoggerFactory.getLogger(ParallelTileObject.class);
+	private static final Logger logger = LoggerFactory.getLogger(ParallelTileObject.class);
 	
 	/**
 	 * Current processing status for the tile.

--- a/qupath-core/src/main/java/qupath/lib/plugins/parameters/ParameterList.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/parameters/ParameterList.java
@@ -52,7 +52,7 @@ public class ParameterList implements Serializable {
 	
 	private static final long serialVersionUID = 1L;
 	
-	private final static Logger logger = LoggerFactory.getLogger(ParameterList.class);
+	private static final Logger logger = LoggerFactory.getLogger(ParameterList.class);
 	
 	private Map<String, Parameter<?>> params = new LinkedHashMap<>();
 	

--- a/qupath-core/src/main/java/qupath/lib/plugins/workflow/SimplePluginWorkflowStep.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/workflow/SimplePluginWorkflowStep.java
@@ -49,19 +49,19 @@ public class SimplePluginWorkflowStep implements ScriptableWorkflowStep, Externa
 	 * Currently this is private (experimental feature for testing)
 	 * @since v0.4.0
 	 */
-	private final static String PROP_KEY_WORKFLOW_ARGS = "script.workflow.args";
+	private static final String PROP_KEY_WORKFLOW_ARGS = "script.workflow.args";
 	
 	/**
 	 * Include workflow args as a {@code Map<String, ?>}, where possible
 	 * @since v0.4.0
 	 */
-	private final static String PROP_WORKFLOW_ARGS_MAP = "map";
+	private static final String PROP_WORKFLOW_ARGS_MAP = "map";
 	
 	/**
 	 * Include workflow args as a String (default)
 	 * @since v0.4.0
 	 */
-	private final static String PROP_WORKFLOW_ARGS_STRING = "string";
+	private static final String PROP_WORKFLOW_ARGS_STRING = "string";
 	
 	private String name;
 	private String pluginClass;

--- a/qupath-core/src/main/java/qupath/lib/plugins/workflow/Workflow.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/workflow/Workflow.java
@@ -51,11 +51,11 @@ public class Workflow implements Externalizable {
 	
 	private static final long serialVersionUID = 1L;
 	
-	final private static Logger logger = LoggerFactory.getLogger(Workflow.class);
+	private static final Logger logger = LoggerFactory.getLogger(Workflow.class);
 	
 	static int version = 1;
 	
-	transient private List<WorkflowListener> listeners = Collections.synchronizedList(new ArrayList<>());
+	private transient List<WorkflowListener> listeners = Collections.synchronizedList(new ArrayList<>());
 	
 	private List<WorkflowStep> steps = new ArrayList<>();
 	

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -153,7 +153,7 @@ class DefaultProject implements Project<BufferedImage> {
 	 * @param ext
 	 * @return
 	 */
-	synchronized static File getUniqueFile(File dir, String name, String ext) {
+	static synchronized File getUniqueFile(File dir, String name, String ext) {
 		if (!ext.startsWith("."))
 			ext = "." + ext;
 		File file = new File(dir, name + ext);

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -82,7 +82,7 @@ import qupath.lib.projects.ResourceManager.Manager;
  */
 class DefaultProject implements Project<BufferedImage> {
 
-	public final static String IMAGE_ID = "PROJECT_ENTRY_ID";
+	public static final String IMAGE_ID = "PROJECT_ENTRY_ID";
 
 	private static String ext = "qpproj";
 	

--- a/qupath-core/src/main/java/qupath/lib/projects/ProjectIO.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/ProjectIO.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ProjectIO {
 
-	final private static Logger logger = LoggerFactory.getLogger(ProjectIO.class);
+	private static final Logger logger = LoggerFactory.getLogger(ProjectIO.class);
 	
 	/**
 	 * Default file name for a QuPath project.

--- a/qupath-core/src/main/java/qupath/lib/projects/ProjectImageEntry.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/ProjectImageEntry.java
@@ -272,7 +272,7 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * 
 	 * @return
 	 */
-	default public String getMetadataSummaryString() {
+	public default String getMetadataSummaryString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("{");
 		for (Entry<String, String> entry : getMetadataMap().entrySet()) {

--- a/qupath-core/src/main/java/qupath/lib/projects/ResourceManager.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/ResourceManager.java
@@ -146,7 +146,7 @@ public class ResourceManager {
 
 	abstract static class FileResourceManager<T> implements Manager<T> {
 		
-		private final static Logger logger = LoggerFactory.getLogger(FileResourceManager.class);
+		private static final Logger logger = LoggerFactory.getLogger(FileResourceManager.class);
 		
 		protected String ext;
 		protected Path dir;

--- a/qupath-core/src/main/java/qupath/lib/projects/ResourceManager.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/ResourceManager.java
@@ -105,7 +105,7 @@ public class ResourceManager {
 		 * @return true if a resource with the name exists, false otherwise
 		 * @throws IOException
 		 */
-		default public boolean contains(String name) throws IOException {
+		public default boolean contains(String name) throws IOException {
 			var names = getNames();
 			for (var n : names) {
 				if (name.equalsIgnoreCase(n))

--- a/qupath-core/src/main/java/qupath/lib/regions/ImagePlane.java
+++ b/qupath-core/src/main/java/qupath/lib/regions/ImagePlane.java
@@ -42,9 +42,9 @@ public class ImagePlane implements Comparable<ImagePlane> {
 	
 	private static ImagePlane DEFAULT_PLANE = new ImagePlane(-1, 0, 0);
 	
-	private final static int NUM_DEFAULTS = 10;
-	private final static ImagePlane[][] DEFAULTS_WITHOUT_CHANNEL = new ImagePlane[NUM_DEFAULTS][NUM_DEFAULTS];
-	private final static ImagePlane[][][] DEFAULTS_WITH_CHANNEL = new ImagePlane[NUM_DEFAULTS][NUM_DEFAULTS][NUM_DEFAULTS];
+	private static final int NUM_DEFAULTS = 10;
+	private static final ImagePlane[][] DEFAULTS_WITHOUT_CHANNEL = new ImagePlane[NUM_DEFAULTS][NUM_DEFAULTS];
+	private static final ImagePlane[][][] DEFAULTS_WITH_CHANNEL = new ImagePlane[NUM_DEFAULTS][NUM_DEFAULTS][NUM_DEFAULTS];
 	
 	static {
 		for (int t = 0; t < NUM_DEFAULTS; t++) {

--- a/qupath-core/src/main/java/qupath/lib/roi/AWTAreaROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/AWTAreaROI.java
@@ -54,7 +54,7 @@ class AWTAreaROI extends AreaROI implements Serializable {
 	
 	// We potentially spend a lot of time drawing polygons & assessing whether or not to draw them...
 	// By caching the bounds this can be speeded up
-	transient private ClosedShapeStatistics stats = null;
+	private transient ClosedShapeStatistics stats = null;
 	
 	AWTAreaROI(Shape shape, ImagePlane plane) {
 		super(RoiTools.getVertices(shape), plane);

--- a/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
@@ -58,7 +58,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class AreaROI extends AbstractPathROI implements Serializable {
 	
-//	final static private Logger logger = LoggerFactory.getLogger(AreaROI.class);
+//	private static final Logger logger = LoggerFactory.getLogger(AreaROI.class);
 	
 	private static final long serialVersionUID = 1L;
 	
@@ -68,7 +68,7 @@ public class AreaROI extends AbstractPathROI implements Serializable {
 
 	// We potentially spend a lot of time drawing polygons & assessing whether or not to draw them...
 	// By caching the bounds this can be speeded up
-	transient private ClosedShapeStatistics stats = null;
+	private transient ClosedShapeStatistics stats = null;
 	
 	// TODO: Consider making this protected - better not to use directly, to ensure validity of vertices
 	AreaROI(List<? extends Vertices> vertices, ImagePlane plane) {

--- a/qupath-core/src/main/java/qupath/lib/roi/ClosedShapeStatistics.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/ClosedShapeStatistics.java
@@ -221,23 +221,23 @@ class ClosedShapeStatistics implements Serializable {
 	}
 	
 	
-	final public double getBoundsX() {
+	public final double getBoundsX() {
 		return minX;
 	}
 
-	final public double getBoundsY() {
+	public final double getBoundsY() {
 		return minY;
 	}
 
-	final public double getBoundsWidth() {
+	public final double getBoundsWidth() {
 		return maxX - minX;
 	}
 
-	final public double getBoundsHeight() {
+	public final double getBoundsHeight() {
 		return maxY - minY;
 	}
 	
-	final private void updateMinMax(final double x, final double y) {
+	private final void updateMinMax(final double x, final double y) {
 		if (x < minX)
 			minX = x;
 		if (x > maxX)
@@ -249,19 +249,19 @@ class ClosedShapeStatistics implements Serializable {
 	}
 	
 	
-	final public double getCentroidX() {
+	public final double getCentroidX() {
 		return centroidXCached;
 	}
 
-	final public double getCentroidY() {
+	public final double getCentroidY() {
 		return centroidYCached;
 	}
 
-	final public double getArea() {
+	public final double getArea() {
 		return areaCached;
 	}
 
-	final public double getPerimeter() {
+	public final double getPerimeter() {
 		return perimeterCached;
 	}
 	
@@ -274,7 +274,7 @@ class ClosedShapeStatistics implements Serializable {
 //		maxY += dy;
 //	}
 	
-	final public int getNVertices() {
+	public final int getNVertices() {
 		return nVertices;
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/roi/ConvexHull.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/ConvexHull.java
@@ -39,7 +39,7 @@ import qupath.lib.geom.Point2;
  */
 public class ConvexHull {
 	
-	final private static Logger logger = LoggerFactory.getLogger(ConvexHull.class);
+	private static final Logger logger = LoggerFactory.getLogger(ConvexHull.class);
 
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/roi/DefaultROIComparator.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/DefaultROIComparator.java
@@ -38,7 +38,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class DefaultROIComparator implements Comparator<ROI>{
 	
-	private final static DefaultROIComparator instance = new DefaultROIComparator();
+	private static final DefaultROIComparator instance = new DefaultROIComparator();
 
 	@Override
 	public int compare(ROI o1, ROI o2) {

--- a/qupath-core/src/main/java/qupath/lib/roi/DefaultVertices.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/DefaultVertices.java
@@ -242,7 +242,7 @@ class DefaultVertices implements Vertices {
 //	
 //	static class DefaultVerticesIterator implements VerticesIterator {
 //
-//		final private DefaultVertices vertices;
+//		private final DefaultVertices vertices;
 //		private int ind = 0;
 //
 //		private DefaultVerticesIterator(final DefaultVertices vertices) {
@@ -250,12 +250,12 @@ class DefaultVertices implements Vertices {
 //		}
 //
 //		@Override
-//		final public boolean hasNext() {
+//		public final boolean hasNext() {
 //			return ind < vertices.size();
 //		}
 //
 //		@Override
-//		final public void next() {
+//		public final void next() {
 //			this.ind++;
 //		}
 //		
@@ -268,7 +268,7 @@ class DefaultVertices implements Vertices {
 //		}
 //
 //		@Override
-//		final public void currentVertex(float[] coords) {
+//		public final void currentVertex(float[] coords) {
 //			coords[0] = vertices.x[ind];
 //			coords[1] = vertices.y[ind];
 //		}

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -96,12 +96,12 @@ public class GeometryTools {
 	
 	private static Logger logger = LoggerFactory.getLogger(GeometryTools.class);
 	
-	private final static GeometryFactory DEFAULT_FACTORY = new GeometryFactory(
+	private static final GeometryFactory DEFAULT_FACTORY = new GeometryFactory(
 			new PrecisionModel(100.0),
 			0,
 			PackedCoordinateSequenceFactory.FLOAT_FACTORY);
 
-	private final static PrecisionModel INTEGER_PRECISION_MODEL = new PrecisionModel(1);
+	private static final PrecisionModel INTEGER_PRECISION_MODEL = new PrecisionModel(1);
     
     private static GeometryConverter DEFAULT_INSTANCE = new GeometryConverter.Builder()
     		.build();

--- a/qupath-core/src/main/java/qupath/lib/roi/PointsROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PointsROI.java
@@ -52,10 +52,10 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 //	@Deprecated
 //	protected double pointRadius = -1;
 	
-	transient private double xMin = Double.NaN, yMin = Double.NaN, xMax = Double.NaN, yMax = Double.NaN;
-	transient private double xCentroid = Double.NaN, yCentroid = Double.NaN;
-	transient private ROI convexHull = null;
-//	transient protected Point2 pointAdjusting = null;
+	private transient double xMin = Double.NaN, yMin = Double.NaN, xMax = Double.NaN, yMax = Double.NaN;
+	private transient double xCentroid = Double.NaN, yCentroid = Double.NaN;
+	private transient ROI convexHull = null;
+//	protected transient Point2 pointAdjusting = null;
 	
 	PointsROI() {
 		this(Double.NaN, Double.NaN);

--- a/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
@@ -49,11 +49,11 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 	
 	private static final long serialVersionUID = 1L;
 	
-//	final private static Logger logger = LoggerFactory.getLogger(PolygonROI.class);
+//	private static final Logger logger = LoggerFactory.getLogger(PolygonROI.class);
 	
 	private Vertices vertices;
 	
-	transient private ClosedShapeStatistics stats = null;
+	private transient ClosedShapeStatistics stats = null;
 	
 
 	PolygonROI() {

--- a/qupath-core/src/main/java/qupath/lib/roi/PolylineROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PolylineROI.java
@@ -49,7 +49,7 @@ public class PolylineROI extends AbstractPathROI implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 	
-//	final private static Logger logger = LoggerFactory.getLogger(PolylineROI.class);
+//	private static final Logger logger = LoggerFactory.getLogger(PolylineROI.class);
 	
 	private Vertices vertices;
 	

--- a/qupath-core/src/main/java/qupath/lib/roi/RoiEditor.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiEditor.java
@@ -352,7 +352,7 @@ public class RoiEditor {
 	
 	
 	
-	static abstract class RoiHandleAdjuster<T extends ROI> {
+	abstract static class RoiHandleAdjuster<T extends ROI> {
 		
 		final int TOP_LEFT = 0;
 		final int TOP_CENTER = 1;
@@ -395,7 +395,7 @@ public class RoiEditor {
 	
 	
 	
-	static abstract class BoundedHandleAdjuster<T extends AbstractPathBoundedROI> extends RoiHandleAdjuster<T> {
+	abstract static class BoundedHandleAdjuster<T extends AbstractPathBoundedROI> extends RoiHandleAdjuster<T> {
 				
 		private T roi;
 		private List<MutablePoint> handles = new ArrayList<>(8);

--- a/qupath-core/src/main/java/qupath/lib/roi/RoiEditor.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiEditor.java
@@ -57,7 +57,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class RoiEditor {
 	
-	final private static Logger logger = LoggerFactory.getLogger(RoiEditor.class);
+	private static final Logger logger = LoggerFactory.getLogger(RoiEditor.class);
 	
 	private ROI pathROI;
 	private MutablePoint activeHandle;
@@ -68,7 +68,7 @@ public class RoiEditor {
 	private MutablePoint pTranslateCurrent;
 	private boolean translateSnapToPixel;
 	
-	transient private RoiHandleAdjuster<?> adjuster;
+	private transient RoiHandleAdjuster<?> adjuster;
 	
 	// Don't instantiate directly - implementation may change
 	private RoiEditor() {};

--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -64,7 +64,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class RoiTools {
 
-	private final static Logger logger = LoggerFactory.getLogger(RoiTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(RoiTools.class);
 
 	/**
 	 * Methods of combining two ROIs.

--- a/qupath-core/src/test/java/qupath/lib/analysis/stats/survival/TestKaplanMeierData.java
+++ b/qupath-core/src/test/java/qupath/lib/analysis/stats/survival/TestKaplanMeierData.java
@@ -35,11 +35,11 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("javadoc")
 public class TestKaplanMeierData {
 	private static KaplanMeierData km;
-	private final static double[] times = new double[] {0.0, 5.0, 7.5, 15.0, 15.0, 17.5, 25.0, 37.5, 37.5, 40.0, 67.5, 78.0, 80.0};
-	private final static boolean[] censored = new boolean[] {false, true, false, false, false, true, false, false, false, false, false, false};
-	private final static int[] eventsAtTime = new int[] {0, 1, 0, 2, 2, 1, 0, 2, 2, 1, 1, 1, 1};
-	private final static int[] atRisk = new int[] {12, 12, 11, 10, 10, 8, 7, 6, 6, 4, 3, 2, 1};
-	private final static double[] stats = new double[times.length-2];
+	private static final double[] times = new double[] {0.0, 5.0, 7.5, 15.0, 15.0, 17.5, 25.0, 37.5, 37.5, 40.0, 67.5, 78.0, 80.0};
+	private static final boolean[] censored = new boolean[] {false, true, false, false, false, true, false, false, false, false, false, false};
+	private static final int[] eventsAtTime = new int[] {0, 1, 0, 2, 2, 1, 0, 2, 2, 1, 1, 1, 1};
+	private static final int[] atRisk = new int[] {12, 12, 11, 10, 10, 8, 7, 6, 6, 4, 3, 2, 1};
+	private static final double[] stats = new double[times.length-2];
 	
 	@BeforeAll
 	public static void init() {

--- a/qupath-core/src/test/java/qupath/lib/common/TestVersion.java
+++ b/qupath-core/src/test/java/qupath/lib/common/TestVersion.java
@@ -31,7 +31,7 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("javadoc")
-public class VersionTest {
+public class TestVersion {
 
 	@Test
 	public void test() {

--- a/qupath-core/src/test/java/qupath/lib/images/servers/TestAffineTransformImageServer.java
+++ b/qupath-core/src/test/java/qupath/lib/images/servers/TestAffineTransformImageServer.java
@@ -38,7 +38,7 @@ import qupath.lib.roi.RoiTools;
 @SuppressWarnings("javadoc")
 public class TestAffineTransformImageServer {
 	
-	private final static Logger logger = LoggerFactory.getLogger(TestAffineTransformImageServer.class);
+	private static final Logger logger = LoggerFactory.getLogger(TestAffineTransformImageServer.class);
 
 	@Test
 	public void test() {

--- a/qupath-core/src/test/java/qupath/lib/images/writers/TestImageWriterIJ.java
+++ b/qupath-core/src/test/java/qupath/lib/images/writers/TestImageWriterIJ.java
@@ -35,7 +35,7 @@ import javax.imageio.ImageIO;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("javadoc")
-public class ImageWriterIJTest {
+public class TestImageWriterIJ {
 
 	@Test
 	public void testWriters() {

--- a/qupath-core/src/test/java/qupath/lib/io/TestPathIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPathIO.java
@@ -50,7 +50,7 @@ import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.roi.ROIs;
 
 @SuppressWarnings("javadoc")
-public class PathIOTest {
+public class TestPathIO {
 	
 	@Test
 	public void test_unzippedExtensions() throws IOException {

--- a/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
@@ -52,7 +52,7 @@ import qupath.lib.roi.ROIs;
 import qupath.lib.roi.interfaces.ROI;
 
 @SuppressWarnings("javadoc")
-public class PathObjectIOTest {
+public class TestPathObjectIO {
 	
 	/**
 	 * Test if importing back exported objects are unchanged (GeoJSON).

--- a/qupath-core/src/test/java/qupath/lib/io/TestPointIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPointIO.java
@@ -48,7 +48,7 @@ import qupath.lib.roi.interfaces.ROI;
 
 @SuppressWarnings("javadoc")
 @TestMethodOrder(MethodOrderer.Alphanumeric.class)
-public class PointIOTest {
+public class TestPointIO {
 
 	static Map<Integer, Double[][]> map;
 	static File file;

--- a/qupath-core/src/test/java/qupath/lib/roi/TestRoiTools.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestRoiTools.java
@@ -50,7 +50,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class TestRoiTools {
 	
-	private final static Logger logger = LoggerFactory.getLogger(TestRoiTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(TestRoiTools.class);
 	
 	/**
 	 * Compare conversion of {@link AffineTransform} and {@link AffineTransformation} objects.

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -1038,12 +1038,12 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 	 */
 	static class ReaderPool implements AutoCloseable {
 		
-		private final static Logger logger = LoggerFactory.getLogger(ReaderPool.class);
+		private static final Logger logger = LoggerFactory.getLogger(ReaderPool.class);
 		
 		/**
 		 * Absolute maximum number of permitted readers (queue capacity)
 		 */
-		private final static int MAX_QUEUE_CAPACITY = 128;
+		private static final int MAX_QUEUE_CAPACITY = 128;
 		
 		private String id;
 		private BioFormatsServerOptions options;

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsOptionsExtension.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsOptionsExtension.java
@@ -51,7 +51,7 @@ import qupath.lib.images.writers.ome.OMEPyramidWriterCommand;
  */
 public class BioFormatsOptionsExtension implements QuPathExtension {
 	
-	private final static Logger logger = LoggerFactory.getLogger(BioFormatsOptionsExtension.class);
+	private static final Logger logger = LoggerFactory.getLogger(BioFormatsOptionsExtension.class);
 	
 	private String bfVersion = null;
 

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerBuilder.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerBuilder.java
@@ -47,7 +47,7 @@ import qupath.lib.images.servers.bioformats.BioFormatsServerOptions.UseBioformat
  */
 public class BioFormatsServerBuilder implements ImageServerBuilder<BufferedImage> {
 	
-	final private static Logger logger = LoggerFactory.getLogger(BioFormatsServerBuilder.class);
+	private static final Logger logger = LoggerFactory.getLogger(BioFormatsServerBuilder.class);
 	
 	@Override
 	public ImageServer<BufferedImage> buildServer(URI uri, String...args) {

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerOptions.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerOptions.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BioFormatsServerOptions {
 	
-	private final static Logger logger = LoggerFactory.getLogger(BioFormatsServerOptions.class);
+	private static final Logger logger = LoggerFactory.getLogger(BioFormatsServerOptions.class);
 
 	/**
 	 * System property controlling whether memoization is allowed or not.

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
@@ -52,7 +52,7 @@ import qupath.lib.images.writers.ome.OMEPyramidWriter.CompressionType;
 @Command(name = "convert-ome", description = "Converts an input image to OME-TIFF.", sortOptions = false)
 public class ConvertCommand implements Runnable, Subcommand {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ConvertCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(ConvertCommand.class);
 	
 	@Parameters(index = "0", description="Path to the file to convert.", paramLabel = "input")
 	private File inputFile;

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriterCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriterCommand.java
@@ -62,7 +62,7 @@ import qupath.lib.regions.RegionRequest;
  */
 public class OMEPyramidWriterCommand implements Runnable {
 
-	private final static Logger logger = LoggerFactory.getLogger(OMEPyramidWriterCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(OMEPyramidWriterCommand.class);
 	
 	private static ObjectProperty<CompressionType> defaultPyramidCompression = PathPrefs.createPersistentPreference(
 			"ome-pyramid-compression", CompressionType.DEFAULT, CompressionType.class);

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
@@ -61,7 +61,7 @@ import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
  */
 public class OpenslideImageServer extends AbstractTileableImageServer {
 	
-	final private static Logger logger = LoggerFactory.getLogger(OpenslideImageServer.class);
+	private static final Logger logger = LoggerFactory.getLogger(OpenslideImageServer.class);
 
 	private static boolean useBoundingBoxes = true;
 	

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
@@ -45,7 +45,7 @@ import qupath.lib.images.servers.FileFormatInfo.ImageCheckType;
  */
 public class OpenslideServerBuilder implements ImageServerBuilder<BufferedImage> {
 	
-	private static Logger logger = LoggerFactory.getLogger(OpenslideServerBuilder.class);
+	private static final Logger logger = LoggerFactory.getLogger(OpenslideServerBuilder.class);
 	private static boolean openslideUnavailable = false;
 	
 	private static List<String> WIN_LIBRARIES = Arrays.asList(

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ExtractRegionCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ExtractRegionCommand.java
@@ -81,7 +81,7 @@ class ExtractRegionCommand implements Runnable {
 	
 	private QuPathGUI qupath;
 	
-	private final static String PIXELS_UNIT = "Pixels (downsample)";
+	private static final String PIXELS_UNIT = "Pixels (downsample)";
 	
 	private double resolution = 1;
 	private String resolutionUnit = PIXELS_UNIT;

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/IJExtension.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/IJExtension.java
@@ -118,7 +118,7 @@ import qupathj.QuPath_Send_ROI_to_QuPath;
  */
 public class IJExtension implements QuPathExtension {
 	
-	final private static Logger logger = LoggerFactory.getLogger(IJExtension.class);
+	private static final Logger logger = LoggerFactory.getLogger(IJExtension.class);
 	
 	// Path to ImageJ - used to determine plugins directory
 	private static StringProperty imageJPath = null;

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
@@ -96,7 +96,7 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 	
 	private String macroText = null;
 
-	transient private Stage dialog;
+	private transient Stage dialog;
 		
 	/**
 	 * Constructor.

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ProcessingExtension.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ProcessingExtension.java
@@ -68,7 +68,7 @@ import qupath.process.gui.commands.ui.LoadResourceCommand;
  */
 public class ProcessingExtension implements QuPathExtension {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ProcessingExtension.class);
+	private static final Logger logger = LoggerFactory.getLogger(ProcessingExtension.class);
 	
 	static {
 		// TODO: Consider a better way to force initialization of key processing classes

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/WandToolCV.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/WandToolCV.java
@@ -78,7 +78,7 @@ import qupath.lib.roi.GeometryTools;
  */
 public class WandToolCV extends BrushTool {
 	
-	final private static Logger logger = LoggerFactory.getLogger(WandToolCV.class);
+	private static final Logger logger = LoggerFactory.getLogger(WandToolCV.class);
 	
 	/**
 	 * Enum reflecting different color images that may be used by the Wand tool.

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateCompositeClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateCompositeClassifierCommand.java
@@ -63,7 +63,7 @@ import qupath.process.gui.commands.ml.ProjectClassifierBindings;
  */
 public class CreateCompositeClassifierCommand implements Runnable {
 	
-	private final static Logger logger = LoggerFactory.getLogger(CreateCompositeClassifierCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(CreateCompositeClassifierCommand.class);
 	
 	private static String title = "Create composite classifier";
 	

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateRegionAnnotationsCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateRegionAnnotationsCommand.java
@@ -84,7 +84,7 @@ public class CreateRegionAnnotationsCommand implements Runnable {
 	
 	static class RegionMaker {
 		
-		private final static Logger logger = LoggerFactory.getLogger(RegionMaker.class);
+		private static final Logger logger = LoggerFactory.getLogger(RegionMaker.class);
 		
 		public static enum RegionLocation {VIEW_CENTER, IMAGE_CENTER, RANDOM;
 			

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/DensityMapCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/DensityMapCommand.java
@@ -35,7 +35,7 @@ import qupath.process.gui.commands.density.DensityMapDialog;
  */
 public class DensityMapCommand implements Runnable {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DensityMapCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(DensityMapCommand.class);
 	
 	private QuPathGUI qupath;
 	private DensityMapDialog dialog;

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ExportTrainingRegionsCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ExportTrainingRegionsCommand.java
@@ -112,7 +112,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class ExportTrainingRegionsCommand implements Runnable {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ExportTrainingRegionsCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(ExportTrainingRegionsCommand.class);
 	
 	private final QuPathGUI qupath;
 	private Stage stage;

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
@@ -144,7 +144,7 @@ import qupath.process.gui.commands.ml.ProjectClassifierBindings;
  */
 public class ObjectClassifierCommand implements Runnable {
 
-	final private static String name = "Train object classifier";
+	private static final String name = "Train object classifier";
 
 	private QuPathGUI qupath;
 
@@ -208,7 +208,7 @@ public class ObjectClassifierCommand implements Runnable {
 
 	static class ObjectClassifierPane implements ChangeListener<ImageData<BufferedImage>>, PathObjectHierarchyListener {
 
-		private final static Logger logger = LoggerFactory.getLogger(ObjectClassifierPane.class);
+		private static final Logger logger = LoggerFactory.getLogger(ObjectClassifierPane.class);
 
 		private QuPathGUI qupath;
 

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierLoadCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierLoadCommand.java
@@ -76,7 +76,7 @@ import qupath.lib.projects.Project;
  */
 public final class ObjectClassifierLoadCommand implements Runnable {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ObjectClassifierLoadCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(ObjectClassifierLoadCommand.class);
 	private final String title = "Object Classifiers";
 	
 	private QuPathGUI qupath;

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SplitProjectTrainingCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SplitProjectTrainingCommand.java
@@ -51,7 +51,7 @@ import qupath.lib.projects.ProjectImageEntry;
  */
 public class SplitProjectTrainingCommand implements Runnable {
 	
-	private final static Logger logger = LoggerFactory.getLogger(SplitProjectTrainingCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(SplitProjectTrainingCommand.class);
 	
 	/**
 	 * Metadata key for the flag indicating the image type (Train, Validation, Test or None).

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapDialog.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapDialog.java
@@ -107,7 +107,7 @@ import qupath.process.gui.commands.density.DensityMapUI.MinMax;
  */
 public class DensityMapDialog {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DensityMapDialog.class);
+	private static final Logger logger = LoggerFactory.getLogger(DensityMapDialog.class);
 	
 	private QuPathGUI qupath;
 			
@@ -501,7 +501,7 @@ public class DensityMapDialog {
 	 */
 	static class ObservableColorModelBuilder {
 		
-		private final static Logger logger = LoggerFactory.getLogger(ObservableColorModelBuilder.class);
+		private static final Logger logger = LoggerFactory.getLogger(ObservableColorModelBuilder.class);
 
 		private final ObjectProperty<ColorMap> colorMap = new SimpleObjectProperty<>();
 
@@ -660,7 +660,7 @@ public class DensityMapDialog {
 	 */
 	static class ObservableDensityMapBuilder {
 		
-		private final static Logger logger = LoggerFactory.getLogger(ObservableDensityMapBuilder.class);
+		private static final Logger logger = LoggerFactory.getLogger(ObservableDensityMapBuilder.class);
 
 		private ObjectProperty<DensityMapObjects> allObjectTypes = new SimpleObjectProperty<>(DensityMapObjects.DETECTIONS);
 		private ObjectProperty<PathClass> allObjectClass = new SimpleObjectProperty<>(DensityMapUI.ANY_CLASS);
@@ -810,7 +810,7 @@ public class DensityMapDialog {
 	 */
 	static class HierarchyClassifierOverlayManager implements PathObjectHierarchyListener, QuPathViewerListener {
 		
-		private final static Logger logger = LoggerFactory.getLogger(HierarchyClassifierOverlayManager.class);
+		private static final Logger logger = LoggerFactory.getLogger(HierarchyClassifierOverlayManager.class);
 
 		private final QuPathGUI qupath;
 

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapUI.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapUI.java
@@ -107,9 +107,9 @@ import qupath.process.gui.commands.ui.SaveResourcePaneBuilder;
  */
 public class DensityMapUI {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DensityMapUI.class);
+	private static final Logger logger = LoggerFactory.getLogger(DensityMapUI.class);
 	
-	private final static String title = "Density maps";
+	private static final String title = "Density maps";
 	
 	/**
 	 * Create a pane that can be used to save a {@link DensityMapBuilder}, with standardized display and prompts.

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapUI.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapUI.java
@@ -334,7 +334,7 @@ public class DensityMapUI {
 	 * Abstract base class for an action that operates on a density map.
 	 * Only intended for internal use.
 	 */
-	private static abstract class DensityMapButtonCommand {
+	private abstract static class DensityMapButtonCommand {
 		
 		protected QuPathGUI qupath;
 		protected ObjectExpression<PixelClassificationOverlay> overlay;
@@ -1027,7 +1027,7 @@ public class DensityMapUI {
 	 */
 	static class ThresholdColorModels {
 	
-		static abstract class ColorModelThreshold {
+		abstract static class ColorModelThreshold {
 			
 			private int transferType;
 						

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/ClassificationResolution.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/ClassificationResolution.java
@@ -43,7 +43,7 @@ public class ClassificationResolution {
 	private static List<String> resolutionNames = Arrays.asList("Full", "Very high", "High", "Moderate", "Low", "Very low", "Extremely low");
 
 	
-	final private String name;
+	private final String name;
 	final PixelCalibration cal;
 	
 	ClassificationResolution(String name, PixelCalibration cal) {

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/ImageDataTransformerBuilder.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/ImageDataTransformerBuilder.java
@@ -61,7 +61,7 @@ import qupath.opencv.tools.MultiscaleFeatures.MultiscaleFeature;
  */
 abstract class ImageDataTransformerBuilder {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ImageDataTransformerBuilder.class);
+	private static final Logger logger = LoggerFactory.getLogger(ImageDataTransformerBuilder.class);
 
 	public abstract ImageDataOp build(ImageData<BufferedImage> imageData, PixelCalibration resolution);
 
@@ -108,7 +108,7 @@ abstract class ImageDataTransformerBuilder {
 
 //	static class ExtractNeighborsFeatureCalculatorBuilder extends FeatureCalculatorBuilder {
 //		
-//		private final static Logger logger = LoggerFactory.getLogger(ExtractNeighborsFeatureCalculatorBuilder.class);
+//		private static final Logger logger = LoggerFactory.getLogger(ExtractNeighborsFeatureCalculatorBuilder.class);
 //
 //		private GridPane pane;
 //		private CheckComboBox<String> comboChannels;
@@ -225,7 +225,7 @@ abstract class ImageDataTransformerBuilder {
 
 	static class DefaultFeatureCalculatorBuilder extends ImageDataTransformerBuilder {
 		
-		private final static Logger logger = LoggerFactory.getLogger(DefaultFeatureCalculatorBuilder.class);
+		private static final Logger logger = LoggerFactory.getLogger(DefaultFeatureCalculatorBuilder.class);
 		
 		private static enum NormalizationType {
 			NONE,

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
@@ -669,7 +669,7 @@ public class PixelClassifierPane {
 	 * 
 	 * @return true if the builder was added, false otherwise.
 	 */
-	public synchronized static boolean installDefaultFeatureClassificationBuilder(ImageDataTransformerBuilder builder) {
+	public static synchronized boolean installDefaultFeatureClassificationBuilder(ImageDataTransformerBuilder builder) {
 		if (!defaultFeatureCalculatorBuilders.contains(builder)) {
 			defaultFeatureCalculatorBuilders.add(builder);
 			return true;

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
@@ -136,7 +136,7 @@ import qupath.process.gui.commands.ml.PixelClassifierTraining.ClassifierTraining
  */
 public class PixelClassifierPane {
 	
-	final static Logger logger = LoggerFactory.getLogger(PixelClassifierPane.class);
+	private static final Logger logger = LoggerFactory.getLogger(PixelClassifierPane.class);
 	
 	private static ObservableList<ImageDataTransformerBuilder> defaultFeatureCalculatorBuilders = FXCollections.observableArrayList();
 	

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierUI.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierUI.java
@@ -86,9 +86,9 @@ import qupath.process.gui.commands.ui.SaveResourcePaneBuilder;
  */
 public class PixelClassifierUI {
 	
-	private final static Logger logger = LoggerFactory.getLogger(PixelClassifierUI.class);
+	private static final Logger logger = LoggerFactory.getLogger(PixelClassifierUI.class);
 	
-	private final static String title = "Pixel classifier";
+	private static final String title = "Pixel classifier";
 
 	/**
 	 * Create a {@link ComboBox} that can be used to select the pixel classification region filter.

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/ProjectClassifierBindings.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/ProjectClassifierBindings.java
@@ -42,7 +42,7 @@ import qupath.lib.projects.Project;
  */
 public class ProjectClassifierBindings {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ProjectClassifierBindings.class);
+	private static final Logger logger = LoggerFactory.getLogger(ProjectClassifierBindings.class);
 	
 	/**
 	 * Set styling for a text field to use pixel classifier names for the current project.

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/JsonHighlighter.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/JsonHighlighter.java
@@ -45,12 +45,12 @@ public class JsonHighlighter implements ScriptHighlighter {
 	 */
 	private static JsonHighlighter INSTANCE;
 
-    final static String PAREN_PATTERN = "\\(|\\)";
-    final static String BRACE_PATTERN = "\\{|\\}";
-    final static String BRACKET_PATTERN = "\\[|\\]";
-    final static String DOUBLE_QUOTE_PATTERN = "\"([^\"\\\\]|\\\\.)*\"";
-    final static String SINGLE_QUOTE_PATTERN = "'([^'\\\\]|\\\\.)*\'";
-    final static String REMAINING_PATTERN = "[^,.:]";
+    static final String PAREN_PATTERN = "\\(|\\)";
+    static final String BRACE_PATTERN = "\\{|\\}";
+    static final String BRACKET_PATTERN = "\\[|\\]";
+    static final String DOUBLE_QUOTE_PATTERN = "\"([^\"\\\\]|\\\\.)*\"";
+    static final String SINGLE_QUOTE_PATTERN = "'([^'\\\\]|\\\\.)*\'";
+    static final String REMAINING_PATTERN = "[^,.:]";
 	
     private static Pattern PATTERN = Pattern.compile(
             "(?<PAREN>" + PAREN_PATTERN + ")"

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/MarkdownHighlighter.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/MarkdownHighlighter.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MarkdownHighlighter implements ScriptHighlighter {
 	
-	private final static Logger logger = LoggerFactory.getLogger(MarkdownHighlighter.class);
+	private static final Logger logger = LoggerFactory.getLogger(MarkdownHighlighter.class);
 	
 	/**
 	 * Instance of this highlighter. Can't be final because of {@link ServiceLoader}.

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/XmlHighlighter.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/XmlHighlighter.java
@@ -167,7 +167,7 @@ public class XmlHighlighter implements ScriptHighlighter {
         return spansBuilder.create();
     }
 	
-	private final static Collection<String> BASE_STYLE = Collections.singletonList("xml");
+	private static final Collection<String> BASE_STYLE = Collections.singletonList("xml");
 	
 	private static void appendSpan(StyleSpansBuilder<Collection<String>> spansBuilder, String style, int length) {
 		if (style == null || style.isEmpty())

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/package-info.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/highlighters/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Classes for syntax highlighting in QuPath's script editor.
+ */
+package qupath.lib.gui.scripting.highlighters;

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -86,7 +86,7 @@ import qupath.lib.gui.tools.MenuTools;
  */
 public class RichScriptEditor extends DefaultScriptEditor {
 	
-	final private static Logger logger = LoggerFactory.getLogger(RichScriptEditor.class);
+	private static final Logger logger = LoggerFactory.getLogger(RichScriptEditor.class);
 	
 	private ExecutorService executor = Executors.newSingleThreadExecutor(ThreadTools.createThreadFactory("rich-text-styling", true));
 	

--- a/qupath-extension-svg/src/main/java/qupath/lib/extension/svg/SvgTools.java
+++ b/qupath-extension-svg/src/main/java/qupath/lib/extension/svg/SvgTools.java
@@ -64,7 +64,7 @@ import qupath.lib.regions.RegionRequest;
  */
 public class SvgTools {
 	
-//	private final static Logger logger = LoggerFactory.getLogger(SvgTools.class);
+//	private static final Logger logger = LoggerFactory.getLogger(SvgTools.class);
 	
 	/**
 	 * Write an SVG image representing the contents of the specified viewer.
@@ -89,7 +89,7 @@ public class SvgTools {
 	 */
 	public static class SvgBuilder {
 		
-		private final static Logger logger = LoggerFactory.getLogger(SvgBuilder.class);
+		private static final Logger logger = LoggerFactory.getLogger(SvgBuilder.class);
 		
 		/**
 		 * Enum defining ways in which raster images may be included in the SVG file.

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/AbstractChannelInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/AbstractChannelInfo.java
@@ -126,11 +126,11 @@ abstract class AbstractChannelInfo implements ModifiableChannelDisplayInfo {
 		return maxDisplay;
 	}
 
-	final static int do8BitRangeCheck(float v) {
+	static final int do8BitRangeCheck(float v) {
 		return v < 0 ? 0 : (v > 255 ? 255 : (int)v);
 	}
 
-	final static int do8BitRangeCheck(int v) {
+	static final int do8BitRangeCheck(int v) {
 		return v < 0 ? 0 : (v > 255 ? 255 : v);
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/DirectServerChannelInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/DirectServerChannelInfo.java
@@ -47,9 +47,9 @@ public class DirectServerChannelInfo extends AbstractSingleChannelInfo {
 
 	private int channel;
 
-	transient private ColorModel cm;
-	transient private ColorModel cmInverted;
-	transient private int[] rgbLUT;
+	private transient ColorModel cm;
+	private transient ColorModel cmInverted;
+	private transient int[] rgbLUT;
 	private int rgb;
 
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -104,7 +104,7 @@ public class ImageDisplay extends AbstractImageRenderer {
 	private ObjectBinding<ChannelDisplayMode> displayMode = Bindings.createObjectBinding(() -> calculateDisplayMode(),
 			useGrayscaleLutProperty(), useInvertedBackgroundProperty());
 	
-	private transient static Map<String, HistogramManager> cachedHistograms = Collections.synchronizedMap(new HashMap<>());
+	private static transient Map<String, HistogramManager> cachedHistograms = Collections.synchronizedMap(new HashMap<>());
 	private HistogramManager histogramManager = null;
 	
 	private static BooleanProperty showAllRGBTransforms = PathPrefs.createPersistentPreference("showAllRGBTransforms", true);

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -75,7 +75,7 @@ import qupath.lib.images.servers.PixelType;
  */
 public class ImageDisplay extends AbstractImageRenderer {
 
-	private final static Logger logger = LoggerFactory.getLogger(ImageDisplay.class);
+	private static final Logger logger = LoggerFactory.getLogger(ImageDisplay.class);
 	
 	/**
 	 * Identifier used when storing/retrieving display settings from ImageData properties.
@@ -104,7 +104,7 @@ public class ImageDisplay extends AbstractImageRenderer {
 	private ObjectBinding<ChannelDisplayMode> displayMode = Bindings.createObjectBinding(() -> calculateDisplayMode(),
 			useGrayscaleLutProperty(), useInvertedBackgroundProperty());
 	
-	transient private static Map<String, HistogramManager> cachedHistograms = Collections.synchronizedMap(new HashMap<>());
+	private transient static Map<String, HistogramManager> cachedHistograms = Collections.synchronizedMap(new HashMap<>());
 	private HistogramManager histogramManager = null;
 	
 	private static BooleanProperty showAllRGBTransforms = PathPrefs.createPersistentPreference("showAllRGBTransforms", true);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/BuildInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/BuildInfo.java
@@ -41,7 +41,7 @@ import qupath.lib.common.Version;
  */
 public class BuildInfo {
 
-	private final static Logger logger = LoggerFactory.getLogger(BuildInfo.class);
+	private static final Logger logger = LoggerFactory.getLogger(BuildInfo.class);
 
 	private String buildString = null;
 	private String versionString = null;
@@ -52,7 +52,7 @@ public class BuildInfo {
 	 */
 	private String latestCommitTag = null;
 	
-	private final static BuildInfo INSTANCE = new BuildInfo();
+	private static final BuildInfo INSTANCE = new BuildInfo();
 
 	/**
 	 * Attempt to parse version information

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ExtensionClassLoader extends URLClassLoader {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ExtensionClassLoader.class);
+	private static final Logger logger = LoggerFactory.getLogger(ExtensionClassLoader.class);
 
 	/**
 	 * Constructor.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
@@ -70,12 +70,12 @@ import qupath.lib.plugins.objects.SplitAnnotationsPlugin;
 
 class Menus {
 	
-	private final static String URL_DOCS       = "https://qupath.readthedocs.io";
-	private final static String URL_VIDEOS     = "https://www.youtube.com/c/QuPath";
-	private final static String URL_CITATION   = "https://qupath.readthedocs.io/en/latest/docs/intro/citing.html";
-	private final static String URL_BUGS       = "https://github.com/qupath/qupath/issues";
-	private final static String URL_FORUM      = "https://forum.image.sc/tags/qupath";
-	private final static String URL_SOURCE     = "https://github.com/qupath/qupath";
+	private static final String URL_DOCS       = "https://qupath.readthedocs.io";
+	private static final String URL_VIDEOS     = "https://www.youtube.com/c/QuPath";
+	private static final String URL_CITATION   = "https://qupath.readthedocs.io/en/latest/docs/intro/citing.html";
+	private static final String URL_BUGS       = "https://github.com/qupath/qupath/issues";
+	private static final String URL_FORUM      = "https://forum.image.sc/tags/qupath";
+	private static final String URL_SOURCE     = "https://github.com/qupath/qupath";
 
 	
 	private QuPathGUI qupath;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/PluginRunnerFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/PluginRunnerFX.java
@@ -62,7 +62,7 @@ import qupath.lib.regions.ImageRegion;
  */
 class PluginRunnerFX extends AbstractPluginRunner<BufferedImage> {
 
-	private final static Logger logger = LoggerFactory.getLogger(PluginRunnerFX.class);
+	private static final Logger logger = LoggerFactory.getLogger(PluginRunnerFX.class);
 	
 	// Time to delay QuPath viewer repaints when running plugin tasks
 	private static long repaintDelayMillis = 1000;
@@ -140,7 +140,7 @@ class PluginRunnerFX extends AbstractPluginRunner<BufferedImage> {
 	
 	static class PluginProgressMonitorFX implements SimpleProgressMonitor {
 
-		final private static Logger logger = LoggerFactory.getLogger(PluginProgressMonitorFX.class);
+		private static final Logger logger = LoggerFactory.getLogger(PluginProgressMonitorFX.class);
 
 		private static String STARTING_MESSAGE = "Starting...";
 		private static String RUNNING_MESSAGE = "Running...";

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
@@ -47,7 +47,7 @@ import qupath.lib.projects.ProjectIO;
  */
 public class QuPathApp extends Application {
 	
-	final static Logger logger = LoggerFactory.getLogger(QuPathApp.class);
+	static final Logger logger = LoggerFactory.getLogger(QuPathApp.class);
 
 	@Override
 	public void start(Stage stage) throws Exception {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -289,7 +289,7 @@ public class QuPathGUI {
 	/**
 	 * Preferred size for toolbar icons.
 	 */
-	final public static int TOOLBAR_ICON_SIZE = 16;
+	public static final int TOOLBAR_ICON_SIZE = 16;
 
 	MultiviewManager viewerManager;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -259,7 +259,7 @@ import qupath.lib.gui.scripting.DefaultScriptEditor;
  */
 public class QuPathGUI {
 	
-	private final static Logger logger = LoggerFactory.getLogger(QuPathGUI.class);
+	private static final Logger logger = LoggerFactory.getLogger(QuPathGUI.class);
 	
 	private static QuPathGUI instance;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ScriptMenuLoader.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ScriptMenuLoader.java
@@ -55,7 +55,7 @@ import qupath.lib.gui.tools.MenuTools;
  */
 class ScriptMenuLoader {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ScriptMenuLoader.class);
+	private static final Logger logger = LoggerFactory.getLogger(ScriptMenuLoader.class);
 	
 	private ObservableStringValue scriptDirectory;
 	private Menu menu;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/SelectableItem.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/SelectableItem.java
@@ -37,12 +37,12 @@ import javafx.scene.control.ToggleGroup;
  */
 public class SelectableItem<T> {
 
-	final private ObjectProperty<T> selected;
-	final private BooleanProperty itemSelected = new SimpleBooleanProperty();
-	final private T item;
+	private final ObjectProperty<T> selected;
+	private final BooleanProperty itemSelected = new SimpleBooleanProperty();
+	private final T item;
 	
-	final private ChangeListener<T> selectedListener;
-	final private ChangeListener<Boolean> itemSelectedListener;
+	private final ChangeListener<T> selectedListener;
+	private final ChangeListener<Boolean> itemSelectedListener;
 	
 	/**
 	 * Constructor.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
@@ -54,7 +54,7 @@ import qupath.lib.gui.viewer.tools.PathTool;
 
 class ToolBarComponent {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ToolBarComponent.class);
+	private static final Logger logger = LoggerFactory.getLogger(ToolBarComponent.class);
 		
 		private QuPathGUI qupath;
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/ChartTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/ChartTools.java
@@ -64,7 +64,7 @@ import javafx.scene.shape.Rectangle;
  */
 public class ChartTools {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ChartTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(ChartTools.class);
 	
 	/**
 	 * Cache of stylesheets for pie charts, which are temp files.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/Charts.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/Charts.java
@@ -71,7 +71,7 @@ public class Charts {
 	
 	// See https://stackoverflow.com/questions/17164375/subclassing-a-java-builder-class/34741836#34741836 
 	// for a great description of what is going on here...
-	static abstract class ChartBuilder<T extends ChartBuilder<T, S>, S extends Chart> {
+	abstract static class ChartBuilder<T extends ChartBuilder<T, S>, S extends Chart> {
 	
 		protected QuPathViewer viewer;
 		protected ImageData<?> imageData;
@@ -436,7 +436,7 @@ public class Charts {
 	}
 	
 	
-	static abstract class XYChartBuilder<T extends XYChartBuilder<T, S, X, Y>, S extends XYChart<X, Y>, X, Y> extends ChartBuilder<T, S> {
+	abstract static class XYChartBuilder<T extends XYChartBuilder<T, S, X, Y>, S extends XYChart<X, Y>, X, Y> extends ChartBuilder<T, S> {
 		
 		protected String xLabel, yLabel;
 		
@@ -463,7 +463,7 @@ public class Charts {
 	}
 	
 	
-	static abstract class XYNumberChartBuilder<T extends XYNumberChartBuilder<T, S>, S extends XYChart<Number, Number>> extends XYChartBuilder<T, S, Number, Number> {
+	abstract static class XYNumberChartBuilder<T extends XYNumberChartBuilder<T, S>, S extends XYChart<Number, Number>> extends XYChartBuilder<T, S, Number, Number> {
 		
 		protected abstract S createNewChart(Axis<Number> xAxis, Axis<Number> yAxis);
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/ExportChartPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/ExportChartPane.java
@@ -529,7 +529,7 @@ class ExportChartPane {
 	}
 
 	
-	private synchronized static void updateStoredPrefs() {
+	private static synchronized void updateStoredPrefs() {
 		List<String> prefs = new ArrayList<>();
 		try {
 			PathPrefs.getUserPreferences().sync();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/ExportChartPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/ExportChartPane.java
@@ -93,7 +93,7 @@ import qupath.lib.io.GsonTools;
  */
 class ExportChartPane {
 
-	private final static Logger logger = LoggerFactory.getLogger(ExportChartPane.class);
+	private static final Logger logger = LoggerFactory.getLogger(ExportChartPane.class);
 
 	public static enum ChartStyle {
 		COLOR("Color"), GRAY("Gray"), BLACK("Black");

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramDisplay.java
@@ -65,7 +65,7 @@ import qupath.lib.plugins.parameters.ParameterList;
  */
 public class HistogramDisplay implements ParameterChangeListener {
 
-	final static Logger logger = LoggerFactory.getLogger(HistogramDisplay.class);
+	static final Logger logger = LoggerFactory.getLogger(HistogramDisplay.class);
 
 	private PathTableData<?> model;
 	private BorderPane pane = new BorderPane();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramPanelFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramPanelFX.java
@@ -64,7 +64,7 @@ import qupath.lib.gui.tools.ColorToolsFX;
  */
 public class HistogramPanelFX {
 	
-	private final static Logger logger = LoggerFactory.getLogger(HistogramPanelFX.class);
+	private static final Logger logger = LoggerFactory.getLogger(HistogramPanelFX.class);
 
 	private final NumberAxis xAxis = new NumberAxis();
 	private final NumberAxis yAxis = new NumberAxis();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPanelCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPanelCommand.java
@@ -72,7 +72,7 @@ import qupath.lib.objects.hierarchy.PathObjectHierarchy;
  */
 public class CountingPanelCommand implements Runnable, ChangeListener<ImageData<BufferedImage>> {
 
-	final private static Logger logger = LoggerFactory.getLogger(CountingPanelCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(CountingPanelCommand.class);
 	
 	private QuPathGUI qupath;
 	private PathObjectHierarchy hierarchy;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
@@ -83,7 +83,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 class EstimateStainVectorsCommand {
 	
-	final private static Logger logger = LoggerFactory.getLogger(EstimateStainVectorsCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(EstimateStainVectorsCommand.class);
 	
 	static int MAX_PIXELS = 4000*4000;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/InputDisplayCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/InputDisplayCommand.java
@@ -80,7 +80,7 @@ import qupath.lib.gui.prefs.PathPrefs;
  */
 public class InputDisplayCommand implements EventHandler<InputEvent> {
 
-	private final static Logger logger = LoggerFactory.getLogger(InputDisplayCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(InputDisplayCommand.class);
 	
 	// To ensure single input command per window
 	private static WeakHashMap<Window, InputDisplayCommand> map = new WeakHashMap<>();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/LogViewerCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/LogViewerCommand.java
@@ -70,7 +70,7 @@ import qupath.lib.gui.prefs.PathPrefs;
  */
 public class LogViewerCommand implements Runnable {
 	
-	final private static Logger logger = LoggerFactory.getLogger(LogViewerCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(LogViewerCommand.class);
 	
 	private QuPathGUI qupath;
 	private Stage dialog = null;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementExportCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementExportCommand.java
@@ -99,7 +99,7 @@ import qupath.lib.projects.Projects;
 public class MeasurementExportCommand implements Runnable {
 	
 	private QuPathGUI qupath;
-	private final static Logger logger = LoggerFactory.getLogger(MeasurementExportCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(MeasurementExportCommand.class);
 	private ObjectProperty<Future<?>> runningTask = new SimpleObjectProperty<>();
 	
 	private Dialog<ButtonType> dialog = null;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementManager.java
@@ -83,7 +83,7 @@ import qupath.lib.scripting.QP;
  */
 class MeasurementManager {
 	
-	private final static Logger logger = LoggerFactory.getLogger(MeasurementManager.class);
+	private static final Logger logger = LoggerFactory.getLogger(MeasurementManager.class);
 	
 	private ComboBox<Class<? extends PathObject>> comboBox;
 	private ListView<String> listView;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MemoryMonitorDialog.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MemoryMonitorDialog.java
@@ -71,7 +71,7 @@ import qupath.lib.gui.prefs.PathPrefs;
  */
 class MemoryMonitorDialog {
 
-	private final static Logger logger = LoggerFactory.getLogger(MemoryMonitorDialog.class);
+	private static final Logger logger = LoggerFactory.getLogger(MemoryMonitorDialog.class);
 
 	private QuPathGUI qupath;
 
@@ -94,8 +94,8 @@ class MemoryMonitorDialog {
 	private LongProperty undoRedoSizeBytes = new SimpleLongProperty();
 
 	// Let's sometimes scale to MB, sometimes to GB
-	private final static double scaleMB = 1.0/1024.0/1024.0;
-	private final static double scaleGB = scaleMB/1024.0;
+	private static final double scaleMB = 1.0/1024.0/1024.0;
+	private static final double scaleGB = scaleMB/1024.0;
 	
 	private final MemoryService service = new MemoryService();
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MiniViewers.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MiniViewers.java
@@ -110,7 +110,7 @@ import qupath.lib.regions.ImageRegion;
  */
 public class MiniViewers {
 	
-	private final static Logger logger = LoggerFactory.getLogger(MiniViewers.class);
+	private static final Logger logger = LoggerFactory.getLogger(MiniViewers.class);
 	
 	private static BooleanProperty showAllChannels = PathPrefs.createPersistentPreference("channelViewerAllChannels", false);
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectCommands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectCommands.java
@@ -63,7 +63,7 @@ import qupath.lib.projects.Projects;
  */
 public class ProjectCommands {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ProjectCommands.class);
+	private static final Logger logger = LoggerFactory.getLogger(ProjectCommands.class);
 
 	/**
 	 * Check the URIs within a project, prompting the user to correct any broken links if required.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
@@ -104,13 +104,13 @@ import qupath.lib.projects.ProjectImageEntry;
  */
 class ProjectImportImagesCommand {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ProjectImportImagesCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(ProjectImportImagesCommand.class);
 		
-	private final static String commandName = "Import images";
+	private static final String commandName = "Import images";
 	
-	private final static BooleanProperty pyramidalizeProperty = PathPrefs.createPersistentPreference("projectImportPyramidalize", true);
-	private final static BooleanProperty importObjectsProperty = PathPrefs.createPersistentPreference("projectImportObjects", false);
-	private final static BooleanProperty showImageSelectorProperty = PathPrefs.createPersistentPreference("showImageSelectorProperty", false);
+	private static final BooleanProperty pyramidalizeProperty = PathPrefs.createPersistentPreference("projectImportPyramidalize", true);
+	private static final BooleanProperty importObjectsProperty = PathPrefs.createPersistentPreference("projectImportObjects", false);
+	private static final BooleanProperty showImageSelectorProperty = PathPrefs.createPersistentPreference("showImageSelectorProperty", false);
 	
 	/**
 	 * Prompt to import images to the current project.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectMetadataEditorCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectMetadataEditorCommand.java
@@ -75,9 +75,9 @@ import qupath.lib.projects.ProjectImageEntry;
  */
 class ProjectMetadataEditorCommand {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ProjectMetadataEditorCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(ProjectMetadataEditorCommand.class);
 
-	private final static String IMAGE_NAME = "Image name";
+	private static final String IMAGE_NAME = "Image name";
 
 	
 	public static void showProjectMetadataEditor(Project<?> project) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/RigidObjectEditorCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/RigidObjectEditorCommand.java
@@ -78,7 +78,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 class RigidObjectEditorCommand implements Runnable, ChangeListener<ImageData<BufferedImage>>, QuPathViewerListener {
 
-	private final static Logger logger = LoggerFactory.getLogger(RigidObjectEditorCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(RigidObjectEditorCommand.class);
 	
 	private QuPathGUI qupath;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ScriptInterpreter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ScriptInterpreter.java
@@ -100,7 +100,7 @@ import qupath.lib.images.ImageData;
  */
 class ScriptInterpreter {
 
-	final private static Logger logger = LoggerFactory.getLogger(ScriptInterpreter.class);
+	private static final Logger logger = LoggerFactory.getLogger(ScriptInterpreter.class);
 
 	private QuPathGUI qupath;
 	private Stage stage;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowInstalledExtensionsCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowInstalledExtensionsCommand.java
@@ -66,7 +66,7 @@ import qupath.lib.images.servers.ImageServerProvider;
  */
 class ShowInstalledExtensionsCommand {
 	
-	final private static Logger logger = LoggerFactory.getLogger(ShowInstalledExtensionsCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(ShowInstalledExtensionsCommand.class);
 	
 	
 	public static void showInstalledExtensions(final QuPathGUI qupath) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowLicensesCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowLicensesCommand.java
@@ -59,7 +59,7 @@ import qupath.lib.gui.tools.GuiTools;
  */
 class ShowLicensesCommand {
 
-	final private static Logger logger = LoggerFactory.getLogger(ShowLicensesCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(ShowLicensesCommand.class);
 
 	public static Stage createLicensesDialog(QuPathGUI qupath) {
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowSystemInfoCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowSystemInfoCommand.java
@@ -45,7 +45,7 @@ import qupath.lib.gui.QuPathGUI;
  */
 class ShowSystemInfoCommand {
 	
-	final private static Logger logger = LoggerFactory.getLogger(ShowSystemInfoCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(ShowSystemInfoCommand.class);
 	
 	public static Stage createShowSystemInfoDialog(QuPathGUI qupath) {
 		var dialog = new Stage();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SummaryMeasurementTableCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SummaryMeasurementTableCommand.java
@@ -124,7 +124,7 @@ import qupath.lib.regions.RegionRequest;
  */
 public class SummaryMeasurementTableCommand {
 
-	private final static Logger logger = LoggerFactory.getLogger(SummaryMeasurementTableCommand.class);
+	private static final Logger logger = LoggerFactory.getLogger(SummaryMeasurementTableCommand.class);
 
 	private QuPathGUI qupath;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMACommands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMACommands.java
@@ -74,7 +74,7 @@ public class TMACommands {
 		}
 	};
 	
-	private final static String NOTE_NAME = "Note";
+	private static final String NOTE_NAME = "Note";
 	
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMADataImporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMADataImporter.java
@@ -74,7 +74,7 @@ import qupath.lib.objects.hierarchy.TMAGrid;
  */
 class TMADataImporter {
 
-	final private static Logger logger = LoggerFactory.getLogger(TMADataImporter.class);
+	private static final Logger logger = LoggerFactory.getLogger(TMADataImporter.class);
 	
 	private static String TITLE = "Import TMA data";
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMAGridView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMAGridView.java
@@ -103,7 +103,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 class TMAGridView implements Runnable, ChangeListener<ImageData<BufferedImage>>, PathObjectHierarchyListener {
 	
-	final private static Logger logger = LoggerFactory.getLogger(TMAGridView.class);
+	private static final Logger logger = LoggerFactory.getLogger(TMAGridView.class);
 	
 	private QuPathGUI qupath;
 	private Stage stage;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
@@ -69,7 +69,7 @@ import qupath.lib.plugins.parameters.ParameterList;
  */
 public class Dialogs {
 	
-	private final static Logger logger = LoggerFactory.getLogger(Dialogs.class);
+	private static final Logger logger = LoggerFactory.getLogger(Dialogs.class);
 	
 	/**
 	 * Possible buttons pressed in a yes/no/cancel dialog.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/ParameterPanelFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/ParameterPanelFX.java
@@ -81,7 +81,7 @@ public class ParameterPanelFX {
 
 	private List<ParameterChangeListener> listeners = Collections.synchronizedList(new ArrayList<>());
 
-	private final static Logger logger = LoggerFactory.getLogger(ParameterPanelFX.class);
+	private static final Logger logger = LoggerFactory.getLogger(ParameterPanelFX.class);
 	
 	private static int DEFAULT_NUMERIC_TEXT_COLS = 8;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/ProjectDialogs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/ProjectDialogs.java
@@ -58,7 +58,7 @@ import qupath.lib.projects.ProjectImageEntry;
  */
 public class ProjectDialogs {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ProjectDialogs.class);
+	private static final Logger logger = LoggerFactory.getLogger(ProjectDialogs.class);
 	
 	/**
 	 * Populates a given {@link ListSelectionView} with all the project entries.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/images/stores/AbstractImageRegionStore.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/images/stores/AbstractImageRegionStore.java
@@ -67,7 +67,7 @@ abstract class AbstractImageRegionStore<T> implements ImageRegionStore<T> {
 	
 	private static final int DEFAULT_THUMBNAIL_WIDTH = 1000;
 	
-	private final static Logger logger = LoggerFactory.getLogger(AbstractImageRegionStore.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractImageRegionStore.class);
 	
 	// Collection of SwingWorkers used to request image tiles
 	private List<TileWorker<T>> workers = Collections.synchronizedList(new ArrayList<>());
@@ -560,7 +560,7 @@ abstract class AbstractImageRegionStore<T> implements ImageRegionStore<T> {
 	
 	class TileRequestManager {
 		
-		final static int MAX_Z_SEPARATION = 10;
+		static final int MAX_Z_SEPARATION = 10;
 		private List<TileRequestCollection<T>> list = new ArrayList<>();
 		
 		private TileRequestComparator<T> comparator = new TileRequestComparator<>();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/logging/LoggingAppender.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/logging/LoggingAppender.java
@@ -146,7 +146,7 @@ class LoggingAppender extends AppenderBase<ILoggingEvent> {
 	 * Get the static {@link LoggingAppender} instance currently used for logging.
 	 * @return
 	 */
-	public synchronized static LoggingAppender getInstance() {
+	public static synchronized LoggingAppender getInstance() {
 		if (instance == null)
 			instance = new LoggingAppender();
 		return instance;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -86,7 +86,7 @@ import qupath.opencv.ml.pixel.PixelClassificationMeasurementManager;
  */
 public class ObservableMeasurementTableData implements PathTableData<PathObject> {
 	
-	final static Logger logger = LoggerFactory.getLogger(ObservableMeasurementTableData.class);
+	static final Logger logger = LoggerFactory.getLogger(ObservableMeasurementTableData.class);
 	
 	private ImageData<?> imageData;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -1138,7 +1138,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	
 	
 	
-	static abstract class StringMeasurementBuilder implements MeasurementBuilder<String> {
+	abstract static class StringMeasurementBuilder implements MeasurementBuilder<String> {
 		
 		protected abstract String getMeasurementValue(final PathObject pathObject);
 		
@@ -1386,7 +1386,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	
 	
 	
-	static abstract class NumericMeasurementBuilder implements MeasurementBuilder<Number> {
+	abstract static class NumericMeasurementBuilder implements MeasurementBuilder<Number> {
 		
 		public double computeValue(final PathObject pathObject) {
 			// TODO: Flip this around!  Create binding from value, not value from binding...
@@ -1427,7 +1427,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	
 	
 	
-	static abstract class RoiMeasurementBuilder extends NumericMeasurementBuilder {
+	abstract static class RoiMeasurementBuilder extends NumericMeasurementBuilder {
 		
 		private ImageData<?> imageData;
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
@@ -82,7 +82,7 @@ import qupath.lib.objects.hierarchy.events.PathObjectSelectionListener;
  */
 public class AnnotationPane implements PathObjectSelectionListener, ChangeListener<ImageData<BufferedImage>>, PathObjectHierarchyListener {
 
-	private final static Logger logger = LoggerFactory.getLogger(AnnotationPane.class);
+	private static final Logger logger = LoggerFactory.getLogger(AnnotationPane.class);
 
 	private QuPathGUI qupath;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ImageDetailsPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ImageDetailsPane.java
@@ -142,7 +142,7 @@ import qupath.lib.scripting.QP;
  */
 public class ImageDetailsPane implements ChangeListener<ImageData<BufferedImage>>, PropertyChangeListener {
 	
-	final private static Logger logger = LoggerFactory.getLogger(ImageDetailsPane.class);
+	private static final Logger logger = LoggerFactory.getLogger(ImageDetailsPane.class);
 	
 	private QuPathGUI qupath;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/MeasurementMapPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/MeasurementMapPane.java
@@ -82,7 +82,7 @@ import qupath.lib.objects.hierarchy.PathObjectHierarchy;
  */
 public class MeasurementMapPane {
 	
-	private final static Logger logger = LoggerFactory.getLogger(MeasurementMapPane.class);
+	private static final Logger logger = LoggerFactory.getLogger(MeasurementMapPane.class);
 	
 	private QuPathGUI qupath;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ObjectDescriptionPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ObjectDescriptionPane.java
@@ -73,7 +73,7 @@ import qupath.lib.objects.hierarchy.events.PathObjectSelectionListener;
  */
 public class ObjectDescriptionPane<T> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(ObjectDescriptionPane.class);
+	private static final Logger logger = LoggerFactory.getLogger(ObjectDescriptionPane.class);
 	
 	private ObservableValue<ImageData<T>> imageData;
 	private ObjectObserver<T> observer;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ObjectTreeBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ObjectTreeBrowser.java
@@ -57,7 +57,7 @@ import qupath.lib.io.GsonTools;
  */
 public class ObjectTreeBrowser {
 
-	final private static Logger logger = LoggerFactory.getLogger(ObjectTreeBrowser.class);
+	private static final Logger logger = LoggerFactory.getLogger(ObjectTreeBrowser.class);
 
 	private static <T> TreeTableView<T> createTreeTable() {
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
@@ -99,7 +99,7 @@ import qupath.lib.scripting.QP;
  */
 public class PathClassPane {
 	
-	private final static Logger logger = LoggerFactory.getLogger(PathClassPane.class);
+	private static final Logger logger = LoggerFactory.getLogger(PathClassPane.class);
 	
 	private QuPathGUI qupath;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -622,7 +622,7 @@ public class PreferencePane {
 	/**
 	 * Base implementation of {@link Item}.
 	 */
-	public static abstract class PropertyItem implements PropertySheet.Item {
+	public abstract static class PropertyItem implements PropertySheet.Item {
 
 		private String name;
 		private String category;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -80,7 +80,7 @@ import qupath.lib.gui.prefs.QuPathStyleManager;
  */
 public class PreferencePane {
 
-	final private static Logger logger = LoggerFactory.getLogger(PreferencePane.class);
+	private static final Logger logger = LoggerFactory.getLogger(PreferencePane.class);
 
 	private PropertySheet propSheet = new PropertySheet();
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -1011,7 +1011,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 	 * @param name
 	 * @return
 	 */
-	private synchronized static <T> boolean setProjectEntryImageName(final ProjectImageEntry<T> entry, final String name) {
+	private static synchronized <T> boolean setProjectEntryImageName(final ProjectImageEntry<T> entry, final String name) {
 		
 		if (entry.getImageName().equals(name)) {
 			logger.warn("Project image name already set to {} - will be left unchanged", name);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -120,7 +120,7 @@ import qupath.lib.projects.ProjectImageEntry;
  */
 public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> {
 
-	final private static Logger logger = LoggerFactory.getLogger(ProjectBrowser.class);
+	private static final Logger logger = LoggerFactory.getLogger(ProjectBrowser.class);
 
 	private Project<BufferedImage> project;
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
@@ -68,7 +68,7 @@ import qupath.lib.objects.hierarchy.events.PathObjectSelectionListener;
 public class SelectedMeasurementTableView implements PathObjectSelectionListener, ChangeListener<ImageData<BufferedImage>>,
 	PathObjectHierarchyListener, PropertyChangeListener {
 	
-	private final static Logger logger = LoggerFactory.getLogger(SelectedMeasurementTableView.class);
+	private static final Logger logger = LoggerFactory.getLogger(SelectedMeasurementTableView.class);
 	
 	private static int nDecimalPlaces = 4;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ServerSelector.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ServerSelector.java
@@ -471,7 +471,7 @@ public class ServerSelector {
 	static class ImageAndNameListCell extends ListCell<ImageServer<BufferedImage>> {
 		
 		private Map<String, BufferedImage> imageCache;
-		final private Canvas canvas = new Canvas();
+		private final Canvas canvas = new Canvas();
 		
 		private Image img;
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/WorkflowCommandLogView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/WorkflowCommandLogView.java
@@ -88,7 +88,7 @@ import qupath.lib.plugins.workflow.WorkflowStep;
  */
 public class WorkflowCommandLogView implements ChangeListener<ImageData<BufferedImage>>, WorkflowListener {
 
-	private final static Logger logger = LoggerFactory.getLogger(WorkflowCommandLogView.class);
+	private static final Logger logger = LoggerFactory.getLogger(WorkflowCommandLogView.class);
 	
 	private QuPathGUI qupath;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -93,20 +93,20 @@ public class PathPrefs {
 	 * Allow preference node name to be specified in system property.
 	 * This is especially useful for debugging without using the same user directory.
 	 */
-	private final static String PROP_PREFS = "qupath.prefs.name";
+	private static final String PROP_PREFS = "qupath.prefs.name";
 	
-//	private final static String PROP_USER_PATH = "qupath.path.user";
+//	private static final String PROP_USER_PATH = "qupath.path.user";
 	
 	
 	/**
 	 * Default name for preference node in this QuPath version
 	 */
-	private final static String DEFAULT_NODE_NAME = "io.github.qupath/0.4";
+	private static final String DEFAULT_NODE_NAME = "io.github.qupath/0.4";
 	
 	/**
 	 * Name for preference node
 	 */
-	private final static String NODE_NAME;
+	private static final String NODE_NAME;
 	
 	static {
 		var name = System.getProperty(PROP_PREFS);
@@ -124,7 +124,7 @@ public class PathPrefs {
 	 * For now, this isn't supported.
 	 */
 	@SuppressWarnings("unused")
-	private final static String PREVIOUS_NODE_NAME = "io.github.qupath/0.3";
+	private static final String PREVIOUS_NODE_NAME = "io.github.qupath/0.3";
 	
 	/**
 	 * Flag used to trigger when properties should be reset to their default values.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -396,7 +396,7 @@ public class PathPrefs {
 	 * 
 	 * @return
 	 */
-	public synchronized static IntegerProperty maxMemoryMBProperty() {
+	public static synchronized IntegerProperty maxMemoryMBProperty() {
 		if (maxMemoryMB == null) {
 			maxMemoryMB = createPersistentPreference("maxMemoryMB", -1);
 			long requestedMaxMemoryMB = maxMemoryMB.get();
@@ -492,7 +492,7 @@ public class PathPrefs {
 	 * Save the preferences.
 	 * @return
 	 */
-	public synchronized static boolean savePreferences() {
+	public static synchronized boolean savePreferences() {
 		try {
 			Preferences prefs = getUserPreferences();
 			prefs.flush();
@@ -507,7 +507,7 @@ public class PathPrefs {
 	/**
 	 * Reset the preferences to their defaults. This requires QuPath to be restarted.
 	 */
-	public synchronized static void resetPreferences() {
+	public static synchronized void resetPreferences() {
 		try {
 			Preferences prefs = getUserPreferences();
 			prefs.removeNode();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -878,7 +877,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 	}
 	
 	
-	private static abstract class LoggerWriter extends Writer {
+	private abstract static class LoggerWriter extends Writer {
 
 		@Override
 		public void write(char[] cbuf, int off, int len) throws IOException {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/QPEx.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/QPEx.java
@@ -93,10 +93,10 @@ import qupath.lib.scripting.QP;
  */
 public class QPEx extends QP {
 
-	final private static Logger logger = LoggerFactory.getLogger(QPEx.class);
+	private static final Logger logger = LoggerFactory.getLogger(QPEx.class);
 	
 	
-	private final static Collection<Class<?>> CORE_CLASSES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+	private static final Collection<Class<?>> CORE_CLASSES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
 			// QuPath classes
 			QuPathGUI.class,
 			Dialogs.class,

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptTab.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptTab.java
@@ -56,7 +56,7 @@ import qupath.lib.gui.scripting.languages.ScriptLanguage;
  */
 public class ScriptTab {
 	
-	final static private Logger logger = LoggerFactory.getLogger(ScriptTab.class);
+	private static final Logger logger = LoggerFactory.getLogger(ScriptTab.class);
 	
 	private File file = null;
 	private long lastModified = -1L;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/DefaultScriptLanguage.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/DefaultScriptLanguage.java
@@ -60,7 +60,7 @@ import qupath.lib.scripting.QP;
  */
 public class DefaultScriptLanguage extends ScriptLanguage implements RunnableLanguage {
 	
-	private final static Logger logger = LoggerFactory.getLogger(DefaultScriptLanguage.class);
+	private static final Logger logger = LoggerFactory.getLogger(DefaultScriptLanguage.class);
 	
 	private ScriptSyntax syntax;
 	private ScriptAutoCompletor completor;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/GroovyAutoCompletor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/GroovyAutoCompletor.java
@@ -44,7 +44,7 @@ import qupath.lib.gui.scripting.ScriptEditorControl;
  */
 public class GroovyAutoCompletor implements ScriptAutoCompletor {
 	
-	private final static Logger logger = LoggerFactory.getLogger(GroovyAutoCompletor.class);
+	private static final Logger logger = LoggerFactory.getLogger(GroovyAutoCompletor.class);
 	
 	private static final Set<Completion> ALL_COMPLETIONS = new HashSet<>();
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/ScriptAutoCompletor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/ScriptAutoCompletor.java
@@ -67,7 +67,7 @@ public interface ScriptAutoCompletor {
 	 */
 	static class Completion implements Comparable<Completion> {
 		
-		private final static Comparator<Completion> COMPARATOR = 
+		private static final Comparator<Completion> COMPARATOR = 
 				Comparator.comparing(Completion::getCompletionText)
 					.thenComparing(Completion::getDisplayText);
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/ScriptLanguageProvider.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/ScriptLanguageProvider.java
@@ -43,7 +43,7 @@ import qupath.lib.gui.QuPathGUI;
  */
 public class ScriptLanguageProvider {
 	
-	final static private Logger logger = LoggerFactory.getLogger(ScriptLanguageProvider.class);
+	private static final Logger logger = LoggerFactory.getLogger(ScriptLanguageProvider.class);
 	
 	private static ServiceLoader<ScriptLanguage> serviceLoader = ServiceLoader.load(ScriptLanguage.class);
 	private static final ScriptEngineManager manager = createManager();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/package-info.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Language and syntax definitions for QuPath scripting.
+ */
+package qupath.lib.gui.scripting.languages;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/DragDropTMADataImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/DragDropTMADataImportListener.java
@@ -45,7 +45,7 @@ import qupath.lib.gui.dialogs.Dialogs;
  */
 class DragDropTMADataImportListener implements EventHandler<DragEvent> {
 	
-	final private static Logger logger = LoggerFactory.getLogger(DragDropTMADataImportListener.class);
+	private static final Logger logger = LoggerFactory.getLogger(DragDropTMADataImportListener.class);
 
 	private TMASummaryViewer tmaViewer;
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/ImageListCell.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/ImageListCell.java
@@ -42,10 +42,10 @@ import qupath.lib.gui.tools.GuiTools;
  */
 class ImageListCell extends ListCell<TMAEntry> {
 
-	final private TMAImageCache imageCache;
+	private final TMAImageCache imageCache;
 	
-	final private Canvas canvas = new Canvas();
-	final private ObservableValue<Boolean> showOverlay;
+	private final Canvas canvas = new Canvas();
+	private final ObservableValue<Boolean> showOverlay;
 	
 	private Image img; // Keep a reference to the last image, so the cache doesn't throw it away
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/ImageTableCell.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/ImageTableCell.java
@@ -51,7 +51,7 @@ import qupath.lib.gui.tools.GuiTools;
  */
 class ImageTableCell extends TreeTableCell<TMAEntry, TMAEntry> {
 		
-		final private Canvas canvas = new Canvas();
+		private final Canvas canvas = new Canvas();
 		
 		private TMAImageCache cache;
 		private boolean isOverlay;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/KaplanMeierChartWrapper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/KaplanMeierChartWrapper.java
@@ -77,7 +77,7 @@ import qupath.lib.gui.charts.ChartTools;
  */
 class KaplanMeierChartWrapper {
 	
-	final private static Logger logger = LoggerFactory.getLogger(KaplanMeierChartWrapper.class);
+	private static final Logger logger = LoggerFactory.getLogger(KaplanMeierChartWrapper.class);
 
 	private List<KaplanMeierData> kmList = new ArrayList<>();
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/KaplanMeierDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/KaplanMeierDisplay.java
@@ -103,7 +103,7 @@ import qupath.lib.plugins.parameters.ParameterList;
  */
 class KaplanMeierDisplay implements ParameterChangeListener, PathObjectHierarchyListener {
 
-	final private static Logger logger = LoggerFactory.getLogger(KaplanMeierDisplay.class);
+	private static final Logger logger = LoggerFactory.getLogger(KaplanMeierDisplay.class);
 
 	// Flag to enable/disable calculating all P-values, and allowing threshold to be set to the lowest
 	private boolean calculateAllPValues = true;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/QuPathTMAViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/QuPathTMAViewer.java
@@ -42,7 +42,7 @@ import javafx.stage.Stage;
  */
 public class QuPathTMAViewer extends Application {
 	
-	final private static Logger logger = LoggerFactory.getLogger(QuPathTMAViewer.class);
+	private static final Logger logger = LoggerFactory.getLogger(QuPathTMAViewer.class);
 	
 	@Override
 	public void start(Stage primaryStage) throws Exception {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMADataIO.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMADataIO.java
@@ -76,7 +76,7 @@ public class TMADataIO {
 	private static final Logger logger = LoggerFactory.getLogger(TMADataIO.class);
 
 	@SuppressWarnings("javadoc")
-	final public static String TMA_DEARRAYING_DATA_EXTENSION = ".qptma";
+	public static final String TMA_DEARRAYING_DATA_EXTENSION = ".qptma";
 	
 	private static double preferredExportPixelSizeMicrons = 1.0;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMADataIO.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMADataIO.java
@@ -73,7 +73,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class TMADataIO {
 
-	final private static Logger logger = LoggerFactory.getLogger(TMADataIO.class);
+	private static final Logger logger = LoggerFactory.getLogger(TMADataIO.class);
 
 	@SuppressWarnings("javadoc")
 	final public static String TMA_DEARRAYING_DATA_EXTENSION = ".qptma";

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryEntry.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryEntry.java
@@ -55,7 +55,7 @@ import qupath.lib.objects.TMACoreObject;
  */
 class TMASummaryEntry implements TMAEntry {
 	
-	private final static Logger logger = LoggerFactory.getLogger(TMASummaryEntry.class);
+	private static final Logger logger = LoggerFactory.getLogger(TMASummaryEntry.class);
 	
 	private ObservableValue<TMAEntries.MeasurementCombinationMethod> method;
 	private ObservableBooleanValue skipMissing;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryViewer.java
@@ -169,7 +169,7 @@ import qupath.lib.projects.ProjectImageEntry;
  */
 public class TMASummaryViewer {
 	
-	private final static Logger logger = LoggerFactory.getLogger(TMASummaryViewer.class);
+	private static final Logger logger = LoggerFactory.getLogger(TMASummaryViewer.class);
 	
 	private IntegerProperty maxSmallWidth = new SimpleIntegerProperty(150);
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -187,7 +187,7 @@ public class GuiTools {
 		FULL_SCREENSHOT
 	}
 
-	private final static Logger logger = LoggerFactory.getLogger(GuiTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(GuiTools.class);
 
 	/**
 	 * Open the directory containing a file for browsing.
@@ -1373,7 +1373,7 @@ public class GuiTools {
 
 	
 	
-	private final static String KEY_REGIONS = "processRegions";
+	private static final String KEY_REGIONS = "processRegions";
 	
 	/**
 	 * Get the parent objects to use when running the plugin, or null if no suitable parent objects are found.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
@@ -71,7 +71,7 @@ public class IconFactory {
 
 	private static GlyphFont icoMoon = GlyphFontRegistry.font("icomoon");
 	
-	final private static Logger logger = LoggerFactory.getLogger(IconFactory.class);
+	private static final Logger logger = LoggerFactory.getLogger(IconFactory.class);
 	
 	/**
 	 * Default icons for QuPath commands.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementExporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementExporter.java
@@ -61,7 +61,7 @@ import qupath.lib.projects.ProjectImageEntry;
  */
 public class MeasurementExporter {
 	
-	private final static Logger logger = LoggerFactory.getLogger(MeasurementExporter.class);
+	private static final Logger logger = LoggerFactory.getLogger(MeasurementExporter.class);
 	
 	private List<String> includeOnlyColumns = new ArrayList<>();
 	private List<String> excludeColumns = new ArrayList<>();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementMapper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementMapper.java
@@ -44,7 +44,7 @@ import qupath.lib.objects.PathTileObject;
  */
 public class MeasurementMapper {
 	
-	private final static Logger logger = LoggerFactory.getLogger(MeasurementMapper.class);
+	private static final Logger logger = LoggerFactory.getLogger(MeasurementMapper.class);
 	
 	private ColorMap colorMapper;
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MenuTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MenuTools.java
@@ -42,7 +42,7 @@ import qupath.lib.gui.ActionTools;
  */
 public class MenuTools {
 	
-	private final static Logger logger = LoggerFactory.getLogger(MenuTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(MenuTools.class);
 	
 	/**
 	 * Create a menu, optionally add new menu items with {@link #addMenuItems(List, Object...)}.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -74,7 +74,7 @@ import qupath.lib.gui.scripting.DefaultScriptEditor;
  */
 public class DragDropImportListener implements EventHandler<DragEvent> {
 	
-	final private static Logger logger = LoggerFactory.getLogger(DragDropImportListener.class);
+	private static final Logger logger = LoggerFactory.getLogger(DragDropImportListener.class);
 
 	private QuPathGUI qupath;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ImageOverview.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ImageOverview.java
@@ -51,7 +51,7 @@ import qupath.lib.objects.PathObject;
  */
 class ImageOverview implements QuPathViewerListener {
 
-	final static private Logger logger = LoggerFactory.getLogger(ImageOverview.class);
+	private static final Logger logger = LoggerFactory.getLogger(ImageOverview.class);
 
 	private QuPathViewer viewer;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathHierarchyPaintingHelper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathHierarchyPaintingHelper.java
@@ -92,7 +92,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class PathHierarchyPaintingHelper {
 	
-	final private static Logger logger = LoggerFactory.getLogger(PathHierarchyPaintingHelper.class);
+	private static final Logger logger = LoggerFactory.getLogger(PathHierarchyPaintingHelper.class);
 
 	private static ShapeProvider shapeProvider = new ShapeProvider();
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathHierarchyPaintingHelper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathHierarchyPaintingHelper.java
@@ -473,7 +473,7 @@ public class PathHierarchyPaintingHelper {
 	}
 	
 
-	static abstract class ShapePool<T extends Shape> {
+	abstract static class ShapePool<T extends Shape> {
 		
 		private Map<Thread, T> map = new WeakHashMap<>();
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -155,7 +155,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHierarchyListener, PathObjectSelectionListener {
 
-	private final static Logger logger = LoggerFactory.getLogger(QuPathViewer.class);
+	private static final Logger logger = LoggerFactory.getLogger(QuPathViewer.class);
 
 	private static final double MIN_ROTATION = 0;
 	private static final double MAX_ROTATION = 360 * Math.PI / 180;
@@ -253,7 +253,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 
 	private ObjectProperty<PathTool> currentTool = new SimpleObjectProperty<>(PathTools.MOVE);
 	private ImageDisplay imageDisplay;
-	transient private long lastDisplayChangeTimestamp = 0; // Used to indicate imageDisplay changes
+	private transient long lastDisplayChangeTimestamp = 0; // Used to indicate imageDisplay changes
 
 	private LongProperty lastRepaintTimestamp = new SimpleLongProperty(0L); // Used for debugging repaint times
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/AbstractImageOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/AbstractImageOverlay.java
@@ -42,7 +42,7 @@ import qupath.lib.regions.ImageRegion;
  */
 public abstract class AbstractImageOverlay extends AbstractOverlay {
 	
-	private final static Logger logger = LoggerFactory.getLogger(AbstractImageOverlay.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractImageOverlay.class);
 	
     private ObjectProperty<ImageInterpolation> interpolation = new SimpleObjectProperty<>(ImageInterpolation.NEAREST);
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
@@ -73,7 +73,7 @@ import qupath.lib.regions.RegionRequest;
  */
 public class HierarchyOverlay extends AbstractOverlay {
 	
-	final static private Logger logger = LoggerFactory.getLogger(HierarchyOverlay.class);
+	private static final Logger logger = LoggerFactory.getLogger(HierarchyOverlay.class);
 
 	private ImageData<BufferedImage> imageData;
 	private PathHierarchyImageServer overlayServer = null;
@@ -90,7 +90,7 @@ public class HierarchyOverlay extends AbstractOverlay {
 	 * Comparator to determine the order in which detections should be painted.
 	 * This should be used with caution! Check out the docs for the class for details.
 	 */
-	transient private DetectionComparator comparator = new DetectionComparator();
+	private transient DetectionComparator comparator = new DetectionComparator();
 
 	/**
 	 * Constructor. Note that a {@link HierarchyOverlay} cannot adapt very efficient to changes in {@link ImageData}, and therefore 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/recording/ViewTracker.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/recording/ViewTracker.java
@@ -78,8 +78,8 @@ public class ViewTracker implements QuPathViewerListener {
 	protected static final DecimalFormat df = new DecimalFormat("#.##");
 	protected static final String LOG_DELIMITER = "\t";
 
-	transient private QuPathGUI qupath;
-	transient private QuPathViewer viewer;
+	private transient QuPathGUI qupath;
+	private transient QuPathViewer viewer;
 	
 	private boolean hasZAndT;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/AbstractPathROITool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/AbstractPathROITool.java
@@ -54,7 +54,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 abstract class AbstractPathROITool extends AbstractPathTool {
 	
-	final private static Logger logger = LoggerFactory.getLogger(AbstractPathROITool.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractPathROITool.class);
 
 	/**
 	 * Create a new ROI with the given starting coordinates.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/AbstractPathTool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/AbstractPathTool.java
@@ -61,7 +61,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 abstract class AbstractPathTool implements EventHandler<MouseEvent> {
 	
-	private final static Logger logger = LoggerFactory.getLogger(AbstractPathTool.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractPathTool.class);
 
 //	private QuPathViewer viewer;
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/AbstractPolyROITool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/AbstractPolyROITool.java
@@ -39,7 +39,7 @@ import qupath.lib.roi.interfaces.ROI;
 
 abstract class AbstractPolyROITool extends AbstractPathROITool {
 	
-	private final static Logger logger = LoggerFactory.getLogger(AbstractPolyROITool.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractPolyROITool.class);
 
 	boolean isFreehandPolyROI = false;
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/MoveTool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/MoveTool.java
@@ -59,7 +59,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class MoveTool extends AbstractPathTool {
 	
-	final static private Logger logger = LoggerFactory.getLogger(MoveTool.class);
+	private static final Logger logger = LoggerFactory.getLogger(MoveTool.class);
 
 	private static boolean requestDynamicDragging = true;
 	

--- a/qupath-gui-fx/src/test/java/qupath/lib/gui/dialogs/TestDialogs.java
+++ b/qupath-gui-fx/src/test/java/qupath/lib/gui/dialogs/TestDialogs.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
-class DialogsTest {
+class TestDialogs {
 
 	/**
 	 * Ensure there are no exceptions when showing basic messages and notifications without the UI.

--- a/qupath-gui-fx/src/test/java/qupath/lib/gui/models/TestObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/test/java/qupath/lib/gui/models/TestObservableMeasurementTableData.java
@@ -48,7 +48,7 @@ import qupath.lib.roi.interfaces.ROI;
  * @author Pete Bankhead
  *
  */
-public class ObservableMeasurementTableDataTest {
+public class TestObservableMeasurementTableData {
 
 	private static final double EPSILON = 1e-15;
 	


### PR DESCRIPTION
Use checkstyle, which can be installed as an eclipse plugin or run with
```
./gradlew check
```
Checks are currently fairly limited, focussing on the order of modifiers and naming of test classes (using `Test*.java`).