### PR TITLE
Fix annoying white line with dark mode dialogs

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
@@ -967,6 +967,12 @@ public class Dialogs {
 			
 			dialog.setResizable(resizable);
 			dialog.initModality(modality);
+			
+			// There's an annoying visual bug with no AlertType and dark mode resulting in a white/light 
+			// thin line at the bottom of the dialog
+			if (alertType == null || alertType == AlertType.NONE)
+				dialog.getDialogPane().setStyle("-fx-padding: 1px;");
+			
 			return dialog;
 		}
 		


### PR DESCRIPTION
There can be an annoying light/white line at the bottom of some dialog box when using QuPath in dark mode.

I spotted it with the 'Save changes?' dialog; it doesn't seem to occur if there is an AlertType set for the dialog.

Adding some padding appears to help.

## Before
<img width="723" alt="Screenshot 2022-09-06 at 12 49 22" src="https://user-images.githubusercontent.com/4690904/188629337-cf1d6dcd-f632-4d7d-837e-8fc1272eb140.png">

## After
<img width="723" alt="Screenshot 2022-09-06 at 12 49 33" src="https://user-images.githubusercontent.com/4690904/188629395-09c656e7-924e-4c19-b655-5b5946e2ae99.png">
