### PR TITLE
Fix IllegalArgumentException for network share URIs on windows

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -170,7 +171,7 @@ public class ImageServerProvider {
 
 	private static <T> List<UriImageSupport<T>> getServerBuilders(final Class<T> cls, final String path, String...args) throws IOException {
 		URI uri = legacyPathToURI(path);
-		if ("file".equals(uri.getScheme()) && !new File(uri).exists()) {
+		if ("file".equals(uri.getScheme()) && !Paths.get(uri).toFile().exists()) {
 			throw new IOException(uri.toString() + " does not exist!");
 		}
 

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -171,7 +172,7 @@ public class ImageServerProvider {
 
 	private static <T> List<UriImageSupport<T>> getServerBuilders(final Class<T> cls, final String path, String...args) throws IOException {
 		URI uri = legacyPathToURI(path);
-		if ("file".equals(uri.getScheme()) && !Paths.get(uri).toFile().exists()) {
+		if ("file".equals(uri.getScheme()) && !Files.exists(Paths.get(uri))) {
 			throw new IOException(uri.toString() + " does not exist!");
 		}
 

--- a/qupath-core/src/test/java/qupath/lib/images/servers/TestImageServerProvider.java
+++ b/qupath-core/src/test/java/qupath/lib/images/servers/TestImageServerProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/qupath-core/src/test/java/qupath/lib/images/servers/TestImageServerProvider.java
+++ b/qupath-core/src/test/java/qupath/lib/images/servers/TestImageServerProvider.java
@@ -27,15 +27,18 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 @SuppressWarnings("javadoc")
 public class TestImageServerProvider {
 
 	@Test
+	@EnabledOnOs(value = { OS.WINDOWS })
 	public void test() {
 		// this should not raise java.lang.IllegalArgumentException: URI has an authority component
 		assertThrows(IOException.class, () -> {
-		    ImageServerProvider.getPreferredUriImageSupport(BufferedImage.class, "file://localhost/C$/image.svs");
+		    ImageServerProvider.getPreferredUriImageSupport(BufferedImage.class, "file://localhost/c$/does-not-exist.svs");
 		});
 	}
 }

--- a/qupath-core/src/test/java/qupath/lib/images/servers/TestImageServerProvider.java
+++ b/qupath-core/src/test/java/qupath/lib/images/servers/TestImageServerProvider.java
@@ -1,0 +1,41 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.images.servers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("javadoc")
+public class TestImageServerProvider {
+
+	@Test
+	public void test() {
+		// this should not raise java.lang.IllegalArgumentException: URI has an authority component
+		assertThrows(IOException.class, () -> {
+		    ImageServerProvider.getPreferredUriImageSupport(BufferedImage.class, "file://localhost/C$/image.svs");
+		});
+	}
+}


### PR DESCRIPTION
Dear QuPath developers,

Quite some time ago a user of `paquo` reported a bug with network share URIs on windows, see: https://github.com/bayer-science-for-a-better-life/paquo/issues/65

This PR get's rid of the immediate issue in ImageServerProvider.getServerBuilders, but I'm not sure if there's more bugs further downstream using network share URIs.

The fix boils down to using `java.nio.Paths.get(uri).toFile()` instead of `java.io.File(uri)` directly. (see: https://github.com/bayer-science-for-a-better-life/paquo/issues/65#issuecomment-970711915)

I am currently unable to test this myself due to lack of access to a windows machine. 

Cheers,
Andreas 😃 