### PR TITLE
Fix style display bug

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/QuPathStyleManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/QuPathStyleManager.java
@@ -59,10 +59,7 @@ public class QuPathStyleManager {
 
 	private static ObservableList<StyleOption> styles = FXCollections.observableArrayList(
 			DEFAULT_STYLE,
-//			new JavaFXStylesheet("Caspian", Application.STYLESHEET_CASPIAN),
-//			new CustomStylesheet("Modena (Helvetica)", "JavaFX Modena stylesheet with Helvetica", "css/helvetica.css"),
 			new CustomStylesheet("Modena Dark", "Darker version of JavaFX Modena stylesheet", "css/dark.css")
-//			new CustomStylesheet("Modena Dark (Helvetica)", "Darker version of JavaFX Modena stylesheet with Helvetica", "css/dark.css", "css/helvetica.css")
 			);
 	
 	private static ObjectProperty<StyleOption> selectedStyle = PathPrefs.createPersistentPreference("qupathStylesheet", DEFAULT_STYLE, s -> s.getName(), QuPathStyleManager::findByName);
@@ -124,15 +121,12 @@ public class QuPathStyleManager {
 		// Add listener to adjust style as required
 		selectedStyle.addListener((v, o, n) -> updateStyle());
 		selectedFont.addListener((v, o, n) -> updateStyle());
-		
-		// Ensure we have set the style
-		updateStyle();
 	}
 	
 	private static void updateStyle() {
 		// Support calling updateStyle from different threads
 		if (!Platform.isFxApplicationThread()) {
-			Platform.runLater(() -> updateStyle());
+			Platform.runLater(QuPathStyleManager::updateStyle);
 			return;
 		}
 		StyleOption n = selectedStyle.get();
@@ -237,6 +231,7 @@ public class QuPathStyleManager {
 		@Override
 		public void setStyle() {
 			Application.setUserAgentStylesheet(cssName);
+			removePreviousStyleSheets(cssName);
 		}
 
 		@Override


### PR DESCRIPTION
Fix regression in https://github.com/qupath/qupath/commit/2a66f7ce7e73c08e5d396f6d259dd050cd6e7804

Setting dark mode wouldn't work reliably if the default font was used (in practice this meant it was generally ok on Mac but broken everywhere else).

Thanks to @finglis!