### PR TITLE
Add ROI.updatePlane(plane) method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ This is a work-in-progress.
   * `PathClassifierTools` methods have been moved to `PathObjectTools` and `ServerTools`
 * Support passing arguments via a map to `runPlugin`, rather than only a JSON-encoded String
 * Add `difference`, `symDifference` and `subtract` methods to `RoiTools` (https://github.com/qupath/qupath/issues/995)
+* Add `ROI.updatePlane(plane)` method to move a ROI to a different z-slice or timepoint (https://github.com/qupath/qupath/issues/1052)
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)

--- a/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
@@ -301,6 +301,14 @@ public class AreaROI extends AbstractPathROI implements Serializable {
 	}
 	
 	
+	/**
+	 * @throws UnsupportedOperationException because AreaROI is a legacy class that is no longer supported
+	 */
+	@Override
+	public ROI updatePlane(ImagePlane plane) {
+		throw new UnsupportedOperationException("Updating the plane for an AreaROI is not supported!");
+	}
+	
 	
 	private Object writeReplace() {
 		return new SerializationProxy(this);

--- a/qupath-core/src/main/java/qupath/lib/roi/EllipseROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/EllipseROI.java
@@ -128,6 +128,18 @@ public class EllipseROI extends AbstractPathBoundedROI implements Serializable {
 		duplicate.t = t;
 		return duplicate;
 	}
+	
+	
+	@Override
+	public ROI updatePlane(ImagePlane plane) {
+		return new EllipseROI(
+				getBoundsX(),
+				getBoundsY(),
+				getBoundsWidth(),
+				getBoundsHeight(),
+				plane);
+	}
+	
 
 	// TODO: Fix the ellipse polygon points to make it less diamond-y
 	/**

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryROI.java
@@ -345,6 +345,13 @@ public class GeometryROI extends AbstractPathROI implements Serializable {
 		var transform = AffineTransformation.scaleInstance(scaleX, scaleY, originX, originY);
 		return new GeometryROI(transform.transform(geometry), getImagePlane());
 	}
+	
+	@Override
+	public ROI updatePlane(ImagePlane plane) {
+		return new GeometryROI(
+				this.geometry,
+				plane);
+	}
 
 //	@Override
 //	public double getMaxDiameter() {

--- a/qupath-core/src/main/java/qupath/lib/roi/LineROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/LineROI.java
@@ -217,6 +217,13 @@ public class LineROI extends AbstractPathROI implements Serializable {
 		return new Line2D.Double(x, y, x2, y2);
 	}
 	
+	@Override
+	public ROI updatePlane(ImagePlane plane) {
+		return new LineROI(
+				x, y, x2, y2,
+				plane);
+	}
+	
 	
 //	public Geometry getGeometry() {
 //		GeometryFactory factory = new GeometryFactory();

--- a/qupath-core/src/main/java/qupath/lib/roi/PointsROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PointsROI.java
@@ -406,6 +406,14 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 	}
 	
 	
+	@Override
+	public ROI updatePlane(ImagePlane plane) {
+		return new PointsROI(
+				points,
+				plane);
+	}
+	
+	
 	private Object writeReplace() {
 		return new SerializationProxy(this);
 	}

--- a/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
@@ -260,6 +260,13 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 	}
 	
 	
+	@Override
+	public ROI updatePlane(ImagePlane plane) {
+		return new PolygonROI(
+				getAllPoints(),
+				plane);
+	}
+	
 	
 	/* (non-Javadoc)
 	 * @see qupath.lib.rois.PolygonROI#getPolygonPoints()

--- a/qupath-core/src/main/java/qupath/lib/roi/PolylineROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PolylineROI.java
@@ -269,6 +269,13 @@ public class PolylineROI extends AbstractPathROI implements Serializable {
 	}
 	
 	@Override
+	public ROI updatePlane(ImagePlane plane) {
+		return new PolylineROI(
+				getAllPoints(),
+				plane);
+	}
+	
+	@Override
 	public boolean contains(double x, double y) {
 		return false;
 	}

--- a/qupath-core/src/main/java/qupath/lib/roi/RectangleROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RectangleROI.java
@@ -139,6 +139,16 @@ public class RectangleROI extends AbstractPathBoundedROI implements Serializable
 	}
 	
 	@Override
+	public ROI updatePlane(ImagePlane plane) {
+		return new RectangleROI(
+				getBoundsX(),
+				getBoundsY(),
+				getBoundsWidth(),
+				getBoundsHeight(),
+				plane);
+	}
+	
+	@Override
 	public ROI scale(double scaleX, double scaleY, double originX, double originY) {
 		double x1 = RoiTools.scaleOrdinate(getBoundsX(), scaleX, originX);
 		double y1 = RoiTools.scaleOrdinate(getBoundsY(), scaleY, originY);

--- a/qupath-core/src/main/java/qupath/lib/roi/interfaces/ROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/interfaces/ROI.java
@@ -312,6 +312,14 @@ public interface ROI {
 	 */
 	public boolean contains(double x, double y);
 	
+	/**
+	 * Create a new ROI defining the same region on a different {@link ImagePlane}.
+	 * The original ROI is unchanged.
+	 * @param plane the new plane to use
+	 * @return
+	 */
+	public ROI updatePlane(ImagePlane plane);
+	
 //	public double getMaxDiameter();
 //	
 //	public double getMinDiameter();


### PR DESCRIPTION
Addresses https://github.com/qupath/qupath/issues/1052

AreaROI omitted in the hope it won't ever be needed (GeometryROI is used instead).