### PR TITLE
Update dark.css

### DIFF
--- a/qupath-gui-fx/src/main/resources/css/dark.css
+++ b/qupath-gui-fx/src/main/resources/css/dark.css
@@ -9,3 +9,7 @@
     -fx-control-inner-background:  rgb(45, 48, 50);
     -fx-light-text-color: rgb(200, 200, 200);
 }
+
+.text-input {  
+    -fx-prompt-text-fill: derive(-fx-control-inner-background, 70%) !important;
+}


### PR DESCRIPTION
Update to search box prompt text in dark mode as it was previously poorly visible due to styling from JavaFX modena that needed to be overridden.

Before: 
![image](https://user-images.githubusercontent.com/42358257/189848622-aeb1dfd2-4c94-4c03-8dd3-191ede8052f5.png)
After:
![image](https://user-images.githubusercontent.com/42358257/189848474-399cb277-1570-4f52-b033-137f67486b9a.png)

Attempts to make the style more specific to override the external style but was unsuccessful so the less preferable !important tag was used. The colour is derived from the current background colour at that time. 