### PR TITLE
Add support for custom styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is a work-in-progress.
   * All objects can now have IDs
     * This aims to make it much easier to match up objects whenever some further analysis is done elsewhere (e.g. classification or clustering in Python or R)
     * See https://github.com/qupath/qupath/pull/959
+* Support user styling via CSS (https://github.com/qupath/qupath/pull/1063)
 * Many script editor improvements, including:
   * Syntax highlighting for Markdown, JSON and XML documents
   * Added 'Replace/Next' and 'Replace all' features to Find window (https://github.com/qupath/qupath/pull/898)

--- a/qupath-extension-script-editor/src/main/resources/scripting_styles.css
+++ b/qupath-extension-script-editor/src/main/resources/scripting_styles.css
@@ -1,11 +1,11 @@
 .text {
-	-fx-fill: -fx-text-inner-color;
+	-fx-fill: -qp-script-text-color;
 }
 .lineno {
-	-fx-background-color: -fx-background;
+	-fx-background-color: -qp-script-background-color;
 }
 .keyword {
-    -fx-fill: darkorange;
+    -fx-fill: -qp-script-keyword-color;
     -fx-font-weight: bold;
 }
 .method {
@@ -21,30 +21,32 @@
     -fx-font-weight: bold;
 }
 .string {
-    -fx-fill: seagreen;
+    -fx-fill: -qp-script-string-color;
 }
 .comment {
-    -fx-fill: rgb(128, 128, 128);
+    -fx-fill: -qp-script-comment-color;
 }
 .error {
-    -fx-fill: red;
+    -fx-fill: -qp-script-error-color;
 }
 .warning {
-    -fx-fill: orange;
+    -fx-fill: -qp-script-warning-color;
 }
 .semicolon {
     -fx-font-weight: bold;
 }
+
+
 .remaining {
-    -fx-fill: darkorange;
+    -fx-fill: -qp-script-tag-color;
 }
 .caret {
-    -fx-stroke: -fx-text-inner-color;
+    -fx-stroke: -qp-script-text-color;
 }
 
 
 .md {
-    -fx-fill: -fx-text-inner-color;
+    -fx-fill: -qp-script-text-color:
     -fx-font-family: sans-serif;
 }
 .md.h1 {
@@ -77,40 +79,40 @@
     -fx-font-style: italic;
 }
 .md.list {
-    -fx-fill: darkorange;
+    -fx-fill: -qp-script-tag-color;
 }
 .md.link {
-    -fx-fill: purple;
+    -fx-fill: -qp-script-link-color;
 }
 .md.code {
 	-fx-font-family: monospace;
 }
 .md.quote {
-	-fx-fill: rgb(128, 128, 128);
+	-fx-fill: -qp-script-comment-color:
 }
 .md.image {
-	-fx-fill: seagreen;
+	-fx-fill: -qp-script-attribute-color;
 }
 .md.raw {
 	-fx-font-family: monospace;
-	-fx-fill: red;
+	-fx-fill: -qp-script-error-color;
 }
 
 .xml.body {
-	-fx-fill: -fx-text-inner-color;
+	-fx-fill: -qp-script-text-color:
 }
 .xml.attribute {
-	-fx-fill: royalblue;
+	-fx-fill: -qp-script-attribute-color;
 }
 .xml.tagmark {
-	-fx-fill: -fx-text-inner-color;
+	-fx-fill: -qp-script-text-color:
 }
 .xml.anytag {
-	-fx-fill: darkorange;
+	-fx-fill: -qp-script-tag-color:;
 }
 .xml.avalue {
-	-fx-fill: seagreen;
+	-fx-fill: -qp-script-string-color;
 }
 .xml.comment {
-    -fx-fill: rgb(128, 128, 128);
+    -fx-fill: -qp-script-comment-color:
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
@@ -76,6 +76,10 @@ public class ExtensionClassLoader extends URLClassLoader {
 			logger.debug("Extensions directory is null - no extensions will be loaded");
 			return;
 		}
+		if (!dirExtensions.exists()) {
+			logger.debug("No extensions directory exists at {}", dirExtensions);
+			return;			
+		}
 		if (!dirExtensions.isDirectory()) {
 			logger.error("Invalid extensions directory! '{}' is not a directory.", dirExtensions);
 			return;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -717,13 +717,21 @@ public class PathPrefs {
 	}
 		
 	
-	private static StringProperty userPath = createPersistentPreference("userPath", (String)null); // Base directory containing extensions
+	private static ObjectProperty<String> userPath = createPersistentPreference("userPath", (String)null, PathPrefs::blankStringToNull, PathPrefs::blankStringToNull); // Base directory containing extensions
 
+	
+	private static String blankStringToNull(String input) {
+		if (input == null)
+			return null;
+		return input.isBlank() ? null : input;
+	}
+	
+	
 	/**
 	 * A path where additional files may be stored, such as extensions and log files.
 	 * @return
 	 */
-	public static StringProperty userPathProperty() {
+	public static ObjectProperty<String> userPathProperty() {
 		return userPath;
 	}
 	
@@ -1656,7 +1664,9 @@ public class PathPrefs {
 				getUserPreferences().remove(name);
 			else {
 				var string = serializer.apply(n);
-				if (string.length() > Preferences.MAX_VALUE_LENGTH)
+				if (string == null) {
+					getUserPreferences().remove(name);
+				} else if (string.length() > Preferences.MAX_VALUE_LENGTH)
 					logger.warn("Unable to set preference {} to {} - String representation exceeds maximum length ({})", name, n, Preferences.MAX_VALUE_LENGTH);
 				else
 					getUserPreferences().put(name, string);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -737,7 +737,8 @@ public class PathPrefs {
 	
 	/**
 	 * Get the path to where extensions should be stored. This depends upon {@link #userPathProperty()}.
-	 * @return
+	 * @return the path if available, or null if {@link #getUserPath()} returns null
+	 * @implSpec a non-null return value does not guarantee that the path exists, rather it just represents the expected extensions directory.
 	 */
 	public static String getExtensionsPath() {
 		String userPath = getUserPath();
@@ -747,8 +748,22 @@ public class PathPrefs {
 	}
 	
 	/**
+	 * Get the path to where user directory for storing CSS styles. This depends upon {@link #userPathProperty()}.
+	 * @return the path if available, or null if {@link #getUserPath()} returns null
+	 * @implSpec a non-null return value does not guarantee that the path exists, rather it just represents the expected CSS directory.
+	 * @since v0.4.0
+	 */
+	public static String getCssStylesPath() {
+		String userPath = getUserPath();
+		if (userPath == null)
+			return null;
+		return new File(userPath, "css").getAbsolutePath();
+	}
+	
+	/**
 	 * Get the path to where log files should be written. This depends upon {@link #userPathProperty()}.
-	 * @return
+	 * @return the path if available, or null if {@link #getUserPath()} returns null
+	 * @implSpec a non-null return value does not guarantee that the path exists, rather it just represents the expected log file directory.
 	 */
 	public static String getLoggingPath() {
 		String userPath = getUserPath();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/QuPathStyleManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/QuPathStyleManager.java
@@ -23,11 +23,23 @@
 
 package qupath.lib.gui.prefs;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,8 +48,11 @@ import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener.Change;
 import javafx.collections.ObservableList;
 import qupath.lib.common.GeneralTools;
+import qupath.lib.common.ThreadTools;
+import qupath.lib.gui.tools.GuiTools;
 
 
 /**
@@ -52,29 +67,59 @@ public class QuPathStyleManager {
 	
 	private static Logger logger = LoggerFactory.getLogger(QuPathStyleManager.class);
 	
-	private static JavaFXStylesheet DEFAULT_STYLE = new JavaFXStylesheet("Modena Light", Application.STYLESHEET_MODENA);
+	/**
+	 * Main stylesheet, used to define new colors for QuPath.
+	 * This should always be applied, since it defines colors that are required for scripting.
+	 */
+	private static final String STYLESHEET_MAIN = "css/main.css";
 
-	// Maintain a record of what we've added, so we can try to clean up later if needed
-	private static List<String> previouslyAddedStyleSheets = new ArrayList<>();
+	/**
+	 * Default dark stylesheet.
+	 */
+	private static final String STYLESHEET_DARK = "css/dark.css";
 
-	private static ObservableList<StyleOption> styles = FXCollections.observableArrayList(
+	/**
+	 * Default JavaFX stylesheet
+	 */
+	private static final StyleOption DEFAULT_STYLE = new JavaFXStylesheet("Modena Light", Application.STYLESHEET_MODENA);
+
+	/**
+	 * Default QuPath stylesheet used for 'dark mode'
+	 */
+	private static final StyleOption DEFAULT_DARK_STYLE = new CustomStylesheet("Modena Dark", "Darker version of JavaFX Modena stylesheet", STYLESHEET_DARK);
+
+	// Maintain a record of what stylesheets we've added, so we can try to clean up later if needed
+	private static final List<String> previouslyAddedStyleSheets = new ArrayList<>();
+
+	private static final ObservableList<StyleOption> styles = FXCollections.observableArrayList(
 			DEFAULT_STYLE,
-			new CustomStylesheet("Modena Dark", "Darker version of JavaFX Modena stylesheet", "css/dark.css")
+			DEFAULT_DARK_STYLE
 			);
 	
-	private static ObjectProperty<StyleOption> selectedStyle = PathPrefs.createPersistentPreference("qupathStylesheet", DEFAULT_STYLE, s -> s.getName(), QuPathStyleManager::findByName);
-
+	private static final ObservableList<StyleOption> stylesUnmodifiable = FXCollections.unmodifiableObservableList(styles);
 	
+	private static ObjectProperty<StyleOption> selectedStyle;
+
+	/**
+	 * Find the first available {@link StyleOption} with the specified name.
+	 * @param name
+	 * @return
+	 */
 	private static StyleOption findByName(String name) {
-		return styles.stream().filter(s -> Objects.equals(s.getName(), name)).findFirst().orElse(null);
+		return styles.stream().filter(s -> Objects.equals(s.getName(), name)).findFirst().orElse(DEFAULT_STYLE);
 	}
+	
+	/**
+	 * Watch for custom styles, which the user may add, remove or modify.
+	 */
+	private static CssStylesWatcher watcher;
 	
 	/**
 	 * Available font families.
 	 */
 	public static enum Fonts {
 		/**
-		 * JavaFX default. May not look great on macOS.
+		 * JavaFX default. May not look great on macOS, which lacks support for bold font weight by default.
 		 */
 		DEFAULT,
 		/**
@@ -112,12 +157,35 @@ public class QuPathStyleManager {
 		}
 	}
 
-	private static ObservableList<Fonts> availableFonts = FXCollections.observableArrayList(Fonts.values());
+	private static ObservableList<Fonts> availableFonts = 
+			FXCollections.unmodifiableObservableList(
+					FXCollections.observableArrayList(Fonts.values()));
 
 	private static ObjectProperty<Fonts> selectedFont = PathPrefs.createPersistentPreference("selectedFont", 
 			GeneralTools.isMac() ? Fonts.SANS_SERIF : Fonts.DEFAULT, Fonts.class);
 
 	static {
+		
+		/**
+		 * Add custom user styles, if available.
+		 * We need to do this before setting the default (since the last used style might be one of these)
+		 */
+		try {
+			var cssPathString = PathPrefs.getCssStylesPath();
+			if (cssPathString != null) {
+				var cssPath = Paths.get(cssPathString);
+				watcher = new CssStylesWatcher(cssPath);
+				watcher.styles.addListener((Change<? extends StyleOption> c) -> {
+					updateAvailableStyles();
+				});
+			}
+		} catch (Exception e) {
+			logger.warn("Exception searching for css files: " + e.getLocalizedMessage(), e);
+		}
+
+		updateAvailableStyles();
+		selectedStyle = PathPrefs.createPersistentPreference("qupathStylesheet", DEFAULT_STYLE, s -> s.getName(), QuPathStyleManager::findByName);
+		
 		// Add listener to adjust style as required
 		selectedStyle.addListener((v, o, n) -> updateStyle());
 		selectedFont.addListener((v, o, n) -> updateStyle());
@@ -144,6 +212,32 @@ public class QuPathStyleManager {
 		}
 	}
 	
+	private static void updateAvailableStyles() {
+		// Cache the current selection, since it could become lost during the update
+		var previouslySelected = selectedStyle == null ? null : selectedStyle.get();
+		
+		// Update all available styles
+		if (watcher == null || watcher.styles.isEmpty())
+			styles.setAll(DEFAULT_STYLE, DEFAULT_DARK_STYLE);
+		else {
+			var temp = new ArrayList<StyleOption>();
+			temp.add(DEFAULT_STYLE);
+			temp.add(DEFAULT_DARK_STYLE);
+			temp.addAll(watcher.styles);
+//			temp.sort(Comparator.comparing(StyleOption::getName));
+			styles.setAll(temp);
+		}
+		
+		// Reinstate the selection, or use the default if necessary
+		if (selectedStyle != null) {
+			if (previouslySelected == null || !styles.contains(previouslySelected))
+				selectedStyle.set(DEFAULT_STYLE);
+			else
+				selectedStyle.set(previouslySelected);
+		}
+	}
+	
+	
 	/**
 	 * Refresh the current style.
 	 * This should not normally be required, but may be useful during startup to ensure 
@@ -162,11 +256,12 @@ public class QuPathStyleManager {
 	}
 	
 	/**
-	 * Get the current available styles.
+	 * Get the current available styles as an observable list.
+	 * The list is unmodifiable, since any changes should be made via {@link PathPrefs#getCssStylesPath()}.
 	 * @return
 	 */
 	public static ObservableList<StyleOption> availableStylesProperty() {
-		return styles;
+		return stylesUnmodifiable;
 	}
 	
 	/**
@@ -179,6 +274,8 @@ public class QuPathStyleManager {
 	
 	/**
 	 * Get a list of available fonts.
+	 * The list is unmodifiable, since this is primarily used to overcome issues with the default font on macOS 
+	 * by changing the font family. More fine-grained changes can be made via css.
 	 * @return list of available fonts
 	 */
 	public static ObservableList<Fonts> availableFontsProperty() {
@@ -218,6 +315,9 @@ public class QuPathStyleManager {
 	}
 	
 	
+	/**
+	 * Default JavaFX stylesheet.
+	 */
 	static class JavaFXStylesheet implements StyleOption {
 		
 		private String name;
@@ -232,6 +332,7 @@ public class QuPathStyleManager {
 		public void setStyle() {
 			Application.setUserAgentStylesheet(cssName);
 			removePreviousStyleSheets(cssName);
+			addStyleSheets(STYLESHEET_MAIN);
 		}
 
 		@Override
@@ -248,10 +349,30 @@ public class QuPathStyleManager {
 		public String toString() {
 			return getName();
 		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(cssName, name);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			JavaFXStylesheet other = (JavaFXStylesheet) obj;
+			return Objects.equals(cssName, other.cssName) && Objects.equals(name, other.name);
+		}
 		
 	}
 	
 	
+	/**
+	 * Custom stylesheets, requiring one or more URLs (added on top of the default).
+	 */
 	static class CustomStylesheet implements StyleOption {
 		
 		private String name;
@@ -262,6 +383,10 @@ public class QuPathStyleManager {
 			this.name = name;
 			this.description = description;
 			this.urls = urls.clone();
+		}
+		
+		CustomStylesheet(final Path path) {
+			this(GeneralTools.getNameWithoutExtension(path.toFile()), path.toString(), path.toUri().toString());
 		}
 
 		@Override
@@ -284,16 +409,54 @@ public class QuPathStyleManager {
 			return getName();
 		}
 		
+		/**
+		 * Check if a specified url is used as part of this stylesheet.
+		 * @param url
+		 * @return
+		 */
+		private boolean containsUrl(String url) {
+			for (var css: urls) {
+				if (Objects.equals(url, css))
+					return true;
+			}
+			return false;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + Arrays.hashCode(urls);
+			result = prime * result + Objects.hash(description, name);
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			CustomStylesheet other = (CustomStylesheet) obj;
+			return Objects.equals(description, other.description) && Objects.equals(name, other.name)
+					&& Arrays.equals(urls, other.urls);
+		}
+		
 	}
 	
 	private static void setStyleSheets(String... urls) {
 		Application.setUserAgentStylesheet(null);
-		// Check if we need to do anything
-		var toAdd = Arrays.asList(urls);
-		if (previouslyAddedStyleSheets.equals(toAdd))
-			return;
+//		// Check if we need to do anything
+//		var toAdd = Arrays.asList(urls);
+//		if (previouslyAddedStyleSheets.equals(toAdd))
+//			return;
 		// Replace previous stylesheets with the new ones
 		removePreviousStyleSheets();
+		
+		addStyleSheets(STYLESHEET_MAIN);
+		
 		addStyleSheets(urls);
 	}
 		
@@ -334,5 +497,132 @@ public class QuPathStyleManager {
 			logger.error("Unable to call addUserAgentStylesheet", e);
 		}
 	}
+	
+	
+	/**
+	 * Class to run a background thread that picks up changes to a directory containing CSS files, 
+	 * and updates the current or available styles as required.
+	 */
+	private static class CssStylesWatcher implements Runnable {
+		
+		private static final ThreadFactory THREAD_FACTORY = ThreadTools.createThreadFactory("css-watcher", true);
+		
+		private Thread thread;
+		
+		private Path cssPath;
+		private WatchService watcher;
+		
+		private ObservableList<StyleOption> styles = FXCollections.observableArrayList();
+		
+		private CssStylesWatcher(Path cssPath) {
+			thread = THREAD_FACTORY.newThread(this);
+			try {
+				watcher = FileSystems.getDefault().newWatchService();
+				logger.debug("Watching for changes in {}", cssPath);
+			} catch (IOException e) {
+				logger.error("Exception setting up CSS watcher: " + e.getLocalizedMessage(), e);
+			}
+			setCssPath(cssPath);
+			thread.start();
+		}
+		
+		private void setCssPath(Path cssPath) {
+			if (Objects.equals(this.cssPath, cssPath))
+				return;
+			this.cssPath = cssPath;
+			if (Files.isDirectory(cssPath)) {
+				try {
+					cssPath.register(watcher,
+							StandardWatchEventKinds.ENTRY_MODIFY,
+							StandardWatchEventKinds.ENTRY_CREATE,
+							StandardWatchEventKinds.ENTRY_DELETE);
+					logger.debug("Watching for changes in {}", cssPath);
+				} catch (IOException e) {
+					logger.error("Exception setting up CSS watcher: " + e.getLocalizedMessage(), e);
+				}
+			}
+			refreshStylesheets();
+		}
+		
+		
+		@Override
+		public void run() {
+			while (watcher != null) {
+				
+				WatchKey key = null;
+				synchronized(this) {
+					try {
+						key = watcher.take();
+						if (key == null)
+							continue;
+					} catch (InterruptedException e) {
+						return;
+					}
+				}
+				
+				for (WatchEvent<?> ev: key.pollEvents()) {
+					if (ev.kind() == StandardWatchEventKinds.OVERFLOW)
+						continue;
+
+					// Get the path to whatever changed
+					var event = (WatchEvent<Path>)ev;
+					var basePath = (Path)key.watchable();
+					if (!Objects.equals(cssPath, basePath))
+						continue;
+					
+					var path = basePath.resolve(event.context());
+					
+					// An existing stylesheet has changed
+					if (ev.kind() == StandardWatchEventKinds.ENTRY_MODIFY && Files.isRegularFile(path)) {
+						try {
+							var currentStyle = selectedStyle.get();
+							if (currentStyle instanceof CustomStylesheet) {
+								var currentCustomStyle = ((CustomStylesheet)currentStyle);
+								var url = path.toUri().toString();
+								if (currentCustomStyle.containsUrl(url)) {
+									logger.info("Refreshing style {}", currentStyle.getName());
+									refresh();
+								}
+								break;
+							}
+						} catch (Exception e) {
+							logger.warn("Exception processing CSS refresh: " + e.getLocalizedMessage(), e);
+						}
+					} else {
+						// For everything else, refresh the available stylesheets
+						refreshStylesheets();
+					}
+					
+				}
+
+				boolean valid = key.reset();
+				if (!valid) {
+					break;
+				}
+			}
+		}
+		
+		
+		private void refreshStylesheets() {
+			try {
+				if (Files.isDirectory(cssPath)) {
+					var newStyles = Files.list(cssPath)
+						.filter(p -> Files.isRegularFile(p) && p.getFileName().toString().toLowerCase().endsWith(".css"))
+						.map(path -> new CustomStylesheet(path))
+						.sorted(Comparator.comparing(StyleOption::getName))
+						.collect(Collectors.toList());
+					GuiTools.runOnApplicationThread(() -> styles.setAll(newStyles));
+					return;
+				}
+			} catch (IOException e) {
+				logger.warn(e.getLocalizedMessage(), e);
+			}
+			GuiTools.runOnApplicationThread(() -> styles.clear());
+		}
+				
+		
+		
+	}
+	
 	
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptEditorDragDropListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptEditorDragDropListener.java
@@ -62,7 +62,7 @@ public class ScriptEditorDragDropListener implements EventHandler<DragEvent> {
 				return;
 			
 			List<File> jars = list.stream().filter(f -> f.getName().toLowerCase().endsWith(".jar")).collect(Collectors.toList());
-			if (!jars.isEmpty() && qupath.canInstallExtensions())
+			if (!jars.isEmpty())
 				qupath.installExtensions(list);
 			List<File> remainingFiles = list.stream().filter(f -> !f.getName().toLowerCase().endsWith(".jar")).collect(Collectors.toList());
 			var supported = ScriptLanguageProvider.getAvailableScriptLanguages().stream().flatMap(l -> Arrays.stream(l.getExtensions())).collect(Collectors.toCollection(HashSet::new));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/CssLanguage.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/CssLanguage.java
@@ -1,0 +1,77 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.scripting.languages;
+
+import java.util.ServiceLoader;
+
+/**
+ * Class for representing CSS in QuPath.
+ * 
+ * @author Pete Bankhead
+ * @since v0.4.0
+ */
+public class CssLanguage extends ScriptLanguage {
+	
+	/**
+	 * Instance of this language. Can't be final because of {@link ServiceLoader}.
+	 */
+	private static CssLanguage INSTANCE;
+	
+	private ScriptSyntax syntax;
+	private ScriptAutoCompletor completor;
+	
+	/**
+	 * Constructor for JSON language. This constructor should never be 
+	 * called. Instead, use the static {@link #getInstance()} method.
+	 * <p>
+	 * Note: this has to be public for the {@link ServiceLoader} to work.
+	 */
+	public CssLanguage() {
+		super("CSS", new String[]{".css"});
+		this.syntax = PlainSyntax.getInstance();
+		this.completor = new PlainAutoCompletor();
+		
+		if (INSTANCE != null)
+			throw new UnsupportedOperationException("Language classes cannot be instantiated more than once!");
+		
+		// Because of ServiceLoader, have to assign INSTANCE here.
+		CssLanguage.INSTANCE = this;
+	}
+
+	/**
+	 * Get the static instance of this class.
+	 * @return instance
+	 */
+	public static CssLanguage getInstance() {
+		return INSTANCE;
+	}
+	
+	@Override
+	public ScriptSyntax getSyntax() {
+		return syntax;
+	}
+
+	@Override
+	public ScriptAutoCompletor getAutoCompletor() {
+		return completor;
+	}
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -26,6 +26,8 @@ package qupath.lib.gui.viewer;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -52,6 +54,7 @@ import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.commands.ProjectCommands;
 import qupath.lib.gui.dialogs.Dialogs;
+import qupath.lib.gui.dialogs.Dialogs.DialogButton;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.scripting.ScriptEditor;
 import qupath.lib.gui.tma.TMADataIO;
@@ -275,17 +278,23 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 			return;
 		}
 		
-		// Check if we have only jar files
+		// Check if we have only jar or css files
 		int nJars = 0;
+		int nCss = 0;
 		for (File file : list) {
-			if (file.getName().toLowerCase().endsWith(".jar"))
+			var ext = GeneralTools.getExtension(file).orElse("").toLowerCase();
+			if (ext.equals(".jar"))
 				nJars++;
+			else if (ext.equals(".css"))
+				nCss++;
 		}
 		if (nJars == list.size()) {
-			if (qupath.canInstallExtensions())
-				qupath.installExtensions(list);
-			else
-				Dialogs.showErrorMessage("Install extensions", "Sorry, extensions can only be installed when QuPath is run as a standalone application.");
+			qupath.installExtensions(list);
+			return;
+		}
+		// Handle installing CSS files (styles)
+		if (nCss == list.size()) {
+			qupath.installStyles(list);
 			return;
 		}
 		
@@ -504,6 +513,8 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 		else
 			Dialogs.showErrorMessage("Drag & drop", "Sorry, I couldn't figure out what to do with " + list.get(0).getName());
 	}
+    
+        
     
     
     /**

--- a/qupath-gui-fx/src/main/resources/META-INF/services/qupath.lib.gui.scripting.languages.ScriptLanguage
+++ b/qupath-gui-fx/src/main/resources/META-INF/services/qupath.lib.gui.scripting.languages.ScriptLanguage
@@ -3,3 +3,4 @@ qupath.lib.gui.scripting.languages.GroovyLanguage
 qupath.lib.gui.scripting.languages.JsonLanguage
 qupath.lib.gui.scripting.languages.MarkdownLanguage
 qupath.lib.gui.scripting.languages.XmlLanguage
+qupath.lib.gui.scripting.languages.CssLanguage

--- a/qupath-gui-fx/src/main/resources/css/dark.css
+++ b/qupath-gui-fx/src/main/resources/css/dark.css
@@ -1,8 +1,11 @@
 /*
-* See https://tomsondev.bestsolution.at/2014/03/13/eclipse-on-javafx-get-dark-the-power-of-javafx-css/
-* 
-* Improvements welcome...
-*/
+ * QuPath's default dark mode.
+ * Should be applied after main.css.
+ *
+ * See https://tomsondev.bestsolution.at/2014/03/13/eclipse-on-javafx-get-dark-the-power-of-javafx-css/
+ * for some useful info about JavaFX styling via CSS.
+ * 
+ */
 .root {
     -fx-base: rgb(45, 48, 50);
     -fx-background: rgb(45, 48, 50);
@@ -10,17 +13,17 @@
     -fx-light-text-color: rgb(200, 200, 200);
 }
 
-/*Input prompt text colour*/
+/* Input prompt text colour */
 .text-input {  
     -fx-prompt-text-fill: derive(-fx-control-inner-background, 70%) !important;
 }
 
-/*Expandable component text*/
+/* Expandable dialog text */
 .dialog-pane > .button-bar > .container > .details-button {
-    -fx-text-fill:-fx-text-background-color;
+    -fx-text-fill: -fx-text-background-color;
 }
 
-/*Expandable component icon*/
+/* Expandable dialog icon */
 .dialog-pane > .button-bar > .container > * > .image-view {
     -fx-blend-mode: soft-light;
 }

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -1,0 +1,36 @@
+/*
+ * Some CSS that should be applied in QuPath.
+ */
+
+/* Define colors that may be used by script editors */
+.root {
+  
+  -qp-script-background-color: -fx-background;
+  
+  -qp-script-text-color: -fx-text-base-color;
+  
+  -qp-script-keyword-color: ladder(-qp-script-background-color, darkorange 50%, orange 51%);
+
+  -qp-script-comment-color: ladder(-qp-script-background-color, derive(-qp-script-text-color, -30%) 49%, derive(-qp-script-text-color, 30%) 50%);
+  
+  -qp-script-error-color: ladder(-qp-script-background-color, red 30%, darkred 50%, red 70%);
+
+  -qp-script-warning-color: ladder(-qp-script-background-color, orange 30%, darkorange 50%, orange 70%);
+  
+  -qp-script-string-color: ladder(-qp-script-background-color, derive(seagreen, 50%) 49%, derive(seagreen, -5%) 50%);
+
+
+  -qp-script-link-color: ladder(-qp-script-background-color, derive(purple, 25%) 49%, derive(purple, -5%) 50%);
+
+  -qp-script-tag-color: ladder(-qp-script-background-color, derive(orange, 25%) 49%, derive(orange, -5%) 50%);
+
+  -qp-script-attribute-color: ladder(-qp-script-background-color, derive(royalblue, 25%) 49%, derive(royalblue, -5%) 50%);
+
+}
+
+
+/* Soften the main toolbar icons */
+
+.tool-bar .qupath-icon {
+  -fx-opacity: 0.8;
+}


### PR DESCRIPTION
This adds support to add custom styles by adding .css files to the a css subdirectory inside the user directory (which is where extensions go, usually at ~/QuPath/v0.4/ or similar).

If the custom css directory exists, a `WatchService` is created to check for changes. This means that users can add/remove/modify .css files in the directory, and see live updates (albeit with some seconds of delay, at least on macOS).

To make this work, the PreferencePane needed to be updated to directly use any ObservableList with combo boxes. A new `PathPrefs.getCssStylesPath()` was also added.

Additionally, `IconFactory.DuplicableGlyph` was improved to allow glyphs to respond to the `-fx-text-fill` property, and this in turn means that the toolbar icons can now be styled by css (rather than being fixed to a neutral gray).

Finally, main.css was introduced to enable more QuPath-specific styling, even when using the default modena.css with JavaFX. This is particularly relevant for defining several colors reused by the script editor.


----

Examples of some minimal (not necessarily pleasing) css files and their impact:

### Blue

```css
.root {
    -fx-base: rgb(30, 28, 75);
    -fx-light-text-color: rgb(200, 200, 255);
    -fx-background: derive(-fx-base, -10%);
    -fx-control-inner-background: derive(-fx-base, 10%);
}
```

![blue](https://user-images.githubusercontent.com/4690904/192768467-440d75fc-2611-415d-b1ba-7009d7399c13.png)


### Red

```css
.root {
    -fx-base: rgb(130, 28, 25);
    -fx-light-text-color: white;
    -fx-background: derive(-fx-base, -10%);
    -fx-control-inner-background: derive(-fx-base, -10%);
}
```

![red](https://user-images.githubusercontent.com/4690904/192768409-c2d38a7b-c1b0-49bd-9324-38b971833707.png)
