### PR TITLE
Fix arrow colors for ListSelectionView

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateCompositeClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateCompositeClassifierCommand.java
@@ -50,6 +50,7 @@ import qupath.lib.classifiers.object.ObjectClassifiers;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.dialogs.Dialogs;
+import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.gui.tools.PaneTools;
 import qupath.lib.plugins.workflow.DefaultScriptableWorkflowStep;
 import qupath.lib.plugins.workflow.WorkflowStep;
@@ -80,8 +81,7 @@ public class CreateCompositeClassifierCommand implements Runnable {
 	@Override
 	public void run() {
 		
-		ListSelectionView<ClassifierWrapper<BufferedImage>> view = new ListSelectionView<>();
-		
+		ListSelectionView<ClassifierWrapper<BufferedImage>> view = GuiTools.createListSelectionView();
 		try {
 			updateAvailableClassifiers(view);
 		} catch (IOException e) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/ProjectDialogs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/ProjectDialogs.java
@@ -50,6 +50,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.paint.Color;
 import javafx.scene.text.TextAlignment;
 import qupath.lib.gui.QuPathGUI;
+import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.gui.tools.PaneTools;
 import qupath.lib.projects.ProjectImageEntry;
 
@@ -74,7 +75,7 @@ public class ProjectDialogs {
 								List<ProjectImageEntry<BufferedImage>> selectedImages,
 								String openImageWarning) {
 		
-		ListSelectionView<ProjectImageEntry<BufferedImage>> listSelectionView = new ListSelectionView<>();
+		ListSelectionView<ProjectImageEntry<BufferedImage>> listSelectionView = GuiTools.createListSelectionView();
 		listSelectionView.getSourceItems().setAll(availableImages);
 //		if (selectedImages != null && !selectedImages.isEmpty()) {
 //			listSelectionView.getSourceItems().removeAll(selectedImages);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
@@ -37,8 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import javafx.beans.binding.Bindings;
 import javafx.beans.value.ObservableIntegerValue;
-import javafx.css.StyleOrigin;
-import javafx.css.StyleableObjectProperty;
 import javafx.scene.Node;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.ClosePath;
@@ -172,50 +170,17 @@ public class IconFactory {
 					g.color(color);
 			} else {
 				// Respond to color changes
-				g = new DuplicatableGlyph(g);
+				g = GuiTools.ensureDuplicatableGlyph(g);
 				g.textFillProperty().bind(Bindings.createObjectBinding(() -> {
 					return ColorToolsFX.getCachedColor(observableColor.get());
 				}, observableColor));
 			}
-			return new DuplicatableGlyph(g);
+			return GuiTools.ensureDuplicatableGlyph(g);
 		}
 		
 	};
 	
-	/**
-	 * This exists because Glyph.duplicate() does not bind to fill color changes.
-	 * The duplicate method is called each time a new GUI component is created, because the same node 
-	 * cannot appear more than once in the scene graph.
-	 */
-	private static class DuplicatableGlyph extends Glyph {
-		
-		DuplicatableGlyph(Glyph glyph) {
-			super();
-			setText(glyph.getText());
-			setFontFamily(glyph.getFontFamily());
-	        setIcon(glyph.getIcon());
-	        setFontSize(glyph.getFontSize());
-	        getStyleClass().setAll(glyph.getStyleClass());
-	        
-	        setStyle(glyph.getStyle());
-
-	        // Be careful with setting the text fill, since an apparent controlsfx bug means this 
-	        // can be locked to become black.
-	        // Here, we check if it's a bound property; if so we use that.
-	        // Otherwise, we only set the value if the StyleOrigin is USER (otherwise we let the default be used)
-	        var textFill = glyph.textFillProperty();
-	        if (textFill.isBound())
-	        	textFillProperty().bind(glyph.textFillProperty());
-	        else if (textFill instanceof StyleableObjectProperty<?> && ((StyleableObjectProperty<?>)textFill).getStyleOrigin() == StyleOrigin.USER)
-	        	setTextFill(textFill.get());
-		}
-		
-		@Override
-		public Glyph duplicate() {
-			return new DuplicatableGlyph(this);
-		}
-		
-	}
+	
 	
 	/**
 	 * Create an icon depicting a PathObject.


### PR DESCRIPTION
Add support to construct (and initialize) a ListSelectionView from GuiTools, to work around a ControlsFX issue that can make the arrows resistant to changes in style via css.

Add `GuiTools.ensureDuplicatableGlyph(glyph)` method to make this more generally useful, extracting the logic from `IconFactory`.