### PR TITLE
Fix pie chart legends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ This is a work-in-progress.
 * Training a new object classifier with the same settings and annotations can give a different result when an image is reopened (https://github.com/qupath/qupath/issues/1016)
 * It isn't possible to run cell detection on channels with " in the name (https://github.com/qupath/qupath/issues/1022)
 * Fix occasional "One of the arguments' values is out of range" exception with Delaunay triangulation
+* The colors used in pie chart legends were sometimes incorrect (https://github.com/qupath/qupath/issues/1062)
 
 ### Changes through Bio-Formats 6.10.1
 * Bio-Formats 6.10.1 brings several important new features to QuPath, including:

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
@@ -1316,6 +1316,7 @@ public class ObjectClassifierCommand implements Runnable {
 			 * Training proportions (pie chart)
 			 */
 			pieChart = new PieChart();
+			pieChart.setAnimated(false);
 
 			pieChart.setLabelsVisible(false);
 			pieChart.setLegendVisible(true);

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
@@ -367,6 +367,7 @@ public class PixelClassifierPane {
 		pane.add(btnLive, 0, row++, pane.getColumnCount(), 1);
 		
 		pieChart = new PieChart();
+		pieChart.setAnimated(false);
 		
 //		var hierarchy = viewer.getHierarchy();
 //		Map<PathClass, List<PathObject>> map = hierarchy == null ? Collections.emptyMap() : PathClassificationLabellingHelper.getClassificationMap(hierarchy, false);


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/1062 - at least when using modena.css as a basis.

Also addresses two issues with the pie charts shown when training a pixel/object classifier:
* the legend should now be correct even when more than 8 classes are used
* there is no longer any need to write a temporary css file for styling

Pixel and object classifiers can be checked by training one of each.

The `Charts` class can be checked with a script like this one:
```groovy
def chartData =
     [(getPathClass('Negative')): 5,
     (getPathClass('1+')): 2,
     (getPathClass('2+')): 3,
     (getPathClass('3+')): 4,
     (getPathClass('Tumor')): 2,
     (getPathClass('Stroma')): 2,
     (getPathClass('Immune cells')): 2,
     (getPathClass('Other')): 2,
     (getPathClass('Ignore*')): 2,
     (getPathClass('Region*')): 2,
     (getPathClass('Necrosis')): 2]
     
Charts.pieChart()
    .title('Test Chart')
    .data(chartData)
    .convertToPercentages(true)
    .show()
```