### PR TITLE
Improve PathClass JSON (de)serialization

### DIFF
--- a/qupath-core/src/test/java/qupath/lib/io/TestGsonTools.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestGsonTools.java
@@ -1,0 +1,62 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+import qupath.lib.common.ColorTools;
+import qupath.lib.objects.classes.PathClass;
+import qupath.lib.objects.classes.PathClassFactory;
+
+@SuppressWarnings("javadoc")
+public class TestGsonTools {
+	
+	@Test
+	public void test_PathClasses() throws IOException {
+		
+		testToJson(null);
+		testToJson(PathClassFactory.getPathClassUnclassified());
+		testToJson(PathClassFactory.getPathClass("Tumor"));
+		testToJson(PathClassFactory.getPathClass("Tumor: Positive"));
+		testToJson(PathClassFactory.getPathClass("Tumor: Positive: Other", ColorTools.packRGB(1, 2, 3)));
+
+		testToJson(PathClassFactory.getPathClass(Arrays.asList("Class 1", "Class 2", "Class 3")));
+	}
+	
+	
+	private static void testToJson(PathClass pathClass) {
+		
+		var gson = GsonTools.getInstance();
+		var json = gson.toJson(pathClass);
+		
+		var pathClass2 = gson.fromJson(json, PathClass.class);
+		
+		assertEquals(pathClass, pathClass2);
+		assertSame(pathClass, pathClass);
+	}
+	
+	
+}


### PR DESCRIPTION
Make classifications easier to work with when using GeoJSON. Now a "classification" property need only have a String value, or can be an object in the form `{"name": "classification: string", "color": [r, g, b]}`

This should be simpler when generating a Feature outside of QuPath that should then become a PathObject eventually.

Previously, the default Gson serialization was used - but this could result in rather awkward representations, with packed RGB values and retaining references to parent classes.

Example script:
```groovy
def pathClass = getPathClass('Tumor: Positive')
println GsonTools.getInstance(false).toJson(pathClass)
```

Output with this PR:
```
{"name":"Tumor: Positive","color":[200,50,50]}
```

Output before this PR:
```json
{"parentClass":{"name":"Tumor","colorRGB":-6750208},"name":"Positive","colorRGB":-3657166}
```