### PR TITLE
Minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ This is a work-in-progress.
 ### Dependency updates
 * Adoptium OpenJDK 17
 * Bio-Formats 6.11.0
+* ControlsFX 11.1.2
 * JavaFX 19.0.0
 * Java Topology Suite 1.19.0
 * Groovy 4.0.5

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ slf4j         = { module = "org.slf4j:slf4j-api",              version = "2.0.1"
 
 commons-math  = { module = "org.apache.commons:commons-math3", version = "3.6.1" }
 commons-text  = { module = "org.apache.commons:commons-text",  version = "1.9" }
-controlsfx    = { module = "org.controlsfx:controlsfx",        version = "11.1.1" }
+controlsfx    = { module = "org.controlsfx:controlsfx",        version = "11.1.2" }
 jfxtras       = { module = "org.jfxtras:jfxtras-menu",         version = "11-r2" }
 guava         = { module = "com.google.guava:guava",           version = "31.1-jre" }
 imagej        = { module = "net.imagej:ij",                    version = "1.53t" }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javafx.application.Platform;
+import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
@@ -968,9 +969,9 @@ public class Dialogs {
 			dialog.setResizable(resizable);
 			dialog.initModality(modality);
 			
-			// There's an annoying visual bug with no AlertType and dark mode resulting in a white/light 
-			// thin line at the bottom of the dialog
-			if (alertType == null || alertType == AlertType.NONE)
+			// There's sometimes annoying visual bug in dark mode that results in a white/light 
+			// thin line at the bottom of the dialog - padding seems to fix it
+			if (Insets.EMPTY.equals(dialog.getDialogPane().getPadding()))
 				dialog.getDialogPane().setStyle("-fx-padding: 1px;");
 			
 			return dialog;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -506,6 +506,16 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			ProjectImageEntry<BufferedImage> selectedEntry = selected == null ? null : ProjectTreeRow.getEntry(selected.getValue());
 			var entries = getSelectedImageRowsRecursive();
 			boolean isImageEntry = selectedEntry != null;
+			
+			int nSelectedEntries = ProjectTreeRow.getEntries(entries).size();
+			if (nSelectedEntries == 1) {
+				actionDuplicateImages.setText("Duplicate image");
+				actionRemoveImage.setText("Remove image");
+			} else {
+				actionDuplicateImages.setText("Duplicate " + nSelectedEntries + " images");
+				actionRemoveImage.setText("Remove " + nSelectedEntries + " images");				
+			}
+			
 //			miOpenProjectDirectory.setVisible(project != null && project.getBaseDirectory().exists());
 			miOpenImage.setVisible(isImageEntry);
 			miDuplicateImage.setVisible(isImageEntry);


### PR DESCRIPTION
- Update to ControlsFX 11.1.2
- Attempt to further improve dialogs in dark mode (duplicating images in a project had a light boundary)
- Replace 'Remove/Duplicate image(s)' with the actual number of images in the project context menu