### PR TITLE
Updated PathObject setting/getting colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ This is a work-in-progress.
   * Added `checkMinVersion(version)` and `checkVersionRange(min, max)` methods to block scripts running with the wrong QuPath version
   * Added `Timeit` class to checkpoint & report running times
   * Adapted `getCurrentImageData()` and `getProject()` to return those open in the viewer if not called from a running script (rather than null)
+* API changes (improvements...)
+  * Replaced `ImageServer.readBufferedImage()` with `readRegion()`, and made `RegionRequest` optional
+    * Retrieve pixels with `server.readRegion(downsample, x, y, width, height, z, t)` (https://github.com/qupath/qupath/pull/1072)
+  * Replaced `PathObject.get/setColorRGB(Integer)` with `PathObject.get/setColor(Integer)` and `PathObject.setColor(int, int, int)` (https://github.com/qupath/qupath/issues/1086)
+    * Improved consistency with `PathClass`, optionally provide unpacked r, g and b values
 * Log messages are now color-coded, making errors and warnings easier to spot (https://github.com/qupath/qupath/pull/1079)
 * Pixel classifier improvements
   * Making measurements is *much* faster in some circumstances (https://github.com/qupath/qupath/pull/1076)

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
@@ -578,7 +578,7 @@ public class IJTools {
 			pathObject.setPathClass(PathClassFactory.getPathClass("Group " + roi.getGroup(), colorRGB));
 		}
 		if (colorRGB != null && pathObject.getPathClass() == null) {
-			pathObject.setColorRGB(colorRGB);
+			pathObject.setColor(colorRGB);
 		}
 	}
 	

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/DilateAnnotationPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/DilateAnnotationPlugin.java
@@ -243,7 +243,7 @@ public class DilateAnnotationPlugin<T> extends AbstractInteractivePlugin<T> {
 		// Create a new annotation, with properties based on the original
 		PathObject annotation2 = PathObjects.createAnnotationObject(roi2, pathObject.getPathClass());
 		annotation2.setName(pathObject.getName());
-		annotation2.setColorRGB(pathObject.getColorRGB());
+		annotation2.setColor(pathObject.getColor());
 
 		if (constrainToParent || isErosion)
 		    hierarchy.addPathObjectBelowParent(parent, annotation2, true);

--- a/qupath-core-processing/src/main/java/qupath/opencv/CellCountsCV.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/CellCountsCV.java
@@ -331,7 +331,7 @@ public class CellCountsCV extends AbstractTileableDetectionPlugin<BufferedImage>
 					pathObject.getMeasurementList().putMeasurement(stain2Name + " OD", stain2Value);
 					pathObject.getMeasurementList().close();
 				} else
-					pathObject.setColorRGB(color);
+					pathObject.setColor(color);
 
 				contour.release();
 				pathObjects.add(pathObject);

--- a/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
@@ -569,7 +569,7 @@ public class DelaunayTools {
 			Integer color = pathClass == null ? null : pathClass.getColor();
 			for (var pathObject : cluster) {
 				pathObject.setName(name);
-				pathObject.setColorRGB(color);
+				pathObject.setColor(color);
 				list.add(pathObject);
 			}
 			c++;

--- a/qupath-core/src/main/java/qupath/lib/common/ColorTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/ColorTools.java
@@ -137,6 +137,66 @@ public final class ColorTools {
 	}
 	
 	/**
+	 * Unpack a packed (A)RGB int into red, green and blue values, 
+	 * returning the result as a 3-element int array.
+	 * @param rgb
+	 * @return
+	 * @since v0.4.0
+	 */
+	public static int[] unpackRGB(int rgb) {
+		return unpackRGB(rgb, null);
+	}
+	
+	/**
+	 * Unpack a packed (A)RGB int into red, green and blue values, 
+	 * into a 3-element int array.
+	 * @param rgb
+	 * @param array optional preallocated input array
+	 * @return the red, green and blue values in {@code array} if provided and long enough, 
+	 *         otherwise a new int array storing the values
+	 * @since v0.4.0
+	 */
+	public static int[] unpackRGB(int rgb, int[] array) {
+		if (array == null || array.length < 3)
+			array = new int[3];
+		array[0] = red(rgb);
+		array[1] = green(rgb);
+		array[2] = blue(rgb);
+		return array;
+	}
+	
+	/**
+	 * Unpack a packed ARGB int into red, green and blue values, 
+	 * returning the result as a 4-element int array.
+	 * @param rgb
+	 * @return
+	 * @since v0.4.0
+	 */
+	public static int[] unpackARGB(int rgb) {
+		return unpackARGB(rgb, null);
+	}
+	
+	/**
+	 * Unpack a packed ARGB int into red, green and blue values, 
+	 * into a 4-element int array.
+	 * @param rgb
+	 * @param array optional preallocated input array
+	 * @return the alpha, red, green and blue values in {@code array} if provided and long enough, 
+	 *         otherwise a new int array storing the values
+	 * @since v0.4.0
+	 */
+	public static int[] unpackARGB(int rgb, int[] array) {
+		if (array == null || array.length < 4)
+			array = new int[4];
+		array[0] = alpha(rgb);
+		array[1] = red(rgb);
+		array[2] = green(rgb);
+		array[3] = blue(rgb);
+		return array;
+	}
+	
+	
+	/**
 	 * Make a packed RGB value from specified input values, clipping to the range 0-255.
 	 * This is equivalent to an ARGB value with alpha set to 255, following Java {@link Color}.
 	 * <p>

--- a/qupath-core/src/main/java/qupath/lib/common/LogTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/LogTools.java
@@ -1,0 +1,91 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.common;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+/**
+ * Helper class for logging.
+ * 
+ * @author Pete Bankhead
+ * @since v0.4.0
+ */
+public class LogTools {
+	
+	private static Map<Logger, Map<Level, Set<String>>> alreadyLogged = new ConcurrentHashMap<>();
+
+	/**
+	 * Log a message once at the specified level.
+	 * <p>
+	 * This is intended primarily to give a way to warn the user if methods are deprecated, 
+	 * but avoid emitting large numbers of identical messages if the method is called many times.
+	 * 
+	 * @param logger
+	 * @param level
+	 * @param message
+	 * @return true if the message was logged, false otherwise (i.e. it has already been logged)
+	 */
+	public static boolean logOnce(Logger logger, Level level, String message) {
+		var map = alreadyLogged.computeIfAbsent(logger, l -> new ConcurrentHashMap<>());
+		var set = map.computeIfAbsent(level, l -> ConcurrentHashMap.newKeySet());
+		if (set.add(message)) {
+			logger.atLevel(level).log(message);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Log a message once at the INFO level.
+	 * <p>
+	 * This is intended primarily to give a way to notify the user if methods are deprecated, 
+	 * but avoid emitting large numbers of identical messages if the method is called many times.
+	 * 
+	 * @param logger
+	 * @param message
+	 * @return true if the message was logged, false otherwise (i.e. it has already been logged)
+	 */
+	public static boolean logOnce(Logger logger, String message) {
+		return logOnce(logger, Level.INFO, message);
+	}
+
+	/**
+	 * Log a message once at the WARN level.
+	 * <p>
+	 * This is intended primarily to give a way to warn the user if methods are deprecated, 
+	 * but avoid emitting large numbers of identical messages if the method is called many times.
+	 * 
+	 * @param logger
+	 * @param message
+	 * @return true if the message was logged, false otherwise (i.e. it has already been logged)
+	 */
+	public static boolean warnOnce(Logger logger, String message) {
+		return logOnce(logger, Level.WARN, message);
+	}
+	
+
+}

--- a/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
@@ -263,7 +263,7 @@ class PathObjectTypeAdapters {
 				out.value(name);
 			}
 			
-			Integer color = value.getColorRGB();
+			Integer color = value.getColor();
 			if (color != null) {
 				out.name("color");
 				out.beginArray();
@@ -465,7 +465,7 @@ class PathObjectTypeAdapters {
 				pathObject.setName(name);
 			
 			if (color != null)
-				pathObject.setColorRGB(color);
+				pathObject.setColor(color);
 			
 			if (isLocked)
 				pathObject.setLocked(isLocked);

--- a/qupath-core/src/main/java/qupath/lib/io/PointIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PointIO.java
@@ -119,7 +119,7 @@ public class PointIO {
 				pathObject.setName(name);
 			if (pathClass != null && pathClass.length() > 0 && !"null".equals(pathClass))
 				pathObject.setPathClass(PathClassFactory.getPathClass(pathClass, color));
-			pathObject.setColorRGB(color);
+			pathObject.setColor(color);
 			
 			if (pathObject != null)
 				pathObjects.add(pathObject);
@@ -171,7 +171,7 @@ public class PointIO {
 			ImagePlane defaultPlane = ImagePlane.getDefaultPlane();
 			boolean hasClass = pathObjects.stream().anyMatch(p -> p.getPathClass() != null);
 			boolean hasName = pathObjects.stream().anyMatch(p -> p.getName() != null);
-			boolean hasColor = pathObjects.stream().anyMatch(p -> p.getColorRGB() != null);
+			boolean hasColor = pathObjects.stream().anyMatch(p -> p.getColor() != null);
 			boolean hasC = pathObjects.stream().anyMatch(p -> p.getROI().getC() > defaultPlane.getC());
 			boolean hasZ = pathObjects.stream().anyMatch(p -> p.getROI().getZ() > defaultPlane.getZ());
 			boolean hasT = pathObjects.stream().anyMatch(p -> p.getROI().getT() > defaultPlane.getT());
@@ -216,7 +216,7 @@ public class PointIO {
 					if (hasName)
 						row[cols.indexOf("name")] = pathObject.getName() != null ? sep + pathObject.getName() : sep;
 					if (hasColor)
-						row[cols.indexOf("color")] = pathObject.getColorRGB() != null ? sep + pathObject.getColorRGB() : sep;
+						row[cols.indexOf("color")] = pathObject.getColor() != null ? sep + pathObject.getColor() : sep;
 					
 					for (String val: row)
 						writer.write(val);
@@ -340,7 +340,7 @@ public class PointIO {
 		PathObject pathObject = PathObjects.createAnnotationObject(points);
 		if (name != null && name.length() > 0 && !"null".equals(name))
 			pathObject.setName(name);
-		pathObject.setColorRGB(color);
+		pathObject.setColor(color);
 		return pathObject;
 	}	
 }

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -41,6 +41,8 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import qupath.lib.common.ColorTools;
+import qupath.lib.common.LogTools;
 import qupath.lib.io.PathIO;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.measurements.MeasurementListFactory;
@@ -738,19 +740,65 @@ public abstract class PathObject implements Externalizable {
 	/**
 	 * Return any stored color as a packed RGB value.
 	 * <p>
+	 * This may be null if no color has been set.
+	 * @return
+	 * @see #setColorRGB(Integer)
+	 * @see ColorTools#red(int)
+	 * @see ColorTools#green(int)
+	 * @see ColorTools#blue(int)
+	 * @since v0.4.0
+	 */
+	public Integer getColor() {
+		return color;
+	}
+	
+	/**
+	 * Return any stored color as a packed RGB value.
+	 * <p>
 	 * This may be null if no color has been set
 	 * @return
+	 * @deprecated since v0.4.0, use {@link #getColor()} instead.
 	 */
+	@Deprecated
 	public Integer getColorRGB() {
-		return color;
+		LogTools.warnOnce(logger, "PathObject.getColorRGB() is deprecated since v0.4.0 - use getColor() instead");
+		return getColor();
 	}
 	
 	/**
 	 * Set the display color.
 	 * @param color
+	 * @deprecated since v0.4.0, use {@link #setColor(Integer)} instead.
 	 */
+	@Deprecated
 	public void setColorRGB(Integer color) {
+		LogTools.warnOnce(logger, "PathObject.setColorRGB(Integer) is deprecated since v0.4.0 - use setColor(Integer) instead");
+		setColor(color);
+	}
+	
+	/**
+	 * Set the display color as a packed (A)RGB integer (alpha may not be used 
+	 * by viewing code).
+	 * @param color packed (A)RGB value, or null if a color should not stored
+	 * @since v0.4.0
+	 * @see #setColor(int, int, int)
+	 * @see ColorTools#packRGB(int, int, int)
+	 * @implNote any alpha value is retained, but may not be used; it is recommended to 
+	 *           use only RGB values with alpha 255.
+	 */
+	public void setColor(Integer color) {
 		this.color = color;
+	}
+	
+	/**
+	 * Set the display color as 8-bit RGB values
+	 * @param red 
+	 * @param green 
+	 * @param blue 
+	 * @since v0.4.0
+	 */
+	public void setColor(int red, int green, int blue) {
+		setColor(ColorTools.packRGB(red, green, blue));
 	}
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -729,7 +729,7 @@ public class PathObjectTools {
 	public static void swapNameAndClass(PathObject pathObject, boolean includeColor) {
 		var pathClass = pathObject.getPathClass();
 		var name = pathObject.getName();
-		var color = pathObject.getColorRGB();
+		var color = pathObject.getColor();
 		if (name == null)
 			pathObject.setPathClass(null);
 		else
@@ -737,11 +737,11 @@ public class PathObjectTools {
 		if (pathClass == null) {
 			pathObject.setName(null);
 			if (includeColor)
-				pathObject.setColorRGB(null);
+				pathObject.setColor(null);
 		} else {
 			pathObject.setName(pathClass.toString());
 			if (includeColor)
-				pathObject.setColorRGB(pathClass.getColor());				
+				pathObject.setColor(pathClass.getColor());				
 		}
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/PathROIObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathROIObject.java
@@ -153,7 +153,7 @@ public abstract class PathROIObject extends PathObject {
 		this.classProbability = classProbability;
 		// Forget any previous color, if we have a PathClass
 		if (this.pathClass != null)
-			setColorRGB(null);
+			setColor(null);
 	}
 	
 	@Override

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
@@ -223,6 +223,17 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 	}
 	
 	/**
+	 * Set the color as 8-bit RGB values
+	 * @param red 
+	 * @param green 
+	 * @param blue 
+	 * @since v0.4.0
+	 */
+	public void setColor(int red, int green, int blue) {
+		setColor(ColorTools.packRGB(red, green, blue));
+	}
+	
+	/**
 	 * Get the color that should be used to display objects with this classification.
 	 * @return packed (A)RGB value representing the classification color.
 	 */

--- a/qupath-core/src/main/java/qupath/lib/plugins/ParallelTileObject.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/ParallelTileObject.java
@@ -109,7 +109,7 @@ public class ParallelTileObject extends PathTileObject implements TemporaryObjec
 		this.bounds = getBounds2D(pathROI);
 		this.hierarchy = hierarchy;
 		this.countdown = countdown;
-		setColorRGB(ColorTools.packRGB(128, 128, 128));
+		setColor(ColorTools.packRGB(128, 128, 128));
 	}
 
 

--- a/qupath-core/src/test/java/qupath/lib/color/TestColors.java
+++ b/qupath-core/src/test/java/qupath/lib/color/TestColors.java
@@ -23,11 +23,13 @@
 
 package qupath.lib.color;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Locale;
+import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
@@ -263,6 +265,44 @@ public class TestColors {
 //		ColorDeconvolution.colorDeconvolveReconvolveRGBArray(new int[]{MIN_RGB, MAX_RGB}, myCDS2, myCDS2, false, buf_output);
 		
 	}
+	
+	
+	@Test
+	public void test_ColorTools() {
+		
+		var random = new Random(100L);
+		for (int i = 0; i < 10; i++) {
+			
+			int a = random.nextInt(255);
+			int r = random.nextInt(255);
+			int g = random.nextInt(255);
+			int b = random.nextInt(255);
+			
+			int rgb = ColorTools.packRGB(r, g, b);
+			assertEquals(255, ColorTools.alpha(rgb));
+			assertEquals(r, ColorTools.red(rgb));
+			assertEquals(g, ColorTools.green(rgb));
+			assertEquals(b, ColorTools.blue(rgb));
+			
+			assertArrayEquals(new int[] {r, g, b}, ColorTools.unpackRGB(rgb));
+			assertArrayEquals(new int[] {255, r, g, b}, ColorTools.unpackARGB(rgb));
+			
+			assertArrayEquals(new int[] {r, g, b}, ColorTools.unpackRGB(rgb));
+			assertArrayEquals(new int[] {255, r, g, b}, ColorTools.unpackARGB(rgb));
+
+			int argb = ColorTools.packARGB(a, r, g, b);
+			assertEquals(a, ColorTools.alpha(argb));
+			assertEquals(r, ColorTools.red(argb));
+			assertEquals(g, ColorTools.green(argb));
+			assertEquals(b, ColorTools.blue(argb));
+
+			assertArrayEquals(new int[] {r, g, b}, ColorTools.unpackRGB(argb));
+			assertArrayEquals(new int[] {a, r, g, b}, ColorTools.unpackARGB(argb));
+		}
+		
+		
+	}
+	
 	
 }
 

--- a/qupath-core/src/test/java/qupath/lib/common/TestLogTools.java
+++ b/qupath-core/src/test/java/qupath/lib/common/TestLogTools.java
@@ -1,0 +1,58 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.lib.common;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+@SuppressWarnings("javadoc")
+public class TestLogTools {
+	
+	private static Logger logger = LoggerFactory.getLogger(TestLogTools.class);
+	
+	@Test
+	public void test_loggingOnce() {
+		
+		assertTrue(LogTools.warnOnce(logger, "This warning is expected"));
+		assertFalse(LogTools.warnOnce(logger, "This warning is expected"));
+		assertFalse(LogTools.logOnce(logger, Level.WARN, "This warning is expected"));
+
+		assertTrue(LogTools.logOnce(logger, Level.WARN, "This warning is also expected"));
+
+		assertTrue(LogTools.logOnce(logger, "This warning is expected"));
+		assertFalse(LogTools.logOnce(logger, "This warning is expected"));
+		assertFalse(LogTools.logOnce(logger, Level.INFO, "This warning is expected"));
+
+		assertTrue(LogTools.logOnce(logger, Level.DEBUG, "This warning is expected"));
+
+		assertTrue(LogTools.warnOnce(LoggerFactory.getLogger("Something else"), "This warning is expected"));
+		
+		
+	}
+	
+}

--- a/qupath-core/src/test/java/qupath/lib/io/TestPointIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPointIO.java
@@ -147,7 +147,7 @@ public class TestPointIO {
 				pathObject.setName("bar");
 			}
 			
-			pathObject.setColorRGB(colors[entry.getKey()-1]);
+			pathObject.setColor(colors[entry.getKey()-1]);
 			pathObjects.add(pathObject);
 		}
 

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -203,11 +203,11 @@ class TestPathObject {
 	}
 	//@Test
 	public void test_getColorRGB(PathObject myPO, Integer colorrgb) {
-		assertEquals(myPO.getColorRGB(), colorrgb);
+		assertEquals(myPO.getColor(), colorrgb);
 	}
 	//@Test
 	public void test_setColorRGB(PathObject myPO, Integer colorrgb) {
-		myPO.setColorRGB(colorrgb);
-		assertEquals((Integer)myPO.getColorRGB(), colorrgb);
+		myPO.setColor(colorrgb);
+		assertEquals((Integer)myPO.getColor(), colorrgb);
 	}
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -980,7 +980,7 @@ public class Commands {
 		if (!newROI.isEmpty()) {
 			newObject = PathObjects.createAnnotationObject(newROI, pathObject.getPathClass());
 			newObject.setName(pathObject.getName());
-			newObject.setColorRGB(pathObject.getColorRGB());
+			newObject.setColor(pathObject.getColor());
 		}
 
 		// Remove previous objects

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/ColorToolsFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/ColorToolsFX.java
@@ -226,7 +226,7 @@ public class ColorToolsFX {
 	 */
 	public static Integer getDisplayedColorARGB(final PathObject pathObject) {
 		// Check if any color has been set - if so, return it
-		Integer color = pathObject.getColorRGB();
+		Integer color = pathObject.getColor();
 		if (color != null)
 			return color;
 		// Check if any class has been set, if so then use its color

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -1011,7 +1011,7 @@ public class GuiTools {
 			else
 				temp.setName(null);
 			if (promptForColor && colorChanged.get())
-				temp.setColorRGB(ColorToolsFX.getARGB(colorPicker.getValue()));
+				temp.setColor(ColorToolsFX.getARGB(colorPicker.getValue()));
 	
 			// Set the description only if we have to
 			String description = textAreaDescription.getText();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/BrushTool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/BrushTool.java
@@ -391,7 +391,7 @@ public class BrushTool extends AbstractPathROITool {
 			PathObject pathObjectNew = PathObjects.createAnnotationObject(roiNew, PathPrefs.autoSetAnnotationClassProperty().get());
 			if (currentObject != null) {
 				pathObjectNew.setName(currentObject.getName());
-				pathObjectNew.setColorRGB(currentObject.getColorRGB());
+				pathObjectNew.setColor(currentObject.getColor());
 				pathObjectNew.setPathClass(currentObject.getPathClass());
 			}
 			return pathObjectNew;


### PR DESCRIPTION
See https://github.com/qupath/qupath/issues/1086
- Improve consistency between `PathClass` and `PathObject`, and reduce requirement to always set packed int values.
- Add `ColorTools.unpackRGB` method
- Add LogTools to facilitate printing log messages once