### PR TITLE
Improve working with measurements and classifications

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/ObjectMeasurements.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/ObjectMeasurements.java
@@ -50,11 +50,11 @@ class ObjectMeasurements {
 	 * @param prefix
 	 */
 	public static void addShapeStatistics(MeasurementList measurementList, PolygonROI roi, double pixelWidth, double pixelHeight, String prefix) {
-		measurementList.putMeasurement(prefix + "Area", roi.getScaledArea(pixelWidth, pixelHeight));
-		measurementList.putMeasurement(prefix + "Perimeter", roi.getScaledLength(pixelWidth, pixelHeight));
-		measurementList.putMeasurement(prefix + "Circularity", RoiTools.getCircularity(roi, pixelWidth, pixelHeight));
+		measurementList.put(prefix + "Area", roi.getScaledArea(pixelWidth, pixelHeight));
+		measurementList.put(prefix + "Perimeter", roi.getScaledLength(pixelWidth, pixelHeight));
+		measurementList.put(prefix + "Circularity", RoiTools.getCircularity(roi, pixelWidth, pixelHeight));
 //		measurementList.putMeasurement(prefix + "Convex area", roi.getScaledConvexArea(pixelWidth, pixelHeight));
-		measurementList.putMeasurement(prefix + "Solidity", roi.getSolidity());
+		measurementList.put(prefix + "Solidity", roi.getSolidity());
 	}
 
 	public static void addShapeStatistics(MeasurementList measurementList, Roi roi, ImageProcessor ip, Calibration cal, String prefix) {
@@ -77,14 +77,14 @@ class ObjectMeasurements {
 	
 		// TODO: Add units!
 		if (roi.isArea())
-			measurementList.putMeasurement(prefix + "Area", shapeStats.area());
-		measurementList.putMeasurement(prefix + "Perimeter", shapeStats.perimeter());
-		measurementList.putMeasurement(prefix + "Circularity", shapeStats.circularity());
-		measurementList.putMeasurement(prefix + "Max caliper", shapeStats.maxCaliper());
-		measurementList.putMeasurement(prefix + "Min caliper", shapeStats.minCaliper());
+			measurementList.put(prefix + "Area", shapeStats.area());
+		measurementList.put(prefix + "Perimeter", shapeStats.perimeter());
+		measurementList.put(prefix + "Circularity", shapeStats.circularity());
+		measurementList.put(prefix + "Max caliper", shapeStats.maxCaliper());
+		measurementList.put(prefix + "Min caliper", shapeStats.minCaliper());
 //		measurementList.putMeasurement(prefix + "Major axis", shapeStats.majorAxisLength());
 //		measurementList.putMeasurement(prefix + "Minor axis", shapeStats.minorAxisLength());
-		measurementList.putMeasurement(prefix + "Eccentricity", shapeStats.eccentricity());
+		measurementList.put(prefix + "Eccentricity", shapeStats.eccentricity());
 	
 		// Note: Roundness correlates closely with eccentricity, so was removed
 		// Major & Minor axis correlate closely with max & min caliper, so were removed

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/PositiveCellDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/PositiveCellDetection.java
@@ -145,7 +145,7 @@ public class PositiveCellDetection extends WatershedCellDetection {
 			double threshold3 = params.getDoubleParameterValue("thresholdPositive3");
 			boolean singleThreshold = params.getBooleanParameterValue("singleThreshold");
 			for (PathObject pathObject : detections) {
-				double val = pathObject.getMeasurementList().getMeasurementValue(measurement);
+				double val = pathObject.getMeasurementList().get(measurement);
 				if (singleThreshold) {
 					if (val >= threshold1) {
 						pathObject.setPathClass(PathClassFactory.getPositive(pathObject.getPathClass()));

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/PositiveCellDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/PositiveCellDetection.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import qupath.lib.color.ColorDeconvolutionStains;
 import qupath.lib.images.ImageData;
 import qupath.lib.objects.PathObject;
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.plugins.ObjectDetector;
 import qupath.lib.plugins.parameters.ParameterList;
 import qupath.lib.roi.interfaces.ROI;
@@ -148,19 +148,19 @@ public class PositiveCellDetection extends WatershedCellDetection {
 				double val = pathObject.getMeasurementList().get(measurement);
 				if (singleThreshold) {
 					if (val >= threshold1) {
-						pathObject.setPathClass(PathClassFactory.getPositive(pathObject.getPathClass()));
+						pathObject.setPathClass(PathClass.getPositive(pathObject.getPathClass()));
 					} else {
-						pathObject.setPathClass(PathClassFactory.getNegative(pathObject.getPathClass()));
+						pathObject.setPathClass(PathClass.getNegative(pathObject.getPathClass()));
 					}
 				} else {
 					if (val >= threshold3) {
-						pathObject.setPathClass(PathClassFactory.getThreePlus(pathObject.getPathClass()));
+						pathObject.setPathClass(PathClass.getThreePlus(pathObject.getPathClass()));
 					} else if (val >= threshold2){
-						pathObject.setPathClass(PathClassFactory.getTwoPlus(pathObject.getPathClass()));
+						pathObject.setPathClass(PathClass.getTwoPlus(pathObject.getPathClass()));
 					} else if (val >= threshold1){
-						pathObject.setPathClass(PathClassFactory.getOnePlus(pathObject.getPathClass()));
+						pathObject.setPathClass(PathClass.getOnePlus(pathObject.getPathClass()));
 					} else
-						pathObject.setPathClass(PathClassFactory.getNegative(pathObject.getPathClass()));
+						pathObject.setPathClass(PathClass.getNegative(pathObject.getPathClass()));
 				}
 			}
 			return detections;

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
@@ -73,7 +73,6 @@ import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.TMACoreObject;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.classes.PathClassTools;
 import qupath.lib.plugins.AbstractInteractivePlugin;
 import qupath.lib.plugins.PluginRunner;
@@ -362,7 +361,7 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 					boolean isCluster = spotOrCluster.getMeasurementList().get("Num spots") > 1;
 					int rgb = imageWrapper.getChannelColor(channelName);
 					rgb = isCluster ? ColorTools.makeScaledRGB(rgb, 0.5) : ColorTools.makeScaledRGB(rgb, 1.5);
-					PathClass pathClass = PathClassFactory.getDerivedPathClass(spotOrCluster.getPathClass(), channelName + " object", rgb);
+					PathClass pathClass = PathClass.getInstance(spotOrCluster.getPathClass(), channelName + " object", rgb);
 					spotOrCluster.setPathClass(pathClass);
 					
 					spotOrCluster.getMeasurementList().put("Subcellular cluster: " + channelName + ": Area", stats.pixelCount * pixelWidth * pixelHeight);					
@@ -471,9 +470,9 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 	static PathObject createSubcellularObject(final ROI roi, final double nSpots) {
 		var pathObject = PathObjects.createDetectionObject(roi);
 		if (nSpots != 1)
-			pathObject.setPathClass(PathClassFactory.getPathClass("Subcellular cluster", ColorTools.packRGB(220, 200, 50)));
+			pathObject.setPathClass(PathClass.getInstance("Subcellular cluster", ColorTools.packRGB(220, 200, 50)));
 		else
-			pathObject.setPathClass(PathClassFactory.getPathClass("Subcellular spot", ColorTools.packRGB(100, 220, 50)));
+			pathObject.setPathClass(PathClass.getInstance("Subcellular spot", ColorTools.packRGB(100, 220, 50)));
 		pathObject.getMeasurementList().put("Num spots", nSpots);
 		pathObject.getMeasurementList().close();
 		return pathObject;
@@ -502,9 +501,9 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 		SubcellularObject(final ROI roi, final double nSpots) {
 			super(roi, null);
 			if (nSpots != 1)
-				setPathClass(PathClassFactory.getPathClass("Subcellular cluster", ColorTools.packRGB(220, 200, 50)));
+				setPathClass(PathClass.getInstance("Subcellular cluster", ColorTools.packRGB(220, 200, 50)));
 			else
-				setPathClass(PathClassFactory.getPathClass("Subcellular spot", ColorTools.packRGB(100, 220, 50)));
+				setPathClass(PathClass.getInstance("Subcellular spot", ColorTools.packRGB(100, 220, 50)));
 			getMeasurementList().put("Num spots", nSpots);
 			getMeasurementList().close();
 //			color = isCluster ? ColorTools.makeRGB(220, 200, 50) : ColorTools.makeRGB(100, 220, 50);

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
@@ -359,14 +359,14 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 				}
 				if (spotOrCluster != null) {
 					
-					boolean isCluster = spotOrCluster.getMeasurementList().getMeasurementValue("Num spots") > 1;
+					boolean isCluster = spotOrCluster.getMeasurementList().get("Num spots") > 1;
 					int rgb = imageWrapper.getChannelColor(channelName);
 					rgb = isCluster ? ColorTools.makeScaledRGB(rgb, 0.5) : ColorTools.makeScaledRGB(rgb, 1.5);
 					PathClass pathClass = PathClassFactory.getDerivedPathClass(spotOrCluster.getPathClass(), channelName + " object", rgb);
 					spotOrCluster.setPathClass(pathClass);
 					
-					spotOrCluster.getMeasurementList().putMeasurement("Subcellular cluster: " + channelName + ": Area", stats.pixelCount * pixelWidth * pixelHeight);					
-					spotOrCluster.getMeasurementList().putMeasurement("Subcellular cluster: " + channelName +  ": Mean channel intensity", stats.mean);
+					spotOrCluster.getMeasurementList().put("Subcellular cluster: " + channelName + ": Area", stats.pixelCount * pixelWidth * pixelHeight);					
+					spotOrCluster.getMeasurementList().put("Subcellular cluster: " + channelName +  ": Mean channel intensity", stats.mean);
 //					cluster.getMeasurementList().putMeasurement("Subcellular cluster: " + channelName +  ": Max channel intensity", stats.max);
 					spotOrCluster.getMeasurementList().close();
 					if (isCluster)
@@ -378,9 +378,9 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 
 			// Add measurements
 			MeasurementList measurementList = pathObject.getMeasurementList();
-			measurementList.putMeasurement("Subcellular: " + channelName +  ": Num spots estimated", estimatedSpots);
-			measurementList.putMeasurement("Subcellular: " + channelName +  ": Num single spots", spotObjects.size());
-			measurementList.putMeasurement("Subcellular: " + channelName +  ": Num clusters", clusterObjects.size());
+			measurementList.put("Subcellular: " + channelName +  ": Num spots estimated", estimatedSpots);
+			measurementList.put("Subcellular: " + channelName +  ": Num single spots", spotObjects.size());
+			measurementList.put("Subcellular: " + channelName +  ": Num clusters", clusterObjects.size());
 
 			// Add spots
 			pathObject.addPathObjects(spotObjects);
@@ -474,7 +474,7 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 			pathObject.setPathClass(PathClassFactory.getPathClass("Subcellular cluster", ColorTools.packRGB(220, 200, 50)));
 		else
 			pathObject.setPathClass(PathClassFactory.getPathClass("Subcellular spot", ColorTools.packRGB(100, 220, 50)));
-		pathObject.getMeasurementList().putMeasurement("Num spots", nSpots);
+		pathObject.getMeasurementList().put("Num spots", nSpots);
 		pathObject.getMeasurementList().close();
 		return pathObject;
 	}
@@ -505,7 +505,7 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 				setPathClass(PathClassFactory.getPathClass("Subcellular cluster", ColorTools.packRGB(220, 200, 50)));
 			else
 				setPathClass(PathClassFactory.getPathClass("Subcellular spot", ColorTools.packRGB(100, 220, 50)));
-			getMeasurementList().putMeasurement("Num spots", nSpots);
+			getMeasurementList().put("Num spots", nSpots);
 			getMeasurementList().close();
 //			color = isCluster ? ColorTools.makeRGB(220, 200, 50) : ColorTools.makeRGB(100, 220, 50);
 		}

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
@@ -847,12 +847,12 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 					for (String key : channels.keySet()) {
 						List<RunningStatistics> statsList = statsMap.get(key);
 						RunningStatistics stats = statsList.get(i);
-						measurementList.addMeasurement("Nucleus: " + key + " mean", stats.getMean());
-						measurementList.addMeasurement("Nucleus: " + key + " sum", stats.getSum());
-						measurementList.addMeasurement("Nucleus: " + key + " std dev", stats.getStdDev());
-						measurementList.addMeasurement("Nucleus: " + key + " max", stats.getMax());
-						measurementList.addMeasurement("Nucleus: " + key + " min", stats.getMin());
-						measurementList.addMeasurement("Nucleus: " + key + " range", stats.getRange());
+						measurementList.putMeasurement("Nucleus: " + key + " mean", stats.getMean());
+						measurementList.putMeasurement("Nucleus: " + key + " sum", stats.getSum());
+						measurementList.putMeasurement("Nucleus: " + key + " std dev", stats.getStdDev());
+						measurementList.putMeasurement("Nucleus: " + key + " max", stats.getMax());
+						measurementList.putMeasurement("Nucleus: " + key + " min", stats.getMin());
+						measurementList.putMeasurement("Nucleus: " + key + " range", stats.getRange());
 					}
 				}
 				
@@ -948,10 +948,10 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 						for (String key : channelsCell.keySet()) {
 							if (statsMapCell.containsKey(key)) {
 								RunningStatistics stats = statsMapCell.get(key).get(i);
-								measurementList.addMeasurement("Cell: " + key + " mean", stats.getMean());
-								measurementList.addMeasurement("Cell: " + key + " std dev", stats.getStdDev());
-								measurementList.addMeasurement("Cell: " + key + " max", stats.getMax());
-								measurementList.addMeasurement("Cell: " + key + " min", stats.getMin());
+								measurementList.putMeasurement("Cell: " + key + " mean", stats.getMean());
+								measurementList.putMeasurement("Cell: " + key + " std dev", stats.getStdDev());
+								measurementList.putMeasurement("Cell: " + key + " max", stats.getMax());
+								measurementList.putMeasurement("Cell: " + key + " min", stats.getMin());
 		//						pathObject.addMeasurement("Cytoplasm: " + key + " range", stats.getRange());
 							}
 						}
@@ -960,10 +960,10 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 						for (String key : channelsCell.keySet()) {
 							if (statsMapCytoplasm.containsKey(key)) {
 								RunningStatistics stats = statsMapCytoplasm.get(key).get(i);
-								measurementList.addMeasurement("Cytoplasm: " + key + " mean", stats.getMean());
-								measurementList.addMeasurement("Cytoplasm: " + key + " std dev", stats.getStdDev());
-								measurementList.addMeasurement("Cytoplasm: " + key + " max", stats.getMax());
-								measurementList.addMeasurement("Cytoplasm: " + key + " min", stats.getMin());
+								measurementList.putMeasurement("Cytoplasm: " + key + " mean", stats.getMean());
+								measurementList.putMeasurement("Cytoplasm: " + key + " std dev", stats.getStdDev());
+								measurementList.putMeasurement("Cytoplasm: " + key + " max", stats.getMax());
+								measurementList.putMeasurement("Cytoplasm: " + key + " min", stats.getMin());
 		//						pathObject.addMeasurement("Cytoplasm: " + key + " range", stats.getRange());
 							}
 						}
@@ -972,7 +972,7 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 						if (nucleus != null && nucleus.getROI().isArea()) {
 							double nucleusArea = nucleus.getROI().getArea();
 							double cellArea = pathROI.getArea();
-							measurementList.addMeasurement("Nucleus/Cell area ratio", Math.min(nucleusArea / cellArea, 1.0));
+							measurementList.putMeasurement("Nucleus/Cell area ratio", Math.min(nucleusArea / cellArea, 1.0));
 	//						measurementList.addMeasurement("Nucleus/Cell expansion", cellArea - nucleusArea);
 						}
 					}

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
@@ -847,12 +847,12 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 					for (String key : channels.keySet()) {
 						List<RunningStatistics> statsList = statsMap.get(key);
 						RunningStatistics stats = statsList.get(i);
-						measurementList.putMeasurement("Nucleus: " + key + " mean", stats.getMean());
-						measurementList.putMeasurement("Nucleus: " + key + " sum", stats.getSum());
-						measurementList.putMeasurement("Nucleus: " + key + " std dev", stats.getStdDev());
-						measurementList.putMeasurement("Nucleus: " + key + " max", stats.getMax());
-						measurementList.putMeasurement("Nucleus: " + key + " min", stats.getMin());
-						measurementList.putMeasurement("Nucleus: " + key + " range", stats.getRange());
+						measurementList.put("Nucleus: " + key + " mean", stats.getMean());
+						measurementList.put("Nucleus: " + key + " sum", stats.getSum());
+						measurementList.put("Nucleus: " + key + " std dev", stats.getStdDev());
+						measurementList.put("Nucleus: " + key + " max", stats.getMax());
+						measurementList.put("Nucleus: " + key + " min", stats.getMin());
+						measurementList.put("Nucleus: " + key + " range", stats.getRange());
 					}
 				}
 				
@@ -948,10 +948,10 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 						for (String key : channelsCell.keySet()) {
 							if (statsMapCell.containsKey(key)) {
 								RunningStatistics stats = statsMapCell.get(key).get(i);
-								measurementList.putMeasurement("Cell: " + key + " mean", stats.getMean());
-								measurementList.putMeasurement("Cell: " + key + " std dev", stats.getStdDev());
-								measurementList.putMeasurement("Cell: " + key + " max", stats.getMax());
-								measurementList.putMeasurement("Cell: " + key + " min", stats.getMin());
+								measurementList.put("Cell: " + key + " mean", stats.getMean());
+								measurementList.put("Cell: " + key + " std dev", stats.getStdDev());
+								measurementList.put("Cell: " + key + " max", stats.getMax());
+								measurementList.put("Cell: " + key + " min", stats.getMin());
 		//						pathObject.addMeasurement("Cytoplasm: " + key + " range", stats.getRange());
 							}
 						}
@@ -960,10 +960,10 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 						for (String key : channelsCell.keySet()) {
 							if (statsMapCytoplasm.containsKey(key)) {
 								RunningStatistics stats = statsMapCytoplasm.get(key).get(i);
-								measurementList.putMeasurement("Cytoplasm: " + key + " mean", stats.getMean());
-								measurementList.putMeasurement("Cytoplasm: " + key + " std dev", stats.getStdDev());
-								measurementList.putMeasurement("Cytoplasm: " + key + " max", stats.getMax());
-								measurementList.putMeasurement("Cytoplasm: " + key + " min", stats.getMin());
+								measurementList.put("Cytoplasm: " + key + " mean", stats.getMean());
+								measurementList.put("Cytoplasm: " + key + " std dev", stats.getStdDev());
+								measurementList.put("Cytoplasm: " + key + " max", stats.getMax());
+								measurementList.put("Cytoplasm: " + key + " min", stats.getMin());
 		//						pathObject.addMeasurement("Cytoplasm: " + key + " range", stats.getRange());
 							}
 						}
@@ -972,7 +972,7 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 						if (nucleus != null && nucleus.getROI().isArea()) {
 							double nucleusArea = nucleus.getROI().getArea();
 							double cellArea = pathROI.getArea();
-							measurementList.putMeasurement("Nucleus/Cell area ratio", Math.min(nucleusArea / cellArea, 1.0));
+							measurementList.put("Nucleus/Cell area ratio", Math.min(nucleusArea / cellArea, 1.0));
 	//						measurementList.addMeasurement("Nucleus/Cell expansion", cellArea - nucleusArea);
 						}
 					}

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
@@ -78,7 +78,7 @@ import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.plugins.AbstractTileableDetectionPlugin;
 import qupath.lib.plugins.ObjectDetector;
 import qupath.lib.plugins.parameters.DoubleParameter;
@@ -362,8 +362,8 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 				return "1 nucleus detected";
 			String s = String.format("%d nuclei detected", nDetections);
 			if (nucleiClassified) {
-				int nPositive = PathObjectTools.countObjectsWithClass(pathObjects, PathClassFactory.getNegative(null), false);
-				int nNegative = PathObjectTools.countObjectsWithClass(pathObjects, PathClassFactory.getPositive(null), false);
+				int nPositive = PathObjectTools.countObjectsWithClass(pathObjects, PathClass.getNegative(null), false);
+				int nNegative = PathObjectTools.countObjectsWithClass(pathObjects, PathClass.getPositive(null), false);
 				return String.format("%s (%.3f%% positive)", s, ((double)nPositive * 100.0 / (nPositive + nNegative)));			
 			} else
 				return s;

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellMembraneDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellMembraneDetection.java
@@ -816,20 +816,20 @@ public class WatershedCellMembraneDetection extends AbstractTileableDetectionPlu
 	//				PathObjectIJ.computeShapeStatistics(pathObject, pathImage, fpH, pathImage.getImage().getCalibration(), "Nucleus: ");
 					
 					RunningStatistics stats = statsHematoxylin.get(i);
-					measurementList.putMeasurement("Nucleus: Hematoxylin OD mean", stats.getMean());
-					measurementList.putMeasurement("Nucleus: Hematoxylin OD sum", stats.getSum());
-					measurementList.putMeasurement("Nucleus: Hematoxylin OD std dev", stats.getStdDev());
-					measurementList.putMeasurement("Nucleus: Hematoxylin OD max", stats.getMax());
-					measurementList.putMeasurement("Nucleus: Hematoxylin OD min", stats.getMin());
-					measurementList.putMeasurement("Nucleus: Hematoxylin OD range", stats.getRange());
+					measurementList.put("Nucleus: Hematoxylin OD mean", stats.getMean());
+					measurementList.put("Nucleus: Hematoxylin OD sum", stats.getSum());
+					measurementList.put("Nucleus: Hematoxylin OD std dev", stats.getStdDev());
+					measurementList.put("Nucleus: Hematoxylin OD max", stats.getMax());
+					measurementList.put("Nucleus: Hematoxylin OD min", stats.getMin());
+					measurementList.put("Nucleus: Hematoxylin OD range", stats.getRange());
 					if (statsDAB != null) {
 						stats = statsDAB.get(i);
-						measurementList.putMeasurement("Nucleus: DAB OD mean", stats.getMean());
-						measurementList.putMeasurement("Nucleus: DAB OD sum", stats.getSum());
-						measurementList.putMeasurement("Nucleus: DAB OD std dev", stats.getStdDev());
-						measurementList.putMeasurement("Nucleus: DAB OD max", stats.getMax());
-						measurementList.putMeasurement("Nucleus: DAB OD min", stats.getMin());
-						measurementList.putMeasurement("Nucleus: DAB OD range", stats.getRange());
+						measurementList.put("Nucleus: DAB OD mean", stats.getMean());
+						measurementList.put("Nucleus: DAB OD sum", stats.getSum());
+						measurementList.put("Nucleus: DAB OD std dev", stats.getStdDev());
+						measurementList.put("Nucleus: DAB OD max", stats.getMax());
+						measurementList.put("Nucleus: DAB OD min", stats.getMin());
+						measurementList.put("Nucleus: DAB OD range", stats.getRange());
 					}
 				}
 				
@@ -981,30 +981,30 @@ public class WatershedCellMembraneDetection extends AbstractTileableDetectionPlu
 						// Add cell measurements
 						if (statsDABCell != null) {
 							RunningStatistics stats = statsDABCell.get(label-1);
-							measurementList.putMeasurement("Cell: DAB OD mean", stats.getMean());
-							measurementList.putMeasurement("Cell: DAB OD std dev", stats.getStdDev());
-							measurementList.putMeasurement("Cell: DAB OD max", stats.getMax());
-							measurementList.putMeasurement("Cell: DAB OD min", stats.getMin());
+							measurementList.put("Cell: DAB OD mean", stats.getMean());
+							measurementList.put("Cell: DAB OD std dev", stats.getStdDev());
+							measurementList.put("Cell: DAB OD max", stats.getMax());
+							measurementList.put("Cell: DAB OD min", stats.getMin());
 	//						pathObject.putMeasurement("Cytoplasm: DAB OD range", stats.getRange());
 						}
 						
 						// Add cytoplasm measurements
 						if (statsDABCytoplasm != null) {
 							RunningStatistics stats = statsDABCytoplasm.get(label-1);
-							measurementList.putMeasurement("Cytoplasm: DAB OD mean", stats.getMean());
-							measurementList.putMeasurement("Cytoplasm: DAB OD std dev", stats.getStdDev());
-							measurementList.putMeasurement("Cytoplasm: DAB OD max", stats.getMax());
-							measurementList.putMeasurement("Cytoplasm: DAB OD min", stats.getMin());
+							measurementList.put("Cytoplasm: DAB OD mean", stats.getMean());
+							measurementList.put("Cytoplasm: DAB OD std dev", stats.getStdDev());
+							measurementList.put("Cytoplasm: DAB OD max", stats.getMax());
+							measurementList.put("Cytoplasm: DAB OD min", stats.getMin());
 	//						pathObject.putMeasurement("Cytoplasm: DAB OD range", stats.getRange());
 						}
 						
 						// Add membrane measurements
 						if (statsDABMembrane != null) {
 							RunningStatistics stats = statsDABMembrane.get(label-1);
-							measurementList.putMeasurement("Membrane: DAB OD mean", stats.getMean());
-							measurementList.putMeasurement("Membrane: DAB OD std dev", stats.getStdDev());
-							measurementList.putMeasurement("Membrane: DAB OD max", stats.getMax());
-							measurementList.putMeasurement("Membrane: DAB OD min", stats.getMin());
+							measurementList.put("Membrane: DAB OD mean", stats.getMean());
+							measurementList.put("Membrane: DAB OD std dev", stats.getStdDev());
+							measurementList.put("Membrane: DAB OD max", stats.getMax());
+							measurementList.put("Membrane: DAB OD min", stats.getMin());
 	//						pathObject.putMeasurement("Cytoplasm: DAB OD range", stats.getRange());
 						}
 						
@@ -1012,7 +1012,7 @@ public class WatershedCellMembraneDetection extends AbstractTileableDetectionPlu
 						if (nucleus != null && nucleus.getROI().isArea()) {
 							double nucleusArea = nucleus.getROI().getArea();
 							double cellArea = pathROI.getArea();
-							measurementList.putMeasurement("Nucleus/Cell area ratio", Math.min(nucleusArea / cellArea, 1.0));
+							measurementList.put("Nucleus/Cell area ratio", Math.min(nucleusArea / cellArea, 1.0));
 	//						measurementList.putMeasurement("Nucleus/Cell expansion", cellArea - nucleusArea);
 						}
 					}

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellMembraneDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellMembraneDetection.java
@@ -816,20 +816,20 @@ public class WatershedCellMembraneDetection extends AbstractTileableDetectionPlu
 	//				PathObjectIJ.computeShapeStatistics(pathObject, pathImage, fpH, pathImage.getImage().getCalibration(), "Nucleus: ");
 					
 					RunningStatistics stats = statsHematoxylin.get(i);
-					measurementList.addMeasurement("Nucleus: Hematoxylin OD mean", stats.getMean());
-					measurementList.addMeasurement("Nucleus: Hematoxylin OD sum", stats.getSum());
-					measurementList.addMeasurement("Nucleus: Hematoxylin OD std dev", stats.getStdDev());
-					measurementList.addMeasurement("Nucleus: Hematoxylin OD max", stats.getMax());
-					measurementList.addMeasurement("Nucleus: Hematoxylin OD min", stats.getMin());
-					measurementList.addMeasurement("Nucleus: Hematoxylin OD range", stats.getRange());
+					measurementList.putMeasurement("Nucleus: Hematoxylin OD mean", stats.getMean());
+					measurementList.putMeasurement("Nucleus: Hematoxylin OD sum", stats.getSum());
+					measurementList.putMeasurement("Nucleus: Hematoxylin OD std dev", stats.getStdDev());
+					measurementList.putMeasurement("Nucleus: Hematoxylin OD max", stats.getMax());
+					measurementList.putMeasurement("Nucleus: Hematoxylin OD min", stats.getMin());
+					measurementList.putMeasurement("Nucleus: Hematoxylin OD range", stats.getRange());
 					if (statsDAB != null) {
 						stats = statsDAB.get(i);
-						measurementList.addMeasurement("Nucleus: DAB OD mean", stats.getMean());
-						measurementList.addMeasurement("Nucleus: DAB OD sum", stats.getSum());
-						measurementList.addMeasurement("Nucleus: DAB OD std dev", stats.getStdDev());
-						measurementList.addMeasurement("Nucleus: DAB OD max", stats.getMax());
-						measurementList.addMeasurement("Nucleus: DAB OD min", stats.getMin());
-						measurementList.addMeasurement("Nucleus: DAB OD range", stats.getRange());
+						measurementList.putMeasurement("Nucleus: DAB OD mean", stats.getMean());
+						measurementList.putMeasurement("Nucleus: DAB OD sum", stats.getSum());
+						measurementList.putMeasurement("Nucleus: DAB OD std dev", stats.getStdDev());
+						measurementList.putMeasurement("Nucleus: DAB OD max", stats.getMax());
+						measurementList.putMeasurement("Nucleus: DAB OD min", stats.getMin());
+						measurementList.putMeasurement("Nucleus: DAB OD range", stats.getRange());
 					}
 				}
 				
@@ -981,39 +981,39 @@ public class WatershedCellMembraneDetection extends AbstractTileableDetectionPlu
 						// Add cell measurements
 						if (statsDABCell != null) {
 							RunningStatistics stats = statsDABCell.get(label-1);
-							measurementList.addMeasurement("Cell: DAB OD mean", stats.getMean());
-							measurementList.addMeasurement("Cell: DAB OD std dev", stats.getStdDev());
-							measurementList.addMeasurement("Cell: DAB OD max", stats.getMax());
-							measurementList.addMeasurement("Cell: DAB OD min", stats.getMin());
-	//						pathObject.addMeasurement("Cytoplasm: DAB OD range", stats.getRange());
+							measurementList.putMeasurement("Cell: DAB OD mean", stats.getMean());
+							measurementList.putMeasurement("Cell: DAB OD std dev", stats.getStdDev());
+							measurementList.putMeasurement("Cell: DAB OD max", stats.getMax());
+							measurementList.putMeasurement("Cell: DAB OD min", stats.getMin());
+	//						pathObject.putMeasurement("Cytoplasm: DAB OD range", stats.getRange());
 						}
 						
 						// Add cytoplasm measurements
 						if (statsDABCytoplasm != null) {
 							RunningStatistics stats = statsDABCytoplasm.get(label-1);
-							measurementList.addMeasurement("Cytoplasm: DAB OD mean", stats.getMean());
-							measurementList.addMeasurement("Cytoplasm: DAB OD std dev", stats.getStdDev());
-							measurementList.addMeasurement("Cytoplasm: DAB OD max", stats.getMax());
-							measurementList.addMeasurement("Cytoplasm: DAB OD min", stats.getMin());
-	//						pathObject.addMeasurement("Cytoplasm: DAB OD range", stats.getRange());
+							measurementList.putMeasurement("Cytoplasm: DAB OD mean", stats.getMean());
+							measurementList.putMeasurement("Cytoplasm: DAB OD std dev", stats.getStdDev());
+							measurementList.putMeasurement("Cytoplasm: DAB OD max", stats.getMax());
+							measurementList.putMeasurement("Cytoplasm: DAB OD min", stats.getMin());
+	//						pathObject.putMeasurement("Cytoplasm: DAB OD range", stats.getRange());
 						}
 						
 						// Add membrane measurements
 						if (statsDABMembrane != null) {
 							RunningStatistics stats = statsDABMembrane.get(label-1);
-							measurementList.addMeasurement("Membrane: DAB OD mean", stats.getMean());
-							measurementList.addMeasurement("Membrane: DAB OD std dev", stats.getStdDev());
-							measurementList.addMeasurement("Membrane: DAB OD max", stats.getMax());
-							measurementList.addMeasurement("Membrane: DAB OD min", stats.getMin());
-	//						pathObject.addMeasurement("Cytoplasm: DAB OD range", stats.getRange());
+							measurementList.putMeasurement("Membrane: DAB OD mean", stats.getMean());
+							measurementList.putMeasurement("Membrane: DAB OD std dev", stats.getStdDev());
+							measurementList.putMeasurement("Membrane: DAB OD max", stats.getMax());
+							measurementList.putMeasurement("Membrane: DAB OD min", stats.getMin());
+	//						pathObject.putMeasurement("Cytoplasm: DAB OD range", stats.getRange());
 						}
 						
 						// Add nucleus area ratio, if available
 						if (nucleus != null && nucleus.getROI().isArea()) {
 							double nucleusArea = nucleus.getROI().getArea();
 							double cellArea = pathROI.getArea();
-							measurementList.addMeasurement("Nucleus/Cell area ratio", Math.min(nucleusArea / cellArea, 1.0));
-	//						measurementList.addMeasurement("Nucleus/Cell expansion", cellArea - nucleusArea);
+							measurementList.putMeasurement("Nucleus/Cell area ratio", Math.min(nucleusArea / cellArea, 1.0));
+	//						measurementList.putMeasurement("Nucleus/Cell expansion", cellArea - nucleusArea);
 						}
 					}
 

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellMembraneDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellMembraneDetection.java
@@ -76,7 +76,6 @@ import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.plugins.AbstractTileableDetectionPlugin;
 import qupath.lib.plugins.ObjectDetector;
 import qupath.lib.plugins.parameters.Parameter;
@@ -338,8 +337,8 @@ public class WatershedCellMembraneDetection extends AbstractTileableDetectionPlu
 				return "1 nucleus detected";
 			String s = String.format("%d nuclei detected", nDetections);
 			if (nucleiClassified) {
-				int nPositive = PathObjectTools.countObjectsWithClass(pathObjects, PathClassFactory.getPositive(null), false);
-				int nNegative = PathObjectTools.countObjectsWithClass(pathObjects, PathClassFactory.getNegative(null), false);
+				int nPositive = PathObjectTools.countObjectsWithClass(pathObjects, PathClass.getPositive(null), false);
+				int nNegative = PathObjectTools.countObjectsWithClass(pathObjects, PathClass.getNegative(null), false);
 				return String.format("%s (%.3f%% positive)", s, ((double)nPositive * 100.0 / (nPositive + nNegative)));			
 			} else
 				return s;

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/PositivePixelCounterIJ.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/PositivePixelCounterIJ.java
@@ -214,13 +214,13 @@ public class PositivePixelCounterIJ extends AbstractDetectionPlugin<BufferedImag
 				PathObject pathObject = PathObjects.createDetectionObject(roiTissue);
 				PathClass pathClass = null;
 				if (useLegacyMeasurements) {
-					pathObject.getMeasurementList().addMeasurement("Num pixels", nNegative);
-					pathObject.getMeasurementList().addMeasurement("Mean hematoxylin OD", meanNegative);
+					pathObject.getMeasurementList().putMeasurement("Num pixels", nNegative);
+					pathObject.getMeasurementList().putMeasurement("Mean hematoxylin OD", meanNegative);
 					pathClass = PathClassFactory.getNegative(null);
 				} else {
 					areaNegative = roiTissue.getScaledArea(pixelWidth, pixelHeight);
-					pathObject.getMeasurementList().addMeasurement("Stained area " + areaUnits + paramsString, areaNegative);
-					pathObject.getMeasurementList().addMeasurement("Mean " + stains.getStain(1).getName() + " OD" + paramsString, meanNegative);
+					pathObject.getMeasurementList().putMeasurement("Stained area " + areaUnits + paramsString, areaNegative);
+					pathObject.getMeasurementList().putMeasurement("Mean " + stains.getStain(1).getName() + " OD" + paramsString, meanNegative);
 					pathClass = PathClassFactory.getPathClass("Pixel count negative", ColorTools.makeScaledRGB(PathClassFactory.getNegative(null).getColor(), 1.25));
 				}
 				pathObject.setPathClass(pathClass);
@@ -233,13 +233,13 @@ public class PositivePixelCounterIJ extends AbstractDetectionPlugin<BufferedImag
 				PathClass pathClass = null;
 				PathObject pathObject = PathObjects.createDetectionObject(roiPositive);
 				if (useLegacyMeasurements) {
-					pathObject.getMeasurementList().addMeasurement("Num pixels", nPositive);
-					pathObject.getMeasurementList().addMeasurement("Mean DAB OD", meanPositive);
+					pathObject.getMeasurementList().putMeasurement("Num pixels", nPositive);
+					pathObject.getMeasurementList().putMeasurement("Mean DAB OD", meanPositive);
 					pathClass = PathClassFactory.getPositive(null);
 				} else {
 					areaPositive = roiPositive.getScaledArea(pixelWidth, pixelHeight);
-					pathObject.getMeasurementList().addMeasurement("Stained area " + areaUnits + paramsString, areaPositive);
-					pathObject.getMeasurementList().addMeasurement("Mean " + stains.getStain(2).getName() + " OD" + paramsString, meanPositive);
+					pathObject.getMeasurementList().putMeasurement("Stained area " + areaUnits + paramsString, areaPositive);
+					pathObject.getMeasurementList().putMeasurement("Mean " + stains.getStain(2).getName() + " OD" + paramsString, meanPositive);
 					pathClass = PathClassFactory.getPathClass("Pixel count positive", ColorTools.makeScaledRGB(PathClassFactory.getPositive(null).getColor(), 1.25));
 				}
 				pathObject.setPathClass(pathClass);

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/PositivePixelCounterIJ.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/PositivePixelCounterIJ.java
@@ -52,7 +52,6 @@ import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.plugins.AbstractDetectionPlugin;
 import qupath.lib.plugins.DetectionPluginTools;
 import qupath.lib.plugins.ObjectDetector;
@@ -63,7 +62,7 @@ import qupath.lib.roi.interfaces.ROI;
 
 /**
  * Simple command to detect regions with positive staining.
- * 
+ * <p>
  * For versions &lt;= v0.1.2 this gave simple measurements that were influenced by the downsample values used.
  * Later versions make calibrated measurements and give more flexibility in terms of output.
  * 
@@ -216,12 +215,12 @@ public class PositivePixelCounterIJ extends AbstractDetectionPlugin<BufferedImag
 				if (useLegacyMeasurements) {
 					pathObject.getMeasurementList().put("Num pixels", nNegative);
 					pathObject.getMeasurementList().put("Mean hematoxylin OD", meanNegative);
-					pathClass = PathClassFactory.getNegative(null);
+					pathClass = PathClass.getNegative(null);
 				} else {
 					areaNegative = roiTissue.getScaledArea(pixelWidth, pixelHeight);
 					pathObject.getMeasurementList().put("Stained area " + areaUnits + paramsString, areaNegative);
 					pathObject.getMeasurementList().put("Mean " + stains.getStain(1).getName() + " OD" + paramsString, meanNegative);
-					pathClass = PathClassFactory.getPathClass("Pixel count negative", ColorTools.makeScaledRGB(PathClassFactory.getNegative(null).getColor(), 1.25));
+					pathClass = PathClass.getInstance("Pixel count negative", ColorTools.makeScaledRGB(PathClass.getNegative(null).getColor(), 1.25));
 				}
 				pathObject.setPathClass(pathClass);
 				pathObject.getMeasurementList().close();
@@ -235,12 +234,12 @@ public class PositivePixelCounterIJ extends AbstractDetectionPlugin<BufferedImag
 				if (useLegacyMeasurements) {
 					pathObject.getMeasurementList().put("Num pixels", nPositive);
 					pathObject.getMeasurementList().put("Mean DAB OD", meanPositive);
-					pathClass = PathClassFactory.getPositive(null);
+					pathClass = PathClass.getPositive(null);
 				} else {
 					areaPositive = roiPositive.getScaledArea(pixelWidth, pixelHeight);
 					pathObject.getMeasurementList().put("Stained area " + areaUnits + paramsString, areaPositive);
 					pathObject.getMeasurementList().put("Mean " + stains.getStain(2).getName() + " OD" + paramsString, meanPositive);
-					pathClass = PathClassFactory.getPathClass("Pixel count positive", ColorTools.makeScaledRGB(PathClassFactory.getPositive(null).getColor(), 1.25));
+					pathClass = PathClass.getInstance("Pixel count positive", ColorTools.makeScaledRGB(PathClass.getPositive(null).getColor(), 1.25));
 				}
 				pathObject.setPathClass(pathClass);
 				pathObject.getMeasurementList().close();

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/PositivePixelCounterIJ.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/PositivePixelCounterIJ.java
@@ -214,13 +214,13 @@ public class PositivePixelCounterIJ extends AbstractDetectionPlugin<BufferedImag
 				PathObject pathObject = PathObjects.createDetectionObject(roiTissue);
 				PathClass pathClass = null;
 				if (useLegacyMeasurements) {
-					pathObject.getMeasurementList().putMeasurement("Num pixels", nNegative);
-					pathObject.getMeasurementList().putMeasurement("Mean hematoxylin OD", meanNegative);
+					pathObject.getMeasurementList().put("Num pixels", nNegative);
+					pathObject.getMeasurementList().put("Mean hematoxylin OD", meanNegative);
 					pathClass = PathClassFactory.getNegative(null);
 				} else {
 					areaNegative = roiTissue.getScaledArea(pixelWidth, pixelHeight);
-					pathObject.getMeasurementList().putMeasurement("Stained area " + areaUnits + paramsString, areaNegative);
-					pathObject.getMeasurementList().putMeasurement("Mean " + stains.getStain(1).getName() + " OD" + paramsString, meanNegative);
+					pathObject.getMeasurementList().put("Stained area " + areaUnits + paramsString, areaNegative);
+					pathObject.getMeasurementList().put("Mean " + stains.getStain(1).getName() + " OD" + paramsString, meanNegative);
 					pathClass = PathClassFactory.getPathClass("Pixel count negative", ColorTools.makeScaledRGB(PathClassFactory.getNegative(null).getColor(), 1.25));
 				}
 				pathObject.setPathClass(pathClass);
@@ -233,13 +233,13 @@ public class PositivePixelCounterIJ extends AbstractDetectionPlugin<BufferedImag
 				PathClass pathClass = null;
 				PathObject pathObject = PathObjects.createDetectionObject(roiPositive);
 				if (useLegacyMeasurements) {
-					pathObject.getMeasurementList().putMeasurement("Num pixels", nPositive);
-					pathObject.getMeasurementList().putMeasurement("Mean DAB OD", meanPositive);
+					pathObject.getMeasurementList().put("Num pixels", nPositive);
+					pathObject.getMeasurementList().put("Mean DAB OD", meanPositive);
 					pathClass = PathClassFactory.getPositive(null);
 				} else {
 					areaPositive = roiPositive.getScaledArea(pixelWidth, pixelHeight);
-					pathObject.getMeasurementList().putMeasurement("Stained area " + areaUnits + paramsString, areaPositive);
-					pathObject.getMeasurementList().putMeasurement("Mean " + stains.getStain(2).getName() + " OD" + paramsString, meanPositive);
+					pathObject.getMeasurementList().put("Stained area " + areaUnits + paramsString, areaPositive);
+					pathObject.getMeasurementList().put("Mean " + stains.getStain(2).getName() + " OD" + paramsString, meanPositive);
 					pathClass = PathClassFactory.getPathClass("Pixel count positive", ColorTools.makeScaledRGB(PathClassFactory.getPositive(null).getColor(), 1.25));
 				}
 				pathObject.setPathClass(pathClass);
@@ -257,17 +257,17 @@ public class PositivePixelCounterIJ extends AbstractDetectionPlugin<BufferedImag
 			
 			if (addMeasurements) {
 				if (useLegacyMeasurements) {
-					parent.getMeasurementList().putMeasurement("Positive pixel %", positivePercentage);
-					parent.getMeasurementList().putMeasurement("Positive pixel count", nPositive);
-					parent.getMeasurementList().putMeasurement("Negative pixel count", nNegative);
-					parent.getMeasurementList().putMeasurement("Mean positive DAB staining OD", meanPositive);
-					parent.getMeasurementList().putMeasurement("Stained pixel count", nPositive + nNegative);
+					parent.getMeasurementList().put("Positive pixel %", positivePercentage);
+					parent.getMeasurementList().put("Positive pixel count", nPositive);
+					parent.getMeasurementList().put("Negative pixel count", nNegative);
+					parent.getMeasurementList().put("Mean positive DAB staining OD", meanPositive);
+					parent.getMeasurementList().put("Stained pixel count", nPositive + nNegative);
 					parent.getMeasurementList().close();
 				} else {
-					parent.getMeasurementList().putMeasurement("Positive % of stained pixels" + paramsString, positivePercentage);
-					parent.getMeasurementList().putMeasurement("Positive pixel area " + areaUnits + paramsString, areaPositive);
-					parent.getMeasurementList().putMeasurement("Negative pixel area " + areaUnits + paramsString, areaNegative);
-					parent.getMeasurementList().putMeasurement("Stained area (Positive + Negative)" + areaUnits + paramsString, areaPositive + areaNegative);					
+					parent.getMeasurementList().put("Positive % of stained pixels" + paramsString, positivePercentage);
+					parent.getMeasurementList().put("Positive pixel area " + areaUnits + paramsString, areaPositive);
+					parent.getMeasurementList().put("Negative pixel area " + areaUnits + paramsString, areaNegative);
+					parent.getMeasurementList().put("Stained area (Positive + Negative)" + areaUnits + paramsString, areaPositive + areaNegative);					
 					//					parent.getMeasurementList().putMeasurement("Positive pixel count (full image)", nPositive * downsample * downsample);
 //					parent.getMeasurementList().putMeasurement("Negative pixel count (full image)", nNegative * downsample * downsample);
 //					// Uncalibrated counts really only might be useful for a sanity check
@@ -284,9 +284,9 @@ public class PositivePixelCounterIJ extends AbstractDetectionPlugin<BufferedImag
 					if (roisMatch && roiParent.isArea()) {
 						// Clip to 100% (could conceivably go slightly above because of sub-pixel errors)
 						double areaROI = roiParent.getScaledArea(pixelWidth, pixelHeight);
-						parent.getMeasurementList().putMeasurement("Total ROI area " + areaUnits + paramsString, areaROI);					
+						parent.getMeasurementList().put("Total ROI area " + areaUnits + paramsString, areaROI);					
 //						parent.getMeasurementList().putMeasurement("Stained % of total ROI area" + paramsString, Math.min(100, (areaPositive + areaNegative) / areaROI * 100.0));					
-						parent.getMeasurementList().putMeasurement("Positive % of total ROI area" + paramsString, Math.min(100, areaPositive / areaROI * 100.0));
+						parent.getMeasurementList().put("Positive % of total ROI area" + paramsString, Math.min(100, areaPositive / areaROI * 100.0));
 					}
 					
 					parent.getMeasurementList().close();					

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
@@ -83,7 +83,7 @@ import qupath.lib.images.servers.ServerTools;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.regions.ImageRegion;
 import qupath.lib.regions.RegionRequest;
@@ -575,7 +575,7 @@ public class IJTools {
 			pathObject.setName(name);
 		} else if (roi.getGroup() > 0) {
 			// If the group is set, use it as a classification
-			pathObject.setPathClass(PathClassFactory.getPathClass("Group " + roi.getGroup(), colorRGB));
+			pathObject.setPathClass(PathClass.getInstance("Group " + roi.getGroup(), colorRGB));
 		}
 		if (colorRGB != null && pathObject.getPathClass() == null) {
 			pathObject.setColor(colorRGB);

--- a/qupath-core-processing/src/main/java/qupath/lib/algorithms/CoherenceFeaturePlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/algorithms/CoherenceFeaturePlugin.java
@@ -262,11 +262,11 @@ public class CoherenceFeaturePlugin extends AbstractInteractivePlugin<BufferedIm
 
 	static void addBasicStatistics(final SimpleImage img, final MeasurementList measurementList, final String name) {
 		RunningStatistics stats = StatisticsHelper.computeRunningStatistics(img);
-		measurementList.putMeasurement(name + " Mean", stats.getMean());
-		measurementList.putMeasurement(name + " Min", stats.getMin());
-		measurementList.putMeasurement(name + " Max", stats.getMax());
-		measurementList.putMeasurement(name + " Range", stats.getRange());
-		measurementList.putMeasurement(name + " Std.dev.", stats.getStdDev());
+		measurementList.put(name + " Mean", stats.getMean());
+		measurementList.put(name + " Min", stats.getMin());
+		measurementList.put(name + " Max", stats.getMax());
+		measurementList.put(name + " Range", stats.getRange());
+		measurementList.put(name + " Std.dev.", stats.getStdDev());
 		
 //		measurementList.putMeasurement(String.format("%s Mean", name), stats.getMean());
 //		measurementList.putMeasurement(String.format("%s Min", name), stats.getMin());
@@ -323,7 +323,7 @@ public class CoherenceFeaturePlugin extends AbstractInteractivePlugin<BufferedIm
 	
 	
 	static void addCoherenceFeature(final double value, final MeasurementList measurementList, final String name) {
-		measurementList.putMeasurement(String.format("%s coherence", name), value);
+		measurementList.put(String.format("%s coherence", name), value);
 	}
 
 

--- a/qupath-core-processing/src/main/java/qupath/lib/algorithms/HaralickFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/algorithms/HaralickFeaturesPlugin.java
@@ -348,7 +348,7 @@ public class HaralickFeaturesPlugin extends AbstractInteractivePlugin<BufferedIm
 				sinX += Math.sin(alpha);
 				cosX += Math.cos(alpha);
 			}
-			measurementList.putMeasurement("Mean hue", Math.atan2(sinX, cosX) / (2 * Math.PI) + 0.5);
+			measurementList.put("Mean hue", Math.atan2(sinX, cosX) / (2 * Math.PI) + 0.5);
 //			measurementList.putMeasurement("Mean saturation", hsb[1]);
 //			measurementList.putMeasurement("Mean brightness", hsb[2]);
 			processTransformedImage(SimpleImages.createFloatImage(pixelsSaturation, w, h), buf, pixelsSaturation, measurementList, "Saturation"+postfix, null, minValue, maxValue, d, nBins, stains, maskBytes, includeStats, doCircular);
@@ -401,11 +401,11 @@ public class HaralickFeaturesPlugin extends AbstractInteractivePlugin<BufferedIm
 
 	static void addBasicStatistics(final SimpleImage img, final MeasurementList measurementList, final String name) {
 		RunningStatistics stats = StatisticsHelper.computeRunningStatistics(img);
-		measurementList.putMeasurement(name + " Mean", stats.getMean());
-		measurementList.putMeasurement(name + " Min", stats.getMin());
-		measurementList.putMeasurement(name + " Max", stats.getMax());
-		measurementList.putMeasurement(name + " Range", stats.getRange());
-		measurementList.putMeasurement(name + " Std.dev.", stats.getStdDev());
+		measurementList.put(name + " Mean", stats.getMean());
+		measurementList.put(name + " Min", stats.getMin());
+		measurementList.put(name + " Max", stats.getMax());
+		measurementList.put(name + " Range", stats.getRange());
+		measurementList.put(name + " Std.dev.", stats.getStdDev());
 		
 		// Compute skewness and kurtosis
 		double m = stats.getMean();
@@ -429,14 +429,14 @@ public class HaralickFeaturesPlugin extends AbstractInteractivePlugin<BufferedIm
 ////		double sigma = stats.getStdDev();
 ////		System.out.println("Variance difference: " + variance + ",  " + stats.getVariance());
 ////		measurementList.putMeasurement(name + " Variance (again)", variance);
-		measurementList.putMeasurement(name + " Skewness", skewness/(variance*Math.sqrt(variance)));
-		measurementList.putMeasurement(name + " Kurtosis", kurtosis/(variance*variance));
+		measurementList.put(name + " Skewness", skewness/(variance*Math.sqrt(variance)));
+		measurementList.put(name + " Kurtosis", kurtosis/(variance*variance));
 	}
 
 	
 	static void addHaralickFeatures(final HaralickFeatures haralickFeatures, final MeasurementList measurementList, final String name) {
 		for (int i = 0; i < haralickFeatures.nFeatures(); i++) {
-			measurementList.putMeasurement(String.format("%s Haralick %s (F%d)", name,
+			measurementList.put(String.format("%s Haralick %s (F%d)", name,
 					haralickFeatures.getFeatureName(i),
 					i), haralickFeatures.getFeature(i));
 		}

--- a/qupath-core-processing/src/main/java/qupath/lib/algorithms/IntensityFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/algorithms/IntensityFeaturesPlugin.java
@@ -842,7 +842,7 @@ public class IntensityFeaturesPlugin extends AbstractInteractivePlugin<BufferedI
 		public void addMeasurements(PathObject pathObject, String name, ParameterList params) {
 			// Handle Hue special case
 			if (hueStats != null) {
-				pathObject.getMeasurementList().putMeasurement(name + " Mean", hueStats.getMeanHue());
+				pathObject.getMeasurementList().put(name + " Mean", hueStats.getMeanHue());
 				return;
 			}
 			
@@ -852,12 +852,12 @@ public class IntensityFeaturesPlugin extends AbstractInteractivePlugin<BufferedI
 			
 			MeasurementList measurementList = pathObject.getMeasurementList();
 			if (params.getBooleanParameterValue(Feature.MEAN.key))
-				measurementList.putMeasurement(name + " Mean", stats.getMean());
+				measurementList.put(name + " Mean", stats.getMean());
 			if (params.getBooleanParameterValue(Feature.STD_DEV.key))
-				measurementList.putMeasurement(name + " Std.dev.", stats.getStdDev());
+				measurementList.put(name + " Std.dev.", stats.getStdDev());
 			if (params.getBooleanParameterValue(Feature.MIN_MAX.key)) {
-				measurementList.putMeasurement(name + " Min", stats.getMin());
-				measurementList.putMeasurement(name + " Max", stats.getMax());
+				measurementList.put(name + " Min", stats.getMin());
+				measurementList.put(name + " Max", stats.getMax());
 			}
 			
 			logger.trace("Measured pixel count: {}", stats.size());
@@ -1015,7 +1015,7 @@ public class IntensityFeaturesPlugin extends AbstractInteractivePlugin<BufferedI
 			
 			// Add to measurement list
 			MeasurementList measurementList = pathObject.getMeasurementList();
-			measurementList.putMeasurement(name + " Median", median);
+			measurementList.put(name + " Median", median);
 		}
 		
 	}
@@ -1084,7 +1084,7 @@ public class IntensityFeaturesPlugin extends AbstractInteractivePlugin<BufferedI
 			MeasurementList measurementList = pathObject.getMeasurementList();
 			HaralickFeatures haralickFeatures = matrices.getMeanFeatures();
 			for (int i = 0; i < haralickFeatures.nFeatures(); i++) {
-				measurementList.putMeasurement(String.format("%s Haralick %s (F%d)", name,
+				measurementList.put(String.format("%s Haralick %s (F%d)", name,
 						haralickFeatures.getFeatureName(i),
 						i), haralickFeatures.getFeature(i));
 			}
@@ -1260,7 +1260,7 @@ public class IntensityFeaturesPlugin extends AbstractInteractivePlugin<BufferedI
 			NumberFormat formatter = GeneralTools.createFormatter(3);
 			for (int i = 0; i < histogram.length; i++) {
 				double value = minBin + i * binWidth;
-				measurementList.putMeasurement(name + " >= " + formatter.format(value), proportions[i]);
+				measurementList.put(name + " >= " + formatter.format(value), proportions[i]);
 			}
 		}
 		

--- a/qupath-core-processing/src/main/java/qupath/lib/algorithms/LocalBinaryPatternsPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/algorithms/LocalBinaryPatternsPlugin.java
@@ -263,11 +263,11 @@ public class LocalBinaryPatternsPlugin extends AbstractInteractivePlugin<Buffere
 
 	static void addBasicStatistics(final SimpleImage img, final MeasurementList measurementList, final String name) {
 		RunningStatistics stats = StatisticsHelper.computeRunningStatistics(img);
-		measurementList.addMeasurement(name + " Mean", stats.getMean());
-		measurementList.addMeasurement(name + " Min", stats.getMin());
-		measurementList.addMeasurement(name + " Max", stats.getMax());
-		measurementList.addMeasurement(name + " Range", stats.getRange());
-		measurementList.addMeasurement(name + " Std.dev.", stats.getStdDev());
+		measurementList.putMeasurement(name + " Mean", stats.getMean());
+		measurementList.putMeasurement(name + " Min", stats.getMin());
+		measurementList.putMeasurement(name + " Max", stats.getMax());
+		measurementList.putMeasurement(name + " Range", stats.getRange());
+		measurementList.putMeasurement(name + " Std.dev.", stats.getStdDev());
 		
 //		measurementList.addMeasurement(String.format("%s Mean", name), stats.getMean());
 //		measurementList.addMeasurement(String.format("%s Min", name), stats.getMin());
@@ -279,7 +279,7 @@ public class LocalBinaryPatternsPlugin extends AbstractInteractivePlugin<Buffere
 	
 	static void addLocalBinaryFeatures(final double[] histogram, final MeasurementList measurementList, final String name) {
 		for (int i = 0; i < histogram.length; i++) {
-			measurementList.addMeasurement(String.format("%s LBP %d", name,
+			measurementList.putMeasurement(String.format("%s LBP %d", name,
 					i+1), histogram[i]);
 		}
 	}

--- a/qupath-core-processing/src/main/java/qupath/lib/algorithms/LocalBinaryPatternsPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/algorithms/LocalBinaryPatternsPlugin.java
@@ -263,11 +263,11 @@ public class LocalBinaryPatternsPlugin extends AbstractInteractivePlugin<Buffere
 
 	static void addBasicStatistics(final SimpleImage img, final MeasurementList measurementList, final String name) {
 		RunningStatistics stats = StatisticsHelper.computeRunningStatistics(img);
-		measurementList.putMeasurement(name + " Mean", stats.getMean());
-		measurementList.putMeasurement(name + " Min", stats.getMin());
-		measurementList.putMeasurement(name + " Max", stats.getMax());
-		measurementList.putMeasurement(name + " Range", stats.getRange());
-		measurementList.putMeasurement(name + " Std.dev.", stats.getStdDev());
+		measurementList.put(name + " Mean", stats.getMean());
+		measurementList.put(name + " Min", stats.getMin());
+		measurementList.put(name + " Max", stats.getMax());
+		measurementList.put(name + " Range", stats.getRange());
+		measurementList.put(name + " Std.dev.", stats.getStdDev());
 		
 //		measurementList.addMeasurement(String.format("%s Mean", name), stats.getMean());
 //		measurementList.addMeasurement(String.format("%s Min", name), stats.getMin());
@@ -279,7 +279,7 @@ public class LocalBinaryPatternsPlugin extends AbstractInteractivePlugin<Buffere
 	
 	static void addLocalBinaryFeatures(final double[] histogram, final MeasurementList measurementList, final String name) {
 		for (int i = 0; i < histogram.length; i++) {
-			measurementList.putMeasurement(String.format("%s LBP %d", name,
+			measurementList.put(String.format("%s LBP %d", name,
 					i+1), histogram[i]);
 		}
 	}

--- a/qupath-core-processing/src/main/java/qupath/lib/analysis/features/ObjectMeasurements.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/analysis/features/ObjectMeasurements.java
@@ -237,7 +237,7 @@ public class ObjectMeasurements {
 				double pixelWidth = cal.getPixelWidth().doubleValue();
 				double pixelHeight = cal.getPixelHeight().doubleValue();
 				double nucleusCellAreaRatio = GeneralTools.clipValue(roiNucleus.getScaledArea(pixelWidth, pixelHeight) / roiCell.getScaledArea(pixelWidth, pixelHeight), 0, 1);
-				ml.putMeasurement("Nucleus/Cell area ratio", nucleusCellAreaRatio);
+				ml.put("Nucleus/Cell area ratio", nucleusCellAreaRatio);
 			}
 		}
 		
@@ -323,26 +323,26 @@ public class ObjectMeasurements {
 		double pixelHeight = cal.getPixelHeight().doubleValue();
 		
 		if (features.contains(ShapeFeatures.AREA))
-			ml.putMeasurement(baseName + "Area " + units2, ellipse.getScaledArea(pixelWidth, pixelHeight));
+			ml.put(baseName + "Area " + units2, ellipse.getScaledArea(pixelWidth, pixelHeight));
 		if (features.contains(ShapeFeatures.LENGTH))
-			ml.putMeasurement(baseName + "Length " + units, ellipse.getLength());
+			ml.put(baseName + "Length " + units, ellipse.getLength());
 		
 		if (features.contains(ShapeFeatures.CIRCULARITY)) {
-			ml.putMeasurement(baseName + "Circularity", 1.0);
+			ml.put(baseName + "Circularity", 1.0);
 		}
 		
 		if (features.contains(ShapeFeatures.SOLIDITY)) {
-			ml.putMeasurement(baseName + "Solidity", 1.0);
+			ml.put(baseName + "Solidity", 1.0);
 		}
 		
 		if (features.contains(ShapeFeatures.MAX_DIAMETER)) {
 			double maxDiameter = Math.max(ellipse.getBoundsWidth() * pixelWidth, ellipse.getBoundsHeight() * pixelHeight);
-			ml.putMeasurement(baseName + "Max diameter " + units, maxDiameter);
+			ml.put(baseName + "Max diameter " + units, maxDiameter);
 		}
 
 		if (features.contains(ShapeFeatures.MIN_DIAMETER)) {
 			double minDiameter = Math.min(ellipse.getBoundsWidth() * pixelWidth, ellipse.getBoundsHeight() * pixelHeight);
-			ml.putMeasurement(baseName + "Min diameter " + units, minDiameter);
+			ml.put(baseName + "Min diameter " + units, minDiameter);
 		}
 	}
 	
@@ -358,9 +358,9 @@ public class ObjectMeasurements {
 		double length = geom.getLength();
 		
 		if (isArea && features.contains(ShapeFeatures.AREA))
-			ml.putMeasurement(baseName + "Area " + units2, area);
+			ml.put(baseName + "Area " + units2, area);
 		if ((isArea || isLine) && features.contains(ShapeFeatures.LENGTH))
-			ml.putMeasurement(baseName + "Length " + units, length);
+			ml.put(baseName + "Length " + units, length);
 		
 		if (isArea && features.contains(ShapeFeatures.CIRCULARITY)) {
 			if (geom instanceof Polygon) {
@@ -375,7 +375,7 @@ public class ObjectMeasurements {
 					ringLength = Length.ofLine(ring);
 				}
 				double circularity = Math.PI * 4 * ringArea / (ringLength * ringLength);
-				ml.putMeasurement(baseName + "Circularity", circularity);
+				ml.put(baseName + "Circularity", circularity);
 			} else {
 				logger.debug("Cannot compute circularity for {}", geom.getClass());
 			}
@@ -383,17 +383,17 @@ public class ObjectMeasurements {
 		
 		if (isArea && features.contains(ShapeFeatures.SOLIDITY)) {
 			double solidity = area / geom.convexHull().getArea();
-			ml.putMeasurement(baseName + "Solidity", solidity);
+			ml.put(baseName + "Solidity", solidity);
 		}
 		
 		if (features.contains(ShapeFeatures.MAX_DIAMETER)) {
 			double minCircleRadius = new MinimumBoundingCircle(geom).getRadius();
-			ml.putMeasurement(baseName + "Max diameter " + units, minCircleRadius*2);
+			ml.put(baseName + "Max diameter " + units, minCircleRadius*2);
 		}
 
 		if (features.contains(ShapeFeatures.MIN_DIAMETER)) {
 			double minDiameter = new MinimumDiameter(geom).getLength();
-			ml.putMeasurement(baseName + "Min diameter " + units, minDiameter);
+			ml.put(baseName + "Min diameter " + units, minDiameter);
 		}
 
 	}
@@ -615,7 +615,7 @@ public class ObjectMeasurements {
 			var stats = allStats[i];
 			try (var ml = pathObject.getMeasurementList()) {
 				for (var m : measurements) {
-					ml.putMeasurement(baseName + ": " + m.getMeasurementName(), m.getMeasurement(stats));
+					ml.put(baseName + ": " + m.getMeasurementName(), m.getMeasurement(stats));
 				}
 			}
 		}

--- a/qupath-core-processing/src/main/java/qupath/lib/analysis/heatmaps/DensityMaps.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/analysis/heatmaps/DensityMaps.java
@@ -62,8 +62,6 @@ import qupath.lib.objects.PathObjectPredicates.PathObjectPredicate;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.projects.Project;
 import qupath.lib.regions.ImagePlane;
@@ -497,8 +495,8 @@ public class DensityMaps {
 		logger.debug("Thresholding {} with thresholds {}, options", densityServer, thresholds, Arrays.asList(options));
 
 		// Apply threshold to densities
-		PathClass lessThan = PathClassFactory.getPathClass(StandardPathClasses.IGNORE);
-		PathClass greaterThan = PathClassFactory.getPathClass(pathClassName);
+		PathClass lessThan = PathClass.StandardPathClasses.IGNORE;
+		PathClass greaterThan = PathClass.fromString(pathClassName);
 		
 		// If we request to delete existing objects, apply this only to annotations with the target class
 		var optionsList = Arrays.asList(options);

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/ShapeFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/ShapeFeaturesPlugin.java
@@ -149,11 +149,11 @@ public class ShapeFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 	private static void addMeasurements(final MeasurementList measurementList, final ROI roi, final String prefix, final double pixelWidth, final double pixelHeight, final String unit,
 			final boolean doArea, final boolean doPerimeter, final boolean doCircularity) {
 		if (doArea)
-			measurementList.putMeasurement(prefix + "Area " + unit + "^2", roi.getScaledArea(pixelWidth, pixelHeight));
+			measurementList.put(prefix + "Area " + unit + "^2", roi.getScaledArea(pixelWidth, pixelHeight));
 		if (doPerimeter)
-			measurementList.putMeasurement(prefix + "Perimeter " + unit, roi.getScaledLength(pixelWidth, pixelHeight));
+			measurementList.put(prefix + "Perimeter " + unit, roi.getScaledLength(pixelWidth, pixelHeight));
 		if (doCircularity)
-			measurementList.putMeasurement(prefix + "Circularity", RoiTools.getCircularity(roi));		
+			measurementList.put(prefix + "Circularity", RoiTools.getCircularity(roi));		
 	}
 	
 	

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
@@ -267,7 +267,7 @@ public class SmoothFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 			MeasurementList measurementList = pathObject.getMeasurementList();
 			int ind = 0;
 			for (String name : measurements) {
-				float value = (float)measurementList.getMeasurementValue(name);
+				float value = (float)measurementList.get(name);
 				
 				measurementValues[i][ind] = value;   // Used to cache values
 				measurementsWeighted[i][ind] = value; // Based on distances and measurements
@@ -364,7 +364,7 @@ public class SmoothFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 					maxDenominator = denominator;
 				
 				String nameToAdd = prefix + name + postfix;
-				measurementList.putMeasurement(nameToAdd, mWeighted[ind] / denominator);
+				measurementList.put(nameToAdd, mWeighted[ind] / denominator);
 				
 //				measurementsAdded.add(nameToAdd);
 //				measurementList.putMeasurement(name + " - weighted sum", mWeighted[ind]); // TODO: Support optionally providing weighted sums
@@ -373,11 +373,11 @@ public class SmoothFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 				ind++;
 			}
 			if (pathObject instanceof PathDetectionObject && denomName != null) {
-				measurementList.putMeasurement(denomName, maxDenominator);
+				measurementList.put(denomName, maxDenominator);
 //				measurementsAdded.add(denomName);
 			}
 			if (pathObject instanceof PathDetectionObject && countsName != null) {
-				measurementList.putMeasurement(countsName, nearbyDetectionCounts[i]);
+				measurementList.put(countsName, nearbyDetectionCounts[i]);
 //				measurementsAdded.add(countsName);
 			}
 			measurementList.close();

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/TileClassificationsToAnnotationsPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/TileClassificationsToAnnotationsPlugin.java
@@ -46,7 +46,6 @@ import qupath.lib.objects.PathRootObject;
 import qupath.lib.objects.PathTileObject;
 import qupath.lib.objects.TMACoreObject;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.classes.PathClassTools;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.plugins.AbstractDetectionPlugin;
@@ -125,7 +124,7 @@ public class TileClassificationsToAnnotationsPlugin<T> extends AbstractDetection
 				}
 				
 			});
-			PathClass allClasses = PathClassFactory.getPathClass("All classes");
+			PathClass allClasses = PathClass.getInstance("All classes");
 			PathClass defaultChoice = allClasses;
 			choices.add(0, allClasses);
 //			PathClass classTumor = PathClassFactory.getDefaultPathClass(PathClasses.TUMOR); // Tumor is the most likely choice, so default to it if available

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -1915,7 +1915,7 @@ public class QP {
 	 * @return
 	 */
 	public static boolean hasMeasurement(final PathObject pathObject, final String measurementName) {
-		return pathObject != null && pathObject.getMeasurementList().containsNamedMeasurement(measurementName);
+		return pathObject != null && pathObject.getMeasurementList().containsKey(measurementName);
 	}
 
 	/**
@@ -1926,7 +1926,7 @@ public class QP {
 	 * @return
 	 */
 	public static double measurement(final PathObject pathObject, final String measurementName) {
-		return pathObject == null ? Double.NaN : pathObject.getMeasurementList().getMeasurementValue(measurementName);
+		return pathObject == null ? Double.NaN : pathObject.getMeasurementList().get(measurementName);
 	}
 
 	
@@ -2280,8 +2280,8 @@ public class QP {
 				double value = scanner.nextDouble();
 
 				Predicate<PathObject> predicateNew = p -> {
-					double v = p.getMeasurementList().getMeasurementValue(measurement);
-					return !Double.isNaN(v) && mapComparison.get(comparison).test(Double.compare(p.getMeasurementList().getMeasurementValue(measurement), value));
+					double v = p.getMeasurementList().get(measurement);
+					return !Double.isNaN(v) && mapComparison.get(comparison).test(Double.compare(p.getMeasurementList().get(measurement), value));
 				};
 				if (negate)
 					predicateNew = predicateNew.negate();

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -154,6 +154,7 @@ import qupath.opencv.tools.OpenCVTools;
  * @author Pete Bankhead
  *
  */
+@SuppressWarnings("deprecation")
 public class QP {
 	
 	private static final Logger logger = LoggerFactory.getLogger(QP.class);
@@ -2224,7 +2225,7 @@ public class QP {
 		if (pathClasses == null)
 			pathClassSet = Set.of((PathClass)null);
 		else
-			pathClassSet = Arrays.stream(pathClasses).map(p -> p == PathClassFactory.getPathClassUnclassified() ? null : p).collect(Collectors.toCollection(HashSet::new));
+			pathClassSet = Arrays.stream(pathClasses).map(p -> p == PathClass.NULL_CLASS ? null : p).collect(Collectors.toCollection(HashSet::new));
 		selectObjects(hierarchy, p -> pathClassSet.contains(p.getPathClass()));
 	}
 
@@ -2340,7 +2341,7 @@ public class QP {
 	 * @param pathClassName
 	 */
 	public static void classifySelected(final PathObjectHierarchy hierarchy, final String pathClassName) {
-		PathClass pathClass = PathClassFactory.getPathClass(pathClassName);
+		PathClass pathClass = PathClass.fromString(pathClassName);
 		Collection<PathObject> selected = hierarchy.getSelectionModel().getSelectedObjects();
 		if (selected.isEmpty()) {
 			logger.info("No objects selected");
@@ -2474,7 +2475,7 @@ public class QP {
 	 * @return
 	 */
 	public static PathClass getPathClass(final String name) {
-		return PathClassFactory.getPathClass(name);
+		return PathClass.fromString(name);
 	}
 
 	/**
@@ -2492,7 +2493,7 @@ public class QP {
 	 * @see ColorTools#makeRGB
 	 */
 	public static PathClass getPathClass(final String name, final Integer rgb) {
-		return PathClassFactory.getPathClass(name, rgb);
+		return PathClass.fromString(name, rgb);
 	}
 
 	/**
@@ -2526,7 +2527,7 @@ public class QP {
 	 * @return
 	 */
 	public static PathClass getDerivedPathClass(final PathClass baseClass, final String name, final Integer rgb) {
-		return PathClassFactory.getDerivedPathClass(baseClass, name, rgb);
+		return PathClass.getInstance(baseClass, name, rgb);
 	}
 
 	/**
@@ -3152,9 +3153,9 @@ public class QP {
 	 * @param newClass
 	 */
 	public static void replaceClassification(Collection<PathObject> pathObjects, PathClass originalClass, PathClass newClass) {
-		if (PathClassFactory.getPathClassUnclassified() == originalClass)
+		if (PathClass.NULL_CLASS == originalClass)
 			originalClass = null;
-		if (PathClassFactory.getPathClassUnclassified() == newClass)
+		if (PathClass.NULL_CLASS == newClass)
 			newClass = null;
 		for (var pathObject : pathObjects) {
 			if (pathObject.getPathClass() == originalClass)
@@ -3650,7 +3651,7 @@ public class QP {
 	public static void findDensityMapHotspots(ImageData<BufferedImage> imageData, DensityMapBuilder densityMap, int channel, int numHotspots, double minCounts, boolean deleteExisting, boolean peaksOnly) throws IOException {
 		var densityServer = densityMap.buildServer(imageData);
 		double radius = densityMap.buildParameters().getRadius();
-		var pathClass = PathClassFactory.getPathClass(densityServer.getChannel(channel).getName());
+		var pathClass = PathClass.fromString(densityServer.getChannel(channel).getName());
 		DensityMaps.findHotspots(imageData.getHierarchy(), densityServer, channel, numHotspots, radius, minCounts, pathClass, deleteExisting, peaksOnly);
 	}
 

--- a/qupath-core-processing/src/main/java/qupath/opencv/CellCountsCV.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/CellCountsCV.java
@@ -52,7 +52,7 @@ import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.plugins.AbstractTileableDetectionPlugin;
 import qupath.lib.plugins.ObjectDetector;
 import qupath.lib.plugins.parameters.ParameterList;
@@ -325,9 +325,9 @@ public class CellCountsCV extends AbstractTileableDetectionPlugin<BufferedImage>
 					int cy = (int)((tempROI.getCentroidY() - y)/scaleY);
 					float stain2Value = indexerStain2.get(cy, cx);
 					if (detectInPositiveChannel || stain2Value >= stain2Threshold)
-						pathObject.setPathClass(PathClassFactory.getPositive(null));
+						pathObject.setPathClass(PathClass.getPositive(null));
 					else
-						pathObject.setPathClass(PathClassFactory.getNegative(null));
+						pathObject.setPathClass(PathClass.getNegative(null));
 					pathObject.getMeasurementList().put(stain2Name + " OD", stain2Value);
 					pathObject.getMeasurementList().close();
 				} else

--- a/qupath-core-processing/src/main/java/qupath/opencv/CellCountsCV.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/CellCountsCV.java
@@ -328,7 +328,7 @@ public class CellCountsCV extends AbstractTileableDetectionPlugin<BufferedImage>
 						pathObject.setPathClass(PathClassFactory.getPositive(null));
 					else
 						pathObject.setPathClass(PathClassFactory.getNegative(null));
-					pathObject.getMeasurementList().putMeasurement(stain2Name + " OD", stain2Value);
+					pathObject.getMeasurementList().put(stain2Name + " OD", stain2Value);
 					pathObject.getMeasurementList().close();
 				} else
 					pathObject.setColor(color);

--- a/qupath-core-processing/src/main/java/qupath/opencv/DetectCytokeratinCV.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/DetectCytokeratinCV.java
@@ -53,8 +53,7 @@ import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.plugins.AbstractDetectionPlugin;
 import qupath.lib.plugins.DetectionPluginTools;
 import qupath.lib.plugins.ObjectDetector;
@@ -219,7 +218,7 @@ public class DetectCytokeratinCV extends AbstractDetectionPlugin<BufferedImage> 
 				if (!areaTissue.isEmpty()) {
 					ROI roiTissue = RoiTools.getShapeROI(areaTissue, request.getPlane());
 					roiTissue = ShapeSimplifier.simplifyShape(roiTissue, simplifyAmount);
-					pathObjects.add(PathObjects.createAnnotationObject(roiTissue, PathClassFactory.getPathClass(StandardPathClasses.STROMA)));
+					pathObjects.add(PathObjects.createAnnotationObject(roiTissue, PathClass.StandardPathClasses.STROMA));
 				}
 			}
 			if (areaDAB != null) {
@@ -230,7 +229,7 @@ public class DetectCytokeratinCV extends AbstractDetectionPlugin<BufferedImage> 
 				if (!areaDAB.isEmpty()) {
 					ROI roiDAB = RoiTools.getShapeROI(areaDAB, request.getPlane());
 					roiDAB = ShapeSimplifier.simplifyShape(roiDAB, simplifyAmount);
-					pathObjects.add(PathObjects.createAnnotationObject(roiDAB, PathClassFactory.getPathClass(StandardPathClasses.TUMOR)));
+					pathObjects.add(PathObjects.createAnnotationObject(roiDAB, PathClass.StandardPathClasses.TUMOR));
 				}
 			}
 

--- a/qupath-core-processing/src/main/java/qupath/opencv/WatershedNucleiCV.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/WatershedNucleiCV.java
@@ -268,16 +268,16 @@ public class WatershedNucleiCV extends AbstractTileableDetectionPlugin<BufferedI
 							MeasurementList measurementList = MeasurementListFactory.createMeasurementList(20, MeasurementList.MeasurementListType.FLOAT);
 							PathObject pathObject = PathObjects.createDetectionObject(pathPolygon, null, measurementList);
 
-							measurementList.putMeasurement("Area", pathPolygon.getArea());
-							measurementList.putMeasurement("Perimeter", pathPolygon.getLength());
-							measurementList.putMeasurement("Circularity", RoiTools.getCircularity(pathPolygon));
-							measurementList.putMeasurement("Solidity", pathPolygon.getSolidity());
+							measurementList.put("Area", pathPolygon.getArea());
+							measurementList.put("Perimeter", pathPolygon.getLength());
+							measurementList.put("Circularity", RoiTools.getCircularity(pathPolygon));
+							measurementList.put("Solidity", pathPolygon.getSolidity());
 
 							// I am making an assumption regarding square pixels here...
 							RotatedRect rrect = opencv_imgproc.minAreaRect(contour);
 							Size2f size = rrect.size();
-							measurementList.putMeasurement("Min axis", Math.min(size.width(), size.height()) * downsample);
-							measurementList.putMeasurement("Max axis", Math.max(size.width(), size.height()) * downsample);
+							measurementList.put("Min axis", Math.min(size.width(), size.height()) * downsample);
+							measurementList.put("Max axis", Math.max(size.width(), size.height()) * downsample);
 
 							// Store the object
 							pathObjects.add(pathObject);
@@ -301,19 +301,19 @@ public class WatershedNucleiCV extends AbstractTileableDetectionPlugin<BufferedI
 						MeasurementList measurementList = pathObject.getMeasurementList();
 						RunningStatistics statsHaem = statsHematoxylinList.get(ind);
 						//    	pathObject.addMeasurement("Area (px)", statsHaem.nPixels() * downsample * downsample);
-						measurementList.putMeasurement("Hematoxylin mean", statsHaem.getMean());
-						measurementList.putMeasurement("Hematoxylin std dev", statsHaem.getStdDev());
-						measurementList.putMeasurement("Hematoxylin min", statsHaem.getMin());
-						measurementList.putMeasurement("Hematoxylin max", statsHaem.getMax());
-						measurementList.putMeasurement("Hematoxylin range", statsHaem.getRange());
+						measurementList.put("Hematoxylin mean", statsHaem.getMean());
+						measurementList.put("Hematoxylin std dev", statsHaem.getStdDev());
+						measurementList.put("Hematoxylin min", statsHaem.getMin());
+						measurementList.put("Hematoxylin max", statsHaem.getMax());
+						measurementList.put("Hematoxylin range", statsHaem.getRange());
 
 						if (pxDAB != null) {
 							RunningStatistics statsDAB = statsDABList.get(ind);
-							measurementList.putMeasurement("DAB mean", statsDAB.getMean());
-							measurementList.putMeasurement("DAB std dev", statsDAB.getStdDev());
-							measurementList.putMeasurement("DAB min", statsDAB.getMin());
-							measurementList.putMeasurement("DAB max", statsDAB.getMax());
-							measurementList.putMeasurement("DAB range", statsDAB.getRange());
+							measurementList.put("DAB mean", statsDAB.getMean());
+							measurementList.put("DAB std dev", statsDAB.getStdDev());
+							measurementList.put("DAB min", statsDAB.getMin());
+							measurementList.put("DAB max", statsDAB.getMax());
+							measurementList.put("DAB range", statsDAB.getRange());
 						}
 
 						measurementList.close();

--- a/qupath-core-processing/src/main/java/qupath/opencv/WatershedNucleiCV.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/WatershedNucleiCV.java
@@ -268,16 +268,16 @@ public class WatershedNucleiCV extends AbstractTileableDetectionPlugin<BufferedI
 							MeasurementList measurementList = MeasurementListFactory.createMeasurementList(20, MeasurementList.MeasurementListType.FLOAT);
 							PathObject pathObject = PathObjects.createDetectionObject(pathPolygon, null, measurementList);
 
-							measurementList.addMeasurement("Area", pathPolygon.getArea());
-							measurementList.addMeasurement("Perimeter", pathPolygon.getLength());
-							measurementList.addMeasurement("Circularity", RoiTools.getCircularity(pathPolygon));
-							measurementList.addMeasurement("Solidity", pathPolygon.getSolidity());
+							measurementList.putMeasurement("Area", pathPolygon.getArea());
+							measurementList.putMeasurement("Perimeter", pathPolygon.getLength());
+							measurementList.putMeasurement("Circularity", RoiTools.getCircularity(pathPolygon));
+							measurementList.putMeasurement("Solidity", pathPolygon.getSolidity());
 
 							// I am making an assumption regarding square pixels here...
 							RotatedRect rrect = opencv_imgproc.minAreaRect(contour);
 							Size2f size = rrect.size();
-							measurementList.addMeasurement("Min axis", Math.min(size.width(), size.height()) * downsample);
-							measurementList.addMeasurement("Max axis", Math.max(size.width(), size.height()) * downsample);
+							measurementList.putMeasurement("Min axis", Math.min(size.width(), size.height()) * downsample);
+							measurementList.putMeasurement("Max axis", Math.max(size.width(), size.height()) * downsample);
 
 							// Store the object
 							pathObjects.add(pathObject);
@@ -301,19 +301,19 @@ public class WatershedNucleiCV extends AbstractTileableDetectionPlugin<BufferedI
 						MeasurementList measurementList = pathObject.getMeasurementList();
 						RunningStatistics statsHaem = statsHematoxylinList.get(ind);
 						//    	pathObject.addMeasurement("Area (px)", statsHaem.nPixels() * downsample * downsample);
-						measurementList.addMeasurement("Hematoxylin mean", statsHaem.getMean());
-						measurementList.addMeasurement("Hematoxylin std dev", statsHaem.getStdDev());
-						measurementList.addMeasurement("Hematoxylin min", statsHaem.getMin());
-						measurementList.addMeasurement("Hematoxylin max", statsHaem.getMax());
-						measurementList.addMeasurement("Hematoxylin range", statsHaem.getRange());
+						measurementList.putMeasurement("Hematoxylin mean", statsHaem.getMean());
+						measurementList.putMeasurement("Hematoxylin std dev", statsHaem.getStdDev());
+						measurementList.putMeasurement("Hematoxylin min", statsHaem.getMin());
+						measurementList.putMeasurement("Hematoxylin max", statsHaem.getMax());
+						measurementList.putMeasurement("Hematoxylin range", statsHaem.getRange());
 
 						if (pxDAB != null) {
 							RunningStatistics statsDAB = statsDABList.get(ind);
-							measurementList.addMeasurement("DAB mean", statsDAB.getMean());
-							measurementList.addMeasurement("DAB std dev", statsDAB.getStdDev());
-							measurementList.addMeasurement("DAB min", statsDAB.getMin());
-							measurementList.addMeasurement("DAB max", statsDAB.getMax());
-							measurementList.addMeasurement("DAB range", statsDAB.getRange());
+							measurementList.putMeasurement("DAB mean", statsDAB.getMean());
+							measurementList.putMeasurement("DAB std dev", statsDAB.getStdDev());
+							measurementList.putMeasurement("DAB min", statsDAB.getMin());
+							measurementList.putMeasurement("DAB max", statsDAB.getMax());
+							measurementList.putMeasurement("DAB range", statsDAB.getRange());
 						}
 
 						measurementList.close();

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnTools.java
@@ -621,7 +621,7 @@ public class DnnTools {
 		boolean changed = pathClass != pathObject.getPathClass();
 		pathObject.setPathClass(pathClass);
 		if (predictionMeasurement != null) {
-			pathObject.getMeasurementList().putMeasurement(predictionMeasurement, result.second());
+			pathObject.getMeasurementList().put(predictionMeasurement, result.second());
 			pathObject.getMeasurementList().close();
 		}
 		result.close();
@@ -727,7 +727,7 @@ public class DnnTools {
 				var pathObject = creator.apply(roi);
 				pathObject.setPathClass(pathClass);
 				try (var ml = pathObject.getMeasurementList()) {
-					ml.putMeasurement("Probability", pred);
+					ml.put("Probability", pred);
 				}
 				pathObjects.add(pathObject);
 			}

--- a/qupath-core-processing/src/main/java/qupath/opencv/features/DelaunayTriangulation.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/features/DelaunayTriangulation.java
@@ -88,7 +88,7 @@ public class DelaunayTriangulation implements PathObjectConnectionGroup {
 		Collection<String> measurements = PathObjectTools.getAvailableFeatures(pathObjects);
 		for (String name : measurements) {
 			RunningStatistics stats = new RunningStatistics();
-			pathObjects.stream().forEach(p -> stats.addValue(p.getMeasurementList().getMeasurementValue(name)));
+			pathObjects.stream().forEach(p -> stats.addValue(p.getMeasurementList().get(name)));
 		}
 	}
 	
@@ -451,7 +451,7 @@ public class DelaunayTriangulation implements PathObjectConnectionGroup {
 				MeasurementList ml = pathObject.getMeasurementList();
 				for (int i = 0; i < measurementNames.size(); i++) {
 					String name = measurementNames.get(i);
-					double val = ml.getMeasurementValue(name);
+					double val = ml.get(name);
 					if (Double.isFinite(val)) {
 						averagedMeasurements[i].addValue(val);
 					} else
@@ -462,9 +462,9 @@ public class DelaunayTriangulation implements PathObjectConnectionGroup {
 			for (PathObject pathObject : cluster) {
 				MeasurementList ml = pathObject.getMeasurementList();
 				for (int i = 0; i < measurementNames.size(); i++) {
-					ml.putMeasurement(key + "mean: " + measurementNames.get(i), averagedMeasurements[i].getMean());
+					ml.put(key + "mean: " + measurementNames.get(i), averagedMeasurements[i].getMean());
 				}
-				ml.putMeasurement(key + "size", n);
+				ml.put(key + "size", n);
 				ml.close();
 			}
 
@@ -515,7 +515,7 @@ public class DelaunayTriangulation implements PathObjectConnectionGroup {
 					double sum = 0;
 					int n = 0;
 					for (PathObject tempObject : neighborSet) {
-						double value = tempObject.getMeasurementList().getMeasurementValue(name);
+						double value = tempObject.getMeasurementList().get(name);
 						if (Double.isNaN(value))
 							continue;
 						sum += value;
@@ -526,15 +526,15 @@ public class DelaunayTriangulation implements PathObjectConnectionGroup {
 			}
 			
 			// TODO: PUT MEASUREMENTS IN UNITS OTHER THAN PIXELS????
-			measurementList.putMeasurement("Delaunay: Num neighbors", node.nNeighbors());
-			measurementList.putMeasurement("Delaunay: Mean distance", node.meanDistance());
-			measurementList.putMeasurement("Delaunay: Median distance", node.medianDistance());
-			measurementList.putMeasurement("Delaunay: Max distance", node.maxDistance());
-			measurementList.putMeasurement("Delaunay: Min distance", node.minDistance());
+			measurementList.put("Delaunay: Num neighbors", node.nNeighbors());
+			measurementList.put("Delaunay: Mean distance", node.meanDistance());
+			measurementList.put("Delaunay: Median distance", node.medianDistance());
+			measurementList.put("Delaunay: Max distance", node.maxDistance());
+			measurementList.put("Delaunay: Min distance", node.minDistance());
 //			measurementList.putMeasurement("Delaunay: Displacement sum mag", node.magDisplacementSum());
 			
-			measurementList.putMeasurement("Delaunay: Mean triangle area", node.getMeanTriangleArea());
-			measurementList.putMeasurement("Delaunay: Max triangle area", node.getMaxTriangleArea());
+			measurementList.put("Delaunay: Mean triangle area", node.getMeanTriangleArea());
+			measurementList.put("Delaunay: Max triangle area", node.getMaxTriangleArea());
 			
 			
 			// Put in averaged measurements using immediate neighbours
@@ -543,7 +543,7 @@ public class DelaunayTriangulation implements PathObjectConnectionGroup {
 					String name = measurementNames[i];
 					if (name == null || name.startsWith("Delaunay"))
 						continue;
-					measurementList.putMeasurement("Delaunay averaged (" + averagingSeparation + "): " + name, averagedMeasurements[i]);
+					measurementList.put("Delaunay averaged (" + averagingSeparation + "): " + name, averagedMeasurements[i]);
 				}			
 			}
 			
@@ -694,7 +694,7 @@ public class DelaunayTriangulation implements PathObjectConnectionGroup {
 		
 		
 		private double getMeasurementValue(final String measurement) {
-			return pathObject.getMeasurementList().getMeasurementValue(measurement);
+			return pathObject.getMeasurementList().get(measurement);
 		}
 		
 		

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/OpenCVMLClassifier.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/OpenCVMLClassifier.java
@@ -45,7 +45,6 @@ import qupath.lib.images.ImageData;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectFilter;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.classes.PathClassTools;
 import qupath.lib.objects.classes.Reclassifier;
 import qupath.opencv.ml.objects.features.FeatureExtractor;
@@ -210,7 +209,7 @@ public class OpenCVMLClassifier<T> extends AbstractObjectClassifier<T> {
 									classifications.add(pathClass.getName());
 							}
 						}
-						var pathClass = PathClassFactory.getPathClass(classifications);
+						var pathClass = PathClass.fromCollection(classifications);
 						if (PathClassTools.isIgnoredClass(pathClass)) {
 							pathClass = null;
 						}

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/features/DefaultFeatureExtractor.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/objects/features/DefaultFeatureExtractor.java
@@ -65,7 +65,7 @@ class DefaultFeatureExtractor<T> implements FeatureExtractor<T> {
 	private void extractFeatures(final PathObject pathObject, FloatBuffer buffer) {
 		var measurementList = pathObject.getMeasurementList();
 		for (var m : measurements) {
-			double value = measurementList.getMeasurementValue(m);
+			double value = measurementList.get(m);
 			buffer.put((float)value);
 		}
 	}
@@ -75,7 +75,7 @@ class DefaultFeatureExtractor<T> implements FeatureExtractor<T> {
 		List<String> missing = null;
 		var ml = pathObject.getMeasurementList();
 		for (var name : measurements) {
-			if (!ml.containsNamedMeasurement(name)) {
+			if (!ml.containsKey(name)) {
 				if (missing == null)
 					missing = new ArrayList<>();
 				missing.add(name);

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassificationMeasurementManager.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassificationMeasurementManager.java
@@ -174,7 +174,7 @@ public class PixelClassificationMeasurementManager {
 				return null;
 			map.put(roi, ml);
 		}
-		return ml.getMeasurementValue(name);
+		return ml.get(name);
 	}
 
 	/**
@@ -518,9 +518,9 @@ public class PixelClassificationMeasurementManager {
 			if (counts != null) {
 				long count = entry.getValue();
 				if (pathClassTotals.size() > 1)
-					measurementList.putMeasurement(namePercentage, (double)count/totalWithoutIgnored * 100.0);
+					measurementList.put(namePercentage, (double)count/totalWithoutIgnored * 100.0);
 				if (!Double.isNaN(pixelArea)) {
-					measurementList.putMeasurement(nameArea, count * pixelArea);
+					measurementList.put(nameArea, count * pixelArea);
 				}
 			}
     	}
@@ -533,8 +533,8 @@ public class PixelClassificationMeasurementManager {
     			tempList.add(nameArea);
     			tempList.add(nameAreaWithoutIgnored);
     		}
-			measurementList.putMeasurement(nameArea, totalWithoutIgnored * pixelArea);
-			measurementList.putMeasurement(nameAreaWithoutIgnored, total * pixelArea);
+			measurementList.put(nameArea, totalWithoutIgnored * pixelArea);
+			measurementList.put(nameAreaWithoutIgnored, total * pixelArea);
 		}
 
     	measurementList.close();

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
@@ -38,7 +38,6 @@ import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.classes.Reclassifier;
 import qupath.lib.objects.classes.PathClassTools;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
@@ -331,7 +330,7 @@ public class PixelClassifierTools {
 		var labels = new LinkedHashMap<Integer, PathClass>();
 		for (var entry : labelsOrig.entrySet()) {
 			var pathClass = entry.getValue();
-			if (pathClass == null || pathClass == PathClassFactory.getPathClassUnclassified() || (!includeIgnored && PathClassTools.isIgnoredClass(pathClass)))				
+			if (pathClass == null || pathClass == PathClass.NULL_CLASS || (!includeIgnored && PathClassTools.isIgnoredClass(pathClass)))				
 				continue;
 			labels.put(entry.getKey(), pathClass);
 		}

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
@@ -590,7 +590,7 @@ public class PixelClassifierTools {
 				for (String name : manager.getMeasurementNames()) {
 					Number value = manager.getMeasurementValue(pathObject, name, false);
 					double val = value == null ? Double.NaN : value.doubleValue();
-					ml.putMeasurement(measurementID + name, val);
+					ml.put(measurementID + name, val);
 				}
 			}
 			// We really want to lock objects so we don't end up with wrong measurements

--- a/qupath-core-processing/src/test/java/qupath/opencv/ml/pixel/TestPixelClassifierTools.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/ml/pixel/TestPixelClassifierTools.java
@@ -54,7 +54,6 @@ import qupath.lib.images.servers.ImageServers;
 import qupath.lib.images.servers.WrappedBufferedImageServer;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.opencv.ml.pixel.PixelClassifierTools.CreateObjectOptions;
 
@@ -137,7 +136,7 @@ class TestPixelClassifierTools {
 		var classificationLabels = new LinkedHashMap<Integer, PathClass>();
 		var classificationLabelsReverse = new HashMap<PathClass, Integer>();
 		for (int i = 0; i <= max; i++) {
-			var pathClass = PathClassFactory.getPathClass("Class " + i);
+			var pathClass = PathClass.getInstance("Class " + i);
 			classificationLabels.put(i, pathClass);
 			classificationLabelsReverse.put(pathClass, i);
 		}

--- a/qupath-core-processing/src/test/java/qupath/opencv/ml/pixel/TestPixelClassifiers.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/ml/pixel/TestPixelClassifiers.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import qupath.lib.classifiers.pixel.PixelClassifier;
 import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.io.GsonTools;
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.scripting.QP;
 
 @SuppressWarnings("javadoc")
@@ -44,7 +44,7 @@ public class TestPixelClassifiers {
 		
 		// Make sure we can JSON serialize and deserialize a threshold classifier
 		var classifier = PixelClassifiers.createThresholdClassifier(PixelCalibration.getDefaultInstance().createScaledInstance(2, 2),
-				0, 1, PathClassFactory.getPathClass("Ignore*"), PathClassFactory.getPathClass("Tumor"));
+				0, 1, PathClass.getInstance("Ignore*"), PathClass.getInstance("Tumor"));
 		
 		var gson = GsonTools.getInstance(true);
 		var json = gson.toJson(classifier, PixelClassifier.class);

--- a/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
@@ -64,7 +64,6 @@ import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.GeometryTools;
 import qupath.lib.roi.RoiTools;
@@ -548,7 +547,7 @@ public class DelaunayTools {
 	 * @return a collection of objects that have had their classifications set by this method
 	 */
 	public static Collection<PathObject> classifyObjectsByCluster(Collection<Collection<? extends PathObject>> clusters) {
-		return classifyObjectsByCluster(clusters, c -> PathClassFactory.getPathClass("Cluster " + (c + 1)));
+		return classifyObjectsByCluster(clusters, c -> PathClass.getInstance("Cluster " + (c + 1)));
 	}
 	
 	
@@ -583,7 +582,7 @@ public class DelaunayTools {
 	 * @return a collection of objects that have had their classifications set by this method
 	 */
 	public static Collection<PathObject> nameObjectsByCluster(Collection<Collection<? extends PathObject>> clusters) {
-		return nameObjectsByCluster(clusters, c -> PathClassFactory.getPathClass("Cluster " + (c + 1)));
+		return nameObjectsByCluster(clusters, c -> PathClass.getInstance("Cluster " + (c + 1)));
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/analysis/DistanceTools.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/DistanceTools.java
@@ -337,7 +337,7 @@ public class DistanceTools {
 					double distance = Math.min(lineDistance, Math.min(pointDistance, shapeDistance));
 					
 					try (var ml = p.getMeasurementList()) {
-						ml.putMeasurement(measurementName, distance);
+						ml.put(measurementName, distance);
 					}
 				});
 			}

--- a/qupath-core/src/main/java/qupath/lib/analysis/stats/Histogram.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/stats/Histogram.java
@@ -438,7 +438,7 @@ public class Histogram { // implements Serializable {
 		double[] values = new double[pathObjects.size()];
 		int ind = 0;
 		for (PathObject pathObject : pathObjects) {
-			values[ind] = pathObject.getMeasurementList().getMeasurementValue(measurementName);
+			values[ind] = pathObject.getMeasurementList().get(measurementName);
 			ind++;
 		}
 		return values;

--- a/qupath-core/src/main/java/qupath/lib/classifiers/object/ObjectClassifiers.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/object/ObjectClassifiers.java
@@ -415,7 +415,7 @@ public class ObjectClassifiers {
 
 		@Override
 		public PathClass apply(PathObject pathObject) {
-			double val = pathObject.getMeasurementList().getMeasurementValue(measurement);
+			double val = pathObject.getMeasurementList().get(measurement);
 			if (Double.isNaN(val))
 				return null;
 			if (val > threshold)

--- a/qupath-core/src/main/java/qupath/lib/classifiers/object/ObjectClassifiers.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/object/ObjectClassifiers.java
@@ -42,7 +42,6 @@ import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectFilter;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 
 /**
  * Helper class for creating {@linkplain ObjectClassifier ObjectClassifiers}.
@@ -145,7 +144,7 @@ public class ObjectClassifiers {
 	 * @see PathObjectFilter
 	 */
 	public static <T> ObjectClassifier<T> createChannelClassifier(PathObjectFilter filter, ImageChannel channel, String measurement, double threshold) {
-		var pathClass = PathClassFactory.getPathClass(channel.getName(), channel.getColor());
+		var pathClass = PathClass.fromString(channel.getName(), channel.getColor());
 		return new ClassifyByMeasurementBuilder<T>(measurement)
 			.threshold(threshold)
 			.filter(filter)
@@ -253,7 +252,7 @@ public class ObjectClassifiers {
 		 * @see #threshold(double)
 		 */
 		public ClassifyByMeasurementBuilder<T> above(String pathClassName) {
-			var pathClass = PathClassFactory.getPathClass(pathClassName);
+			var pathClass = PathClass.fromString(pathClassName);
 			this.pathClassAbove = pathClass;
 			return this;
 		}
@@ -265,7 +264,7 @@ public class ObjectClassifiers {
 		 * @see #threshold(double)
 		 */
 		public ClassifyByMeasurementBuilder<T> aboveEquals(String pathClassName) {
-			var pathClass = PathClassFactory.getPathClass(pathClassName);
+			var pathClass = PathClass.fromString(pathClassName);
 			this.pathClassAbove = pathClass;
 			this.pathClassEquals = pathClass;
 			return this;
@@ -278,7 +277,7 @@ public class ObjectClassifiers {
 		 * @see #threshold(double)
 		 */
 		public ClassifyByMeasurementBuilder<T> belowEquals(String pathClassName) {
-			var pathClass = PathClassFactory.getPathClass(pathClassName);
+			var pathClass = PathClass.fromString(pathClassName);
 			this.pathClassBelow = pathClass;
 			this.pathClassEquals = pathClass;
 			return this;
@@ -291,7 +290,7 @@ public class ObjectClassifiers {
 		 * @see #threshold(double)
 		 */
 		public ClassifyByMeasurementBuilder<T> below(String pathClassName) {
-			var pathClass = PathClassFactory.getPathClass(pathClassName);
+			var pathClass = PathClass.fromString(pathClassName);
 			this.pathClassBelow = pathClass;
 			return this;
 		}
@@ -303,7 +302,7 @@ public class ObjectClassifiers {
 		 * @see #threshold(double)
 		 */
 		public ClassifyByMeasurementBuilder<T> equalTo(String pathClassName) {
-			var pathClass = PathClassFactory.getPathClass(pathClassName);
+			var pathClass = PathClass.fromString(pathClassName);
 			this.pathClassEquals = pathClass;
 			return this;
 		}
@@ -400,9 +399,9 @@ public class ObjectClassifiers {
 		ClassifyByMeasurementFunction(String measurement, double threshold, PathClass pathClassBelow, PathClass pathClassEquals, PathClass pathClassAbove) {
 			this.measurement = measurement;
 			this.threshold = threshold;
-			this.pathClassBelow = pathClassBelow == PathClassFactory.getPathClassUnclassified() ? null : pathClassBelow;
-			this.pathClassEquals = pathClassEquals == PathClassFactory.getPathClassUnclassified() ? null : pathClassEquals;
-			this.pathClassAbove = pathClassAbove == PathClassFactory.getPathClassUnclassified() ? null : pathClassAbove;
+			this.pathClassBelow = pathClassBelow == PathClass.NULL_CLASS ? null : pathClassBelow;
+			this.pathClassEquals = pathClassEquals == PathClass.NULL_CLASS ? null : pathClassEquals;
+			this.pathClassAbove = pathClassAbove == PathClass.NULL_CLASS ? null : pathClassAbove;
 		}
 		
 		/**

--- a/qupath-core/src/main/java/qupath/lib/classifiers/object/SimpleClassifier.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/object/SimpleClassifier.java
@@ -81,7 +81,7 @@ class SimpleClassifier<T> extends AbstractObjectClassifier<T> {
 			var name = ((ClassifyByMeasurementFunction)function).getMeasurement();
 			if (name != null) {
 				for (var pathObject : pathObjects) {
-					if (!pathObject.getMeasurementList().containsNamedMeasurement(name))
+					if (!pathObject.getMeasurementList().containsKey(name))
 						nMissing++;
 				}
 			}

--- a/qupath-core/src/main/java/qupath/lib/classifiers/pixel/PixelClassifierMetadata.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/pixel/PixelClassifierMetadata.java
@@ -36,7 +36,6 @@ import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.images.servers.PixelType;
 import qupath.lib.images.servers.ServerTools;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 
 /**
  * Metadata to control the behavior of a pixel classifier.
@@ -146,7 +145,7 @@ public class PixelClassifierMetadata {
     		classificationLabels = new LinkedHashMap<>();
     		for (int i = 0; i < outputChannels.size(); i++) {
     			var channel = outputChannels.get(i);
-    			classificationLabels.put(i, PathClassFactory.getPathClass(channel.getName(), channel.getColor()));
+    			classificationLabels.put(i, PathClass.fromString(channel.getName(), channel.getColor()));
     		}
     	}
     	return classificationLabels == null ? Collections.emptyMap() : Collections.unmodifiableMap(classificationLabels);

--- a/qupath-core/src/main/java/qupath/lib/color/ColorModelFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorModelFactory.java
@@ -47,8 +47,6 @@ import qupath.lib.common.GeneralTools;
 import qupath.lib.images.servers.ImageChannel;
 import qupath.lib.images.servers.PixelType;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
 import qupath.lib.objects.classes.PathClassTools;
 
 /**
@@ -87,12 +85,12 @@ public final class ColorModelFactory {
         
         for (var entry: channels.entrySet()) {
     		var pathClass = entry.getValue();
-    		if (pathClass == null || pathClass == PathClassFactory.getPathClassUnclassified()) {
+    		if (pathClass == null || pathClass == PathClass.NULL_CLASS) {
     			cmap[entry.getKey()] = ColorTools.packARGB(0, 255, 255, 255);
     		} else if (PathClassTools.isIgnoredClass(entry.getValue())) {
         		var color = pathClass == null ? 0 : pathClass.getColor();
         		int alpha = 192;
-        		if (pathClass == PathClassFactory.getPathClass(StandardPathClasses.IGNORE))
+        		if (pathClass == PathClass.StandardPathClasses.IGNORE)
         			alpha = 32;
             	cmap[entry.getKey()] = ColorTools.packARGB(alpha, ColorTools.red(color), ColorTools.green(color), ColorTools.blue(color));
         	} else

--- a/qupath-core/src/main/java/qupath/lib/images/servers/LabeledImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/LabeledImageServer.java
@@ -60,7 +60,6 @@ import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectFilter;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.regions.ImageRegion;
 import qupath.lib.regions.RegionRequest;
@@ -141,8 +140,8 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 				var pathClass = getPathClass(entry.getKey());
 				var label = entry.getValue();
 				var previousClass = classificationLabels.put(label, pathClass);
-				if (previousClass != null && previousClass != PathClassFactory.getPathClassUnclassified()) {
-					classificationLabels.put(label, PathClassFactory.getDerivedPathClass(previousClass, pathClass.getName(), null));
+				if (previousClass != null && previousClass != PathClass.NULL_CLASS) {
+					classificationLabels.put(label, PathClass.getInstance(previousClass, pathClass.getName(), null));
 				}
 			}
 		}
@@ -151,8 +150,8 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 			var pathClass = getPathClass(entry.getKey());
 			var label = entry.getValue();
 			var previousClass = classificationLabels.put(label, pathClass);
-			if (previousClass != null && previousClass != PathClassFactory.getPathClassUnclassified()) {
-				classificationLabels.put(label, PathClassFactory.getDerivedPathClass(previousClass, pathClass.getName(), null));
+			if (previousClass != null && previousClass != PathClass.NULL_CLASS) {
+				classificationLabels.put(label, PathClass.getInstance(previousClass, pathClass.getName(), null));
 			}
 		}
 		
@@ -254,7 +253,7 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 	 * @return the input classification, or the unclassified classification if the input is null
 	 */
 	private static PathClass getPathClass(PathClass pathClass) {
-		return pathClass == null ? PathClassFactory.getPathClassUnclassified() : pathClass;
+		return pathClass == null ? PathClass.NULL_CLASS : pathClass;
 	}
 	
 	/**
@@ -275,7 +274,7 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 	private static PathClass instanceLabelToClass(Integer label) {
 		if (label == null)
 			return null;
-		return PathClassFactory.getPathClass("Label " + label);
+		return PathClass.getInstance("Label " + label);
 	}
 	
 //	/**
@@ -335,7 +334,7 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 		 * Previously, this was achieved with a UUID - although this looks strange if exporting classes.
 		 */
 //		private PathClass unannotatedClass = PathClassFactory.getPathClass("Unannotated " + UUID.randomUUID().toString());
-		private PathClass unannotatedClass = PathClassFactory.getPathClass("*Background*");
+		private PathClass unannotatedClass = PathClass.getInstance("*Background*");
 		
 		private Predicate<PathObject> objectFilter = PathObjectFilter.ANNOTATIONS;
 		private Function<PathObject, ROI> roiFunction = p -> p.getROI();
@@ -648,7 +647,7 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 		 * @return
 		 */
 		public Builder addLabel(String pathClassName, int label, Integer color) {
-			return addLabel(PathClassFactory.getPathClass(pathClassName), label, color);
+			return addLabel(PathClass.fromString(pathClassName), label, color);
 		}
 
 		/**
@@ -682,7 +681,7 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 		 * @return
 		 */
 		public Builder addUnclassifiedLabel(int label, Integer color) {
-			return addLabel(params.labels, PathClassFactory.getPathClassUnclassified(), label, color);
+			return addLabel(params.labels, PathClass.NULL_CLASS, label, color);
 		}
 		
 		/**
@@ -692,7 +691,7 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 		 * @return
 		 */
 		public Builder addUnclassifiedLabel(int label) {
-			return addLabel(params.labels, PathClassFactory.getPathClassUnclassified(), label, null);
+			return addLabel(params.labels, PathClass.NULL_CLASS, label, null);
 		}
 		
 		
@@ -736,7 +735,7 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 		 * @return
 		 */
 		public Builder setBoundaryLabel(String pathClassName, int label, Integer color) {
-			return setBoundaryLabel(PathClassFactory.getPathClass(pathClassName), label, color);
+			return setBoundaryLabel(PathClass.fromString(pathClassName), label, color);
 		}
 		
 		private Builder addLabel(Map<PathClass, Integer> map, PathClass pathClass, int label, Integer color) {

--- a/qupath-core/src/main/java/qupath/lib/io/GsonTools.java
+++ b/qupath-core/src/main/java/qupath/lib/io/GsonTools.java
@@ -50,7 +50,6 @@ import qupath.lib.io.PathObjectTypeAdapters.FeatureCollection;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.interfaces.ROI;
 
@@ -349,7 +348,7 @@ public class GsonTools {
 		@Override
 		public void write(JsonWriter out, PathClass value) throws IOException {
 			// Use a proxy object for easier use elsewhere
-			if (value == null || value == PathClassFactory.getPathClassUnclassified()) {
+			if (value == null || value == PathClass.NULL_CLASS) {
 				// Write in the default way
 				gson.toJson(value, PathClass.class, out);				
 			} else {
@@ -372,17 +371,17 @@ public class GsonTools {
 			
 			// Accept a classification just from a string (i.e. no color specified)
 			if (token == JsonToken.STRING)
-				return PathClassFactory.getPathClass(in.nextString());
+				return PathClass.fromString(in.nextString());
 			
 			// Handle objects
 			if (token == JsonToken.BEGIN_OBJECT) {
 				JsonObject pathClassObject = gson.fromJson(in, JsonObject.class);	
 				// Check if we have just serialized in the default way (with the usual private field name for color)
-				// This also should be used with PathClassFactory.getPathClassUnclassified() (which has an empty object)
+				// This also should be used with PathClass.NULL_CLASS (which has an empty object)
 				if (pathClassObject.size() == 0 || pathClassObject.has("colorRGB") || pathClassObject.has("parentClass")) {
 					// Read in the default way, then replace with a singleton instance
 					PathClass pathClass = gson.fromJson(pathClassObject, PathClass.class);
-					return PathClassFactory.getSingletonPathClass(pathClass);					
+					return PathClass.getSingleton(pathClass);					
 				}
 				
 				// Check if we have a proxy object
@@ -405,7 +404,7 @@ public class GsonTools {
 				if (name == null)
 					return null;
 				Integer rgb = arrayToRgb(color);
-				return PathClassFactory.getPathClass(name, rgb);
+				return PathClass.fromString(name, rgb);
 			}
 			
 		}

--- a/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
@@ -455,7 +455,7 @@ class PathObjectTypeAdapters {
 			if (measurementList != null && !measurementList.isEmpty()) {
 				try (var ml = pathObject.getMeasurementList()) {
 					for (int i = 0; i < measurementList.size(); i++)
-						ml.addMeasurement(measurementList.getMeasurementName(i), measurementList.getMeasurementValue(i));
+						ml.putMeasurement(measurementList.getMeasurementName(i), measurementList.getMeasurementValue(i));
 				}
 			}
 			if (pathClass != null)
@@ -508,7 +508,7 @@ class PathObjectTypeAdapters {
 			MeasurementList list = MeasurementListFactory.createMeasurementList(array.size(), MeasurementListType.DOUBLE);
 			for (int i = 0; i < array.size(); i++) {
 				JsonObject obj = array.get(i).getAsJsonObject();
-				list.addMeasurement(obj.get("name").getAsString(), obj.get("value").getAsDouble());
+				list.putMeasurement(obj.get("name").getAsString(), obj.get("value").getAsDouble());
 			}
 			list.close();
 			return list;

--- a/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
@@ -455,7 +455,7 @@ class PathObjectTypeAdapters {
 			if (measurementList != null && !measurementList.isEmpty()) {
 				try (var ml = pathObject.getMeasurementList()) {
 					for (int i = 0; i < measurementList.size(); i++)
-						ml.putMeasurement(measurementList.getMeasurementName(i), measurementList.getMeasurementValue(i));
+						ml.put(measurementList.getMeasurementName(i), measurementList.getMeasurementValue(i));
 				}
 			}
 			if (pathClass != null)
@@ -508,7 +508,7 @@ class PathObjectTypeAdapters {
 			MeasurementList list = MeasurementListFactory.createMeasurementList(array.size(), MeasurementListType.DOUBLE);
 			for (int i = 0; i < array.size(); i++) {
 				JsonObject obj = array.get(i).getAsJsonObject();
-				list.putMeasurement(obj.get("name").getAsString(), obj.get("value").getAsDouble());
+				list.put(obj.get("name").getAsString(), obj.get("value").getAsDouble());
 			}
 			list.close();
 			return list;

--- a/qupath-core/src/main/java/qupath/lib/io/PointIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PointIO.java
@@ -54,7 +54,7 @@ import qupath.lib.geom.Point2;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.PointsROI;
 import qupath.lib.roi.ROIs;
@@ -118,7 +118,7 @@ public class PointIO {
 			if (name != null && name.length() > 0 && !"null".equals(name))
 				pathObject.setName(name);
 			if (pathClass != null && pathClass.length() > 0 && !"null".equals(pathClass))
-				pathObject.setPathClass(PathClassFactory.getPathClass(pathClass, color));
+				pathObject.setPathClass(PathClass.fromString(pathClass, color));
 			pathObject.setColor(color);
 			
 			if (pathObject != null)

--- a/qupath-core/src/main/java/qupath/lib/io/TMAScoreImporter.java
+++ b/qupath-core/src/main/java/qupath/lib/io/TMAScoreImporter.java
@@ -185,13 +185,13 @@ public class TMAScoreImporter {
 						if (core == null)
 							continue;
 						if (isOverallSurvival)
-							core.getMeasurementList().putMeasurement(TMACoreObject.KEY_OVERALL_SURVIVAL, vals[i]);
+							core.getMeasurementList().put(TMACoreObject.KEY_OVERALL_SURVIVAL, vals[i]);
 						else if (isRecurrenceFreeSurvival)
-							core.getMeasurementList().putMeasurement(TMACoreObject.KEY_RECURRENCE_FREE_SURVIVAL, vals[i]);
+							core.getMeasurementList().put(TMACoreObject.KEY_RECURRENCE_FREE_SURVIVAL, vals[i]);
 						else if (isOSCensored)
-							core.getMeasurementList().putMeasurement(TMACoreObject.KEY_OS_CENSORED, vals[i] > 0 ? 1 : 0);
+							core.getMeasurementList().put(TMACoreObject.KEY_OS_CENSORED, vals[i] > 0 ? 1 : 0);
 						else if (isRFSCensored)
-							core.getMeasurementList().putMeasurement(TMACoreObject.KEY_RFS_CENSORED, vals[i] > 0 ? 1 : 0);
+							core.getMeasurementList().put(TMACoreObject.KEY_RFS_CENSORED, vals[i] > 0 ? 1 : 0);
 						else
 							core.putMetadataValue(entry.getKey(), entry.getValue().get(i));
 					}
@@ -200,7 +200,7 @@ public class TMAScoreImporter {
 				// If we have a numeric column, add to measurement list
 				for (int i : cores.keySet()) {
 					for (TMACoreObject core : cores.get(i)) {
-						core.getMeasurementList().putMeasurement(entry.getKey(), vals[i]);
+						core.getMeasurementList().put(entry.getKey(), vals[i]);
 					}
 				}
 			}

--- a/qupath-core/src/main/java/qupath/lib/io/TMAScoreImporter.java
+++ b/qupath-core/src/main/java/qupath/lib/io/TMAScoreImporter.java
@@ -200,7 +200,7 @@ public class TMAScoreImporter {
 				// If we have a numeric column, add to measurement list
 				for (int i : cores.keySet()) {
 					for (TMACoreObject core : cores.get(i)) {
-						core.getMeasurementList().addMeasurement(entry.getKey(), vals[i]);
+						core.getMeasurementList().putMeasurement(entry.getKey(), vals[i]);
 					}
 				}
 			}

--- a/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
@@ -26,6 +26,7 @@ package qupath.lib.measurements;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A MeasurementList implementation that simply stores a list of Measurement objects.
@@ -43,6 +44,8 @@ class DefaultMeasurementList implements MeasurementList {
 	private static final long serialVersionUID = 1L;
 	
 	private ArrayList<Measurement> list;
+	
+	private transient Map<String, Double> mapView;
 	
 	DefaultMeasurementList() {
 		list = new ArrayList<>();
@@ -171,6 +174,16 @@ class DefaultMeasurementList implements MeasurementList {
 		}
 	}
 
+	@Override
+	public Map<String, Double> asMap() {
+		if (mapView == null) {
+			synchronized(this) {
+				if (mapView == null)
+					mapView = new MeasurementsMap(this);
+			}
+		}
+		return mapView;
+	}
 	
 	@Override
 	public synchronized String toString() {

--- a/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
@@ -53,11 +53,6 @@ class DefaultMeasurementList implements MeasurementList {
 	}
 	
 	@Override
-	public synchronized boolean addMeasurement(String name, double value) {
-		return add(MeasurementFactory.createMeasurement(name, value));
-	}
-	
-	@Override
 	public synchronized void clear() {
 		this.list.clear();
 	}
@@ -144,10 +139,6 @@ class DefaultMeasurementList implements MeasurementList {
 		}
 		list.add(measurement);
 		return null;
-	}
-	
-	private synchronized boolean add(Measurement measurement) {
-		return list.add(measurement);
 	}
 
 //	@Override

--- a/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
@@ -73,7 +73,7 @@ class DefaultMeasurementList implements MeasurementList {
 	}
 
 	@Override
-	public synchronized double getMeasurementValue(String name) {
+	public synchronized double get(String name) {
 		for (Measurement m : list) {
 			if (m.getName().equals(name))
 				return m.getValue();
@@ -82,7 +82,7 @@ class DefaultMeasurementList implements MeasurementList {
 	}
 		
 	@Override
-	public synchronized boolean containsNamedMeasurement(String measurement) {
+	public synchronized boolean containsKey(String measurement) {
 		for (Measurement m : list)
 			if (m.getName().equals(measurement))
 				return true;
@@ -152,7 +152,7 @@ class DefaultMeasurementList implements MeasurementList {
 	}
 
 	@Override
-	public synchronized void putMeasurement(String name, double value) {
+	public synchronized void put(String name, double value) {
 		putMeasurement(MeasurementFactory.createMeasurement(name, value));
 	}
 

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
@@ -353,6 +353,19 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 */
 	public void clear();
 	
+	/**
+	 * Get a map view of this measurements list. 
+	 * This is a map that is backed by the list, which means that putting or retrieving elements 
+	 * modifies the list. It also means that there can be some loss of precision if the list does 
+	 * not support Double (e.g. it uses a float array for storage).
+	 * <p>
+	 * @return a map view of this measurement list
+	 * @implSpec The returned map should already be synchronized.
+	 */
+	public default Map<String, Double> asMap() {
+		return Collections.synchronizedMap(new MeasurementsMap(this));
+	}
+	
 //	/**
 //	 * Return a Map view over this list. Changes made to the map will be stored in the list.
 //	 * @return

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementListFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementListFactory.java
@@ -23,6 +23,9 @@
 
 package qupath.lib.measurements;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * Factory for creating new measurement lists.
  * <p>
@@ -51,6 +54,15 @@ public class MeasurementListFactory {
 		default:
 			return new DefaultMeasurementList(capacity);
 		}
+	}
+	
+	/**
+	 * Wrap in a map representation, backed by the list.
+	 * @param list
+	 * @return
+	 */
+	public static Map<String, Double> wrapList(MeasurementList list) {
+		return Collections.synchronizedMap(new MeasurementsMap(list));
 	}
 
 }

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementListFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementListFactory.java
@@ -23,9 +23,6 @@
 
 package qupath.lib.measurements;
 
-import java.util.Collections;
-import java.util.Map;
-
 /**
  * Factory for creating new measurement lists.
  * <p>
@@ -55,14 +52,4 @@ public class MeasurementListFactory {
 			return new DefaultMeasurementList(capacity);
 		}
 	}
-	
-	/**
-	 * Wrap in a map representation, backed by the list.
-	 * @param list
-	 * @return
-	 */
-	public static Map<String, Double> wrapList(MeasurementList list) {
-		return Collections.synchronizedMap(new MeasurementsMap(list));
-	}
-
 }

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
@@ -1,0 +1,194 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.lib.measurements;
+
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Wrapper class to enable access to a {@link MeasurementList} as if it were a map.
+ * 
+ * @author Pete Bankhead
+ * @since v0.4.0
+ */
+class MeasurementsMap extends AbstractMap<String, Double> implements Map<String, Double> {
+	
+	private MeasurementList list;
+	
+	public MeasurementsMap(MeasurementList list) {
+		this.list = list;
+	}
+
+	@Override
+	public Set<Entry<String, Double>> entrySet() {
+		return new MeasurementEntrySet();
+	}
+	
+	
+	@Override
+	public int size() {
+		return list.size();
+	}
+	
+	@Override
+	public boolean isEmpty() {
+		return list.isEmpty();
+	}
+	
+	@Override
+	public boolean containsKey(Object key) {
+		return key instanceof String && this.list.containsNamedMeasurement((String)key);
+	}
+	
+	@Override
+	public boolean containsValue(Object value) {
+		double val;
+		if (value instanceof Number)
+			val = ((Number)value).doubleValue();
+		else
+			return false;
+		synchronized(list) {
+			for (int i = 0; i < list.size(); i++) {
+				if (list.getMeasurementValue(i) == val)
+					return true;
+			}
+		}
+		return false;
+	}
+	
+	@Override
+	public void clear() {
+		this.list.clear();
+	}
+	
+	@Override
+	public Double get(Object key) {
+		if (!(key instanceof String))
+			return null;
+		String name = (String)key;
+		synchronized(list) {
+			if (list.containsNamedMeasurement(name))
+				return list.getMeasurementValue(name);
+		}
+		return null;
+	}
+	
+	/**
+	 * Put the value into the map.
+	 * Note that value must be non-null, and the value of the number will be stored as a double 
+	 * or float primitive, depending upon the backing {@link MeasurementList} implementation.
+	 * As such, object equality is not guaranteed when retrieving values and loss of precision 
+	 * is possible.
+	 */
+	@Override
+	public Double put(String name, Double value) {
+		Objects.requireNonNull(value);
+		Double current = null;
+		synchronized(list) {
+			if (list.containsNamedMeasurement(name))
+				current = list.getMeasurementValue(name);
+			list.putMeasurement(name, value.doubleValue());
+			list.close();
+		}
+		return current;
+	}
+	
+	@Override
+	public void putAll(Map<? extends String, ? extends Double> map) {
+		synchronized (list) {
+			// Don't repeatedly call put because we only want to close the list once 
+			// and don't need to extract previous values
+			for (Map.Entry<? extends String, ? extends Number> e : map.entrySet()) {
+				Objects.requireNonNull(e.getValue()); // Don't support null values
+				list.putMeasurement(e.getKey(), e.getValue().doubleValue());
+			}
+			list.close();
+		}
+	}
+	
+	@Override
+	public Double remove(Object key) {
+		synchronized (list) {
+			int ind = list.getMeasurementNames().indexOf(key);
+			Double val = null;
+			if (ind >= 0) {
+				val = list.getMeasurementValue(ind);
+				list.removeMeasurements((String)key);
+			}
+			return val;
+		}
+	}
+	
+	
+//	public Double put(String name, double value) {
+//		Double current = null;
+//		synchronized (list) {
+//			if (list.containsNamedMeasurement(name))
+//				current = list.getMeasurementValue(name);
+//			list.putMeasurement(name, value);
+//		}
+//		return current;
+//	}
+	
+	
+	class MeasurementEntrySet extends AbstractSet<Entry<String, Double>> {
+
+		@Override
+		public int size() {
+			return list.size();
+		}
+
+		@Override
+		public Iterator<Entry<String, Double>> iterator() {
+			return new Iterator<>() {
+				
+				private int i = 0;
+
+				@Override
+				public boolean hasNext() {
+					return i < size();
+				}
+
+				@Override
+				public Entry<String, Double> next() {
+					SimpleEntry<String, Double> entry = new SimpleEntry<>(list.getMeasurementName(i), list.getMeasurementValue(i));
+					i++;
+					return entry;
+				}
+				
+				@Override
+				public void remove() {
+					list.removeMeasurements(list.getMeasurementName(i - 1));
+				}
+				
+			};
+		}
+		
+	}
+	
+
+}

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
@@ -61,7 +61,7 @@ class MeasurementsMap extends AbstractMap<String, Double> implements Map<String,
 	
 	@Override
 	public boolean containsKey(Object key) {
-		return key instanceof String && this.list.containsNamedMeasurement((String)key);
+		return key instanceof String && this.list.containsKey((String)key);
 	}
 	
 	@Override
@@ -91,8 +91,8 @@ class MeasurementsMap extends AbstractMap<String, Double> implements Map<String,
 			return null;
 		String name = (String)key;
 		synchronized(list) {
-			if (list.containsNamedMeasurement(name))
-				return list.getMeasurementValue(name);
+			if (list.containsKey(name))
+				return list.get(name);
 		}
 		return null;
 	}
@@ -109,9 +109,9 @@ class MeasurementsMap extends AbstractMap<String, Double> implements Map<String,
 		Objects.requireNonNull(value);
 		Double current = null;
 		synchronized(list) {
-			if (list.containsNamedMeasurement(name))
-				current = list.getMeasurementValue(name);
-			list.putMeasurement(name, value.doubleValue());
+			if (list.containsKey(name))
+				current = list.get(name);
+			list.put(name, value.doubleValue());
 			list.close();
 		}
 		return current;
@@ -124,7 +124,7 @@ class MeasurementsMap extends AbstractMap<String, Double> implements Map<String,
 			// and don't need to extract previous values
 			for (Map.Entry<? extends String, ? extends Number> e : map.entrySet()) {
 				Objects.requireNonNull(e.getValue()); // Don't support null values
-				list.putMeasurement(e.getKey(), e.getValue().doubleValue());
+				list.put(e.getKey(), e.getValue().doubleValue());
 			}
 			list.close();
 		}

--- a/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
@@ -104,6 +104,8 @@ class NumericMeasurementList {
 		boolean isClosed = false;
 
 		private Map<String, Integer> map; // Optional map for fast measurement lookup
+		
+		private transient Map<String, Double> mapView;
 
 		AbstractNumericMeasurementList(int capacity) {
 			names = new ArrayList<>(capacity);
@@ -261,6 +263,17 @@ class NumericMeasurementList {
 				throw new UnsupportedOperationException("This MeasurementList does not support dynamic measurements");
 			put(measurement.getName(), measurement.getValue());
 			return null;
+		}
+		
+		@Override
+		public Map<String, Double> asMap() {
+			if (mapView == null) {
+				synchronized(this) {
+					if (mapView == null)
+						mapView = new MeasurementsMap(this);
+				}
+			}
+			return mapView;
 		}
 		
 		

--- a/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
@@ -170,12 +170,6 @@ class NumericMeasurementList {
 			return names.indexOf(name);
 		}
 		
-		private boolean add(Measurement measurement) {
-			if (measurement.isDynamic())
-				throw new UnsupportedOperationException("This MeasurementList does not support dynamic measurements");
-			return addMeasurement(measurement.getName(), measurement.getValue());
-	    }
-		
 		@Override
 		public final int size() {
 			return names.size();
@@ -234,23 +228,17 @@ class NumericMeasurementList {
 		}
 		
 		@Override
-		public synchronized boolean addMeasurement(String name, double value) {
-			// If the list is closed, we have to reopen it
-			ensureListOpen();
-			names.add(name);
-			setValue(size()-1, value);
-			return true;
-		}
-		
-		
-		@Override
 		public synchronized void putMeasurement(String name, double value) {
 			ensureListOpen();
 			int index = getMeasurementIndex(name);
 			if (index >= 0)
 				setValue(index, value);
-			else
-				addMeasurement(name, value);
+			else {
+				// If the list is closed, we have to reopen it
+				ensureListOpen();
+				names.add(name);
+				setValue(size()-1, value);
+			}
 		}
 		
 
@@ -271,16 +259,7 @@ class NumericMeasurementList {
 		public Measurement putMeasurement(Measurement measurement) {
 			if (measurement.isDynamic())
 				throw new UnsupportedOperationException("This MeasurementList does not support dynamic measurements");
-			ensureListOpen();
-			String name = measurement.getName();
-			double value = measurement.getValue();
-			int ind = getMeasurementIndex(name);
-			if (ind >= 0) {
-				Measurement temp = MeasurementFactory.createMeasurement(name, value);
-				setValue(ind, value);
-				return temp;
-			}
-			add(measurement);
+			putMeasurement(measurement.getName(), measurement.getValue());
 			return null;
 		}
 		

--- a/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
@@ -194,12 +194,12 @@ class NumericMeasurementList {
 		}
 		
 		@Override
-		public double getMeasurementValue(String name) {
+		public double get(String name) {
 			return getMeasurementValue(getMeasurementIndex(name));
 		}
 
 		@Override
-		public boolean containsNamedMeasurement(String measurementName) {
+		public boolean containsKey(String measurementName) {
 			if (!isClosed)
 				logger.trace("containsNamedMeasurement called on open NumericMeasurementList - consider closing list earlier for efficiency");
 			return names.contains(measurementName);
@@ -228,7 +228,7 @@ class NumericMeasurementList {
 		}
 		
 		@Override
-		public synchronized void putMeasurement(String name, double value) {
+		public synchronized void put(String name, double value) {
 			ensureListOpen();
 			int index = getMeasurementIndex(name);
 			if (index >= 0)
@@ -259,7 +259,7 @@ class NumericMeasurementList {
 		public Measurement putMeasurement(Measurement measurement) {
 			if (measurement.isDynamic())
 				throw new UnsupportedOperationException("This MeasurementList does not support dynamic measurements");
-			putMeasurement(measurement.getName(), measurement.getValue());
+			put(measurement.getName(), measurement.getValue());
 			return null;
 		}
 		

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -47,7 +47,6 @@ import qupath.lib.io.PathIO;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.measurements.MeasurementListFactory;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.roi.interfaces.ROI;
 
@@ -753,7 +752,7 @@ public abstract class PathObject implements Externalizable {
 			var set = new LinkedHashSet<>(classifications);
 			if (set.size() < classifications.size())
 				logger.warn("Input to setClassifications() contains duplicate elements - {} will be replaced by {}", classifications, set);
-			setPathClass(PathClassFactory.getPathClass(set));
+			setPathClass(PathClass.getInstance(set));
 		}
 	}
 	
@@ -778,7 +777,7 @@ public abstract class PathObject implements Externalizable {
 		if (pc == null)
 			return Collections.emptySet();
 		else
-			return pc.asSet();
+			return pc.toSet();
 	}
 	
 

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -747,9 +747,9 @@ public abstract class PathObject implements Externalizable {
 	public Collection<String> getClassifications() {
 		var pc = getPathClass();
 		if (pc == null)
-			return Collections.emptySet();
+			return Collections.emptyList();
 		else if (!pc.isDerivedClass())
-			return Collections.singleton(pc.toString());
+			return Collections.singletonList(pc.toString());
 		else
 			return Collections.unmodifiableList(PathClassTools.splitNames(pc));
 	}

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -203,7 +203,7 @@ public abstract class PathObject implements Externalizable {
 		if (measurementsMap == null) {
 			synchronized(this) {
 				if (measurementsMap == null)
-					measurementsMap = MeasurementListFactory.wrapList(measurements);
+					measurementsMap = measurements.asMap();
 			}
 		}
 		return measurementsMap;

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -47,6 +47,8 @@ import qupath.lib.io.PathIO;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.measurements.MeasurementListFactory;
 import qupath.lib.objects.classes.PathClass;
+import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClassTools;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.roi.interfaces.ROI;
 
@@ -714,25 +716,43 @@ public abstract class PathObject implements Externalizable {
 	}
 	
 	
-	// Still to come...
-//	public void setClassifications(Collection<String> classifications) {
-//		if (classifications.isEmpty())
-//			setPathClass((PathClass)null);
-//		else {
-//			setPathClass(PathClassFactory.getPathClass(new ArrayList<>(classifications)));
-//		}
-//	}
-//	
-//	
-//	public Set<String> getClassifications() {
-//		var pc = getPathClass();
-//		if (pc == null)
-//			return Collections.emptySet();
-//		else if (!pc.isDerivedClass())
-//			return Collections.singleton(pc.toString());
-//		else
-//			return new LinkedHashSet<>(PathClassTools.splitNames(pc));
-//	}
+	/**
+	 * Set the {@link PathClass} from a collection of names according to the rules:
+	 * <ul>
+	 * <li>If the collection is empty, reset the PathClass</li>
+	 * <li>If the collection has one element, set it to be the name of the PathClass</li>
+	 * <li>If the collection has multiple element, create and set a derived PathClass with each element 
+	 * the name of a PathClass component</li>
+	 * </ul>
+	 * Ultimately, a single {@link PathClass} object is created to encapsulate the classification 
+	 * and the color used for display - but this provides a different (complementary) way to think of 
+	 * classifications within QuPath.
+	 * @param classifications
+	 * @since v0.4.0
+	 */
+	public void setClassifications(Collection<String> classifications) {
+		if (classifications.isEmpty())
+			resetPathClass();
+		else {
+			setPathClass(PathClassFactory.getPathClass(new ArrayList<>(classifications)));
+		}
+	}
+	
+	/**
+	 * Get the components of the {@link PathClass} as an unmodifiable collection.
+	 * @return an empty collection is the PathClass is null, otherwise a collection of strings 
+	 *         where each string gives the name of one component of the PathClass
+	 * @since v0.4.0
+	 */
+	public Collection<String> getClassifications() {
+		var pc = getPathClass();
+		if (pc == null)
+			return Collections.emptySet();
+		else if (!pc.isDerivedClass())
+			return Collections.singleton(pc.toString());
+		else
+			return Collections.unmodifiableList(PathClassTools.splitNames(pc));
+	}
 	
 
 	/**

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -746,13 +746,13 @@ public abstract class PathObject implements Externalizable {
 		if (classifications.isEmpty())
 			resetPathClass();
 		else if (classifications instanceof Set) {
-			setPathClass(PathClass.fromSet((Set<String>)classifications));
+			setPathClass(PathClass.fromCollection((Set<String>)classifications));
 		} else {
 			// Use LinkedHashSet to maintain ordering
 			var set = new LinkedHashSet<>(classifications);
 			if (set.size() < classifications.size())
 				logger.warn("Input to setClassifications() contains duplicate elements - {} will be replaced by {}", classifications, set);
-			setPathClass(PathClass.getInstance(set));
+			setPathClass(PathClass.fromCollection(set));
 		}
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -1133,7 +1133,7 @@ public class PathObjectTools {
 			for (int i = 0; i < measurements.size(); i++) {
 				String name = measurements.getMeasurementName(i);
 				double value = measurements.getMeasurementValue(i);
-				newObject.getMeasurementList().putMeasurement(name, value);
+				newObject.getMeasurementList().put(name, value);
 			}
 			newObject.getMeasurementList().close();
 		}
@@ -1708,7 +1708,7 @@ public class PathObjectTools {
 		if (!PathClassTools.isNullClass(baseClass) && PathClassTools.isIgnoredClass(baseClass))
 			return pathObject.getPathClass();
 		
-		double intensityValue = pathObject.getMeasurementList().getMeasurementValue(measurementName);
+		double intensityValue = pathObject.getMeasurementList().get(measurementName);
 		
 		boolean singleThreshold = thresholds.length == 1;
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -1133,7 +1133,7 @@ public class PathObjectTools {
 			for (int i = 0; i < measurements.size(); i++) {
 				String name = measurements.getMeasurementName(i);
 				double value = measurements.getMeasurementValue(i);
-				newObject.getMeasurementList().addMeasurement(name, value);
+				newObject.getMeasurementList().putMeasurement(name, value);
 			}
 			newObject.getMeasurementList().close();
 		}

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -54,7 +54,6 @@ import qupath.lib.geom.Point2;
 import qupath.lib.images.ImageData;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.classes.PathClassTools;
 import qupath.lib.objects.hierarchy.DefaultTMAGrid;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
@@ -733,7 +732,7 @@ public class PathObjectTools {
 		if (name == null)
 			pathObject.resetPathClass();
 		else
-			pathObject.setPathClass(PathClassFactory.getPathClass(name, color));
+			pathObject.setPathClass(PathClass.fromString(name, color));
 		if (pathClass == null) {
 			pathObject.setName(null);
 			if (includeColor)
@@ -1653,7 +1652,7 @@ public class PathObjectTools {
 		for (var entry : classificationMap.entrySet()) {
 			var pathObject = entry.getKey();
 			var pathClass = entry.getValue();
-			if (pathClass == PathClassFactory.getPathClassUnclassified())
+			if (pathClass == PathClass.NULL_CLASS)
 				pathClass = null;
 			if (!Objects.equals(pathObject.getPathClass(), pathClass)) {
 				pathObject.setPathClass(pathClass);
@@ -1715,16 +1714,16 @@ public class PathObjectTools {
 		if (Double.isNaN(intensityValue))	// If the measurement is missing, reset to base class
 			pathObject.setPathClass(baseClass);
 		else if (intensityValue < thresholds[0])
-			pathObject.setPathClass(PathClassFactory.getNegative(baseClass));
+			pathObject.setPathClass(PathClass.getNegative(baseClass));
 		else {
 			if (singleThreshold)
-				pathObject.setPathClass(PathClassFactory.getPositive(baseClass));
+				pathObject.setPathClass(PathClass.getPositive(baseClass));
 			else if (thresholds.length >= 3 && intensityValue >= thresholds[2])
-				pathObject.setPathClass(PathClassFactory.getThreePlus(baseClass));				
+				pathObject.setPathClass(PathClass.getThreePlus(baseClass));				
 			else if (thresholds.length >= 2 && intensityValue >= thresholds[1])
-				pathObject.setPathClass(PathClassFactory.getTwoPlus(baseClass));				
+				pathObject.setPathClass(PathClass.getTwoPlus(baseClass));				
 			else if (intensityValue >= thresholds[0])
-				pathObject.setPathClass(PathClassFactory.getOnePlus(baseClass));				
+				pathObject.setPathClass(PathClass.getOnePlus(baseClass));				
 		}
 		return pathObject.getPathClass();
 	}

--- a/qupath-core/src/main/java/qupath/lib/objects/PathROIObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathROIObject.java
@@ -140,8 +140,8 @@ public abstract class PathROIObject extends PathObject {
 			this.classProbability = classProbability;
 			return;
 		}
-		if (pathClass == PathClassFactory.getPathClassUnclassified()) {
-			logger.warn("Please use PathObject.resetPathClass() instead of setting to PathClassFactory.getPathClassUnclassified()");	
+		if (pathClass == PathClass.NULL_CLASS) {
+			logger.warn("Please use PathObject.resetPathClass() instead of setting to PathClassFactory.NULL_CLASS");	
 			pathClass = null;
 		} else if (!pathClass.isValid()) {
 			logger.warn("Classification {} is invalid! Will be set to null instead", pathClass);
@@ -150,8 +150,12 @@ public abstract class PathROIObject extends PathObject {
 		this.pathClass = pathClass;
 		this.classProbability = classProbability;
 		// Forget any previous color, if we have a PathClass
-		if (this.pathClass != null)
-			setColor(null);
+		if (this.pathClass != null) {
+			if (getColor() != null) {
+				logger.debug("Resetting PathObject color to use the color of the PathClass instead");
+				setColor(null);
+			}
+		}
 	}
 	
 	@Override

--- a/qupath-core/src/main/java/qupath/lib/objects/PathROIObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathROIObject.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.roi.interfaces.ROI;
 
 /**
@@ -203,7 +202,7 @@ public abstract class PathROIObject extends PathObject {
 		// TODO: STORE PATHCLASSES AS STRINGS OR SOMETHING BETTER THAN JUST USING SERIALIZATION!
 		// Go via the factory to ensure that we don't end up with multiple classes with the same name
 		if (pathClass != null)
-			pathClass = PathClassFactory.getSingletonPathClass(pathClass);
+			pathClass = PathClass.getSingleton(pathClass);
 		pathROI = (ROI)in.readObject();
 		classProbability = in.readDouble();
 	}

--- a/qupath-core/src/main/java/qupath/lib/objects/PathRootObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathRootObject.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.roi.interfaces.ROI;
 
 /**
@@ -51,7 +50,7 @@ public class PathRootObject extends PathObject {
 
 	@Override
 	public PathClass getPathClass() {
-		return PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IMAGE_ROOT);
+		return PathClass.StandardPathClasses.IMAGE_ROOT;
 	}
 
 	@Override

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2021 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -45,16 +45,19 @@ import org.slf4j.LoggerFactory;
 import qupath.lib.common.ColorTools;
 
 /**
- * Representation of an object's classification - which can be defined using any unique string identifier (e.g. tumour, lymphocyte, gland, benign, malignant).
+ * Representation of an object's classification - which can be defined using any unique string
+ * identifier (e.g. tumour, lymphocyte, gland, benign, malignant).
  * <p>
- * The constructors in this class should never be called directly, because there should only ever be one instance of each classification - 
+ * The constructors in this class should never be called directly, because there should only ever
+ * be one instance of each classification - 
  * shared among all objects with that classification.
  * This is important for checking if classifications are identical, and also assigning colors to them for display.
  * <p>
- * To achieve this, be sure to use one of the {@code getInstance()} methods each time you want to access or create a new {@link PathClass} instance.
+ * To achieve this, be sure to use one of the {@code getInstance()} or {@code fromXXX()} methods each time
+ * you want to access or create a new {@link PathClass} instance.
  * <p>
- * This class has been with QuPath since the beginning, but was thoroughly revised for v0.4.0 to simplify the code, improve the validation, and 
- * make it easier to use.
+ * This class has been with QuPath since the beginning, but was thoroughly revised for v0.4.0 to simplify the code,
+ * improve the validation, and make it easier to use.
  * 
  * @see PathClassFactory
  * 
@@ -93,6 +96,12 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 	 * Default name for a class representing "3+" staining intensity (i.e. strongly positive)
 	 */
 	public static final String NAME_THREE_PLUS = "3+";
+	
+//	
+//	public static Set<String> PERMITTED_CHARACTERS = Arrays.stream(
+//			"[](){}\\/,''@£$#+-_"
+//			.split("")).collect(Collectors.toSet());
+	
 		
 	private static final Integer COLOR_POSITIVE = ColorTools.packRGB(200, 50, 50);
 	private static final Integer COLOR_NEGATIVE = ColorTools.packRGB(90, 90, 180);
@@ -177,7 +186,7 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 	}
 
 	/**
-	 * This constructor should <i>not<i> be called explicitly; rather, use {@link PathClassFactory}. 
+	 * This constructor should <i>not<i> be called explicitly; rather, use one of the static {@code getInstance()} methods.
 	 * <p>
 	 * Only one instance of a PathClass should exist for any given name and list of ancestors.
 	 * 
@@ -218,7 +227,7 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 		else
 			this.colorRGB = colorRGB;
 		
-		if (existingClasses.containsKey(getCacheString(this)))
+		if (existingClasses.containsKey(createCacheString(this)))
 			throw new IllegalStateException("Cannot create the same PathClass more than once!");
 		
 	}
@@ -326,22 +335,29 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 		return name;
 	}
 	
-	static String derivedClassToString(PathClass parent, String name) {
-		return parent == null ? name : parent.toString() + ": " + name.strip();
-	}
-	
 	@Override
 	public String toString() {
 		if (stringRep == null) {
-			if (name == null)
-				stringRep = defaultName;
-			else if (isDerivedClass())
-				stringRep = derivedClassToString(parentClass, name);
-			else
-				stringRep = name;
+			stringRep = toString(DELIMITER + " ");
 		}
 		return stringRep;
 	}
+	
+	/**
+	 * Create a string representation, using the specified delimiter between 
+	 * elements of derived PathClasses.
+	 * @param delimiter
+	 * @return
+	 */
+	public String toString(String delimiter) {
+		if (name == null)
+			return defaultName;
+		else if (isDerivedClass())
+			return createString(parentClass, name, delimiter);
+		else
+			return name;
+	}
+	
 	
 	/**
 	 * A PathClass is valid if its name is not null.
@@ -364,11 +380,11 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 	 * <p>
 	 * <b>Important!</b> If any path class component names are duplicates, these will 
 	 * (necessarily) be removed from the set. Therefore it is <i>not</i> guaranteed that 
-	 * calling {@link PathClass#fromSet(Set)} on the output will return the same {@link PathClass} object.
+	 * calling {@link PathClass#fromCollection(Collection)} on the output will return the same {@link PathClass} object.
 	 * <pre>{@code 
 	 * var pathClass = ...;
-	 * var pathClass2 = PathClass.fromSet(pathClass.toSet());
-	 * assert pathClass == pathClass2; // This may not be true!
+	 * var pathClass2 = PathClass.getInstance(pathClass.toSet());
+	 * assert pathClass == pathClass2; // This may or may not be true!
 	 * }</pre>
 	 * <p>
 	 * However the {@link PathClass} objects should be the same if the name components are all valid and 
@@ -385,16 +401,6 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 		return set;
 	}
 	
-	/**
-	 * Create a {@link PathClass} from a set of names, each giving a component of the class.
-	 * This can be used to convert multiple classifications into a single representative object.
-	 * @param names
-	 * @return
-	 */
-	public static PathClass fromSet(Set<String> names) {
-		return getInstance(names);
-	}
-	
 	
 	List<String> toList() {
 		if (list == null) {
@@ -407,7 +413,7 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 	}
 	
 	private List<String> createList() {
-		if (this == PathClassFactory.getPathClassUnclassified())
+		if (this == PathClass.NULL_CLASS)
 			return Collections.emptyList();
 		if (!isDerivedClass())
 			return	Collections.singletonList(getName());
@@ -416,7 +422,7 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 	
 	
 	private Set<String> createSet() {
-		if (this == PathClassFactory.getPathClassUnclassified())
+		if (this == PathClass.NULL_CLASS)
 			return Collections.emptySet();
 		if (!isDerivedClass())
 			return	Collections.singleton(getName());
@@ -462,61 +468,131 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 	}
 	
 	
-	
-	static PathClass getNullClass() {
+	/**
+	 * Get the value of {@link #NULL_CLASS}, used to represent no classification.
+	 * In most cases, {@code null} should be used instead; this exists only as a 
+	 * representation in cases where {@code null} is not permitted (e.g. in some collection 
+	 * implementations).
+	 * @return
+	 */
+	public static PathClass getNullClass() {
 		return NULL_CLASS;
 	}
 	
-	
-	private static String getCacheString(PathClass pathClass) {
-		// Avoid creating list if we don't have to
-		if (pathClass == null || !pathClass.isDerivedClass())
-			return getCacheString(pathClass.getName());
-		return getCacheString(pathClass.toList());
+	/**
+	 * Delimiter to use when creating the cache string
+	 * Newline since that isn't normally permitted
+	 */
+	private static final String CACHE_DELIMITER = "\n";
+
+	private static String createCacheStringForNameCollection(Collection<String> names) {
+		return createStringForNameCollection(names, CACHE_DELIMITER);
 	}
 
-	private static String getCacheString(PathClass parent, String name) {
-		if (parent == null)
-			return getCacheString(name);
-		return getCacheString(parent) + "\n" + getCacheString(name);
+	private static String createCacheString(PathClass parent) {
+		return createString(parent, null, CACHE_DELIMITER); // Use newlines, since they aren't permitted normally
 	}
 
+	private static String createCacheString(PathClass parent, String name) {
+		return createString(parent, name, CACHE_DELIMITER); // Use newlines, since they aren't permitted normally
+	}
+
+	private static String createString(PathClass parent, String name, String delimiter) {
+		if (parent == null || parent == NULL_CLASS)
+			return createStringForSingleName(name);
+		String start;
+		if (!parent.isDerivedClass())
+			start = createStringForSingleName(parent.getName());
+		else
+			start = createStringForNameCollection(parent.toList(), delimiter);
+		if (name == null)
+			return start;
+		return start + delimiter + createStringForSingleName(name);
+	}
 	
-	private static String getCacheString(Collection<String> names) {
+	private static String createStringForNameCollection(Collection<String> names, String delimiter) {
 		if (names.isEmpty())
 			return "";
 		if (names.stream().anyMatch(p -> p == null))
 			throw new IllegalArgumentException("PathClass cannot contain 'null' name: " + names);
-		return names.stream().map(n -> validateNameStripped(n, false)).collect(Collectors.joining("\n"));
+		return names.stream().map(n -> validateNameStripped(n, false)).collect(Collectors.joining(delimiter));
 	}
 
-	private static String getCacheString(String name) {
+	private static String createStringForSingleName(String name) {
 		if (name == null)
 			return "";
 		return validateNameStripped(name, false);
 	}
 
+	/**
+	 * Get a PathClass instance from a string representation, without specifying a default color.
+	 * <p>
+	 * This calls {@link #fromString(String, Integer)} with the second argument as {@code null}.
+	 * @param string
+	 * @return
+	 */
+	public static PathClass fromString(String string) {
+		return fromString(string, null);
+	}
 	
-	static PathClass getInstanceFromString(String string, Integer color) {
+	/**
+	 * Get a PathClass instance from a string representation, optionally providing a default color 
+	 * if a new instance needs to be created.
+	 * <p>
+	 * This ultimately calls {@link #getInstance(PathClass, String, Integer)} but differs in that it 
+	 * accepts a string representation that may include the {@link #DELIMITER}.
+	 * If so, this is used to split the string into different name components that are passed to 
+	 * {@link #fromCollection(Collection, Integer)}.
+	 * @param string a string representation containing one or more name elements, separated by {@link #DELIMITER}
+	 * @param color a default color (optional, may be null)
+	 * @return
+	 */
+	public static PathClass fromString(String string, Integer color) {
+		if (string == null)
+			return NULL_CLASS;
 		var names = Arrays.stream(string.split(DELIMITER)).map(s -> s.strip()).collect(Collectors.toList());
-		return getInstance(names, color);
+		return fromCollection(names, color);
 	}
 
-	public static PathClass getInstance(Collection<String> names) {
-		return getInstance(names, null);
+	/**
+	 * Get a PathClass using all the name elements specified in the collection, 
+	 * without providing a default color.
+	 * @param names
+	 * @return
+	 * @see #fromCollection(Collection)
+	 */
+	public static PathClass fromCollection(Collection<String> names) {
+		return fromCollection(names, null);
 	}
 	
-	static PathClass getInstance(Collection<String> names, Integer color) {
+	/**
+	 * Get a PathClass instance using all the name elements specified in 
+	 * the collection, with optional default color if a new instance is created.
+	 * The rules are:
+	 * <ul>
+	 * <li>If the collection is empty, {@link #NULL_CLASS} is returned</li>
+	 * <li>If the collection has one element, this is equivalent to calling {@link #getInstance(String, Integer)}</li>
+	 * <li>If the collection has multiple element, this is equivalent to creating a base class from 
+	 * the first element and deriving subclassifications by calling  {@link #getInstance(PathClass, String, Integer)} 
+	 * for each element, in the order returned by the collection's iterator</li>
+	 * </ul>
+	 * 
+	 * @param names
+	 * @param color
+	 * @return
+	 * @see #getInstance(PathClass, String, Integer)
+	 */
+	public static PathClass fromCollection(Collection<String> names, Integer color) {
 		if (names.isEmpty())
 			return NULL_CLASS;
 		
 		// Single name
 		if (names.size() == 1)
-			return getInstance(null, names.iterator().next(), color);
+			return getInstance(names.iterator().next(), color);
 		
 		// Multiple names - need derived PathClass
 		// Attempt to speed things up for checking for cached classes
-		var string = getCacheString(names);
+		var string = createCacheStringForNameCollection(names);
 		var pathClass = existingClasses.getOrDefault(string, null);
 		if (pathClass != null)
 			return pathClass;
@@ -531,24 +607,73 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 		return pathClass;
 	}
 	
-	static PathClass getInstance(String name) {
+	public static PathClass getInstance(String name) {
 		return getInstance(name, null);
 	}
 	
-	static PathClass getInstance(String name, Integer color) {
+	/**
+	 * Get a base PathClass instance, without any parent PathClass.
+	 * <p>
+	 * This is equivalent to calling {@link #getInstance(PathClass, String, Integer)} with 
+	 * the first argument as {@code null}.
+	 * 
+	 * @param name
+	 * @param color
+	 * @return
+	 * @see #getInstance(PathClass, String, Integer)
+	 */
+	public static PathClass getInstance(String name, Integer color) {
 		return getInstance(null, name, color);
 	}
 	
 	
-	static PathClass getInstance(PathClass parent, String name, Integer color) {
+	/**
+	 * Get a derived PathClass instance with the specified parent.
+	 * <p>
+	 * This will be derived from the parent PathClass (if provided) and have the specified 
+	 * name, stripped to remove any leading or training whitespace.
+	 * <p>
+	 * Note that the name should generally be an alphanumeric string, optionally including 
+	 * punctuation symbols but <b>not</b> including {@link #DELIMITER}.
+	 * <p>
+	 * The delimiter is currently a colon {@code ":"} but it is advised not to rely upon 
+	 * this and to avoid punctuation where possible, because the delimiter may possibly change 
+	 * in a future release - primarily because the choice of colon can be problematic in some 
+	 * cases, e.g. <a href="https://github.com/qupath/qupath/issues/507">when using ontologies</a>.
+	 * 
+	 * 
+	 * @param parent parent class (optional, may be null)
+	 * @param name name of the PathClass
+	 * @param color color to use if a new instance is created (may be null to use the default)
+	 * @return a PathClass instance; the same instance will be returned given the same parent and name
+	 * 
+	 * @implSpec the color is only used if a new PathClass instance needs to be created.
+	 *           If a suitable instance has already been created, then that will be returned instead 
+	 *           and the color will not be created.
+	 *           
+	 * @see #fromString(String, Integer)
+	 * @see #fromCollection(Collection, Integer)
+	 */
+	public static PathClass getInstance(PathClass parent, String name, Integer color) {
 		if (parent == NULL_CLASS)
 			parent = null;
+		
+		if (name != null && name.contains(DELIMITER)) {
+//			if (parent == null) {
+//				logger.warn("Name '{}' contains the delimiter '{}' - switching to use getInstanceFromString instead", name, DELIMITER);
+//				return getInstanceFromString(name, color);
+//			} else {
+				throw new IllegalArgumentException(
+						String.format("Name '%s' contains the delimiter '%s' - please use a valid name or getInstanceFromString()", 
+								name, DELIMITER));				
+//			}
+		}
 		
 		if (parent == null) {
 			if (name == null)
 				return NULL_CLASS;
 			
-			var string = getCacheString(name);
+			var string = createStringForSingleName(name);
 			var pathClass = existingClasses.getOrDefault(string, null);
 			if (pathClass != null)
 				return pathClass;
@@ -561,18 +686,65 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 			if (name == null)
 				throw new IllegalArgumentException("Cannot derive a PathClass with a null name and non-null parent");
 			
-			var string = getCacheString(parent, name);
+			var string = createCacheString(parent, name);
 			var pathClass = existingClasses.getOrDefault(string, null);
 			if (pathClass != null)
 				return pathClass;
 			
 			var parent2 = parent;
-			var rgb = getDefaultColor(null, name, color, string);
+			var rgb = getDefaultColor(parent, name, color, string);
 			synchronized (existingClasses) {
 				return existingClasses.computeIfAbsent(string, s -> new PathClass(secret, parent2, name, rgb));
 			}
 		}
 	}
+	
+	
+	/**
+	 * Get a standalone or derived 1+ classification, indicating weak positivity
+	 * @param parentClass parent classification (may be null)
+	 * @return
+	 */
+	public static PathClass getOnePlus(PathClass parentClass) {
+		return PathClass.getInstance(parentClass, PathClass.NAME_ONE_PLUS, null);
+	}
+
+	/**
+	 * Get a standalone or derived 2+ classification, indicating moderate positivity
+	 * @param parentClass parent classification (may be null)
+	 * @return
+	 */
+	public static PathClass getTwoPlus(PathClass parentClass) {
+		return PathClass.getInstance(parentClass, PathClass.NAME_TWO_PLUS, null);
+	}
+
+	/**
+	 * Get a standalone or derived 3+ classification, indicating strong positivity
+	 * @param parentClass parent classification (may be null)
+	 * @return
+	 */
+	public static PathClass getThreePlus(PathClass parentClass) {
+		return PathClass.getInstance(parentClass, PathClass.NAME_THREE_PLUS, null);
+	}
+	
+	/**
+	 * Get a standalone or derived Negative classification
+	 * @param parentClass parent classification (may be null)
+	 * @return
+	 */
+	public static PathClass getNegative(PathClass parentClass) {
+		return PathClass.getInstance(parentClass, PathClass.NAME_NEGATIVE, null);
+	}
+	
+	/**
+	 * Get a standalone or derived Positive classification
+	 * @param parentClass parent classification (may be null)
+	 * @return
+	 */
+	public static PathClass getPositive(PathClass parentClass) {
+		return PathClass.getInstance(parentClass, PathClass.NAME_POSITIVE, null);
+	}
+	
 	
 	
 	private static Integer getDefaultColor(PathClass parent, String name, Integer integer, String cacheName) {
@@ -626,15 +798,43 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 				);
 	}
 	
-	
-	static synchronized PathClass getSingleton(PathClass pathClass) {
+	/**
+	 * Get the singleton PathClass that is equivalent to the PathClass provided.
+	 * <p>
+	 * This is important because there should only ever be one PathClass instance for 
+	 * any classification - and accessing PathClasses only via the {@code getInstance()} 
+	 * methods here should ensure that.
+	 * <p>
+	 * However, if receiving a PathClass from some other source then it is <i>possible</i> 
+	 * that the PathClass was created some other way and duplicates could emerge. 
+	 * Calling this method returns resolves that problem by returning the single instance 
+	 * that should be used.
+	 * <p>
+	 * This is significant if the PathClass has been created via Java deserialization, 
+	 * which skips the required use of {@code getInstance()} by default.
+	 * 
+	 * @param pathClass
+	 * @return either the input PathClass, or an equivalent that should be used
+	 */
+	public static synchronized PathClass getSingleton(PathClass pathClass) {
 		if (pathClass == null)
 			return null;
 		// This can occur during deserialization
 		if (!pathClass.isDerivedClass() && pathClass.getName() == null)
 			return NULL_CLASS;
-		var previous = existingClasses.putIfAbsent(getCacheString(pathClass), pathClass);
+		var previous = existingClasses.putIfAbsent(createCacheString(pathClass), pathClass);
 		return previous == null ? pathClass : previous;
+	}
+	
+	/**
+	 * Get a PathClass from an array of individual names.
+	 * @param names
+	 * @return
+	 * @see #fromCollection(Collection)
+	 * @see #getInstance(PathClass, String, Integer)
+	 */
+	public static PathClass fromArray(String... names) {
+		return fromCollection(Arrays.asList(names));
 	}
 	
 	
@@ -665,7 +865,7 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 	/**
 	 * Accept any letter (including from different languages), numbers, 
 	 */
-	private static final Pattern PATTERN_NAME = Pattern.compile("[\\w\\p{L}\\d .#\\+\\*\\$\\?]+");
+	private static final Pattern PATTERN_NAME = Pattern.compile("[\\w\\p{L}\\d\\p{Punct}]+");
 	
 	private static String validateNameCharacters(String name, boolean exceptOnFail) {
 		if (name.contains(DELIMITER))
@@ -678,6 +878,64 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 		else
 			logger.warn("PathClass name '{}' contains invalid characters - this may fail on later QuPath versions", name);
 		return name;
+	}
+	
+	
+	
+	/**
+	 * Enum representing standard classifications. Exists mostly to ensure consisting naming (including capitalization).
+	 */
+	public static class StandardPathClasses { 
+		/**
+		 * Tumor classification
+		 */
+		public static final PathClass TUMOR = getInstance("Tumor", ColorTools.packRGB(200, 0, 0));
+		/**
+		 * Stroma classification
+		 */
+		public static final PathClass STROMA = PathClass.getInstance("Stroma", ColorTools.packRGB(150, 200, 150));
+		/**
+		 * Immune cell classification
+		 */
+		public static final PathClass IMMUNE_CELLS = PathClass.getInstance("Immune cells", ColorTools.packRGB(160, 90, 160));
+		/**
+		 * Ignore classification, indicating what should not be further measured (e.g. background, whitespace)
+		 */
+		public static final PathClass IGNORE = PathClass.getInstance("Ignore*", ColorTools.packRGB(180, 180, 180));
+		/**
+		 * Root object classification
+		 */
+		public static final PathClass IMAGE_ROOT = PathClass.getInstance("Image", ColorTools.packRGB(128, 128, 128));
+		/**
+		 * Necrosis classification
+		 */
+		public static final PathClass NECROSIS = PathClass.getInstance("Necrosis", ColorTools.packRGB(50, 50, 50));
+		/**
+		 * Other classification
+		 */
+		public static final PathClass OTHER = PathClass.getInstance("Other", ColorTools.packRGB(255, 200, 0));
+		/**
+		 * Region class. This behaves slightly differently from other classes, e.g. it is not filled in when applied to
+		 * annotations.  Consequently it is good to heavily annotated regions, or possibly detected tissue 
+		 * containing further annotations inside.
+		 */
+		public static final PathClass REGION = PathClass.getInstance("Region*", ColorTools.packRGB(0, 0, 180));
+		/**
+		 * General class to represent something 'positive'
+		 */
+		public static final PathClass POSITIVE = PathClass.getPositive(null);
+		/**
+		 * General class to represent something 'negative'
+		 */
+		public static final PathClass NEGATIVE = PathClass.getNegative(null);
+		
+//		public static PathClass values() {
+//			return new PathClass[] {
+//					TUMOR, STROMA, IMMUNE_CELLS, IGNORE, NECROSIS, OTHER, REGION, POSITIVE, NEGATIVE
+//			}
+//		}
+
+		
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
@@ -485,7 +485,7 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 	private static String getCacheString(Collection<String> names) {
 		if (names.isEmpty())
 			return "";
-		if (names.contains(null))
+		if (names.stream().anyMatch(p -> p == null))
 			throw new IllegalArgumentException("PathClass cannot contain 'null' name: " + names);
 		return names.stream().map(n -> validateNameStripped(n, false)).collect(Collectors.joining("\n"));
 	}

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
@@ -24,32 +24,95 @@
 package qupath.lib.objects.classes;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import qupath.lib.common.ColorTools;
 
 /**
  * Representation of an object's classification - which can be defined using any unique string identifier (e.g. tumour, lymphocyte, gland, benign, malignant).
  * <p>
- * The constructors in this class should never be called directly.
- * In order to keep the construction of PathClasses under control, they should be accessed using the static methods within {@link PathClassFactory}.
+ * The constructors in this class should never be called directly, because there should only ever be one instance of each classification - 
+ * shared among all objects with that classification.
+ * This is important for checking if classifications are identical, and also assigning colors to them for display.
+ * <p>
+ * To achieve this, be sure to use one of the {@code getInstance()} methods each time you want to access or create a new {@link PathClass} instance.
+ * <p>
+ * This class has been with QuPath since the beginning, but was thoroughly revised for v0.4.0 to simplify the code, improve the validation, and 
+ * make it easier to use.
  * 
  * @see PathClassFactory
  * 
  * @author Pete Bankhead
  *
  */
-public class PathClass implements Comparable<PathClass>, Serializable {
+public final class PathClass implements Comparable<PathClass>, Serializable {
+	
+	private static final Logger logger = LoggerFactory.getLogger(PathClass.class);
 	
 	private static final long serialVersionUID = 1L;
+	
+	private static boolean VALIDATION_STRICT = "true".equalsIgnoreCase(System.getProperty("pathClassString", "false").strip());
+	
+	/**
+	 * Default name for a class representing "Positive" staining intensity
+	 */
+	public static final String NAME_POSITIVE = "Positive";
+	
+	/**
+	 * Default name for a class representing "Negative" staining intensity
+	 */
+	public static final String NAME_NEGATIVE = "Negative";
+	
+	/**
+	 * Default name for a class representing "1+" staining intensity (i.e. weakly positive)
+	 */
+	public static final String NAME_ONE_PLUS = "1+";
+	
+	/**
+	 * Default name for a class representing "2+" staining intensity (i.e. moderately positive)
+	 */
+	public static final String NAME_TWO_PLUS = "2+";
+	
+	/**
+	 * Default name for a class representing "3+" staining intensity (i.e. strongly positive)
+	 */
+	public static final String NAME_THREE_PLUS = "3+";
+		
+	private static final Integer COLOR_POSITIVE = ColorTools.packRGB(200, 50, 50);
+	private static final Integer COLOR_NEGATIVE = ColorTools.packRGB(90, 90, 180);
+	private static final Integer COLOR_ONE_PLUS = ColorTools.packRGB(255, 215, 0);
+	private static final Integer COLOR_TWO_PLUS = ColorTools.packRGB(225, 150, 50);
+	private static final Integer COLOR_THREE_PLUS = ColorTools.packRGB(200, 50, 50);
+	
+	private static final String DELIMITER_DEFAULT = ":";
+	
+	/**
+	 * Get the delimiter to use between names of the PathClass when converting to a string.
+	 */
+	public static final String DELIMITER = validDelimiterOrDefault(System.getProperty("pathClassDelimiter"));
+	
+	// Get a valid delimiter, or use the default
+	private static String validDelimiterOrDefault(String delim) {
+		if (delim == null || delim.isEmpty())
+			return DELIMITER_DEFAULT;
+		return delim.contains("\n") ? DELIMITER_DEFAULT : delim;
+	}
 
 	private static String defaultName = "Unclassified";
 	private static Integer DEFAULT_COLOR = ColorTools.packRGB(64, 64, 64);
@@ -58,20 +121,47 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 	private final String name;
 	private Integer colorRGB;
 	
+	// Included to thwart Groovy... we *really* don't want users accessing the 
+	// PathClass constructor and creating multiple instances of (what should be) 
+	// the same PathClass
 	private static final UUID secret = UUID.randomUUID();
 	
+	// Without this, Groovy would allow {@code PathClass.secret}
+	@SuppressWarnings("unused")
+	private static final UUID getSecret() {
+		throw new UnsupportedOperationException("Don't ask me to share my secret!");
+	}
+
 	/**
 	 * Cached String representation
 	 */
 	private transient String stringRep = null;
 	
-	private static final PathClass NULL_CLASS = new PathClass(secret);
+	/**
+	 * Default PathClass that represents no classification.
+	 * Usually no classification is represented by {@code null}, so this is not normally 
+	 * needed; however, sometimes it is required in contexts where a null is not permitted 
+	 * (e.g. some collections).
+	 */
+	public static final PathClass NULL_CLASS = new PathClass(secret);
 	
 	private static final List<String> illegalCharacters = Arrays.asList("\n", ":", "\r");
 	
-	private static final Map<String, PathClass> existingClasses = Collections.synchronizedMap(new HashMap<>());
+	/**
+	 * Cache of existing classes from toString() method
+	 */
+	private static final Map<String, PathClass> existingClasses = new ConcurrentHashMap<>();
+
 	
+	/**
+	 * Cache the set representation
+	 */
 	private transient Set<String> set;
+	
+	/**
+	 * Cache the list representation
+	 */
+	private transient List<String> list;
 
 	private PathClass(UUID mySecret) {
 		if (!Objects.equals(secret, mySecret))
@@ -97,13 +187,28 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 	 */
 	private PathClass(UUID mySecret, PathClass parent, String name, Integer colorRGB) {
 		if (!Objects.equals(secret, mySecret))
-			throw new IllegalStateException("You should not access the PathClass constructor!");
+			throw new IllegalStateException("You should not access the PathClass constructor! Use PathClass.getInstance() instead.");
 		
-		if (name != null)
-			name = name.strip();
+		// Ensure name is not null
+		name = validateNameNotNull(name, true);
+		
+		if (parent == null)
+			logger.debug("Creating PathClass with name '{}'", name);
+		else
+			logger.debug("Deriving PathClass from {} with name '{}'", parent, name);
+		
+		// Strip leading and trailing whitespace
+		name = validateNameStripped(name, VALIDATION_STRICT ? true : false);
+		
+		// Check not empty (or blank)
+		name = validateNameNotBlank(name, true);
 
+		// Previous (minimal) additional validation from v0.3.2 and before
 		if (!isValidName(name))
 			throw new IllegalArgumentException(name + " is not a valid PathClass name!");
+		
+		// More extensive validation for v0.4.0 and later
+		name = validateNameCharacters(name, VALIDATION_STRICT ? true : false);
 		
 		this.parentClass = parent;
 		this.name = name;
@@ -113,44 +218,10 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 		else
 			this.colorRGB = colorRGB;
 		
-		if (PathClassFactory.classExists(toString()))
+		if (existingClasses.containsKey(getCacheString(this)))
 			throw new IllegalStateException("Cannot create the same PathClass more than once!");
 		
 	}
-	
-	/**
-	 * Return whether the specified name is a valid name for a PathClass.
-	 * To be valid, it should be non-null, non-blank, and not contain any illegal characters (colons, linebreaks).
-	 * @param name
-	 */
-	private static boolean isValidName(String name) {
-		if (name == null || name.isBlank())
-			return false;
-		for (var illegal : illegalCharacters)
-			if (name.contains(illegal))
-				return false;
-		return true;
-	}
-	
-	static synchronized PathClass getNullClass() {
-		return NULL_CLASS;
-	}
-	
-	static synchronized PathClass getInstance(PathClass parent, String name, Integer colorRGB) {
-		if (parent == getNullClass())
-			parent = null;
-		
-		if (parent == null && name == null)
-			return getNullClass();
-		
-		var pathClass = new PathClass(secret, parent, name, colorRGB);
-		var s = pathClass.toString();
-		
-		// Make a last attempt to return an existing class with the same name, if we can
-		var previous = existingClasses.putIfAbsent(s, pathClass);
-		return previous == null ? pathClass : previous;
-	}
-	
 	
 	/**
 	 * Get the parent classification, or null if this classification has no parent.
@@ -304,7 +375,7 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 	 * there are no duplicates (which should normally be the case).
 	 * @return
 	 */
-	public Set<String> asSet() {
+	public Set<String> toSet() {
 		if (set == null) {
 			synchronized (this) {
 				if (set == null)
@@ -315,12 +386,32 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 	}
 	
 	/**
-	 * Create a 
+	 * Create a {@link PathClass} from a set of names, each giving a component of the class.
+	 * This can be used to convert multiple classifications into a single representative object.
 	 * @param names
 	 * @return
 	 */
 	public static PathClass fromSet(Set<String> names) {
-		return PathClassFactory.getPathClass(names);
+		return getInstance(names);
+	}
+	
+	
+	List<String> toList() {
+		if (list == null) {
+			synchronized (this) {
+				if (list == null)
+					list = createList();
+			}
+		}
+		return list;
+	}
+	
+	private List<String> createList() {
+		if (this == PathClassFactory.getPathClassUnclassified())
+			return Collections.emptyList();
+		if (!isDerivedClass())
+			return	Collections.singletonList(getName());
+		return PathClassTools.splitNames(this);
 	}
 	
 	
@@ -328,7 +419,7 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 		if (this == PathClassFactory.getPathClassUnclassified())
 			return Collections.emptySet();
 		if (!isDerivedClass())
-			return	Collections.singleton(toString());
+			return	Collections.singleton(getName());
 		return Collections.unmodifiableSet(
 					new LinkedHashSet<>(
 							PathClassTools.splitNames(this)
@@ -353,17 +444,241 @@ public class PathClass implements Comparable<PathClass>, Serializable {
 	@Override
 	public int compareTo(PathClass o) {
 		return toString().compareTo(o.toString());
-		// Old behavior (v0.1.2) - can give unexpected results with Groovy == comparisons
-//		if (name == null) {
-//			if (o.getName() == null)
-//				return 0;
-//			else
-//				return -1;
-//		} else if (o.getName() == null)
-//			return 1;
-//		return name.compareTo(o.getName());
+	}
+		
+	
+	/**
+	 * Return whether the specified name is a valid name for a PathClass.
+	 * To be valid, it should be non-null, non-blank, and not contain any illegal characters (colons, linebreaks).
+	 * @param name
+	 */
+	private static boolean isValidName(String name) {
+		if (name == null || name.isBlank())
+			return false;
+		for (var illegal : illegalCharacters)
+			if (name.contains(illegal))
+				return false;
+		return true;
 	}
 	
+	
+	
+	static PathClass getNullClass() {
+		return NULL_CLASS;
+	}
+	
+	
+	private static String getCacheString(PathClass pathClass) {
+		// Avoid creating list if we don't have to
+		if (pathClass == null || !pathClass.isDerivedClass())
+			return getCacheString(pathClass.getName());
+		return getCacheString(pathClass.toList());
+	}
+
+	private static String getCacheString(PathClass parent, String name) {
+		if (parent == null)
+			return getCacheString(name);
+		return getCacheString(parent) + "\n" + getCacheString(name);
+	}
+
+	
+	private static String getCacheString(Collection<String> names) {
+		if (names.isEmpty())
+			return "";
+		if (names.contains(null))
+			throw new IllegalArgumentException("PathClass cannot contain 'null' name: " + names);
+		return names.stream().map(n -> validateNameStripped(n, false)).collect(Collectors.joining("\n"));
+	}
+
+	private static String getCacheString(String name) {
+		if (name == null)
+			return "";
+		return validateNameStripped(name, false);
+	}
+
+	
+	static PathClass getInstanceFromString(String string, Integer color) {
+		var names = Arrays.stream(string.split(DELIMITER)).map(s -> s.strip()).collect(Collectors.toList());
+		return getInstance(names, color);
+	}
+
+	public static PathClass getInstance(Collection<String> names) {
+		return getInstance(names, null);
+	}
+	
+	static PathClass getInstance(Collection<String> names, Integer color) {
+		if (names.isEmpty())
+			return NULL_CLASS;
+		
+		// Single name
+		if (names.size() == 1)
+			return getInstance(null, names.iterator().next(), color);
+		
+		// Multiple names - need derived PathClass
+		// Attempt to speed things up for checking for cached classes
+		var string = getCacheString(names);
+		var pathClass = existingClasses.getOrDefault(string, null);
+		if (pathClass != null)
+			return pathClass;
+		
+		// Need to build the class
+		var list = new ArrayList<>(names);
+		int n = list.size();
+		for (int i = 0; i < n; i++) {
+			// Use the color only for the last name
+			pathClass = getInstance(pathClass, list.get(i), i == n-1 ? color : color);
+		}
+		return pathClass;
+	}
+	
+	static PathClass getInstance(String name) {
+		return getInstance(name, null);
+	}
+	
+	static PathClass getInstance(String name, Integer color) {
+		return getInstance(null, name, color);
+	}
+	
+	
+	static PathClass getInstance(PathClass parent, String name, Integer color) {
+		if (parent == NULL_CLASS)
+			parent = null;
+		
+		if (parent == null) {
+			if (name == null)
+				return NULL_CLASS;
+			
+			var string = getCacheString(name);
+			var pathClass = existingClasses.getOrDefault(string, null);
+			if (pathClass != null)
+				return pathClass;
+			
+			var rgb = getDefaultColor(null, name, color, string);
+			synchronized (existingClasses) {
+				return existingClasses.computeIfAbsent(string, s -> new PathClass(secret, null, name, rgb));
+			}
+		} else {
+			if (name == null)
+				throw new IllegalArgumentException("Cannot derive a PathClass with a null name and non-null parent");
+			
+			var string = getCacheString(parent, name);
+			var pathClass = existingClasses.getOrDefault(string, null);
+			if (pathClass != null)
+				return pathClass;
+			
+			var parent2 = parent;
+			var rgb = getDefaultColor(null, name, color, string);
+			synchronized (existingClasses) {
+				return existingClasses.computeIfAbsent(string, s -> new PathClass(secret, parent2, name, rgb));
+			}
+		}
+	}
+	
+	
+	private static Integer getDefaultColor(PathClass parent, String name, Integer integer, String cacheName) {
+		if (integer != null)
+			return integer;
+		
+		if (parent == null) {
+			if (name.equals(NAME_ONE_PLUS)) {
+				return ColorTools.makeScaledRGB(COLOR_ONE_PLUS, 1.25);
+			} else if (name.equals(NAME_TWO_PLUS)) {
+				return ColorTools.makeScaledRGB(COLOR_TWO_PLUS, 1.25);
+			} else if (name.equals(NAME_THREE_PLUS))
+				return ColorTools.makeScaledRGB(COLOR_THREE_PLUS, 1.25);
+			else if (name.equals(NAME_POSITIVE)) {
+				return ColorTools.makeScaledRGB(COLOR_POSITIVE, 1.25);
+			} else if (name.equals(NAME_NEGATIVE)) {
+				return ColorTools.makeScaledRGB(COLOR_NEGATIVE, 1.25);
+			}
+		} else {
+			
+			
+			// Since 'Tumor' is so common as a class for QuPath applications, 
+			// handle it using more distinctive colors; for others, use 'darkness' of the base color
+			// TODO: Make sure 'Tumor' is standard name
+			boolean isTumor = !parent.isDerivedClass() && "Tumor".equals(parent.getName());
+			int parentRGB = parent.getColor();
+			if (name.equals(NAME_ONE_PLUS)) {
+				return isTumor ? COLOR_ONE_PLUS : ColorTools.makeScaledRGB(parentRGB, 0.9);
+			} else if (name.equals(NAME_TWO_PLUS)) {
+				return isTumor ? COLOR_TWO_PLUS : ColorTools.makeScaledRGB(parentRGB, 0.6);
+			} else if (name.equals(NAME_THREE_PLUS))
+				return isTumor ? COLOR_THREE_PLUS : ColorTools.makeScaledRGB(parentRGB, 0.4);
+			else if (name.equals(NAME_POSITIVE)) {
+				return isTumor ? COLOR_POSITIVE : ColorTools.makeScaledRGB(parentRGB, 0.75);
+			} else if (name.equals(NAME_NEGATIVE)) {
+				return isTumor ? COLOR_NEGATIVE : ColorTools.makeScaledRGB(parentRGB, 1.25);
+			} else {
+				double scale = 1.5;
+				return ColorTools.makeScaledRGB(parentRGB, scale);
+			}
+			
+			
+		}
+		
+		// Create a random color, using the cache code of the cacheName for reproducibility
+		var random = new Random(cacheName.hashCode());
+		return ColorTools.packRGB(
+				random.nextInt(256),
+				random.nextInt(256),
+				random.nextInt(256)
+				);
+	}
+	
+	
+	static synchronized PathClass getSingleton(PathClass pathClass) {
+		if (pathClass == null)
+			return null;
+		// This can occur during deserialization
+		if (!pathClass.isDerivedClass() && pathClass.getName() == null)
+			return NULL_CLASS;
+		var previous = existingClasses.putIfAbsent(getCacheString(pathClass), pathClass);
+		return previous == null ? pathClass : previous;
+	}
+	
+	
+	
+	private static String validateNameNotNull(String name, boolean exceptOnFail) {
+		if (name == null && exceptOnFail)
+			throw new IllegalArgumentException("Requested PathClass name cannot be null!");
+		return name;
+	}
+	
+	private static String validateNameNotBlank(String name, boolean exceptOnFail) {
+		if (name.isBlank() && exceptOnFail)
+			throw new IllegalArgumentException("Requested PathClass name cannot be blank!");
+		return name;
+	}
+	
+	private static String validateNameStripped(String name, boolean exceptOnFail) {
+		var stripped = name.strip();
+		if (name.length() != stripped.length()) {
+			if (exceptOnFail)
+				throw new IllegalArgumentException("Unsupported classification name '" + name + "' - leading or training whitespace is not allowed");
+			else
+				logger.warn("PathClass names should not contain leading or trailing whitespace - '{}' will be stripped to become '{}'", name, stripped);
+		}
+		return stripped;
+	}
+	
+	/**
+	 * Accept any letter (including from different languages), numbers, 
+	 */
+	private static final Pattern PATTERN_NAME = Pattern.compile("[\\w\\p{L}\\d .#\\+\\*\\$\\?]+");
+	
+	private static String validateNameCharacters(String name, boolean exceptOnFail) {
+		if (name.contains(DELIMITER))
+			throw new IllegalArgumentException("Invalid PathClass name - contains delimiter: " + name);
+		
+		if (PATTERN_NAME.matcher(name).matches())
+			return name;
+		if (exceptOnFail)
+			throw new IllegalArgumentException("Invalid PathClass name: " + name);
+		else
+			logger.warn("PathClass name '{}' contains invalid characters - this may fail on later QuPath versions", name);
+		return name;
+	}
 	
 	
 }

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassFactory.java
@@ -24,6 +24,7 @@
 package qupath.lib.objects.classes;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -258,10 +259,22 @@ public final class PathClassFactory {
 	 * 
 	 * @see #getPathClass(String, String...)
 	 */
-	public static PathClass getPathClass(List<String> names) {
+	public static PathClass getPathClass(Collection<String> names) {
 		if (names.isEmpty())
 			return null;//getPathClassUnclassified();
-		return getPathClass(names.get(0), names.subList(1, names.size()).toArray(String[]::new));
+		if (names.size() == 1)
+			return getPathClass(names.iterator().next());
+		String first = null;
+		String[] rest = new String[names.size()-1];
+		int i = 0;
+		for (var name : names) {
+			if (i == 0)
+				first = name;
+			else
+				rest[i-1] = name;
+			i++;
+		}
+		return getPathClass(first, rest);
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassFactory.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import qupath.lib.common.ColorTools;
+import qupath.lib.common.LogTools;
 
 /**
  * Factory for creating PathClasses.
@@ -37,8 +38,9 @@ import qupath.lib.common.ColorTools;
  * only one PathClass with a specified name (and, optionally, ancestry) can exist at any time.
  * 
  * @author Pete Bankhead
- *
+ * @deprecated since v0.4.0 in favor of methods added to {@link PathClass} directly.
  */
+@Deprecated
 public final class PathClassFactory {
 	
 	private static final Logger logger = LoggerFactory.getLogger(PathClassFactory.class);
@@ -99,25 +101,25 @@ public final class PathClassFactory {
 		PathClass getPathClass() {
 			switch (this) {
 			case IGNORE:
-				return PathClassFactory.getPathClass("Ignore*", ColorTools.packRGB(180, 180, 180));
+				return PathClass.getInstance("Ignore*", ColorTools.packRGB(180, 180, 180));
 			case IMAGE_ROOT:
-				return PathClassFactory.getPathClass("Image", ColorTools.packRGB(128, 128, 128));
+				return PathClass.getInstance("Image", ColorTools.packRGB(128, 128, 128));
 			case IMMUNE_CELLS:
-				return PathClassFactory.getPathClass("Immune cells", ColorTools.packRGB(160, 90, 160));
+				return PathClass.getInstance("Immune cells", ColorTools.packRGB(160, 90, 160));
 			case NECROSIS:
-				return PathClassFactory.getPathClass("Necrosis", ColorTools.packRGB(50, 50, 50));
+				return PathClass.getInstance("Necrosis", ColorTools.packRGB(50, 50, 50));
 			case OTHER:
-				return PathClassFactory.getPathClass("Other", ColorTools.packRGB(255, 200, 0));
+				return PathClass.getInstance("Other", ColorTools.packRGB(255, 200, 0));
 			case REGION:
-				return PathClassFactory.getPathClass("Region*", ColorTools.packRGB(0, 0, 180));
+				return PathClass.getInstance("Region*", ColorTools.packRGB(0, 0, 180));
 			case STROMA:
-				return PathClassFactory.getPathClass("Stroma", ColorTools.packRGB(150, 200, 150));
+				return PathClass.getInstance("Stroma", ColorTools.packRGB(150, 200, 150));
 			case TUMOR:
-				return PathClassFactory.getPathClass("Tumor", ColorTools.packRGB(200, 0, 0));
+				return PathClass.getInstance("Tumor", ColorTools.packRGB(200, 0, 0));
 			case POSITIVE:
-				return PathClassFactory.getPositive(null);
+				return PathClass.getPositive(null);
 			case NEGATIVE:
-				return PathClassFactory.getNegative(null);
+				return PathClass.getNegative(null);
 			default:
 				throw new IllegalArgumentException("Unknown value!");
 			}
@@ -132,7 +134,8 @@ public final class PathClassFactory {
 	 * @return
 	 */
 	public static PathClass getPathClass(String name) {
-		return getPathClass(name, (Integer)null);
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.fromString(String) instead");
+		return PathClass.fromString(name, (Integer)null);
 	}
 		
 	/**
@@ -143,11 +146,15 @@ public final class PathClassFactory {
 	 * @param name
 	 * @param rgb
 	 * @return
+	 * @deprecated since v0.4.0 in favor of {@link PathClass#getInstance(String, Integer)} or 
+	 *             {@link PathClass#fromString(String, Integer)}
 	 */
+	@Deprecated
 	public static PathClass getPathClass(String name, Integer rgb) {
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.fromString(String, Integer) instead");
 		if (name == null)
 			return PathClass.NULL_CLASS;
-		return PathClass.getInstanceFromString(name, rgb);
+		return PathClass.fromString(name, rgb);
 	}
 		
 		
@@ -162,10 +169,11 @@ public final class PathClassFactory {
 	 * @param names array of names for each constituent part of the classification.
 	 * 				For each name, a new class will be derived, starting from the base.
 	 * @return a {@link PathClass}, as defined above
-	 * 
-	 * @see #getPathClass(String, Integer)
+	 * @deprecated since v0.4.0 in favor of {@link PathClass#fromArray(String...)}
 	 */
+	@Deprecated
 	public static PathClass getPathClass(String baseName, String... names) {
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.fromArray(String...) instead");
 		if (names.length == 0)
 			return PathClass.getInstance(baseName);
 		List<String> list;
@@ -177,7 +185,7 @@ public final class PathClassFactory {
 			for (var n : names)
 				list.add(n);
 		}
-		return PathClass.getInstance(list);
+		return PathClass.fromCollection(list);
 	}
 	
 	/**
@@ -186,11 +194,12 @@ public final class PathClassFactory {
 	 * 
 	 * @param names list of names for each constituent part of the classification.
 	 * @return a {@link PathClass} containing all names
-	 * 
-	 * @see #getPathClass(String, String...)
+	 * @deprecated since v0.4.0 in favor of {@link PathClass#fromCollection(java.util.Collection)}
 	 */
+	@Deprecated
 	public static PathClass getPathClass(List<String> names) {
-		return PathClass.getInstance(names);
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.fromCollection(Collection<String>) instead");
+		return PathClass.fromCollection(names);
 	}
 	
 	
@@ -200,8 +209,11 @@ public final class PathClassFactory {
 	 * 
 	 * @param pathClass
 	 * @return
+	 * @deprecated since v0.4.0 in favor of {@link PathClass#getSingleton(PathClass)}
 	 */
+	@Deprecated
 	public static PathClass getSingletonPathClass(PathClass pathClass) {
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.getSingleton(PathClass) instead");
 		return PathClass.getSingleton(pathClass);
 	}
 	
@@ -212,8 +224,11 @@ public final class PathClassFactory {
 	 * @param name
 	 * @param rgb
 	 * @return
+	 * @deprecated since v0.4.0, use {@link PathClass#getInstance(PathClass, String, Integer)}
 	 */
+	@Deprecated
 	public static PathClass getDerivedPathClass(PathClass parentClass, String name, Integer rgb) {
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.getInstance(PathClass, String Integer) instead");
 		return PathClass.getInstance(parentClass, name, rgb);
 	}
 	
@@ -221,53 +236,71 @@ public final class PathClassFactory {
 	 * Get a standalone or derived 1+ classification, indicating weak positivity
 	 * @param parentClass parent classification (may be null)
 	 * @return
+	 * @deprecated since v0.4.0, use {@link PathClass#getOnePlus(PathClass)}
 	 */
+	@Deprecated
 	public static PathClass getOnePlus(PathClass parentClass) {
-		return getDerivedPathClass(parentClass, PathClass.NAME_ONE_PLUS, null);
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.getOnePlus(PathClass) instead");
+		return PathClass.getInstance(parentClass, PathClass.NAME_ONE_PLUS, null);
 	}
 
 	/**
 	 * Get a standalone or derived 2+ classification, indicating moderate positivity
 	 * @param parentClass parent classification (may be null)
 	 * @return
+	 * @deprecated since v0.4.0, use {@link PathClass#getTwoPlus(PathClass)}
 	 */
+	@Deprecated
 	public static PathClass getTwoPlus(PathClass parentClass) {
-		return getDerivedPathClass(parentClass, PathClass.NAME_TWO_PLUS, null);
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.getTwoPlus(PathClass) instead");
+		return PathClass.getInstance(parentClass, PathClass.NAME_TWO_PLUS, null);
 	}
 
 	/**
 	 * Get a standalone or derived 3+ classification, indicating strong positivity
 	 * @param parentClass parent classification (may be null)
 	 * @return
+	 * @deprecated since v0.4.0, use {@link PathClass#getThreePlus(PathClass)}
 	 */
+	@Deprecated
 	public static PathClass getThreePlus(PathClass parentClass) {
-		return getDerivedPathClass(parentClass, PathClass.NAME_THREE_PLUS, null);
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.getThreePlus(PathClass) instead");
+		return PathClass.getInstance(parentClass, PathClass.NAME_THREE_PLUS, null);
 	}
 	
 	/**
 	 * Get a standalone or derived Negative classification
 	 * @param parentClass parent classification (may be null)
 	 * @return
+	 * @deprecated since v0.4.0, use {@link PathClass#getNegative(PathClass)}
 	 */
+	@Deprecated
 	public static PathClass getNegative(PathClass parentClass) {
-		return getDerivedPathClass(parentClass, PathClass.NAME_NEGATIVE, null);
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.getNegative(PathClass) instead");
+		return PathClass.getInstance(parentClass, PathClass.NAME_NEGATIVE, null);
 	}
 	
 	/**
 	 * Get a standalone or derived Positive classification
 	 * @param parentClass parent classification (may be null)
 	 * @return
+	 * @deprecated since v0.4.0, use {@link PathClass#getPositive(PathClass)}
 	 */
+	@Deprecated
 	public static PathClass getPositive(PathClass parentClass) {
-		return getDerivedPathClass(parentClass, PathClass.NAME_POSITIVE, null);
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.getPositive(PathClass) instead");
+		return PathClass.getInstance(parentClass, PathClass.NAME_POSITIVE, null);
 	}
 	
 	/**
 	 * Get a standard PathClass.
 	 * @param pathClass
 	 * @return
+	 * @deprecated since v0.4.0, use {@link qupath.lib.objects.classes.PathClass.StandardPathClasses}
 	 */
+	@Deprecated
 	public static PathClass getPathClass(StandardPathClasses pathClass) {
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.StandardPathClasses instead");
 		return pathClass.getPathClass();
 	}
 
@@ -276,11 +309,14 @@ public final class PathClassFactory {
 	 * <p>
 	 * This is useful for displaying available classes; <i>it should not be set as the class for any object</i>, 
 	 * rather an object that is unclassified should have a classification of null.
-	 * 
 	 * @return
+	 * @deprecated since v0.4.0, use instead {@link PathClass#NULL_CLASS}
 	 */
+	@Deprecated
 	public static PathClass getPathClassUnclassified() {
+		LogTools.warnOnce(logger, "PathClassFactory is deprecated since v0.4.0 - use PathClass.NULL_CLASS instead");
 		return PathClass.NULL_CLASS;
 	}
+		
 
 }

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassTools.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import qupath.lib.common.ColorTools;
@@ -44,6 +45,10 @@ public final class PathClassTools {
 		throw new AssertionError();
 	}
 
+	private static Set<String> gradedIntensityClassNames = Set.of(
+			PathClass.NAME_ONE_PLUS, PathClass.NAME_TWO_PLUS, PathClass.NAME_THREE_PLUS);
+
+	
 	/**
 	 * Return true if the PathClass represents a built-in intensity class.
 	 * Here, this means its name is equal to "1+", "2+" or "3+".
@@ -52,7 +57,7 @@ public final class PathClassTools {
 	 * @return
 	 */
 	public static boolean isGradedIntensityClass(final PathClass pathClass) {
-		return pathClass != null && PathClassFactory.intensityClassNames.contains(pathClass.getName());
+		return pathClass != null && gradedIntensityClassNames.contains(pathClass.getName());
 	}
 	
 	/**
@@ -99,7 +104,7 @@ public final class PathClassTools {
 	 * @return
 	 */
 	public static boolean isOnePlus(final PathClass pathClass) {
-		return pathClass != null && PathClassFactory.ONE_PLUS.equals(pathClass.getName());
+		return pathClass != null && PathClass.NAME_ONE_PLUS.equals(pathClass.getName());
 	}
 
 	/**
@@ -108,7 +113,7 @@ public final class PathClassTools {
 	 * @return
 	 */
 	public static boolean isTwoPlus(final PathClass pathClass) {
-		return pathClass != null && PathClassFactory.TWO_PLUS.equals(pathClass.getName());
+		return pathClass != null && PathClass.NAME_TWO_PLUS.equals(pathClass.getName());
 	}
 
 	/**
@@ -117,7 +122,7 @@ public final class PathClassTools {
 	 * @return
 	 */
 	public static boolean isThreePlus(final PathClass pathClass) {
-		return pathClass != null && PathClassFactory.THREE_PLUS.equals(pathClass.getName());
+		return pathClass != null && PathClass.NAME_THREE_PLUS.equals(pathClass.getName());
 	}
 
 	/**
@@ -127,7 +132,7 @@ public final class PathClassTools {
 	 * @return
 	 */
 	public static boolean isPositiveClass(final PathClass pathClass) {
-		return pathClass != null && PathClassFactory.POSITIVE.equals(pathClass.getName());
+		return pathClass != null && PathClass.NAME_POSITIVE.equals(pathClass.getName());
 	}
 	
 	/**
@@ -146,7 +151,7 @@ public final class PathClassTools {
 	 * @return
 	 */
 	public static boolean isNegativeClass(final PathClass pathClass) {
-		return pathClass != null && PathClassFactory.NEGATIVE.equals(pathClass.getName());
+		return pathClass != null && PathClass.NAME_NEGATIVE.equals(pathClass.getName());
 	}
 
 	/**

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassTools.java
@@ -57,7 +57,8 @@ public final class PathClassTools {
 	 * @return
 	 */
 	public static boolean isGradedIntensityClass(final PathClass pathClass) {
-		return pathClass != null && gradedIntensityClassNames.contains(pathClass.getName());
+		return pathClass != null && pathClass != PathClass.NULL_CLASS
+				&& gradedIntensityClassNames.contains(pathClass.getName());
 	}
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassTools.java
@@ -86,17 +86,17 @@ public final class PathClassTools {
 	 * @return 
 	 */
 	public static boolean isNullClass(final PathClass pathClass) {
-		return pathClass == null || pathClass == PathClassFactory.getPathClassUnclassified() || pathClass.getName() == null;
+		return pathClass == null || pathClass == PathClass.NULL_CLASS || pathClass.getName() == null;
 	}
 	
 	/**
 	 * Returns true if the PathClass represents a valid (non-null) classification.
 	 * 
 	 * @param pathClass input classification to check
-	 * @return true if the input represents a valid classification, or false if the input is null or is equivalent to {@link PathClassFactory#getPathClassUnclassified()}.
+	 * @return true if the input represents a valid classification, or false if the input is null or is equivalent to {@link PathClass#NULL_CLASS}.
 	 */
 	public static boolean isValidClass(final PathClass pathClass) {
-		return pathClass != null && pathClass != PathClassFactory.getPathClassUnclassified() && pathClass.getName() != null;
+		return pathClass != null && pathClass != PathClass.NULL_CLASS && pathClass.getName() != null;
 	}
 	
 	/**
@@ -178,7 +178,7 @@ public final class PathClassTools {
 	 * the result of calling {@code PathClass.getName()} for all derived classes, starting from the root. 
 	 */
 	public static List<String> splitNames(PathClass pathClass) {
-		if (pathClass == null || pathClass == PathClassFactory.getPathClassUnclassified())
+		if (pathClass == null || pathClass == PathClass.NULL_CLASS)
 			return Collections.emptyList();
 		List<String> names = new ArrayList<>();
 		while (pathClass != null) {
@@ -199,7 +199,7 @@ public final class PathClassTools {
 		var namesUnique = names.stream().distinct().collect(Collectors.toList());
 		if (names.equals(namesUnique))
 			return pathClass;
-		return PathClassFactory.getPathClass(namesUnique);
+		return PathClass.fromCollection(namesUnique);
 	}
 	
 	/**
@@ -228,7 +228,7 @@ public final class PathClassTools {
 	public static PathClass sortNames(PathClass pathClass, Comparator<String> comparator) {
 		var names = splitNames(pathClass);
 		names.sort(comparator);
-		return PathClassFactory.getPathClass(names);
+		return PathClass.fromCollection(names);
 	}
 	
 	/**
@@ -242,7 +242,7 @@ public final class PathClassTools {
 	public static PathClass removeNames(PathClass pathClass, Collection<String> namesToRemove) {
 		var names = splitNames(pathClass);
 		if (names.removeAll(namesToRemove))
-			return PathClassFactory.getPathClass(names);
+			return PathClass.fromCollection(names);
 		return pathClass;
 	}
 	
@@ -274,10 +274,10 @@ public final class PathClassTools {
 		if (Objects.equals(baseClass, additionalClass))
 			return baseClass;
 
-		if (baseClass == PathClassFactory.getPathClassUnclassified())
+		if (baseClass == PathClass.NULL_CLASS)
 			baseClass = null;
 		
-		if (additionalClass == PathClassFactory.getPathClassUnclassified())
+		if (additionalClass == PathClass.NULL_CLASS)
 			additionalClass = null;
 
 		if (baseClass == null) {
@@ -292,7 +292,7 @@ public final class PathClassTools {
 		PathClass output = baseClass;
 		for (String name : names) {
 			if (!containsName(baseClass, name))
-				output = PathClassFactory.getDerivedPathClass(output, name, averageColors(baseClass.getColor(), additionalClass.getColor()));
+				output = PathClass.getInstance(output, name, averageColors(baseClass.getColor(), additionalClass.getColor()));
 		}
 		return output;
 	}

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/Reclassifier.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/Reclassifier.java
@@ -72,12 +72,12 @@ public class Reclassifier {
 	public boolean apply() {
 		var previousClass = pathObject.getPathClass();
 		var pathClass = this.pathClass;
-		if (pathClass == PathClassFactory.getPathClassUnclassified())
+		if (pathClass == PathClass.NULL_CLASS)
 			pathClass = null;
 		else if (retainIntensityClass && previousClass != null &&
 				(PathClassTools.isPositiveOrGradedIntensityClass(previousClass) || PathClassTools.isNegativeClass(previousClass)) && 
 				(!previousClass.isDerivedClass() || previousClass.getBaseClass() == previousClass.getParentClass())) {
-			pathClass = PathClassFactory.getDerivedPathClass(pathClass, previousClass.getName(), null);
+			pathClass = PathClass.getInstance(pathClass, previousClass.getName(), null);
 		}
 		pathObject.setPathClass(pathClass, probability);
 		return previousClass != pathClass;

--- a/qupath-core/src/main/java/qupath/lib/plugins/ParallelTileObject.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/ParallelTileObject.java
@@ -47,7 +47,6 @@ import qupath.lib.objects.PathROIObject;
 import qupath.lib.objects.PathTileObject;
 import qupath.lib.objects.TemporaryObject;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.plugins.AbstractTileableDetectionPlugin.ParallelDetectionTileManager;
 import qupath.lib.regions.ImageRegion;
@@ -84,13 +83,13 @@ public class ParallelTileObject extends PathTileObject implements TemporaryObjec
 		 */
 		DONE }
 	
-	private static PathClass pathClassPending = PathClassFactory.getPathClass(
+	private static PathClass pathClassPending = PathClass.getInstance(
 			"Tile-Pending", ColorTools.packRGB(50, 50, 200));
 
-	private static PathClass pathClassProcessing = PathClassFactory.getPathClass(
+	private static PathClass pathClassProcessing = PathClass.getInstance(
 			"Tile-Processing", ColorTools.packRGB(50, 200, 50));
 
-	private static PathClass pathClassDone = PathClassFactory.getPathClass(
+	private static PathClass pathClassDone = PathClass.getInstance(
 			"Tile-Done", ColorTools.packRGB(100, 20, 20));
 
 	private ParallelDetectionTileManager manager;

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -69,7 +69,6 @@ import qupath.lib.io.PathIO;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.projects.ResourceManager.ImageResourceManager;
 import qupath.lib.projects.ResourceManager.Manager;
@@ -1125,7 +1124,7 @@ class DefaultProject implements Project<BufferedImage> {
 						if (pathClassObject.has("color") && !pathClassObject.get("color").isJsonNull()) {
 							color = pathClassObject.get("color").getAsInt();							
 						}
-						PathClass pathClass = PathClassFactory.getPathClass(name, color);
+						PathClass pathClass = PathClass.fromString(name, color);
 						if (color != null)
 							pathClass.setColor(color); // Make sure we have the color we want
 						pathClasses.add(pathClass);

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -1084,10 +1084,13 @@ class DefaultProject implements Project<BufferedImage> {
 		
 		JsonArray pathClassArray = new JsonArray();
 		for (PathClass pathClass : pathClasses) {
-			JsonObject jsonEntry = new JsonObject();
-			jsonEntry.addProperty("name", pathClass.toString());
-			jsonEntry.addProperty("color", pathClass.getColor());
-			pathClassArray.add(jsonEntry);
+			// Store any non-default (null) class
+			if (pathClass != PathClass.NULL_CLASS) {
+				JsonObject jsonEntry = new JsonObject();
+				jsonEntry.addProperty("name", pathClass.toString());
+				jsonEntry.addProperty("color", pathClass.getColor());
+				pathClassArray.add(jsonEntry);
+			}
 		}
 		
 		var element = new JsonObject();
@@ -1113,6 +1116,11 @@ class DefaultProject implements Project<BufferedImage> {
 					JsonObject pathClassObject = pathClassesArray.get(i).getAsJsonObject();
 					if (pathClassObject.has("name")) {
 						String name = pathClassObject.get("name").getAsString();
+						if (PathClass.NULL_CLASS.toString().equals(name)) {
+							logger.debug("Skipping PathClass '{}' - shares a name with the null class", name);
+							continue;
+						}
+						
 						Integer color = null;
 						if (pathClassObject.has("color") && !pathClassObject.get("color").isJsonNull()) {
 							color = pathClassObject.get("color").getAsInt();							

--- a/qupath-core/src/test/java/qupath/lib/analysis/TestDistanceTools.java
+++ b/qupath-core/src/test/java/qupath/lib/analysis/TestDistanceTools.java
@@ -33,8 +33,7 @@ import org.junit.jupiter.api.Test;
 
 import qupath.lib.geom.Point2;
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
 
@@ -101,11 +100,11 @@ public class TestDistanceTools {
 			
 				var tumorDetections = tumorCoordinates.stream().map(p -> PathObjects.createDetectionObject(
 						ROIs.createEllipseROI(p.getX()-radius, p.getY()-radius, radius*2, radius*2, sourcePlane),
-						PathClassFactory.getPathClass(StandardPathClasses.TUMOR))).collect(Collectors.toList());
+						PathClass.StandardPathClasses.TUMOR)).collect(Collectors.toList());
 				
 				var stromaDetections = stromaCoordinates.stream().map(p -> PathObjects.createDetectionObject(
 						ROIs.createEllipseROI(p.getX()-radius, p.getY()-radius, radius*2, radius*2, targetPlane),
-						PathClassFactory.getPathClass(StandardPathClasses.STROMA))).collect(Collectors.toList());
+						PathClass.StandardPathClasses.STROMA)).collect(Collectors.toList());
 				
 				if (sourcePlane.equals(targetPlane)) {
 		

--- a/qupath-core/src/test/java/qupath/lib/analysis/TestDistanceTools.java
+++ b/qupath-core/src/test/java/qupath/lib/analysis/TestDistanceTools.java
@@ -72,10 +72,10 @@ public class TestDistanceTools {
 				Arrays.asList(detection), Arrays.asList(tumorAnnotationT2), 1.0, 1.0, "Distance 4");
 		
 		double expectedDistance = Math.sqrt(2 * 50.0 * 50.0) - 50.0;
-		assertEquals(expectedDistance, detection.getMeasurementList().getMeasurementValue("Distance 1"), 0.05);
-		assertEquals(detection.getMeasurementList().getMeasurementValue("Distance 1") * 2.0, detection.getMeasurementList().getMeasurementValue("Distance 2"), 0.01);
-		assertTrue(Double.isNaN(detection.getMeasurementList().getMeasurementValue("Distance 3")));
-		assertTrue(Double.isNaN(detection.getMeasurementList().getMeasurementValue("Distance 4")));
+		assertEquals(expectedDistance, detection.getMeasurementList().get("Distance 1"), 0.05);
+		assertEquals(detection.getMeasurementList().get("Distance 1") * 2.0, detection.getMeasurementList().get("Distance 2"), 0.01);
+		assertTrue(Double.isNaN(detection.getMeasurementList().get("Distance 3")));
+		assertTrue(Double.isNaN(detection.getMeasurementList().get("Distance 4")));
 	}
 	
 	@Test
@@ -111,29 +111,29 @@ public class TestDistanceTools {
 		
 					// Distance to stroma, default pixels
 					DistanceTools.centroidToCentroidDistance2D(tumorDetections, stromaDetections, 1.0, 1.0, "Distance to stroma");
-					assertEquals(tumorDetections.get(0).getMeasurementList().getMeasurementValue("Distance to stroma"), 20, 0.0001);
-					assertEquals(tumorDetections.get(1).getMeasurementList().getMeasurementValue("Distance to stroma"), 10, 0.0001);
-					assertEquals(tumorDetections.get(2).getMeasurementList().getMeasurementValue("Distance to stroma"), Math.sqrt(30*30+50*50), 0.0001);
+					assertEquals(tumorDetections.get(0).getMeasurementList().get("Distance to stroma"), 20, 0.0001);
+					assertEquals(tumorDetections.get(1).getMeasurementList().get("Distance to stroma"), 10, 0.0001);
+					assertEquals(tumorDetections.get(2).getMeasurementList().get("Distance to stroma"), Math.sqrt(30*30+50*50), 0.0001);
 					
 					// Distance to stroma, scaled pixels
 					DistanceTools.centroidToCentroidDistance2D(tumorDetections, stromaDetections, 2.0, 2.0, "Distance to stroma");
-					assertEquals(tumorDetections.get(0).getMeasurementList().getMeasurementValue("Distance to stroma"), 20*2, 0.0001);
-					assertEquals(tumorDetections.get(1).getMeasurementList().getMeasurementValue("Distance to stroma"), 10*2, 0.0001);
-					assertEquals(tumorDetections.get(2).getMeasurementList().getMeasurementValue("Distance to stroma"), Math.sqrt(30*30*4+50*50*4), 0.0001);
+					assertEquals(tumorDetections.get(0).getMeasurementList().get("Distance to stroma"), 20*2, 0.0001);
+					assertEquals(tumorDetections.get(1).getMeasurementList().get("Distance to stroma"), 10*2, 0.0001);
+					assertEquals(tumorDetections.get(2).getMeasurementList().get("Distance to stroma"), Math.sqrt(30*30*4+50*50*4), 0.0001);
 					
 					// Distance to stroma, scaled non-square pixels
 					DistanceTools.centroidToCentroidDistance2D(tumorDetections, stromaDetections, 1.4, 1.6, "Distance to stroma");
-					assertEquals(tumorDetections.get(0).getMeasurementList().getMeasurementValue("Distance to stroma"), 20*1.4, 0.0001);
-					assertEquals(tumorDetections.get(1).getMeasurementList().getMeasurementValue("Distance to stroma"), 10*1.6, 0.0001);
-					assertEquals(tumorDetections.get(2).getMeasurementList().getMeasurementValue("Distance to stroma"), Math.sqrt(30*30*1.4*1.4+50*50*1.6*1.6), 0.0001);
+					assertEquals(tumorDetections.get(0).getMeasurementList().get("Distance to stroma"), 20*1.4, 0.0001);
+					assertEquals(tumorDetections.get(1).getMeasurementList().get("Distance to stroma"), 10*1.6, 0.0001);
+					assertEquals(tumorDetections.get(2).getMeasurementList().get("Distance to stroma"), Math.sqrt(30*30*1.4*1.4+50*50*1.6*1.6), 0.0001);
 					
 					// Ensure no other measurements added
 					for (var stroma : stromaDetections) {
-						assertFalse(stroma.getMeasurementList().containsNamedMeasurement("Distance to stroma"));
-						assertTrue(Double.isNaN(stroma.getMeasurementList().getMeasurementValue("Distance to stroma")));
+						assertFalse(stroma.getMeasurementList().containsKey("Distance to stroma"));
+						assertTrue(Double.isNaN(stroma.getMeasurementList().get("Distance to stroma")));
 					}
 					for (var tumor : tumorDetections) {
-						assertTrue(tumor.getMeasurementList().containsNamedMeasurement("Distance to stroma"));
+						assertTrue(tumor.getMeasurementList().containsKey("Distance to stroma"));
 					}
 				} else {
 					// Ensure no measurements added
@@ -141,11 +141,11 @@ public class TestDistanceTools {
 					for (var tumor : tumorDetections) {
 						// Currently, we don't add a measurement if not on the same plane
 //						assertTrue(tumor.getMeasurementList().containsNamedMeasurement("Distance to stroma"));
-						assertTrue(Double.isNaN(tumor.getMeasurementList().getMeasurementValue("Distance to stroma")));
+						assertTrue(Double.isNaN(tumor.getMeasurementList().get("Distance to stroma")));
 					}
 					for (var stroma : stromaDetections) {
-						assertFalse(stroma.getMeasurementList().containsNamedMeasurement("Distance to stroma"));
-						assertTrue(Double.isNaN(stroma.getMeasurementList().getMeasurementValue("Distance to stroma")));
+						assertFalse(stroma.getMeasurementList().containsKey("Distance to stroma"));
+						assertTrue(Double.isNaN(stroma.getMeasurementList().get("Distance to stroma")));
 					}
 				}
 			}

--- a/qupath-core/src/test/java/qupath/lib/common/TestGeneralTools.java
+++ b/qupath-core/src/test/java/qupath/lib/common/TestGeneralTools.java
@@ -58,8 +58,6 @@ import org.slf4j.LoggerFactory;
 import qupath.lib.color.ColorDeconvolutionStains;
 import qupath.lib.color.ColorDeconvolutionStains.DefaultColorDeconvolutionStains;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
 
 @SuppressWarnings("javadoc")
 public class TestGeneralTools {
@@ -291,7 +289,8 @@ public class TestGeneralTools {
 		
 		// Objects (here PathClass)
 		assertEquals("", GeneralTools.arrayToString(new PathClass[] {}, ","));
-		assertEquals("Ignore*, Positive", GeneralTools.arrayToString(new Object[] {PathClassFactory.getPathClass(StandardPathClasses.IGNORE), PathClassFactory.getPathClass(StandardPathClasses.POSITIVE)}, ", "));
+		assertEquals("Ignore*, Positive", GeneralTools.arrayToString(new Object[] {
+				PathClass.StandardPathClasses.IGNORE, PathClass.StandardPathClasses.POSITIVE}, ", "));
 	}
 	
 	@Test

--- a/qupath-core/src/test/java/qupath/lib/io/TestGsonTools.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestGsonTools.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 
 import qupath.lib.common.ColorTools;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 
 @SuppressWarnings("javadoc")
 public class TestGsonTools {
@@ -38,12 +37,12 @@ public class TestGsonTools {
 	public void test_PathClasses() throws IOException {
 		
 		testToJson(null);
-		testToJson(PathClassFactory.getPathClassUnclassified());
-		testToJson(PathClassFactory.getPathClass("Tumor"));
-		testToJson(PathClassFactory.getPathClass("Tumor: Positive"));
-		testToJson(PathClassFactory.getPathClass("Tumor: Positive: Other", ColorTools.packRGB(1, 2, 3)));
+		testToJson(PathClass.NULL_CLASS);
+		testToJson(PathClass.getInstance("Tumor"));
+		testToJson(PathClass.fromString("Tumor: Positive"));
+		testToJson(PathClass.fromString("Tumor: Positive: Other", ColorTools.packRGB(1, 2, 3)));
 
-		testToJson(PathClassFactory.getPathClass(Arrays.asList("Class 1", "Class 2", "Class 3")));
+		testToJson(PathClass.fromCollection(Arrays.asList("Class 1", "Class 2", "Class 3")));
 	}
 	
 	

--- a/qupath-core/src/test/java/qupath/lib/io/TestPathIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPathIO.java
@@ -45,7 +45,7 @@ import java.util.zip.ZipOutputStream;
 import org.junit.jupiter.api.Test;
 
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.roi.ROIs;
 
@@ -102,7 +102,7 @@ public class TestPathIO {
 	public void test_deserialization() {
 		
 		var roi = ROIs.createEmptyROI();
-		var pathClass = PathClassFactory.getPathClass("Anything");
+		var pathClass = PathClass.getInstance("Anything");
 		var pathObject = PathObjects.createAnnotationObject(roi, pathClass);
 		var hierarchy = new PathObjectHierarchy();
 		

--- a/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
@@ -95,10 +95,10 @@ public class TestPathObjectIO {
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		
 		// Add measurements
-		mlDetection.putMeasurement("TestMeasurement1", 5.0);
-		mlDetection.putMeasurement("TestMeasurement2", 10.0);
-		mlCell.putMeasurement("TestMeasurement3", 15.0);
-		mlCell.putMeasurement("TestMeasurement4", 20.0);
+		mlDetection.put("TestMeasurement1", 5.0);
+		mlDetection.put("TestMeasurement2", 10.0);
+		mlCell.put("TestMeasurement3", 15.0);
+		mlCell.put("TestMeasurement4", 20.0);
 		
 		// Export to GeoJSON
 		PathIO.exportObjectsAsGeoJSON(bos, objs, options);

--- a/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
@@ -95,10 +95,10 @@ public class TestPathObjectIO {
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		
 		// Add measurements
-		mlDetection.addMeasurement("TestMeasurement1", 5.0);
-		mlDetection.addMeasurement("TestMeasurement2", 10.0);
-		mlCell.addMeasurement("TestMeasurement3", 15.0);
-		mlCell.addMeasurement("TestMeasurement4", 20.0);
+		mlDetection.putMeasurement("TestMeasurement1", 5.0);
+		mlDetection.putMeasurement("TestMeasurement2", 10.0);
+		mlCell.putMeasurement("TestMeasurement3", 15.0);
+		mlCell.putMeasurement("TestMeasurement4", 20.0);
 		
 		// Export to GeoJSON
 		PathIO.exportObjectsAsGeoJSON(bos, objs, options);

--- a/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
@@ -46,7 +46,7 @@ import qupath.lib.measurements.MeasurementListFactory;
 import qupath.lib.objects.PathCellObject;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
 import qupath.lib.roi.interfaces.ROI;
@@ -83,10 +83,10 @@ public class TestPathObjectIO {
 		MeasurementList mlDetection = MeasurementListFactory.createMeasurementList(16, MeasurementList.MeasurementListType.GENERAL);
 		MeasurementList mlCell = MeasurementListFactory.createMeasurementList(16, MeasurementList.MeasurementListType.GENERAL);
 		
-		PathObject myPDO = PathObjects.createDetectionObject(roiDetection, PathClassFactory.getPathClass("PathClassTest1", ColorTools.BLACK), mlDetection);
-		PathObject myPAO = PathObjects.createAnnotationObject(roiAnnotation, PathClassFactory.getPathClass("PathClassTest1", ColorTools.BLACK));
-		PathObject myPCO = PathObjects.createCellObject(roiCell1, roiCell2,	PathClassFactory.getPathClass("PathClassTest2", ColorTools.GREEN), mlCell);
-		PathObject myPTO = PathObjects.createTileObject(roiTile, PathClassFactory.getPathClass("PathClassTest2", ColorTools.GREEN), null);
+		PathObject myPDO = PathObjects.createDetectionObject(roiDetection, PathClass.getInstance("PathClassTest1", ColorTools.BLACK), mlDetection);
+		PathObject myPAO = PathObjects.createAnnotationObject(roiAnnotation, PathClass.getInstance("PathClassTest1", ColorTools.BLACK));
+		PathObject myPCO = PathObjects.createCellObject(roiCell1, roiCell2,	PathClass.getInstance("PathClassTest2", ColorTools.GREEN), mlCell);
+		PathObject myPTO = PathObjects.createTileObject(roiTile, PathClass.getInstance("PathClassTest2", ColorTools.GREEN), null);
 		PathObject myTMA = PathObjects.createTMACoreObject(25, 25, 25, false);
 		
 		Collection<PathObject> objs = Arrays.asList(myPDO, myPCO, myPAO, myPTO, myTMA);
@@ -120,13 +120,13 @@ public class TestPathObjectIO {
 			assertNotNull(po.getId());
 			
 			if (po.isTile()) {
-				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest2", ColorTools.GREEN));
+				assertEquals(po.getPathClass(), PathClass.getInstance("PathClassTest2", ColorTools.GREEN));
 				assertEquals(po.getId(), myPTO.getId());
 				assertSameROIs(po.getROI(), roiTile);
 				assertFalse(po.hasMeasurements());
 				countCheck[0]++;
 			} else if (po.isCell()) {
-				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest2", ColorTools.GREEN));
+				assertEquals(po.getPathClass(), PathClass.getInstance("PathClassTest2", ColorTools.GREEN));
 				assertEquals(po.getId(), myPCO.getId());
 				assertSameROIs(po.getROI(), roiCell1);
 				assertSameROIs(((PathCellObject)po).getNucleusROI(), roiCell2);
@@ -137,7 +137,7 @@ public class TestPathObjectIO {
 					assertFalse(po.hasMeasurements());
 				countCheck[1]++;
 			} else if (po.isDetection()) {
-				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest1", ColorTools.BLACK));
+				assertEquals(po.getPathClass(), PathClass.getInstance("PathClassTest1", ColorTools.BLACK));
 				assertEquals(po.getId(), myPDO.getId());
 				assertSameROIs(po.getROI(), roiDetection);
 				if (keepMeasurements) {
@@ -147,7 +147,7 @@ public class TestPathObjectIO {
 					assertFalse(po.hasMeasurements());
 				countCheck[2]++;
 			} else if (po.isAnnotation()) {
-				assertEquals(po.getPathClass(), PathClassFactory.getPathClass("PathClassTest1", ColorTools.BLACK));
+				assertEquals(po.getPathClass(), PathClass.getInstance("PathClassTest1", ColorTools.BLACK));
 				assertEquals(po.getId(), myPAO.getId());
 				assertSameROIs(po.getROI(), roiAnnotation);
 				assertFalse(po.hasMeasurements());

--- a/qupath-core/src/test/java/qupath/lib/io/TestPointIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPointIO.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import qupath.lib.geom.Point2;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
 import qupath.lib.roi.interfaces.ROI;
@@ -139,11 +139,11 @@ public class TestPointIO {
 			PathObject pathObject = PathObjects.createAnnotationObject(points);
 
 			if (entry.getKey() == 3)
-				pathObject.setPathClass(PathClassFactory.getPathClass("Other"));
+				pathObject.setPathClass(PathClass.getInstance("Other"));
 			if (entry.getKey() == 4)
 				pathObject.setName("foo");
 			else if (entry.getKey() == 5) {
-				pathObject.setPathClass(PathClassFactory.getPathClass("Tumor"));
+				pathObject.setPathClass(PathClass.getInstance("Tumor"));
 				pathObject.setName("bar");
 			}
 			

--- a/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementListFactory.java
+++ b/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementListFactory.java
@@ -61,7 +61,7 @@ public class TestMeasurementListFactory {
 			map.put(name, val);
 			names.add(name);
 			// We can use addMeasurement because it's empty
-			list.putMeasurement(name, val);
+			list.put(name, val);
 		}
 		
 		// Change same names
@@ -93,7 +93,7 @@ public class TestMeasurementListFactory {
 			if (!names.contains(name))
 				names.add(name);
 			// We need to use putMeasurement because it's probably not empty
-			list.putMeasurement(name, val);
+			list.put(name, val);
 		}
 		
 		Collections.shuffle(names, rand);
@@ -113,7 +113,7 @@ public class TestMeasurementListFactory {
 	static boolean checkAgreement(MeasurementList list, Map<String, Double> map, Collection<String> namesToCheck) {
 		double eps = 1e-4;
 		for (String name : namesToCheck) {
-			assertEquals(map.get(name), list.getMeasurementValue(name), eps);
+			assertEquals(map.get(name), list.get(name), eps);
 		}
 		return true;
 	}

--- a/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementListFactory.java
+++ b/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementListFactory.java
@@ -61,7 +61,7 @@ public class TestMeasurementListFactory {
 			map.put(name, val);
 			names.add(name);
 			// We can use addMeasurement because it's empty
-			list.addMeasurement(name, val);
+			list.putMeasurement(name, val);
 		}
 		
 		// Change same names

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
@@ -39,7 +39,7 @@ import qupath.lib.roi.ROIs;
 import qupath.lib.roi.interfaces.ROI;
 
 @SuppressWarnings("javadoc")
-public class TestPathAnnotationObject extends TestPathObject { 
+public class TestPathAnnotationObject extends TestPathObjectMethods { 
 	private final Integer nPO = 10; // number of (child) objects to be added
 	private final Double classprobability = 0.5;
 	private final Double line_x = 0.0;

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
@@ -33,7 +33,6 @@ import qupath.lib.measurements.MeasurementFactory;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.measurements.MeasurementListFactory;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
 import qupath.lib.roi.interfaces.ROI;
@@ -48,7 +47,7 @@ public class TestPathAnnotationObject extends TestPathObjectMethods {
 	private final Double valueML = 10.0;
 	//private final double epsilon = 1e-15; 
 	ROI myROI = ROIs.createLineROI(line_x,line_y, ImagePlane.getDefaultPlane());
-	PathClass myPC = PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IMAGE_ROOT);
+	PathClass myPC = PathClass.StandardPathClasses.IMAGE_ROOT;
 	PathAnnotationObject myPO = new PathAnnotationObject();
 	PathAnnotationObject myPO2 = new PathAnnotationObject(myROI);
 	PathAnnotationObject myPO3 = new PathAnnotationObject(myROI, myPC);
@@ -130,11 +129,11 @@ public class TestPathAnnotationObject extends TestPathObjectMethods {
 	@Test
 	public void test_SetGetPathClass() {
 		test_getPathClass(myPO, null); 
-		test_setPathClass(myPO, PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IMAGE_ROOT));
+		test_setPathClass(myPO, PathClass.StandardPathClasses.IMAGE_ROOT);
 		test_getClassProbability(myPO, Double.NaN);
-		test_setPathClass(myPO, PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IMAGE_ROOT), classprobability);
+		test_setPathClass(myPO, PathClass.StandardPathClasses.IMAGE_ROOT, classprobability);
 		test_getClassProbability(myPO, classprobability);
-		test_getPathClass(myPO3, PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IMAGE_ROOT));
+		test_getPathClass(myPO3, PathClass.StandardPathClasses.IMAGE_ROOT);
 		test_getClassProbability(myPO3, Double.NaN);
 	}
 /*	@Test

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathCellObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathCellObject.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
 import qupath.lib.roi.interfaces.ROI;
@@ -39,7 +38,7 @@ public class TestPathCellObject {
 	private final Double xn = 0.0, yn = 0.0, wn = 5.0, hn = 5.0;
 	ROI myROI = ROIs.createEllipseROI(x, y, w, h, ImagePlane.getDefaultPlane());
 	ROI myNROI = ROIs.createEllipseROI(xn, yn, wn, hn, ImagePlane.getDefaultPlane());
-	PathClass myPC = PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IMAGE_ROOT);
+	PathClass myPC = PathClass.StandardPathClasses.IMAGE_ROOT;
 	PathCellObject myPO = new PathCellObject();
 	PathCellObject myPO2 = new PathCellObject(myROI, myNROI, myPC);
 	

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathClassTools.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathClassTools.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.classes.PathClassTools;
 
 @SuppressWarnings("javadoc")
@@ -62,49 +61,49 @@ public class TestPathClassTools {
 	@BeforeAll
 	public static void init() {
 		// Ignored/non-ignored classes and subclasses
-		pc1 = PathClassFactory.getPathClass("test", Color.BLUE.getRGB());
-		pc2 = PathClassFactory.getPathClass("test", "subclass");
-		pc3 = PathClassFactory.getPathClass("test*", Color.BLACK.getRGB());
-		pc4 = PathClassFactory.getPathClass("test*", "subclass");
-		pc5 = PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IGNORE);
+		pc1 = PathClass.getInstance("test", Color.BLUE.getRGB());
+		pc2 = PathClass.fromArray("test", "subclass");
+		pc3 = PathClass.getInstance("test*", Color.BLACK.getRGB());
+		pc4 = PathClass.fromArray("test*", "subclass");
+		pc5 = PathClass.StandardPathClasses.IGNORE;
 		pc5.setColor(Color.BLACK.getRGB());
-		pc6 = PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IGNORE);
-		pc6 = PathClassFactory.getDerivedPathClass(pc6, "subclass", Color.BLACK.getRGB());
-		pc7 = PathClassFactory.getNegative(PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IGNORE));
+		pc6 = PathClass.StandardPathClasses.IGNORE;
+		pc6 = PathClass.getInstance(pc6, "subclass", Color.BLACK.getRGB());
+		pc7 = PathClass.getNegative(PathClass.StandardPathClasses.IGNORE);
 		
 		// Pos/neg & intensity classes
-		pc8 = PathClassFactory.getNegative(PathClassFactory.getPathClass("negativeClass", Color.RED.getRGB()));
-		pc9 = PathClassFactory.getPositive(PathClassFactory.getPathClass("positiveClass", Color.RED.getRGB()));
-		pc10 = PathClassFactory.getOnePlus(PathClassFactory.getPathClass("intensityClass", Color.RED.getRGB()));
-		pc11 = PathClassFactory.getTwoPlus(PathClassFactory.getPathClass("intensityClass", Color.RED.getRGB()));
-		pc12 = PathClassFactory.getThreePlus(PathClassFactory.getPathClass("intensityClass", Color.RED.getRGB()));
+		pc8 = PathClass.getNegative(PathClass.getInstance("negativeClass", Color.RED.getRGB()));
+		pc9 = PathClass.getPositive(PathClass.getInstance("positiveClass", Color.RED.getRGB()));
+		pc10 = PathClass.getOnePlus(PathClass.getInstance("intensityClass", Color.RED.getRGB()));
+		pc11 = PathClass.getTwoPlus(PathClass.getInstance("intensityClass", Color.RED.getRGB()));
+		pc12 = PathClass.getThreePlus(PathClass.getInstance("intensityClass", Color.RED.getRGB()));
 		
 		// Both pos/neg/intensity and subclass classes
-		pc13 = PathClassFactory.getPositive(PathClassFactory.getPathClass("positiveClass", "subclass"));
-		pc14 = PathClassFactory.getOnePlus(PathClassFactory.getPathClass("intensityClass", "subclass"));
+		pc13 = PathClass.getPositive(PathClass.fromArray("positiveClass", "subclass"));
+		pc14 = PathClass.getOnePlus(PathClass.fromArray("intensityClass", "subclass"));
 		
 		// 'Null' classes
-		pc15 = PathClassFactory.getPathClass(null, Color.BLUE.getRGB());
-		pc16 = PathClassFactory.getPathClassUnclassified();
+		pc15 = PathClass.fromString(null, Color.BLUE.getRGB());
+		pc16 = PathClass.NULL_CLASS;
 		
 		// Derived class
-		derivedClass1 = PathClassFactory.getPathClass("First");
-		derivedClass1 = PathClassFactory.getDerivedPathClass(derivedClass1, "Second", Color.RED.getRGB());
-		derivedClass1 = PathClassFactory.getDerivedPathClass(derivedClass1, "Third", Color.RED.getRGB());
-		derivedClass1 = PathClassFactory.getDerivedPathClass(derivedClass1, "Fourth", Color.RED.getRGB());
-		derivedClass1 = PathClassFactory.getDerivedPathClass(derivedClass1, "Fifth", Color.RED.getRGB());
-		derivedClass1 = PathClassFactory.getDerivedPathClass(derivedClass1, "Sixth", Color.RED.getRGB());
-		derivedClass1 = PathClassFactory.getDerivedPathClass(derivedClass1, "Seventh", Color.RED.getRGB());
-		derivedClass1 = PathClassFactory.getDerivedPathClass(derivedClass1, "Eighth", Color.RED.getRGB());
-		derivedClass1 = PathClassFactory.getDerivedPathClass(derivedClass1, "Ninth", Color.RED.getRGB());
-		derivedClass1 = PathClassFactory.getDerivedPathClass(derivedClass1, "Tenth", Color.RED.getRGB());
-		derivedClass1 = PathClassFactory.getDerivedPathClass(derivedClass1, "Eleventh", Color.RED.getRGB());
+		derivedClass1 = PathClass.getInstance("First");
+		derivedClass1 = PathClass.getInstance(derivedClass1, "Second", Color.RED.getRGB());
+		derivedClass1 = PathClass.getInstance(derivedClass1, "Third", Color.RED.getRGB());
+		derivedClass1 = PathClass.getInstance(derivedClass1, "Fourth", Color.RED.getRGB());
+		derivedClass1 = PathClass.getInstance(derivedClass1, "Fifth", Color.RED.getRGB());
+		derivedClass1 = PathClass.getInstance(derivedClass1, "Sixth", Color.RED.getRGB());
+		derivedClass1 = PathClass.getInstance(derivedClass1, "Seventh", Color.RED.getRGB());
+		derivedClass1 = PathClass.getInstance(derivedClass1, "Eighth", Color.RED.getRGB());
+		derivedClass1 = PathClass.getInstance(derivedClass1, "Ninth", Color.RED.getRGB());
+		derivedClass1 = PathClass.getInstance(derivedClass1, "Tenth", Color.RED.getRGB());
+		derivedClass1 = PathClass.getInstance(derivedClass1, "Eleventh", Color.RED.getRGB());
 		
-		derivedClass2 = PathClassFactory.getPathClass("First");
-		derivedClass2 = PathClassFactory.getDerivedPathClass(derivedClass2, "Second", Color.RED.getRGB());
-		derivedClass2 = PathClassFactory.getDerivedPathClass(derivedClass2, "Third", Color.RED.getRGB());
-		derivedClass2 = PathClassFactory.getDerivedPathClass(derivedClass2, "Fourth", Color.RED.getRGB());
-		derivedClass2 = PathClassFactory.getDerivedPathClass(derivedClass2, "Fifth", Color.RED.getRGB());
+		derivedClass2 = PathClass.getInstance("First");
+		derivedClass2 = PathClass.getInstance(derivedClass2, "Second", Color.RED.getRGB());
+		derivedClass2 = PathClass.getInstance(derivedClass2, "Third", Color.RED.getRGB());
+		derivedClass2 = PathClass.getInstance(derivedClass2, "Fourth", Color.RED.getRGB());
+		derivedClass2 = PathClass.getInstance(derivedClass2, "Fifth", Color.RED.getRGB());
 	}
 
 	@Test
@@ -340,33 +339,33 @@ public class TestPathClassTools {
 		assertEquals(pc4, PathClassTools.getNonIntensityAncestorClass(pc4));
 		assertEquals(pc5, PathClassTools.getNonIntensityAncestorClass(pc5));
 		assertEquals(pc6, PathClassTools.getNonIntensityAncestorClass(pc6));
-		assertEquals(PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IGNORE), PathClassTools.getNonIntensityAncestorClass(pc7));
+		assertEquals(PathClass.StandardPathClasses.IGNORE, PathClassTools.getNonIntensityAncestorClass(pc7));
 		
-		assertEquals(PathClassFactory.getPathClass("negativeClass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc8));
-		assertEquals(PathClassFactory.getPathClass("positiveClass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc9));
-		assertEquals(PathClassFactory.getPathClass("intensityClass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc10));
-		assertEquals(PathClassFactory.getPathClass("intensityClass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc11));
-		assertEquals(PathClassFactory.getPathClass("intensityClass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc12));
+		assertEquals(PathClass.getInstance("negativeClass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc8));
+		assertEquals(PathClass.getInstance("positiveClass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc9));
+		assertEquals(PathClass.getInstance("intensityClass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc10));
+		assertEquals(PathClass.getInstance("intensityClass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc11));
+		assertEquals(PathClass.getInstance("intensityClass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc12));
 		
-		assertEquals(PathClassFactory.getPathClass("positiveClass: subclass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc13));
-		assertEquals(PathClassFactory.getPathClass("intensityClass: subclass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc14));
+		assertEquals(PathClass.fromString("positiveClass: subclass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc13));
+		assertEquals(PathClass.fromString("intensityClass: subclass", Color.RED.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc14));
 
-		assertEquals(PathClassFactory.getPathClass(null, Color.BLUE.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc15));
-		assertEquals(PathClassFactory.getPathClassUnclassified(), PathClassTools.getNonIntensityAncestorClass(pc16));
+		assertEquals(PathClass.fromString(null, Color.BLUE.getRGB()), PathClassTools.getNonIntensityAncestorClass(pc15));
+		assertEquals(PathClass.NULL_CLASS, PathClassTools.getNonIntensityAncestorClass(pc16));
 
 		assertEquals(null, PathClassTools.getNonIntensityAncestorClass(null));
 	}
 	
 	@Test
 	public void test_splitNames() {
-		var test = PathClassFactory.getPathClass("test");
-		var test2 = PathClassFactory.getPathClass("test*");
-		var subclass = PathClassFactory.getPathClass("subclass");
-		var intensityClass = PathClassFactory.getPathClass("intensityClass");
-		var negativeClass = PathClassFactory.getPathClass("negativeClass", Color.RED.getRGB());
-		var positiveClass = PathClassFactory.getPathClass("positiveClass", Color.RED.getRGB());
-		var negativeClass2= PathClassFactory.getNegative(null);
-		var positiveClass2 = PathClassFactory.getPositive(null);
+		var test = PathClass.getInstance("test");
+		var test2 = PathClass.getInstance("test*");
+		var subclass = PathClass.getInstance("subclass");
+		var intensityClass = PathClass.getInstance("intensityClass");
+		var negativeClass = PathClass.getInstance("negativeClass", Color.RED.getRGB());
+		var positiveClass = PathClass.getInstance("positiveClass", Color.RED.getRGB());
+		var negativeClass2= PathClass.getNegative(null);
+		var positiveClass2 = PathClass.getPositive(null);
 		
 		assertEquals(getClassNames(pc1), PathClassTools.splitNames(pc1));
 		assertEquals(getClassNames(test, subclass), PathClassTools.splitNames(pc2));
@@ -374,16 +373,16 @@ public class TestPathClassTools {
 		assertEquals(getClassNames(test2, subclass), PathClassTools.splitNames(pc4));
 		assertEquals(getClassNames(pc5), PathClassTools.splitNames(pc5));
 		assertEquals(getClassNames(pc5, subclass), PathClassTools.splitNames(pc6));
-		assertEquals(getClassNames(pc5, PathClassFactory.getNegative(null)), PathClassTools.splitNames(pc7));
+		assertEquals(getClassNames(pc5, PathClass.getNegative(null)), PathClassTools.splitNames(pc7));
 		
 		assertEquals(getClassNames(negativeClass, negativeClass2), PathClassTools.splitNames(pc8));
 		assertEquals(getClassNames(positiveClass, positiveClass2), PathClassTools.splitNames(pc9));
-		assertEquals(getClassNames(intensityClass, PathClassFactory.getOnePlus(null)), PathClassTools.splitNames(pc10));
-		assertEquals(getClassNames(intensityClass, PathClassFactory.getTwoPlus(null)), PathClassTools.splitNames(pc11));
-		assertEquals(getClassNames(intensityClass, PathClassFactory.getThreePlus(null)), PathClassTools.splitNames(pc12));
+		assertEquals(getClassNames(intensityClass, PathClass.getOnePlus(null)), PathClassTools.splitNames(pc10));
+		assertEquals(getClassNames(intensityClass, PathClass.getTwoPlus(null)), PathClassTools.splitNames(pc11));
+		assertEquals(getClassNames(intensityClass, PathClass.getThreePlus(null)), PathClassTools.splitNames(pc12));
 		
 		assertEquals(getClassNames(positiveClass, subclass, positiveClass2), PathClassTools.splitNames(pc13));
-		assertEquals(getClassNames(intensityClass, subclass, PathClassFactory.getOnePlus(null)), PathClassTools.splitNames(pc14));
+		assertEquals(getClassNames(intensityClass, subclass, PathClass.getOnePlus(null)), PathClassTools.splitNames(pc14));
 
 		assertEquals(Arrays.asList(), PathClassTools.splitNames(pc15));
 		assertEquals(Arrays.asList(), PathClassTools.splitNames(pc16));
@@ -415,20 +414,20 @@ public class TestPathClassTools {
 
 		assertEquals(null, PathClassTools.uniqueNames(null));
 
-		var duplicateClasses = PathClassFactory.getNegative(null);
-		duplicateClasses = PathClassFactory.getDerivedPathClass(duplicateClasses, "Negative", Color.CYAN.getRGB());
-		duplicateClasses = PathClassFactory.getDerivedPathClass(duplicateClasses, "Negative", Color.CYAN.getRGB());
-		assertEquals(PathClassFactory.getPathClass("Negative"), PathClassTools.uniqueNames(duplicateClasses));
+		var duplicateClasses = PathClass.getNegative(null);
+		duplicateClasses = PathClass.getInstance(duplicateClasses, "Negative", Color.CYAN.getRGB());
+		duplicateClasses = PathClass.getInstance(duplicateClasses, "Negative", Color.CYAN.getRGB());
+		assertEquals(PathClass.getInstance("Negative"), PathClassTools.uniqueNames(duplicateClasses));
 
-		var duplicateClasses2 = PathClassFactory.getNegative(null);
-		duplicateClasses2 = PathClassFactory.getDerivedPathClass(duplicateClasses2, "negative", Color.CYAN.getRGB());
-		duplicateClasses2 = PathClassFactory.getDerivedPathClass(duplicateClasses2, "Negative", Color.CYAN.getRGB());
-		assertEquals(PathClassFactory.getPathClass("Negative: negative"), PathClassTools.uniqueNames(duplicateClasses2));
+		var duplicateClasses2 = PathClass.getNegative(null);
+		duplicateClasses2 = PathClass.getInstance(duplicateClasses2, "negative", Color.CYAN.getRGB());
+		duplicateClasses2 = PathClass.getInstance(duplicateClasses2, "Negative", Color.CYAN.getRGB());
+		assertEquals(PathClass.fromString("Negative: negative"), PathClassTools.uniqueNames(duplicateClasses2));
 	}
 	
 	@Test
 	public void test_sortNames() {
-		assertEquals(PathClassFactory.getPathClass("Eighth", 
+		assertEquals(PathClass.fromArray("Eighth", 
 				"Eleventh", 
 				"Fifth", 
 				"First", 
@@ -443,18 +442,18 @@ public class TestPathClassTools {
 	
 	@Test
 	public void test_removeNames() {
-		var derivedClassAfter = PathClassFactory.getPathClass("First");
-		derivedClassAfter = PathClassFactory.getDerivedPathClass(derivedClassAfter, "Third", Color.RED.getRGB());
-		derivedClassAfter = PathClassFactory.getDerivedPathClass(derivedClassAfter, "Fifth", Color.RED.getRGB());
-		derivedClassAfter = PathClassFactory.getDerivedPathClass(derivedClassAfter, "Sixth", Color.RED.getRGB());
-		derivedClassAfter = PathClassFactory.getDerivedPathClass(derivedClassAfter, "Eighth", Color.RED.getRGB());
-		derivedClassAfter = PathClassFactory.getDerivedPathClass(derivedClassAfter, "Ninth", Color.RED.getRGB());
-		derivedClassAfter = PathClassFactory.getDerivedPathClass(derivedClassAfter, "Tenth", Color.RED.getRGB());
-		derivedClassAfter = PathClassFactory.getDerivedPathClass(derivedClassAfter, "Eleventh", Color.RED.getRGB());
+		var derivedClassAfter = PathClass.getInstance("First");
+		derivedClassAfter = PathClass.getInstance(derivedClassAfter, "Third", Color.RED.getRGB());
+		derivedClassAfter = PathClass.getInstance(derivedClassAfter, "Fifth", Color.RED.getRGB());
+		derivedClassAfter = PathClass.getInstance(derivedClassAfter, "Sixth", Color.RED.getRGB());
+		derivedClassAfter = PathClass.getInstance(derivedClassAfter, "Eighth", Color.RED.getRGB());
+		derivedClassAfter = PathClass.getInstance(derivedClassAfter, "Ninth", Color.RED.getRGB());
+		derivedClassAfter = PathClass.getInstance(derivedClassAfter, "Tenth", Color.RED.getRGB());
+		derivedClassAfter = PathClass.getInstance(derivedClassAfter, "Eleventh", Color.RED.getRGB());
 
-		var derivedClassAfter2 = PathClassFactory.getPathClass("Second");
-		derivedClassAfter2 = PathClassFactory.getDerivedPathClass(derivedClassAfter2, "Third", Color.RED.getRGB());
-		derivedClassAfter2 = PathClassFactory.getDerivedPathClass(derivedClassAfter2, "Fifth", Color.RED.getRGB());
+		var derivedClassAfter2 = PathClass.getInstance("Second");
+		derivedClassAfter2 = PathClass.getInstance(derivedClassAfter2, "Third", Color.RED.getRGB());
+		derivedClassAfter2 = PathClass.getInstance(derivedClassAfter2, "Fifth", Color.RED.getRGB());
 
 		assertEquals(derivedClassAfter, PathClassTools.removeNames(derivedClass1, "Second", "Fourth", "Seventh"));
 		assertEquals(derivedClassAfter2, PathClassTools.removeNames(derivedClass2, "First", "Fourth"));
@@ -463,30 +462,30 @@ public class TestPathClassTools {
 	
 	@Test
 	public void test_mergeClasses() {
-		assertEquals(PathClassFactory.getPathClass("test: subclass"), PathClassTools.mergeClasses(pc1, pc2));
-		assertEquals(PathClassFactory.getPathClass("test: subclass: test*"), PathClassTools.mergeClasses(pc2, pc3));
-		assertEquals(PathClassFactory.getPathClass("test*: subclass"), PathClassTools.mergeClasses(pc3, pc4));
-		assertEquals(PathClassFactory.getPathClass("test*: subclass: Ignore*"), PathClassTools.mergeClasses(pc4, pc5));
-		assertEquals(PathClassFactory.getPathClass("Ignore*: subclass"), PathClassTools.mergeClasses(pc5, pc6));
-		assertEquals(PathClassFactory.getPathClass("Ignore*: subclass: Negative"), PathClassTools.mergeClasses(pc6, pc7));
-		assertEquals(PathClassFactory.getPathClass("Ignore*: Negative: negativeClass"), PathClassTools.mergeClasses(pc7, pc8));
-		assertEquals(PathClassFactory.getPathClass("negativeClass: Negative: positiveClass: Positive"), PathClassTools.mergeClasses(pc8, pc9));
-		assertEquals(PathClassFactory.getPathClass("positiveClass: Positive: intensityClass: 1+"), PathClassTools.mergeClasses(pc9, pc10));
-		assertEquals(PathClassFactory.getPathClass("intensityClass: 1+: 2+"), PathClassTools.mergeClasses(pc10, pc11));
-		assertEquals(PathClassFactory.getPathClass("intensityClass: 2+: 3+"), PathClassTools.mergeClasses(pc11, pc12));
-		assertEquals(PathClassFactory.getPathClass("intensityClass: 3+: positiveClass: subclass: Positive"), PathClassTools.mergeClasses(pc12, pc13));
-		assertEquals(PathClassFactory.getPathClass("positiveClass: subclass: Positive: intensityClass: 1+"), PathClassTools.mergeClasses(pc13, pc14));
-		assertEquals(PathClassFactory.getPathClass("intensityClass: subclass: 1+"), PathClassTools.mergeClasses(pc14, pc15));
-		assertEquals(PathClassFactory.getPathClassUnclassified(), PathClassTools.mergeClasses(pc15, pc16));
+		assertEquals(PathClass.fromString("test: subclass"), PathClassTools.mergeClasses(pc1, pc2));
+		assertEquals(PathClass.fromString("test: subclass: test*"), PathClassTools.mergeClasses(pc2, pc3));
+		assertEquals(PathClass.fromString("test*: subclass"), PathClassTools.mergeClasses(pc3, pc4));
+		assertEquals(PathClass.fromString("test*: subclass: Ignore*"), PathClassTools.mergeClasses(pc4, pc5));
+		assertEquals(PathClass.fromString("Ignore*: subclass"), PathClassTools.mergeClasses(pc5, pc6));
+		assertEquals(PathClass.fromString("Ignore*: subclass: Negative"), PathClassTools.mergeClasses(pc6, pc7));
+		assertEquals(PathClass.fromString("Ignore*: Negative: negativeClass"), PathClassTools.mergeClasses(pc7, pc8));
+		assertEquals(PathClass.fromString("negativeClass: Negative: positiveClass: Positive"), PathClassTools.mergeClasses(pc8, pc9));
+		assertEquals(PathClass.fromString("positiveClass: Positive: intensityClass: 1+"), PathClassTools.mergeClasses(pc9, pc10));
+		assertEquals(PathClass.fromString("intensityClass: 1+: 2+"), PathClassTools.mergeClasses(pc10, pc11));
+		assertEquals(PathClass.fromString("intensityClass: 2+: 3+"), PathClassTools.mergeClasses(pc11, pc12));
+		assertEquals(PathClass.fromString("intensityClass: 3+: positiveClass: subclass: Positive"), PathClassTools.mergeClasses(pc12, pc13));
+		assertEquals(PathClass.fromString("positiveClass: subclass: Positive: intensityClass: 1+"), PathClassTools.mergeClasses(pc13, pc14));
+		assertEquals(PathClass.fromString("intensityClass: subclass: 1+"), PathClassTools.mergeClasses(pc14, pc15));
+		assertEquals(PathClass.NULL_CLASS, PathClassTools.mergeClasses(pc15, pc16));
 		assertEquals(null, PathClassTools.mergeClasses(null, pc16));
 		assertEquals(pc1, PathClassTools.mergeClasses(pc16, pc1));
 	}
 	
 	@Test
 	public void test_containsName() {
-		assertTrue(PathClassTools.containsName(PathClassFactory.getPathClass("test: subclass"), "subclass"));
-		assertFalse(PathClassTools.containsName(PathClassFactory.getPathClass("test: subclass"), ""));
-		assertFalse(PathClassTools.containsName(PathClassFactory.getPathClass("test: subclass"), "test*"));
+		assertTrue(PathClassTools.containsName(PathClass.fromString("test: subclass"), "subclass"));
+		assertFalse(PathClassTools.containsName(PathClass.fromString("test: subclass"), ""));
+		assertFalse(PathClassTools.containsName(PathClass.fromString("test: subclass"), "test*"));
 		assertFalse(PathClassTools.containsName(null, "test*"));
 		assertFalse(PathClassTools.containsName(pc15, "test*"));
 		assertFalse(PathClassTools.containsName(pc16, "test*"));

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathDetectionObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathDetectionObject.java
@@ -26,7 +26,7 @@ package qupath.lib.objects;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("javadoc")
-public class TestPathDetectionObject extends TestPathObject {
+public class TestPathDetectionObject extends TestPathObjectMethods {
 	PathDetectionObject myPO = new PathDetectionObject();
 	
 	// leaving only those tests that should perform different from Annotations

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -2,9 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
- * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -21,193 +19,166 @@
  * #L%
  */
 
+
 package qupath.lib.objects;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import java.io.ByteArrayOutputStream;
-import java.util.Collection;
-import java.util.HashSet;
-import qupath.lib.measurements.MeasurementList;
-import qupath.lib.objects.classes.PathClass;
-import qupath.lib.roi.interfaces.ROI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.stream.IntStream;
 
-class TestPathObject {
-	private final Double epsilon = 1e-15; // error for double comparison
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import qupath.lib.measurements.MeasurementList.MeasurementListType;
+import qupath.lib.measurements.MeasurementListFactory;
+import qupath.lib.roi.ROIs;
+
+public class TestPathObject {
 	
-	//@Test
-	public void test_getParent(PathObject myPO, PathObject parent) {
-		assertEquals(myPO.getParent(), parent);
+	
+	private static List<PathObject> provideObjects() {
+		return Arrays.asList(
+				PathObjects.createAnnotationObject(ROIs.createEmptyROI()),
+				PathObjects.createTMACoreObject(0, 0, 100, 100, false),
+				PathObjects.createTMACoreObject(0, 0, 100, 100, true),
+				PathObjects.createDetectionObject(ROIs.createEmptyROI()),
+				PathObjects.createTileObject(ROIs.createEmptyROI()),
+				PathObjects.createCellObject(ROIs.createEmptyROI(), ROIs.createEmptyROI(), null, 
+						MeasurementListFactory.createMeasurementList(16, MeasurementListType.DOUBLE))
+				);
 	}
-	//@Test
-	public void test_getLevel(PathObject myPO, Integer level) {
-		assertEquals((Integer)myPO.getLevel(), level);
+	
+	
+	@ParameterizedTest
+	@MethodSource("provideObjects")
+	public void test_measurementMapSynchronization(PathObject p) {
+		
+		var list = p.getMeasurementList();
+		var map = p.getMeasurements();
+		
+		int n = 1000;
+		IntStream.range(0, n)
+			.parallel()
+			.forEach(i ->list.putMeasurement("Measurement " + i, i));
+		
+		assertEquals(n, list.size());
+		assertEquals(n, map.size());
+		
+		map.clear();
+
+		assertEquals(0, list.size());
+		assertEquals(0, map.size());
+		
+		IntStream.range(0, n)
+			.parallel()
+			.forEach(i -> map.put("Measurement " + i, (double)i));
+
+		assertEquals(n, list.size());
+		assertEquals(n, map.size());
+		
+		list.clear();
+
+		assertEquals(0, list.size());
+		assertEquals(0, map.size());
+		
+		IntStream.range(0, n)
+		.parallel()
+		.forEach(i -> list.putMeasurement("Measurement " + i, (double)i));
+		
+		IntStream.range(0, n)
+		.parallel()
+		.forEach(i -> map.put("Measurement " + i, (double)i));
+		
+		assertEquals(n, list.size());
+		assertEquals(n, map.size());
+		
+		assertSame(list, p.getMeasurementList());
+		assertSame(map, p.getMeasurements());
+		
 	}
-	//@Test
-	public void test_isRootObject(PathObject myPO, Boolean isroot) {
-		assertEquals(myPO.isRootObject(), isroot);
+	
+	@ParameterizedTest
+	@MethodSource("provideObjects")
+	public void test_measurementMapAndList(PathObject p) {
+		
+		p.getMeasurementList().addMeasurement("added", 1);
+		assertEquals(1, p.getMeasurementList().size());
+		p.getMeasurementList().addMeasurement("added", 2);
+		assertEquals(1, p.getMeasurementList().size());
+		assertEquals(2, p.getMeasurementList().getMeasurementValue("added"));
+		
+		p.getMeasurementList().putMeasurement("put", 3);
+		assertEquals(2, p.getMeasurementList().size());
+		p.getMeasurementList().putMeasurement("put", 4);
+		assertEquals(2, p.getMeasurementList().size());
+		assertEquals(4, p.getMeasurementList().getMeasurementValue("put"));
+		
+		assertEquals(2, p.getMeasurements().size());
+		assertEquals(2, p.getMeasurements().keySet().size());
+		assertEquals(2, p.getMeasurements().entrySet().size());
+		assertEquals(2, p.getMeasurements().values().size());
+		assertEquals(2.0, p.getMeasurements().get("added"));
+		assertEquals(4.0, p.getMeasurements().get("put"));
+		
+		checkSameKeysAndValues(p);
+		
+		Double val = 5.5; // Note 5.1 wouldn't work because of loss of precision if using a float measurement list!
+		p.getMeasurements().put("mapAdded", val);
+		assertEquals(val, p.getMeasurements().get("mapAdded"));
+		assertEquals(val, p.getMeasurementList().getMeasurementValue("mapAdded"));
+		// Not expected to pass! val is unboxed internally, precise value not stored
+//		assertSame(val, p.getMeasurements().get("mapAdded"));
+		
+		p.getMeasurementList().removeMeasurements("Not there");
+		assertEquals(3, p.getMeasurementList().size());
+		assertEquals(3, p.getMeasurements().size());
+		
+		p.getMeasurementList().removeMeasurements("put");
+		assertEquals(2, p.getMeasurementList().size());
+		assertEquals(2, p.getMeasurements().size());
+
+		p.getMeasurements().remove("added");
+		assertEquals(1, p.getMeasurementList().size());
+		assertEquals(1, p.getMeasurements().size());
+
+		checkSameKeysAndValues(p);
 	}
-	//@Test
-	public void test_isPoint(PathObject myPO, Boolean ispoint) {
-		assertEquals(PathObjectTools.hasPointROI(myPO), ispoint);
-	}
-	//@Test
-	public void test_getMeasurementList(PathObject myPO) {
-		MeasurementList myPOML = myPO.getMeasurementList();
-		assertTrue(myPOML instanceof MeasurementList);
-	}
-	//@Test
-	public void test_getMeasurementList(PathObject myPO, MeasurementList ML) {
-		MeasurementList myPOML = myPO.getMeasurementList();
-		assertEquals(myPOML, ML);
-	}
-	//@Test
-	public void test_equalMeasurementListContent(MeasurementList ML, MeasurementList ML2) {
-		var keys = ML.getMeasurementNames();
-		assertArrayEquals(keys.toArray(), ML2.getMeasurementNames().toArray());
-		for (String name: keys) {
-			assertEquals(ML.getMeasurementValue(name), ML2.getMeasurementValue(name));
-		}
-	}
-	//@Test
-	public void test_nMeasurements(PathObject myPO, Integer nmeasurements) {
-		assertEquals((Integer)myPO.getMeasurementList().size(), nmeasurements);
-	}
-	//@Test
-	public void test_objectCountPostfix(PathObject myPO, String objectcount) {
-		assertEquals(myPO.objectCountPostfix(), objectcount);
-	}
-	//@Test
-	public void test_toString(PathObject myPO, String tostring) {
-		assertEquals(myPO.toString(), tostring); 
-	}
-	//@Test
-	public void test_addPathObject(PathObject myPO, PathObject tPO, Integer nchildren) {
-		myPO.addPathObject(tPO);
-		assertEquals((Integer)myPO.nChildObjects(), nchildren);
-	}
-	//@Test
-	public void test_addPathObjects(PathObject myPO, Collection<PathObject> colPO, Integer nchildren) {
-		myPO.addPathObjects(colPO);
-		assertEquals((Integer)myPO.nChildObjects(), nchildren);
-	}
-	//@Test
-	public void test_removePathObject(PathObject myPO, PathObject tPO, Integer nchildren) {
-		myPO.removePathObject(tPO);
-		assertEquals((Integer)myPO.nChildObjects(), nchildren);
-	}
-	//@Test
-	public void test_removePathObjects(PathObject myPO, Collection<PathObject> colPO, Integer nchildren) {
-		myPO.removePathObjects(colPO);
-		assertEquals((Integer)myPO.nChildObjects(), nchildren);
-	}
-	//@Test
-	public void test_clearPathObjects(PathObject myPO, Integer nchildren) {
-		myPO.clearPathObjects();
-		assertEquals((Integer)myPO.nChildObjects(), nchildren);
-	}
-	//@Test
-	public void test_nChildObjects(PathObject myPO, Integer nchildren) {
-		assertEquals((Integer)myPO.nChildObjects(), nchildren);
-	}
-	//@Test
-	public void test_hasChildren(PathObject myPO, Boolean haschildren) {
-		assertEquals(myPO.nChildObjects()!=0?Boolean.TRUE:Boolean.FALSE, haschildren);
-	}
-	//@Test
-	public void test_hasROI(PathObject myPO, Boolean hasroi) {
-		assertEquals(myPO.getROI()!=null?Boolean.TRUE:Boolean.FALSE, hasroi);
-	}
-	//@Test
-	public void test_isAnnotation(PathObject myPO, Boolean isannotation) {
-		assertEquals(myPO.isAnnotation(), isannotation); 
-	}
-	//@Test
-	public void test_isDetection(PathObject myPO, Boolean isdetection) {
-		assertEquals(myPO.isDetection(), isdetection);
-	}
-	//@Test
-	public void test_hasMeasurements(PathObject myPO, Boolean hasmeasurements) {
-		assertEquals(myPO.getMeasurementList().size()!=0?Boolean.TRUE:Boolean.FALSE, hasmeasurements);
-	}
-	//@Test
-	public void test_isTMACore(PathObject myPO, Boolean istmacore) {
-		assertEquals(myPO.isTMACore(), istmacore);
-	}
-	//@Test
-	public void test_isTile(PathObject myPO, Boolean istile) {
-		assertEquals(myPO.isTile(), istile);
-	}
-	//@Test
-	public void test_isEditable(PathObject myPO, Boolean iseditable) {
-		assertEquals(myPO.isEditable(), iseditable);
-	}
+	
 	
 	/**
-	 * This tests the child objects have the same elements, but ignores order.
-	 * @param myPO
-	 * @param listPO
+	 * Check list and map representations both have identical keys, whether viewed as a list or a set 
+	 * (i.e. they must be unique and ordered)
+	 * @param p
 	 */
-	//@Test
-	public void test_comparePathObjectListContents(PathObject myPO, Collection<PathObject> listPO) {
-		assertEquals(new HashSet<>(myPO.getChildObjects()), new HashSet<>(listPO));
-//		assertEquals(myPO.getChildObjects(), listPO);
-	}	
-	//@Test
-	public void test_getPathClass(PathObject myPO, PathClass PC) {
-		assertEquals(myPO.getPathClass(), PC);	
+	private static void checkSameKeysAndValues(PathObject p) {
+		assertEquals(p.getMeasurementList().getMeasurementNames(), new ArrayList<>(p.getMeasurements().keySet()));
+		assertEquals(new LinkedHashSet<>(p.getMeasurementList().getMeasurementNames()), p.getMeasurements().keySet());
+		
+		double[] listValues = new double[p.getMeasurementList().size()];
+		double[] listValuesByName = new double[p.getMeasurementList().size()];
+		for (int i = 0; i < listValues.length; i++) {
+			listValues[i] = p.getMeasurementList().getMeasurementValue(i);
+			listValuesByName[i] = p.getMeasurementList().getMeasurementValue(p.getMeasurementList().getMeasurementName(i));
+		}
+		double[] mapValues = p.getMeasurements().values().stream().mapToDouble(v -> v.doubleValue()).toArray();
+		double[] mapValuesByIterator = new double[p.getMeasurements().size()];
+		int count = 0;
+		for (var entry : p.getMeasurements().entrySet()) {
+			mapValuesByIterator[count++] = entry.getValue();
+		}
+		
+		assertArrayEquals(listValues, listValuesByName);
+		assertArrayEquals(listValues, mapValues);
+		assertArrayEquals(listValues, mapValuesByIterator);
 	}
-	//@Test
-	public void test_setPathClass(PathObject myPO, String ErrMsg, ByteArrayOutputStream errContent) {
-		myPO.resetPathClass();
-		assertEquals(ErrMsg, errContent.toString());
-	}
-	//@Test
-	public void test_setPathClass(PathObject myPO, PathClass PC) {
-		myPO.setPathClass(PC);
-		assertEquals(myPO.getPathClass(), PC);	
-	}
-	//@Test
-	public void test_setPathClass(PathObject myPO, PathClass PC, Double prob) {
-		myPO.setPathClass(PC, prob);
-		assertEquals(myPO.getPathClass(), PC);
-		assertEquals((Double)myPO.getClassProbability(), prob);
-	}
-	//@Test
-	public void test_getClassProbability(PathObject myPO, Double classprob) {
-		assertEquals(myPO.getClassProbability(), classprob, epsilon);		
-	}
-	//@Test
-	public void test_getDisplayedName(PathObject myPO, String dispname) {
-		assertEquals(myPO.getDisplayedName(), dispname);
-	}
-	//@Test
-	public void test_getName(PathObject myPO, String name) {
-		assertEquals(myPO.getName(), name);
-	}
-	//@Test
-	public void test_setName(PathObject myPO, String name) {
-		myPO.setName(name);
-		assertEquals(myPO.getName(), name);
-	}
-	//@Test
-	public void test_getROI(PathObject myPO, ROI roi) {
-		assertEquals(myPO.getROI(), roi); 
-	}
-	//@Test
-	public void test_equalROIRegions(ROI roi, ROI roi2) {
-		assertEquals(roi.getAllPoints(), roi2.getAllPoints());
-		assertEquals(roi.getImagePlane(), roi.getImagePlane());
-	}
-	//@Test
-	public void test_getColorRGB(PathObject myPO, Integer colorrgb) {
-		assertEquals(myPO.getColor(), colorrgb);
-	}
-	//@Test
-	public void test_setColorRGB(PathObject myPO, Integer colorrgb) {
-		myPO.setColor(colorrgb);
-		assertEquals((Integer)myPO.getColor(), colorrgb);
-	}
+	
+	
+	
+
 }

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -24,7 +24,9 @@ package qupath.lib.objects;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,6 +56,19 @@ public class TestPathObject {
 				);
 	}
 	
+	@ParameterizedTest
+	@MethodSource("provideObjects")
+	public void test_measurementOrDefault(PathObject p) {
+		
+		var list = p.getMeasurementList();
+		
+		list.put("Something", 100.0);
+		assertTrue(Double.isNaN(list.get("Something else")));
+		assertTrue(Double.isNaN(list.getOrDefault("Something else", Double.NaN)));
+		assertFalse(Double.isNaN(list.getOrDefault("Something else", Double.NEGATIVE_INFINITY)));
+		assertEquals(-1, list.getOrDefault("Something else", -1));
+		
+	}
 	
 	@ParameterizedTest
 	@MethodSource("provideObjects")
@@ -69,6 +84,10 @@ public class TestPathObject {
 		
 		assertEquals(n, list.size());
 		assertEquals(n, map.size());
+		
+		// Closing shouldn't make a difference
+		list.close();
+		assertEquals(n, list.size());
 		
 		map.clear();
 
@@ -148,6 +167,11 @@ public class TestPathObject {
 		assertEquals(1, p.getMeasurements().size());
 
 		checkSameKeysAndValues(p);
+		
+		p.getMeasurementList().close();
+		checkSameKeysAndValues(p);
+		assertEquals(1, p.getMeasurementList().size());
+		assertEquals(1, p.getMeasurements().size());
 	}
 	
 	
@@ -162,6 +186,7 @@ public class TestPathObject {
 		
 		double[] listValues = new double[p.getMeasurementList().size()];
 		double[] listValuesByName = new double[p.getMeasurementList().size()];
+		double[] listValuesAsArray = p.getMeasurementList().values();
 		for (int i = 0; i < listValues.length; i++) {
 			listValues[i] = p.getMeasurementList().getMeasurementValue(i);
 			listValuesByName[i] = p.getMeasurementList().getMeasurementValue(p.getMeasurementList().getMeasurementName(i));
@@ -173,6 +198,7 @@ public class TestPathObject {
 			mapValuesByIterator[count++] = entry.getValue();
 		}
 		
+		assertArrayEquals(listValues, listValuesAsArray);
 		assertArrayEquals(listValues, listValuesByName);
 		assertArrayEquals(listValues, mapValues);
 		assertArrayEquals(listValues, mapValuesByIterator);

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -80,7 +80,7 @@ public class TestPathObject {
 		int n = 1000;
 		IntStream.range(0, n)
 			.parallel()
-			.forEach(i ->list.putMeasurement("Measurement " + i, i));
+			.forEach(i ->list.put("Measurement " + i, i));
 		
 		assertEquals(n, list.size());
 		assertEquals(n, map.size());
@@ -108,7 +108,7 @@ public class TestPathObject {
 		
 		IntStream.range(0, n)
 		.parallel()
-		.forEach(i -> list.putMeasurement("Measurement " + i, (double)i));
+		.forEach(i -> list.put("Measurement " + i, (double)i));
 		
 		IntStream.range(0, n)
 		.parallel()
@@ -130,13 +130,13 @@ public class TestPathObject {
 		assertEquals(1, p.getMeasurementList().size());
 		p.getMeasurementList().addMeasurement("added", 2);
 		assertEquals(1, p.getMeasurementList().size());
-		assertEquals(2, p.getMeasurementList().getMeasurementValue("added"));
+		assertEquals(2, p.getMeasurementList().get("added"));
 		
-		p.getMeasurementList().putMeasurement("put", 3);
+		p.getMeasurementList().put("put", 3);
 		assertEquals(2, p.getMeasurementList().size());
-		p.getMeasurementList().putMeasurement("put", 4);
+		p.getMeasurementList().put("put", 4);
 		assertEquals(2, p.getMeasurementList().size());
-		assertEquals(4, p.getMeasurementList().getMeasurementValue("put"));
+		assertEquals(4, p.getMeasurementList().get("put"));
 		
 		assertEquals(2, p.getMeasurements().size());
 		assertEquals(2, p.getMeasurements().keySet().size());
@@ -150,7 +150,7 @@ public class TestPathObject {
 		Double val = 5.5; // Note 5.1 wouldn't work because of loss of precision if using a float measurement list!
 		p.getMeasurements().put("mapAdded", val);
 		assertEquals(val, p.getMeasurements().get("mapAdded"));
-		assertEquals(val, p.getMeasurementList().getMeasurementValue("mapAdded"));
+		assertEquals(val, p.getMeasurementList().get("mapAdded"));
 		// Not expected to pass! val is unboxed internally, precise value not stored
 //		assertSame(val, p.getMeasurements().get("mapAdded"));
 		
@@ -189,7 +189,7 @@ public class TestPathObject {
 		double[] listValuesAsArray = p.getMeasurementList().values();
 		for (int i = 0; i < listValues.length; i++) {
 			listValues[i] = p.getMeasurementList().getMeasurementValue(i);
-			listValuesByName[i] = p.getMeasurementList().getMeasurementValue(p.getMeasurementList().getMeasurementName(i));
+			listValuesByName[i] = p.getMeasurementList().get(p.getMeasurementList().getMeasurementName(i));
 		}
 		double[] mapValues = p.getMeasurements().values().stream().mapToDouble(v -> v.doubleValue()).toArray();
 		double[] mapValuesByIterator = new double[p.getMeasurements().size()];

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectMethods.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectMethods.java
@@ -72,7 +72,7 @@ class TestPathObjectMethods {
 		var keys = ML.getMeasurementNames();
 		assertArrayEquals(keys.toArray(), ML2.getMeasurementNames().toArray());
 		for (String name: keys) {
-			assertEquals(ML.getMeasurementValue(name), ML2.getMeasurementValue(name));
+			assertEquals(ML.get(name), ML2.get(name));
 		}
 	}
 	//@Test

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectMethods.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectMethods.java
@@ -1,0 +1,218 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
+ * Contact: IP Management (ipmanagement@qub.ac.uk)
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.objects;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Collection;
+import java.util.HashSet;
+import qupath.lib.measurements.MeasurementList;
+import qupath.lib.objects.classes.PathClass;
+import qupath.lib.roi.interfaces.ROI;
+
+/**
+ * These tests are actually called from other classes.
+ */
+class TestPathObjectMethods {
+	
+	private final Double epsilon = 1e-15; // error for double comparison
+	
+	//@Test
+	public void test_getParent(PathObject myPO, PathObject parent) {
+		assertEquals(myPO.getParent(), parent);
+	}
+	//@Test
+	public void test_getLevel(PathObject myPO, Integer level) {
+		assertEquals((Integer)myPO.getLevel(), level);
+	}
+	//@Test
+	public void test_isRootObject(PathObject myPO, Boolean isroot) {
+		assertEquals(myPO.isRootObject(), isroot);
+	}
+	//@Test
+	public void test_isPoint(PathObject myPO, Boolean ispoint) {
+		assertEquals(PathObjectTools.hasPointROI(myPO), ispoint);
+	}
+	//@Test
+	public void test_getMeasurementList(PathObject myPO) {
+		MeasurementList myPOML = myPO.getMeasurementList();
+		assertTrue(myPOML instanceof MeasurementList);
+	}
+	//@Test
+	public void test_getMeasurementList(PathObject myPO, MeasurementList ML) {
+		MeasurementList myPOML = myPO.getMeasurementList();
+		assertEquals(myPOML, ML);
+	}
+	//@Test
+	public void test_equalMeasurementListContent(MeasurementList ML, MeasurementList ML2) {
+		var keys = ML.getMeasurementNames();
+		assertArrayEquals(keys.toArray(), ML2.getMeasurementNames().toArray());
+		for (String name: keys) {
+			assertEquals(ML.getMeasurementValue(name), ML2.getMeasurementValue(name));
+		}
+	}
+	//@Test
+	public void test_nMeasurements(PathObject myPO, Integer nmeasurements) {
+		assertEquals((Integer)myPO.getMeasurementList().size(), nmeasurements);
+	}
+	//@Test
+	public void test_objectCountPostfix(PathObject myPO, String objectcount) {
+		assertEquals(myPO.objectCountPostfix(), objectcount);
+	}
+	//@Test
+	public void test_toString(PathObject myPO, String tostring) {
+		assertEquals(myPO.toString(), tostring); 
+	}
+	//@Test
+	public void test_addPathObject(PathObject myPO, PathObject tPO, Integer nchildren) {
+		myPO.addPathObject(tPO);
+		assertEquals((Integer)myPO.nChildObjects(), nchildren);
+	}
+	//@Test
+	public void test_addPathObjects(PathObject myPO, Collection<PathObject> colPO, Integer nchildren) {
+		myPO.addPathObjects(colPO);
+		assertEquals((Integer)myPO.nChildObjects(), nchildren);
+	}
+	//@Test
+	public void test_removePathObject(PathObject myPO, PathObject tPO, Integer nchildren) {
+		myPO.removePathObject(tPO);
+		assertEquals((Integer)myPO.nChildObjects(), nchildren);
+	}
+	//@Test
+	public void test_removePathObjects(PathObject myPO, Collection<PathObject> colPO, Integer nchildren) {
+		myPO.removePathObjects(colPO);
+		assertEquals((Integer)myPO.nChildObjects(), nchildren);
+	}
+	//@Test
+	public void test_clearPathObjects(PathObject myPO, Integer nchildren) {
+		myPO.clearPathObjects();
+		assertEquals((Integer)myPO.nChildObjects(), nchildren);
+	}
+	//@Test
+	public void test_nChildObjects(PathObject myPO, Integer nchildren) {
+		assertEquals((Integer)myPO.nChildObjects(), nchildren);
+	}
+	//@Test
+	public void test_hasChildren(PathObject myPO, Boolean haschildren) {
+		assertEquals(myPO.nChildObjects()!=0?Boolean.TRUE:Boolean.FALSE, haschildren);
+	}
+	//@Test
+	public void test_hasROI(PathObject myPO, Boolean hasroi) {
+		assertEquals(myPO.getROI()!=null?Boolean.TRUE:Boolean.FALSE, hasroi);
+	}
+	//@Test
+	public void test_isAnnotation(PathObject myPO, Boolean isannotation) {
+		assertEquals(myPO.isAnnotation(), isannotation); 
+	}
+	//@Test
+	public void test_isDetection(PathObject myPO, Boolean isdetection) {
+		assertEquals(myPO.isDetection(), isdetection);
+	}
+	//@Test
+	public void test_hasMeasurements(PathObject myPO, Boolean hasmeasurements) {
+		assertEquals(myPO.getMeasurementList().size()!=0?Boolean.TRUE:Boolean.FALSE, hasmeasurements);
+	}
+	//@Test
+	public void test_isTMACore(PathObject myPO, Boolean istmacore) {
+		assertEquals(myPO.isTMACore(), istmacore);
+	}
+	//@Test
+	public void test_isTile(PathObject myPO, Boolean istile) {
+		assertEquals(myPO.isTile(), istile);
+	}
+	//@Test
+	public void test_isEditable(PathObject myPO, Boolean iseditable) {
+		assertEquals(myPO.isEditable(), iseditable);
+	}
+	
+	/**
+	 * This tests the child objects have the same elements, but ignores order.
+	 * @param myPO
+	 * @param listPO
+	 */
+	//@Test
+	public void test_comparePathObjectListContents(PathObject myPO, Collection<PathObject> listPO) {
+		assertEquals(new HashSet<>(myPO.getChildObjects()), new HashSet<>(listPO));
+//		assertEquals(myPO.getChildObjects(), listPO);
+	}	
+	//@Test
+	public void test_getPathClass(PathObject myPO, PathClass PC) {
+		assertEquals(myPO.getPathClass(), PC);	
+	}
+	//@Test
+	public void test_setPathClass(PathObject myPO, String ErrMsg, ByteArrayOutputStream errContent) {
+		myPO.resetPathClass();
+		assertEquals(ErrMsg, errContent.toString());
+	}
+	//@Test
+	public void test_setPathClass(PathObject myPO, PathClass PC) {
+		myPO.setPathClass(PC);
+		assertEquals(myPO.getPathClass(), PC);	
+	}
+	//@Test
+	public void test_setPathClass(PathObject myPO, PathClass PC, Double prob) {
+		myPO.setPathClass(PC, prob);
+		assertEquals(myPO.getPathClass(), PC);
+		assertEquals((Double)myPO.getClassProbability(), prob);
+	}
+	//@Test
+	public void test_getClassProbability(PathObject myPO, Double classprob) {
+		assertEquals(myPO.getClassProbability(), classprob, epsilon);		
+	}
+	//@Test
+	public void test_getDisplayedName(PathObject myPO, String dispname) {
+		assertEquals(myPO.getDisplayedName(), dispname);
+	}
+	//@Test
+	public void test_getName(PathObject myPO, String name) {
+		assertEquals(myPO.getName(), name);
+	}
+	//@Test
+	public void test_setName(PathObject myPO, String name) {
+		myPO.setName(name);
+		assertEquals(myPO.getName(), name);
+	}
+	//@Test
+	public void test_getROI(PathObject myPO, ROI roi) {
+		assertEquals(myPO.getROI(), roi); 
+	}
+	//@Test
+	public void test_equalROIRegions(ROI roi, ROI roi2) {
+		assertEquals(roi.getAllPoints(), roi2.getAllPoints());
+		assertEquals(roi.getImagePlane(), roi.getImagePlane());
+	}
+	//@Test
+	public void test_getColorRGB(PathObject myPO, Integer colorrgb) {
+		assertEquals(myPO.getColor(), colorrgb);
+	}
+	//@Test
+	public void test_setColorRGB(PathObject myPO, Integer colorrgb) {
+		myPO.setColor(colorrgb);
+		assertEquals((Integer)myPO.getColor(), colorrgb);
+	}	
+	
+}

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectPredicates.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectPredicates.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 
 import qupath.lib.objects.PathObjectPredicates.PathObjectPredicate;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.roi.ROIs;
 
 
@@ -45,18 +44,18 @@ public class TestPathObjectPredicates {
 	public void test_predicates() {
 		
 		// Create lots of objects
-		var tumorClass = PathClassFactory.getPathClass("Tumor", (Integer)null);
-		var tumorPositive = PathClassFactory.getDerivedPathClass(tumorClass, "Positive", null);
-		var tumorNegative = PathClassFactory.getDerivedPathClass(tumorClass, "Negative", null);
-		var tumorOnePlus = PathClassFactory.getPathClass("Tumor", "1+");
-		var tumorTwoPlus = PathClassFactory.getPathClass("Tumor", "2+");
-		var tumorThreePlus = PathClassFactory.getPathClass("Tumor", "3+");
+		var tumorClass = PathClass.getInstance("Tumor", (Integer)null);
+		var tumorPositive = PathClass.getInstance(tumorClass, "Positive", null);
+		var tumorNegative = PathClass.getInstance(tumorClass, "Negative", null);
+		var tumorOnePlus = PathClass.fromArray("Tumor", "1+");
+		var tumorTwoPlus = PathClass.fromArray("Tumor", "2+");
+		var tumorThreePlus = PathClass.fromArray("Tumor", "3+");
 		
-		var stromaClass = PathClassFactory.getPathClass("Stroma", (Integer)null);
-		var stromaPositive = PathClassFactory.getDerivedPathClass(stromaClass, "Positive", null);
-		var stromaNegative = PathClassFactory.getDerivedPathClass(stromaClass, "Negative", null);
+		var stromaClass = PathClass.getInstance("Stroma", (Integer)null);
+		var stromaPositive = PathClass.getInstance(stromaClass, "Positive", null);
+		var stromaNegative = PathClass.getInstance(stromaClass, "Negative", null);
 
-		var tumorStromaOtherClass = PathClassFactory.getPathClass("Tumor: Stroma: Other");
+		var tumorStromaOtherClass = PathClass.fromString("Tumor: Stroma: Other");
 		
 		int n = 10;
 		

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
 
@@ -48,9 +48,9 @@ public class TestPathObjectTools extends TestPathObjectMethods {
 				);
 		
 		var pathClasses = Arrays.asList(
-				PathClassFactory.getPathClass("First"),
-				PathClassFactory.getPathClass("Second"),
-				PathClassFactory.getPathClass("Third: Fourth"),
+				PathClass.fromString("First"),
+				PathClass.getInstance("Second"),
+				PathClass.fromString("Third: Fourth"),
 				null
 				);
 		

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools.java
@@ -36,7 +36,7 @@ import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
 
 @SuppressWarnings("javadoc")
-public class TestPathObjectTools extends TestPathObject { 
+public class TestPathObjectTools extends TestPathObjectMethods { 
 	
 	@Test
 	public void test_BasicPO() {

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools2.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools2.java
@@ -94,20 +94,20 @@ public class TestPathObjectTools2 {
 		ml4 = MeasurementListFactory.createMeasurementList(16, MeasurementList.MeasurementListType.GENERAL);
 		
 		// Adding measurement to list2 (all measurements)
-		ml2.putMeasurement("intensityMeasurement1", 0.0);
-		ml2.putMeasurement("intensityMeasurement2", 0.2);
-		ml2.putMeasurement("intensityMeasurement3", 0.6);
-		ml2.putMeasurement("intensityMeasurement4", -4.6);
+		ml2.put("intensityMeasurement1", 0.0);
+		ml2.put("intensityMeasurement2", 0.2);
+		ml2.put("intensityMeasurement3", 0.6);
+		ml2.put("intensityMeasurement4", -4.6);
 		
 		// Adding measurement to list3 (missing intensityMeasurement3)
-		ml3.putMeasurement("intensityMeasurement1", -1.0);
-		ml3.putMeasurement("intensityMeasurement2", 0.9999);
-		ml3.putMeasurement("intensityMeasurement4", 0.999);
+		ml3.put("intensityMeasurement1", -1.0);
+		ml3.put("intensityMeasurement2", 0.9999);
+		ml3.put("intensityMeasurement4", 0.999);
 		
 		// Adding measurement to list4 (missing intensityMeasurement4)
-		ml4.putMeasurement("intensityMeasurement1", 0.2);
-		ml4.putMeasurement("intensityMeasurement2", 0.3);
-		ml4.putMeasurement("intensityMeasurement3", 0.5);
+		ml4.put("intensityMeasurement1", 0.2);
+		ml4.put("intensityMeasurement2", 0.3);
+		ml4.put("intensityMeasurement3", 0.5);
 		
 		po1 = PathObjects.createDetectionObject(ROIs.createRectangleROI(0, 0, 10, 10, ImagePlane.getDefaultPlane()), pathClass1, ml1);
 		po2 = PathObjects.createDetectionObject(ROIs.createEllipseROI(0, 0, 10, 10, ImagePlane.getDefaultPlane()), pathClass2, ml2);

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools2.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools2.java
@@ -94,20 +94,20 @@ public class TestPathObjectTools2 {
 		ml4 = MeasurementListFactory.createMeasurementList(16, MeasurementList.MeasurementListType.GENERAL);
 		
 		// Adding measurement to list2 (all measurements)
-		ml2.addMeasurement("intensityMeasurement1", 0.0);
-		ml2.addMeasurement("intensityMeasurement2", 0.2);
-		ml2.addMeasurement("intensityMeasurement3", 0.6);
-		ml2.addMeasurement("intensityMeasurement4", -4.6);
+		ml2.putMeasurement("intensityMeasurement1", 0.0);
+		ml2.putMeasurement("intensityMeasurement2", 0.2);
+		ml2.putMeasurement("intensityMeasurement3", 0.6);
+		ml2.putMeasurement("intensityMeasurement4", -4.6);
 		
 		// Adding measurement to list3 (missing intensityMeasurement3)
-		ml3.addMeasurement("intensityMeasurement1", -1.0);
-		ml3.addMeasurement("intensityMeasurement2", 0.9999);
-		ml3.addMeasurement("intensityMeasurement4", 0.999);
+		ml3.putMeasurement("intensityMeasurement1", -1.0);
+		ml3.putMeasurement("intensityMeasurement2", 0.9999);
+		ml3.putMeasurement("intensityMeasurement4", 0.999);
 		
 		// Adding measurement to list4 (missing intensityMeasurement4)
-		ml4.addMeasurement("intensityMeasurement1", 0.2);
-		ml4.addMeasurement("intensityMeasurement2", 0.3);
-		ml4.addMeasurement("intensityMeasurement3", 0.5);
+		ml4.putMeasurement("intensityMeasurement1", 0.2);
+		ml4.putMeasurement("intensityMeasurement2", 0.3);
+		ml4.putMeasurement("intensityMeasurement3", 0.5);
 		
 		po1 = PathObjects.createDetectionObject(ROIs.createRectangleROI(0, 0, 10, 10, ImagePlane.getDefaultPlane()), pathClass1, ml1);
 		po2 = PathObjects.createDetectionObject(ROIs.createEllipseROI(0, 0, 10, 10, ImagePlane.getDefaultPlane()), pathClass2, ml2);

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools2.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools2.java
@@ -41,7 +41,6 @@ import qupath.lib.images.servers.ServerTools;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.measurements.MeasurementListFactory;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
@@ -81,12 +80,12 @@ public class TestPathObjectTools2 {
 	
 	@BeforeEach
 	public void init() {
-		pathClass1 = PathClassFactory.getPathClass("TestClass1",  Color.RED.getRGB());
-		pathClass2 = PathClassFactory.getPathClass("TestClass2",  Color.GREEN.getRGB());
-		pathClass3 = PathClassFactory.getPathClass("TestClass3",  Color.BLUE.getRGB());
-		pathClass4 = PathClassFactory.getPathClass("test*",  Color.BLUE.getRGB());
-		pathClass5 = PathClassFactory.getPathClass("Ignore*", ColorTools.packRGB(180, 180, 180));
-		pathClassUnclassified = PathClassFactory.getPathClassUnclassified();
+		pathClass1 = PathClass.getInstance("TestClass1",  Color.RED.getRGB());
+		pathClass2 = PathClass.getInstance("TestClass2",  Color.GREEN.getRGB());
+		pathClass3 = PathClass.getInstance("TestClass3",  Color.BLUE.getRGB());
+		pathClass4 = PathClass.getInstance("test*",  Color.BLUE.getRGB());
+		pathClass5 = PathClass.getInstance("Ignore*", ColorTools.packRGB(180, 180, 180));
+		pathClassUnclassified = PathClass.NULL_CLASS;
 		
 		ml1 = MeasurementListFactory.createMeasurementList(16, MeasurementList.MeasurementListType.GENERAL);
 		ml2 = MeasurementListFactory.createMeasurementList(16, MeasurementList.MeasurementListType.GENERAL);
@@ -138,7 +137,7 @@ public class TestPathObjectTools2 {
 		manualMap.put(po6, null);
 		manualMap.put(po7, pathClass4);
 		manualMap.put(po8, pathClass5);
-		manualMap.put(po9, PathClassFactory.getPathClassUnclassified());
+		manualMap.put(po9, PathClass.NULL_CLASS);
 		
 		// Check that they are equal
 		assertEquals(manualMap.keySet(), map.keySet());
@@ -240,7 +239,7 @@ public class TestPathObjectTools2 {
 		var poIgnore2 = PathObjects.createDetectionObject(ROIs.createEmptyROI(), pathClass5, ml1);
 		assertEquals(pathClass5, PathObjectTools.setIntensityClassification(poIgnore2, "intensityMeasurement1", 0.5));
 
-		var poNull = PathObjects.createDetectionObject(ROIs.createEmptyROI(), PathClassFactory.getPathClassUnclassified(), ml1);
+		var poNull = PathObjects.createDetectionObject(ROIs.createEmptyROI(), PathClass.NULL_CLASS, ml1);
 		assertEquals(null, PathObjectTools.setIntensityClassification(poNull, "intensityMeasurement1", 0.5));
 		
 		// Missing measurements -> unchanged
@@ -250,28 +249,28 @@ public class TestPathObjectTools2 {
 		assertEquals(pathClass1, PathObjectTools.setIntensityClassification(po1, "intensityMeasurement4", 0.5));
 		assertEquals(pathClass1, PathObjectTools.setIntensityClassification(po1, "intensityMeasurement4", 0.5, 1.0, 1.5));
 		
-		assertEquals(PathClassFactory.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement1", 0.5));
-		assertEquals(PathClassFactory.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement2", 0.5));
-		assertEquals(PathClassFactory.getPositive(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement3", 0.5));
-		assertEquals(PathClassFactory.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", 0.5));
-		assertEquals(PathClassFactory.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", 0.5, 1.0, 1.5));
-		assertEquals(PathClassFactory.getOnePlus(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", -5.0, 1.0, 1.5));
-		assertEquals(PathClassFactory.getThreePlus(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", -5.0, -4.9, -4.8));
-		assertEquals(PathClassFactory.getOnePlus(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", -5.0, 1.5));
-		assertEquals(PathClassFactory.getTwoPlus(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", -5.0, -4.7));
-		assertEquals(PathClassFactory.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", 0, 1.5));
+		assertEquals(PathClass.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement1", 0.5));
+		assertEquals(PathClass.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement2", 0.5));
+		assertEquals(PathClass.getPositive(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement3", 0.5));
+		assertEquals(PathClass.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", 0.5));
+		assertEquals(PathClass.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", 0.5, 1.0, 1.5));
+		assertEquals(PathClass.getOnePlus(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", -5.0, 1.0, 1.5));
+		assertEquals(PathClass.getThreePlus(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", -5.0, -4.9, -4.8));
+		assertEquals(PathClass.getOnePlus(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", -5.0, 1.5));
+		assertEquals(PathClass.getTwoPlus(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", -5.0, -4.7));
+		assertEquals(PathClass.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", 0, 1.5));
 		
-		assertEquals(PathClassFactory.getNegative(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement1", 0.5));
-		assertEquals(PathClassFactory.getPositive(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement2", 0.5));
+		assertEquals(PathClass.getNegative(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement1", 0.5));
+		assertEquals(PathClass.getPositive(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement2", 0.5));
 		assertEquals(pathClass3, PathObjectTools.setIntensityClassification(po3, "intensityMeasurement3", 0.5));	// Missing value -> unchanged
-		assertEquals(PathClassFactory.getPositive(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement4", 0.5));
-		assertEquals(PathClassFactory.getOnePlus(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement4", 0.5, 1.0, 1.5));
-		assertEquals(PathClassFactory.getTwoPlus(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement4", -0.5, 0.0, 1.5));
-		assertEquals(PathClassFactory.getThreePlus(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement4", -0.5, 0.0, 0.5));
+		assertEquals(PathClass.getPositive(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement4", 0.5));
+		assertEquals(PathClass.getOnePlus(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement4", 0.5, 1.0, 1.5));
+		assertEquals(PathClass.getTwoPlus(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement4", -0.5, 0.0, 1.5));
+		assertEquals(PathClass.getThreePlus(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement4", -0.5, 0.0, 0.5));
 		
-		assertEquals(PathClassFactory.getNegative(null), PathObjectTools.setIntensityClassification(po4, "intensityMeasurement1", 0.5));
-		assertEquals(PathClassFactory.getNegative(null), PathObjectTools.setIntensityClassification(po4, "intensityMeasurement2", 0.5));
-		assertEquals(PathClassFactory.getPositive(null), PathObjectTools.setIntensityClassification(po4, "intensityMeasurement3", 0.5));
+		assertEquals(PathClass.getNegative(null), PathObjectTools.setIntensityClassification(po4, "intensityMeasurement1", 0.5));
+		assertEquals(PathClass.getNegative(null), PathObjectTools.setIntensityClassification(po4, "intensityMeasurement2", 0.5));
+		assertEquals(PathClass.getPositive(null), PathObjectTools.setIntensityClassification(po4, "intensityMeasurement3", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po4, "intensityMeasurement4", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po4, "intensityMeasurement4", 0.5, 1.0, 1.5));
 
@@ -309,9 +308,9 @@ public class TestPathObjectTools2 {
 		assertEquals(null, PathObjectTools.setIntensityClassification(po9, "intensityMeasurement4", 0.5, 1.0, 1.5));
 		
 		// 'Unclassified' path class should be classified accordingly (Positive (1+, 2+, 3+)/Negative)
-		assertEquals(PathClassFactory.getNegative(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement1", 0.5));
-		assertEquals(PathClassFactory.getNegative(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement2", 0.5));
-		assertEquals(PathClassFactory.getPositive(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement3", 0.5));
+		assertEquals(PathClass.getNegative(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement1", 0.5));
+		assertEquals(PathClass.getNegative(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement2", 0.5));
+		assertEquals(PathClass.getPositive(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement3", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po10, "intensityMeasurement4", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po10, "intensityMeasurement4", 0.5, 1.0, 1.5));
 		
@@ -327,47 +326,47 @@ public class TestPathObjectTools2 {
 	public void test_setIntensityClassification2() {
 		PathObjectTools.setIntensityClassifications(Arrays.asList(po1, po2, po3, po4, po5, po6, po7, po8, po9, po10, po11), "intensityMeasurement1", 0.5);
 		assertEquals(pathClass1, po1.getPathClass());
-		assertEquals(PathClassFactory.getNegative(pathClass2), po2.getPathClass());
-		assertEquals(PathClassFactory.getNegative(pathClass3), po3.getPathClass());
-		assertEquals(PathClassFactory.getNegative(null), po4.getPathClass());
+		assertEquals(PathClass.getNegative(pathClass2), po2.getPathClass());
+		assertEquals(PathClass.getNegative(pathClass3), po3.getPathClass());
+		assertEquals(PathClass.getNegative(null), po4.getPathClass());
 		assertEquals(null, PathObjectTools.setIntensityClassification(po5, "intensityMeasurement1", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po6, "intensityMeasurement1", 0.5));
 		assertEquals(pathClass4, PathObjectTools.setIntensityClassification(po7, "intensityMeasurement1", 0.5));
 		assertEquals(pathClass5, PathObjectTools.setIntensityClassification(po8, "intensityMeasurement1", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po9, "intensityMeasurement1", 0.5));
-		assertEquals(PathClassFactory.getNegative(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement1", 0.5));
+		assertEquals(PathClass.getNegative(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement1", 0.5));
 		assertEquals(pathClass4, PathObjectTools.setIntensityClassification(po11, "intensityMeasurement1", 0.5));
 		
 		PathObjectTools.setIntensityClassifications(Arrays.asList(po1, po2, po3, po4, po5, po6, po7, po8, po9, po10, po11), "intensityMeasurement2", 0.5);
 		assertEquals(pathClass1, po1.getPathClass());
-		assertEquals(PathClassFactory.getNegative(pathClass2), po2.getPathClass());
-		assertEquals(PathClassFactory.getPositive(pathClass3), po3.getPathClass());
-		assertEquals(PathClassFactory.getNegative(null), PathObjectTools.setIntensityClassification(po4, "intensityMeasurement2", 0.5));
+		assertEquals(PathClass.getNegative(pathClass2), po2.getPathClass());
+		assertEquals(PathClass.getPositive(pathClass3), po3.getPathClass());
+		assertEquals(PathClass.getNegative(null), PathObjectTools.setIntensityClassification(po4, "intensityMeasurement2", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po5, "intensityMeasurement2", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po6, "intensityMeasurement2", 0.5));
 		assertEquals(pathClass4, PathObjectTools.setIntensityClassification(po7, "intensityMeasurement2", 0.5));
 		assertEquals(pathClass5, PathObjectTools.setIntensityClassification(po8, "intensityMeasurement2", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po9, "intensityMeasurement2", 0.5));
-		assertEquals(PathClassFactory.getNegative(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement2", 0.5));
+		assertEquals(PathClass.getNegative(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement2", 0.5));
 		assertEquals(pathClass4, PathObjectTools.setIntensityClassification(po11, "intensityMeasurement2", 0.5));
 
 		PathObjectTools.setIntensityClassifications(Arrays.asList(po1, po2, po3, po4, po5, po6, po7, po8, po9, po10, po11), "intensityMeasurement3", 0.5);
 		assertEquals(pathClass1, PathObjectTools.setIntensityClassification(po1, "intensityMeasurement3", 0.5));
-		assertEquals(PathClassFactory.getPositive(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement3", 0.5));
+		assertEquals(PathClass.getPositive(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement3", 0.5));
 		assertEquals(pathClass3, PathObjectTools.setIntensityClassification(po3, "intensityMeasurement3", 0.5));	// Missing value -> unchanged
-		assertEquals(PathClassFactory.getPositive(null), PathObjectTools.setIntensityClassification(po4, "intensityMeasurement3", 0.5));
+		assertEquals(PathClass.getPositive(null), PathObjectTools.setIntensityClassification(po4, "intensityMeasurement3", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po5, "intensityMeasurement3", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po6, "intensityMeasurement3", 0.5));
 		assertEquals(pathClass4, PathObjectTools.setIntensityClassification(po7, "intensityMeasurement3", 0.5));
 		assertEquals(pathClass5, PathObjectTools.setIntensityClassification(po8, "intensityMeasurement3", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po9, "intensityMeasurement3", 0.5));
-		assertEquals(PathClassFactory.getPositive(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement3", 0.5));
+		assertEquals(PathClass.getPositive(null), PathObjectTools.setIntensityClassification(po10, "intensityMeasurement3", 0.5));
 		assertEquals(pathClass4, PathObjectTools.setIntensityClassification(po11, "intensityMeasurement3", 0.5));
 		
 		PathObjectTools.setIntensityClassifications(Arrays.asList(po1, po2, po3, po4, po5, po6, po7, po8, po9, po10, po11), "intensityMeasurement4", 0.5);
 		assertEquals(pathClass1, PathObjectTools.setIntensityClassification(po1, "intensityMeasurement4", 0.5));
-		assertEquals(PathClassFactory.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", 0.5));
-		assertEquals(PathClassFactory.getPositive(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement4", 0.5));
+		assertEquals(PathClass.getNegative(pathClass2), PathObjectTools.setIntensityClassification(po2, "intensityMeasurement4", 0.5));
+		assertEquals(PathClass.getPositive(pathClass3), PathObjectTools.setIntensityClassification(po3, "intensityMeasurement4", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po4, "intensityMeasurement4", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po5, "intensityMeasurement4", 0.5));
 		assertEquals(null, PathObjectTools.setIntensityClassification(po6, "intensityMeasurement4", 0.5));

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathRootObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathRootObject.java
@@ -37,7 +37,7 @@ import qupath.lib.objects.classes.PathClassFactory;
 
 
 @SuppressWarnings("javadoc")
-public class TestPathRootObject extends TestPathObject {
+public class TestPathRootObject extends TestPathObjectMethods {
 	private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
 	private final Integer nPO = 10;
 	PathRootObject myPO = new PathRootObject();

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathRootObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathRootObject.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 
 
 @SuppressWarnings("javadoc")
@@ -115,7 +115,7 @@ public class TestPathRootObject extends TestPathObjectMethods {
 	}
 	@Test
 	public void test_SetGetPathClass() {
-		test_getPathClass(myPO, PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IMAGE_ROOT)); 
+		test_getPathClass(myPO, PathClass.StandardPathClasses.IMAGE_ROOT); 
 		//test_setPathClass(myPO, unclassErrMsg, errContent); // cannot be set
 		test_getClassProbability(myPO, Double.NaN);
 	}

--- a/qupath-core/src/test/java/qupath/lib/objects/classes/TestPathClassFactory.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/classes/TestPathClassFactory.java
@@ -45,26 +45,26 @@ public class TestPathClassFactory {
 	
 	@Test
 	public void test_getPathClass1() {
-		assertEquals("Ignore*", PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IGNORE).getName());
-		assertEquals("Image", PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IMAGE_ROOT).getName());
-		assertEquals("Immune cells", PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IMMUNE_CELLS).getName());
-		assertEquals("Necrosis", PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.NECROSIS).getName());
-		assertEquals("Negative", PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.NEGATIVE).getName());
-		assertEquals("Other", PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.OTHER).getName());
-		assertEquals("Positive", PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.POSITIVE).getName());
-		assertEquals("Region*", PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.REGION).getName());
-		assertEquals("Stroma", PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.STROMA).getName());
+		assertEquals("Ignore*", PathClass.StandardPathClasses.IGNORE.getName());
+		assertEquals("Image", PathClass.StandardPathClasses.IMAGE_ROOT.getName());
+		assertEquals("Immune cells", PathClass.StandardPathClasses.IMMUNE_CELLS.getName());
+		assertEquals("Necrosis", PathClass.StandardPathClasses.NECROSIS.getName());
+		assertEquals("Negative", PathClass.StandardPathClasses.NEGATIVE.getName());
+		assertEquals("Other", PathClass.StandardPathClasses.OTHER.getName());
+		assertEquals("Positive",PathClass.StandardPathClasses.POSITIVE.getName());
+		assertEquals("Region*", PathClass.StandardPathClasses.REGION.getName());
+		assertEquals("Stroma", PathClass.StandardPathClasses.STROMA.getName());
 	}
 	
 	@Test
 	public void test_getPathClass2() {
-		Assertions.assertThrows(IllegalArgumentException.class, () -> PathClassFactory.getPathClass("Class with\nnew line", ColorTools.RED));
+		Assertions.assertThrows(IllegalArgumentException.class, () -> PathClass.fromString("Class with\nnew line", ColorTools.RED));
 		
-		assertEquals("Third", PathClassFactory.getPathClass("First", "Second", "Third").getName());
-		assertEquals("First: Second: Third", PathClassFactory.getPathClass("First", "Second", "Third").toString());
-		assertEquals("Third", PathClassFactory.getPathClass(Arrays.asList("First", "Second", "Third")).getName());
-		assertEquals("First: Second: Third", PathClassFactory.getPathClass(Arrays.asList("First", "Second", "Third")).toString());
-		assertEquals(PathClass.NULL_CLASS, PathClassFactory.getPathClass(Arrays.asList()));
+		assertEquals("Third", PathClass.fromArray("First", "Second", "Third").getName());
+		assertEquals("First: Second: Third", PathClass.fromArray("First", "Second", "Third").toString());
+		assertEquals("Third", PathClass.fromCollection(Arrays.asList("First", "Second", "Third")).getName());
+		assertEquals("First: Second: Third", PathClass.fromCollection(Arrays.asList("First", "Second", "Third")).toString());
+		assertEquals(PathClass.NULL_CLASS, PathClass.fromCollection(Arrays.asList()));
 	}
 	
 	@Test
@@ -74,27 +74,27 @@ public class TestPathClassFactory {
 		var colorTwoPlus = ColorTools.makeScaledRGB(ColorTools.packRGB(225, 150, 50), 1.25);
 		var colorThreePlus = ColorTools.makeScaledRGB(ColorTools.packRGB(200, 50, 50), 1.25);
 		String uniqueName = UUID.randomUUID().toString();
-		checkFields(uniqueName, uniqueName, color1, PathClassFactory.getPathClass(uniqueName, color1));
-		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(null, color1));
-		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(PathClassFactory.getPathClassUnclassified().getName(), color1));
-		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(PathClassFactory.getPathClassUnclassified().getName(), color1));
-		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(PathClassFactory.getPathClassUnclassified().toString(), color1));
+		checkFields(uniqueName, uniqueName, color1, PathClass.getInstance(uniqueName, color1));
+		sameClass(PathClass.NULL_CLASS, PathClass.getInstance((String)null, color1));
+		sameClass(PathClass.NULL_CLASS, PathClass.getInstance(PathClass.NULL_CLASS.getName(), color1));
+		sameClass(PathClass.NULL_CLASS, PathClass.getInstance(PathClass.NULL_CLASS.getName(), color1));
+		sameClass(PathClass.NULL_CLASS, PathClass.getInstance(PathClass.NULL_CLASS.toString(), color1));
 		
-		checkFields("Child", "Parent: Child", color1, PathClassFactory.getPathClass("Parent:Child", color1));
+		checkFields("Child", "Parent: Child", color1, PathClass.fromString("Parent:Child", color1));
 		
 		// New in v0.4.0: don't allow creating a PathClass with an empty parent
-		assertThrows(IllegalArgumentException.class, () -> PathClassFactory.getPathClass(":Child", color1));
-		assertThrows(IllegalArgumentException.class, () -> PathClassFactory.getPathClass("", "Child"));
+		assertThrows(IllegalArgumentException.class, () -> PathClass.getInstance(":Child", color1));
+		assertThrows(IllegalArgumentException.class, () -> PathClass.fromArray("", "Child"));
 		
-		checkFields("1+", "1+", colorOnePlus, PathClassFactory.getPathClass(PathClass.NAME_ONE_PLUS));
-		checkFields("2+", "2+", colorTwoPlus, PathClassFactory.getPathClass(PathClass.NAME_TWO_PLUS));
-		checkFields("3+", "3+", colorThreePlus, PathClassFactory.getPathClass(PathClass.NAME_THREE_PLUS));
+		checkFields("1+", "1+", colorOnePlus, PathClass.getInstance(PathClass.NAME_ONE_PLUS));
+		checkFields("2+", "2+", colorTwoPlus, PathClass.getInstance(PathClass.NAME_TWO_PLUS));
+		checkFields("3+", "3+", colorThreePlus, PathClass.getInstance(PathClass.NAME_THREE_PLUS));
 
-		checkFields(PathClass.NAME_ONE_PLUS, PathClass.NAME_ONE_PLUS, PathClassFactory.getPathClass(PathClass.NAME_ONE_PLUS));
-		checkFields(PathClass.NAME_TWO_PLUS, PathClass.NAME_TWO_PLUS, PathClassFactory.getPathClass(PathClass.NAME_TWO_PLUS));
-		checkFields(PathClass.NAME_THREE_PLUS, PathClass.NAME_THREE_PLUS, PathClassFactory.getPathClass(PathClass.NAME_THREE_PLUS));
-		checkFields(PathClass.NAME_POSITIVE, PathClass.NAME_POSITIVE, PathClassFactory.getPathClass(PathClass.NAME_POSITIVE));
-		checkFields(PathClass.NAME_NEGATIVE, PathClass.NAME_NEGATIVE, PathClassFactory.getPathClass(PathClass.NAME_NEGATIVE));
+		checkFields(PathClass.NAME_ONE_PLUS, PathClass.NAME_ONE_PLUS, PathClass.getInstance(PathClass.NAME_ONE_PLUS));
+		checkFields(PathClass.NAME_TWO_PLUS, PathClass.NAME_TWO_PLUS, PathClass.getInstance(PathClass.NAME_TWO_PLUS));
+		checkFields(PathClass.NAME_THREE_PLUS, PathClass.NAME_THREE_PLUS, PathClass.getInstance(PathClass.NAME_THREE_PLUS));
+		checkFields(PathClass.NAME_POSITIVE, PathClass.NAME_POSITIVE, PathClass.getInstance(PathClass.NAME_POSITIVE));
+		checkFields(PathClass.NAME_NEGATIVE, PathClass.NAME_NEGATIVE, PathClass.getInstance(PathClass.NAME_NEGATIVE));
 		
 		var sameClasses = Arrays.asList(
 				"My:Class",
@@ -110,23 +110,23 @@ public class TestPathClassFactory {
 		var invalidClasses = Arrays.asList(":\n", "My::Invalid\nClass", ": :", ":\n:");
 		
 		for (var clazz: sameClasses) {
-			assertEquals("My", PathClassFactory.getPathClass(clazz, ColorTools.CYAN).getParentClass().getName());
-			assertEquals("Class", PathClassFactory.getPathClass(clazz, ColorTools.CYAN).getName());
-			assertEquals("My: Class", PathClassFactory.getPathClass(clazz, ColorTools.RED).toString());
+			assertEquals("My", PathClass.fromString(clazz, ColorTools.CYAN).getParentClass().getName());
+			assertEquals("Class", PathClass.fromString(clazz, ColorTools.CYAN).getName());
+			assertEquals("My: Class", PathClass.fromString(clazz, ColorTools.RED).toString());
 		}
 		for (var clazz: unclassifiedClasses) {
-			assertEquals(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClass(clazz, ColorTools.CYAN));
+			assertEquals(PathClass.NULL_CLASS, PathClass.fromString(clazz, ColorTools.CYAN));
 		}
 		for (var clazz: invalidClasses) {
-			Assertions.assertThrows(IllegalArgumentException.class, () -> PathClassFactory.getPathClass(clazz, ColorTools.CYAN));
+			Assertions.assertThrows(IllegalArgumentException.class, () -> PathClass.fromString(clazz, ColorTools.CYAN));
 		}
 	}
 	
 	@Test
 	public void test_duplicatePathClass() {
 		// Failed in v0.3.2 and before because second part not stripped
-		var pc1 = PathClassFactory.getPathClass("Something", "else ");
-		var pc2 = PathClassFactory.getPathClass("Something", "else ");
+		var pc1 = PathClass.fromArray("Something", "else ");
+		var pc2 = PathClass.fromArray("Something", "else ");
 		assertEquals(pc1, pc2);
 		assertEquals(pc1.toString(), pc2.toString());
 		assertEquals(pc1.toSet(), pc2.toSet());
@@ -134,8 +134,8 @@ public class TestPathClassFactory {
 		assertSame(pc1, pc2);
 		assertTrue(pc1 == pc2);
 
-		var pc3 = PathClassFactory.getPathClass("Something", "else ", " entirely");
-		var pc4 = PathClassFactory.getPathClass(" Something", " else ", "\tentirely");
+		var pc3 = PathClass.fromArray("Something", "else ", " entirely");
+		var pc4 = PathClass.fromArray(" Something", " else ", "\tentirely");
 		assertEquals(pc3, pc4);
 		assertEquals(pc3.toString(), pc4.toString());
 		assertEquals(pc3.toSet(), pc4.toSet());
@@ -150,10 +150,10 @@ public class TestPathClassFactory {
 		var list = List.of("Some class", "Another");
 		var allClasses = IntStream.range(0, 1000)
 			.parallel()
-			.mapToObj(i -> PathClass.getInstance(list))
+			.mapToObj(i -> PathClass.fromCollection(list))
 			.collect(Collectors.toList());
 		
-		var target = PathClass.getInstance(list);
+		var target = PathClass.fromCollection(list);
 		for (var source : allClasses) {
 			assertSame(target, source);
 		}
@@ -164,20 +164,20 @@ public class TestPathClassFactory {
 	
 	@Test
 	public void test_getOnePlus() {
-		checkFields("1+", "Test: 1+", PathClassFactory.getOnePlus(PathClassFactory.getPathClass("Test")));
-		checkFields("1+", "Test: 1+: 1+", PathClassFactory.getOnePlus(PathClassFactory.getPathClass("Test: 1+")));
+		checkFields("1+", "Test: 1+", PathClass.getOnePlus(PathClass.getInstance("Test")));
+		checkFields("1+", "Test: 1+: 1+", PathClass.getOnePlus(PathClass.fromString("Test: 1+")));
 	}
 	
 	@Test
 	public void test_getTwoPlus() {
-		checkFields("2+", "Test: 2+", PathClassFactory.getTwoPlus(PathClassFactory.getPathClass("Test")));
-		checkFields("2+", "Test: 2+: 2+", PathClassFactory.getTwoPlus(PathClassFactory.getPathClass("Test: 2+")));
+		checkFields("2+", "Test: 2+", PathClass.getTwoPlus(PathClass.getInstance("Test")));
+		checkFields("2+", "Test: 2+: 2+", PathClass.getTwoPlus(PathClass.fromString("Test: 2+")));
 	}
 
 	@Test
 	public void test_getThreePlus() {
-		checkFields("3+", "Test: 3+", PathClassFactory.getThreePlus(PathClassFactory.getPathClass("Test")));
-		checkFields("3+", "Test: 3+: 3+", PathClassFactory.getThreePlus(PathClassFactory.getPathClass("Test: 3+")));
+		checkFields("3+", "Test: 3+", PathClass.getThreePlus(PathClass.getInstance("Test")));
+		checkFields("3+", "Test: 3+: 3+", PathClass.getThreePlus(PathClass.fromString("Test: 3+")));
 	}
 	
 	@Test
@@ -192,8 +192,8 @@ public class TestPathClassFactory {
 	
 	@Test
 	public void test_getPathClassUnclassified() {
-		sameClass(PathClassFactory.getPathClassUnclassified(), PathClassFactory.getPathClassUnclassified().getBaseClass());
-		sameClass(PathClassFactory.getPathClass((String)null), PathClassFactory.getPathClassUnclassified().getBaseClass());
+		sameClass(PathClass.NULL_CLASS, PathClass.NULL_CLASS.getBaseClass());
+		sameClass(PathClass.getInstance((String)null), PathClass.NULL_CLASS.getBaseClass());
 	}
 	
 	private static void sameClass(PathClass expected, PathClass actual) {

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CellIntensityClassificationCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CellIntensityClassificationCommand.java
@@ -155,7 +155,7 @@ public class CellIntensityClassificationCommand implements Runnable {
 			if (o != null)
 				map.put(o, parseValues(sliders));
 			
-			double[] measurementValues = detections.stream().mapToDouble(p -> p.getMeasurementList().getMeasurementValue(n))
+			double[] measurementValues = detections.stream().mapToDouble(p -> p.getMeasurementList().get(n))
 					.filter(d -> Double.isFinite(d)).toArray();
 			var stats = new DescriptiveStatistics(measurementValues);
 			var histogram = new Histogram(measurementValues, 100, stats.getMin(), stats.getMax());

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateChannelTrainingImagesCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateChannelTrainingImagesCommand.java
@@ -37,7 +37,7 @@ import qupath.lib.gui.dialogs.Dialogs;
 import qupath.lib.gui.tools.PaneTools;
 import qupath.lib.images.servers.ImageChannel;
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.classes.PathClassFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
 
@@ -135,10 +135,10 @@ public class CreateChannelTrainingImagesCommand implements Runnable {
 						.addPathObjects(Arrays.asList(
 								PathObjects.createAnnotationObject(
 										ROIs.createPointsROI(ImagePlane.getDefaultPlane()),
-										PathClassFactory.getPathClass(channelName, channel.getColor())),
+										PathClass.getInstance(channelName, channel.getColor())),
 								PathObjects.createAnnotationObject(
 										ROIs.createPointsROI(ImagePlane.getDefaultPlane()),
-										PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IGNORE))
+										PathClass.StandardPathClasses.IGNORE)
 								));
 					entry2.saveImageData(imageData2);
 				}

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateRegionAnnotationsCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateRegionAnnotationsCommand.java
@@ -45,8 +45,6 @@ import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
 
@@ -149,10 +147,10 @@ public class CreateRegionAnnotationsCommand implements Runnable {
 				comboUnits.getSelectionModel().select(RegionUnits.MICRONS);
 			
 			comboClassification.setItems(qupath.getAvailablePathClasses());
-			if (comboClassification.getItems().contains(PathClassFactory.getPathClass(StandardPathClasses.REGION)))
-				comboClassification.getSelectionModel().select(PathClassFactory.getPathClass(StandardPathClasses.REGION));
+			if (comboClassification.getItems().contains(PathClass.StandardPathClasses.REGION))
+				comboClassification.getSelectionModel().select(PathClass.StandardPathClasses.REGION);
 			else
-				comboClassification.getSelectionModel().select(PathClassFactory.getPathClassUnclassified());
+				comboClassification.getSelectionModel().select(PathClass.NULL_CLASS);
 			
 			comboLocation.getItems().setAll(RegionLocation.values());
 			comboLocation.getSelectionModel().select(RegionLocation.VIEW_CENTER);
@@ -198,7 +196,7 @@ public class CreateRegionAnnotationsCommand implements Runnable {
 			double height = tfRegionHeight.getText().isEmpty() ? width : Double.parseDouble(tfRegionHeight.getText());
 			RegionUnits requestedUnits = comboUnits.getSelectionModel().getSelectedItem();
 			PathClass pathClass = comboClassification.getSelectionModel().getSelectedItem();
-			if (pathClass == PathClassFactory.getPathClassUnclassified())
+			if (pathClass == PathClass.NULL_CLASS)
 				pathClass = null;
 			RegionLocation location = comboLocation.getSelectionModel().getSelectedItem();
 			

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateTrainingImageCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateTrainingImageCommand.java
@@ -43,8 +43,6 @@ import qupath.lib.images.servers.ImageServerMetadata;
 import qupath.lib.images.servers.SparseImageServer;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
 import qupath.lib.plugins.parameters.ParameterList;
 import qupath.lib.projects.Project;
 import qupath.lib.projects.ProjectImageEntry;
@@ -63,7 +61,7 @@ public class CreateTrainingImageCommand {
 	
 	private static String NAME = "Create training image";
 
-	private static PathClass pathClass = PathClassFactory.getPathClass(StandardPathClasses.REGION);
+	private static PathClass pathClass = PathClass.StandardPathClasses.REGION;
 	private static int maxWidth = 50000;
 	private static boolean doZ = false;
 	private static boolean rectanglesOnly = false;
@@ -142,7 +140,7 @@ public class CreateTrainingImageCommand {
 	}
 
 	static Predicate<PathObject> createPredicate(PathClass pathClass, boolean rectanglesOnly) {
-		var pathClass2 = pathClass == PathClassFactory.getPathClassUnclassified() ? null : pathClass;
+		var pathClass2 = pathClass == PathClass.NULL_CLASS ? null : pathClass;
 		if (rectanglesOnly)
 			return (PathObject p) -> p.isAnnotation() && p.getPathClass() == pathClass2 && p.getROI() instanceof RectangleROI;
 		else

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ExportTrainingRegionsCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ExportTrainingRegionsCommand.java
@@ -89,8 +89,6 @@ import qupath.lib.images.servers.ServerTools;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.projects.Project;
 import qupath.lib.projects.ProjectImageEntry;
@@ -339,7 +337,7 @@ public class ExportTrainingRegionsCommand implements Runnable {
 			String s = "";
 			int i = 1;
 			// Handle 'regions' separately
-			PathClass regionClass = PathClassFactory.getPathClass(StandardPathClasses.REGION);
+			PathClass regionClass = PathClass.StandardPathClasses.REGION;
 			for (PathClass pathClass : pathClasses) {
 				if (pathClass == regionClass)
 					continue;
@@ -395,7 +393,7 @@ public class ExportTrainingRegionsCommand implements Runnable {
 				int val = entry.getValue();
 				mapLabelColor.put(entry.getKey(), new Color(val, val, val));
 				// Set color for color model
-				PathClass pathClass = PathClassFactory.getPathClass(entry.getKey());
+				PathClass pathClass = PathClass.fromString(entry.getKey());
 				cmap[val] = pathClass.getColor();
 				display.add(new PathClassDisplay(entry.getKey(), val, pathClass.getColor()));
 			}
@@ -522,7 +520,7 @@ public class ExportTrainingRegionsCommand implements Runnable {
 				downsample = resolution;
 			
 			// Split by region & non-region classified annotations
-			PathClass regionClass = PathClassFactory.getPathClass(StandardPathClasses.REGION);
+			PathClass regionClass = PathClass.StandardPathClasses.REGION;
 			List<PathObject> regionAnnotations = hierarchy.getAnnotationObjects().stream().filter(p -> p.getPathClass() == regionClass).collect(Collectors.toList());
 			List<PathObject> otherAnnotations = hierarchy.getAnnotationObjects().stream().filter(p -> p.getPathClass() != regionClass && p.getROI().isArea()).collect(Collectors.toList());
 

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SingleMeasurementClassificationCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SingleMeasurementClassificationCommand.java
@@ -486,7 +486,7 @@ public class SingleMeasurementClassificationCommand implements Runnable {
 				sliderThreshold.setValue(0);
 				return;
 			}
-			double[] allValues = pathObjects.stream().mapToDouble(p -> p.getMeasurementList().getMeasurementValue(measurement))
+			double[] allValues = pathObjects.stream().mapToDouble(p -> p.getMeasurementList().get(measurement))
 					.filter(d -> Double.isFinite(d)).toArray();
 			var stats = new DescriptiveStatistics(allValues);
 			var histogram = new Histogram(allValues, 100, stats.getMin(), stats.getMax());

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapDialog.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapDialog.java
@@ -93,7 +93,6 @@ import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectPredicates;
 import qupath.lib.objects.PathObjectPredicates.PathObjectPredicate;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.hierarchy.events.PathObjectHierarchyEvent;
 import qupath.lib.objects.hierarchy.events.PathObjectHierarchyListener;
 import qupath.process.gui.commands.density.DensityMapUI.DensityMapObjects;
@@ -469,7 +468,7 @@ public class DensityMapDialog {
 	
 	private String classificationText(PathClass pathClass) {
 		if (pathClass == null)
-			pathClass = PathClassFactory.getPathClassUnclassified();
+			pathClass = PathClass.NULL_CLASS;
 		if (pathClass == DensityMapUI.ANY_CLASS)
 			return "Any";
 		if (pathClass == DensityMapUI.ANY_POSITIVE_CLASS)
@@ -778,7 +777,7 @@ public class DensityMapDialog {
 				else if (bothAnyObject)
 					densityClassName = "Density";
 				
-				String primaryClassName = primaryClass == null ? PathClassFactory.getPathClassUnclassified().toString()
+				String primaryClassName = primaryClass == null ? PathClass.NULL_CLASS.toString()
 						                                       : primaryClass.toString();
 				
 				if (primaryClass == DensityMapUI.ANY_CLASS)

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapUI.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapUI.java
@@ -92,7 +92,6 @@ import qupath.lib.objects.PathObjectFilter;
 import qupath.lib.objects.PathObjectPredicates;
 import qupath.lib.objects.PathObjectPredicates.PathObjectPredicate;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.plugins.workflow.DefaultScriptableWorkflowStep;
 import qupath.lib.projects.Project;
 import qupath.lib.regions.RegionRequest;
@@ -309,13 +308,13 @@ public class DensityMapUI {
 	 * Ignore classification (accept all objects).
 	 * Generated with a UUID for uniqueness, and because it should not be serialized.
 	 */
-	public static final PathClass ANY_CLASS = PathClassFactory.getPathClass(UUID.randomUUID().toString());
+	public static final PathClass ANY_CLASS = PathClass.fromString(UUID.randomUUID().toString());
 
 	/**
 	 * Accept any positive classification, including 1+, 2+, 3+.
 	 * Generated with a UUID for uniqueness, and because it should not be serialized.
 	 */
-	public static final PathClass ANY_POSITIVE_CLASS = PathClassFactory.getPathClass(UUID.randomUUID().toString());
+	public static final PathClass ANY_POSITIVE_CLASS = PathClass.fromString(UUID.randomUUID().toString());
 
 	
 	
@@ -604,7 +603,7 @@ public class DensityMapUI {
 			try {
 				bandCounts = densityServer.nChannels() - 1;
 				var channel = densityServer.getChannel(band);
-				aboveThreshold = PathClassFactory.getPathClass(channel.getName(), channel.getColor());
+				aboveThreshold = PathClass.fromString(channel.getName(), channel.getColor());
 				
 				if (!showDialog(densityServer, renderer, getOwner(event)))
 					return;
@@ -797,7 +796,7 @@ public class DensityMapUI {
 				bandCounts = -1;
 						
 				var channel = densityServer.getChannel(bandThreshold);
-				aboveThreshold = PathClassFactory.getPathClass(channel.getName(), channel.getColor());
+				aboveThreshold = PathClass.fromString(channel.getName(), channel.getColor());
 
 				if (!showDialog(densityServer, renderer, getOwner(event)))
 					return;

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/BoundaryStrategy.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/BoundaryStrategy.java
@@ -23,7 +23,6 @@ package qupath.process.gui.commands.ml;
 
 import qupath.lib.common.ColorTools;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.classes.PathClassTools;
 
 /**
@@ -74,7 +73,7 @@ public class BoundaryStrategy {
 		case CLASSIFY:
 			return fixedClass;
 		case DERIVE:
-			return PathClassFactory.getDerivedPathClass(pathClass, "Boundary*", ColorTools.makeScaledRGB(pathClass.getColor(), 0.5));
+			return PathClass.getInstance(pathClass, "Boundary*", ColorTools.makeScaledRGB(pathClass.getColor(), 0.5));
 		case SAME:
 			return pathClass;
 		case SKIP:

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierTraining.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierTraining.java
@@ -38,8 +38,6 @@ import org.bytedeco.opencv.opencv_core.MatVector;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
 import qupath.lib.regions.RegionRequest;
 import qupath.lib.roi.interfaces.ROI;
 import qupath.opencv.ops.ImageDataOp;
@@ -227,7 +225,7 @@ public class PixelClassifierTraining {
     
 
     
-	private static PathClass REGION_CLASS = PathClassFactory.getPathClass(StandardPathClasses.REGION);
+	private static PathClass REGION_CLASS = PathClass.StandardPathClasses.REGION;
 
     /**
      * Test is a PathObject can be used as a classifier training annotation.

--- a/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_Overlay_to_QuPath.java
+++ b/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_Overlay_to_QuPath.java
@@ -205,7 +205,7 @@ public class QuPath_Send_Overlay_to_QuPath implements PlugIn {
 					for (String h : headings) {
 						if ("Label".equals(h))
 							continue;
-						ml.putMeasurement(h, rt.getValue(h, row));
+						ml.put(h, rt.getValue(h, row));
 					}
 					ml.close();
 				}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -236,7 +236,6 @@ import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.TMACoreObject;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.objects.hierarchy.TMAGrid;
 import qupath.lib.plugins.PathInteractivePlugin;
@@ -2004,16 +2003,16 @@ public class QuPathGUI {
 	 */
 	public boolean resetAvailablePathClasses() {
 		List<PathClass> pathClasses = Arrays.asList(
-				PathClassFactory.getPathClassUnclassified(),
-				PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.TUMOR),
-				PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.STROMA),
-				PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IMMUNE_CELLS),
-				PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.NECROSIS),
-				PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.OTHER),
-				PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.REGION),
-				PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.IGNORE),
-				PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.POSITIVE),
-				PathClassFactory.getPathClass(PathClassFactory.StandardPathClasses.NEGATIVE)
+				PathClass.NULL_CLASS,
+				PathClass.StandardPathClasses.TUMOR,
+				PathClass.StandardPathClasses.STROMA,
+				PathClass.StandardPathClasses.IMMUNE_CELLS,
+				PathClass.StandardPathClasses.NECROSIS,
+				PathClass.StandardPathClasses.OTHER,
+				PathClass.StandardPathClasses.REGION,
+				PathClass.StandardPathClasses.IGNORE,
+				PathClass.StandardPathClasses.POSITIVE,
+				PathClass.StandardPathClasses.NEGATIVE
 				);
 		
 		if (availablePathClasses == null) {
@@ -2039,7 +2038,7 @@ public class QuPathGUI {
 			List<PathClass> pathClassesOriginal = (List<PathClass>)in.readObject();
 			List<PathClass> pathClasses = new ArrayList<>();
 			for (PathClass pathClass : pathClassesOriginal) {
-				PathClass singleton = PathClassFactory.getSingletonPathClass(pathClass);
+				PathClass singleton = PathClass.getSingleton(pathClass);
 				// Ensure the color is set
 				if (singleton != null && pathClass.getColor() != null)
 					singleton.setColor(pathClass.getColor());
@@ -4468,9 +4467,9 @@ public class QuPathGUI {
 				project.setPathClasses(getAvailablePathClasses());
 			} else {
 				// Update the available classes
-				if (!pathClasses.contains(PathClassFactory.getPathClassUnclassified())) {
+				if (!pathClasses.contains(PathClass.NULL_CLASS)) {
 					pathClasses = new ArrayList<>(pathClasses);
-					pathClasses.add(0, PathClassFactory.getPathClassUnclassified());
+					pathClasses.add(0, PathClass.NULL_CLASS);
 				}
 				getAvailablePathClasses().setAll(pathClasses);
 			}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -1978,7 +1978,7 @@ public class QuPathGUI {
 			// Therefore if we find some non-unique nor null elements, correct the list as soon as possible
 			var list = c.getList();
 			var set = new LinkedHashSet<PathClass>();
-			set.add(PathClassFactory.getPathClassUnclassified());
+			set.add(PathClass.NULL_CLASS);
 			set.addAll(list);
 			set.remove(null);
 			if (!(set.size() == list.size() && set.containsAll(list))) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/Charts.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/Charts.java
@@ -643,8 +643,8 @@ public class Charts {
 			return series(
 					null,
 					pathObjects,
-					(PathObject p) -> p.getMeasurementList().getMeasurementValue(xMeasurement),
-					(PathObject p) -> p.getMeasurementList().getMeasurementValue(yMeasurement));
+					(PathObject p) -> p.getMeasurementList().get(xMeasurement),
+					(PathObject p) -> p.getMeasurementList().get(yMeasurement));
 		}
 		
 		/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPane.java
@@ -59,7 +59,6 @@ import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.objects.hierarchy.events.PathObjectHierarchyEvent;
 import qupath.lib.objects.hierarchy.events.PathObjectHierarchyListener;
@@ -107,7 +106,7 @@ class CountingPane implements PathObjectSelectionListener, PathObjectHierarchyLi
 		var hierarchy = viewer.getHierarchy();
 		var availableClasses = qupath.getAvailablePathClasses()
 				.stream()
-				.filter(p -> p != null && p != PathClassFactory.getPathClassUnclassified())
+				.filter(p -> p != null && p != PathClass.NULL_CLASS)
 				.collect(Collectors.toList());
 		if (hierarchy == null || availableClasses.isEmpty())
 			return;
@@ -204,7 +203,7 @@ class CountingPane implements PathObjectSelectionListener, PathObjectHierarchyLi
 		mi.setGraphic(rect);
 		mi.setOnAction(e -> {
 			var pathObject = listCounts.getSelectionModel().getSelectedItem();
-			if (pathClass == PathClassFactory.getPathClassUnclassified())
+			if (pathClass == PathClass.NULL_CLASS)
 				pathObject.resetPathClass();
 			else
 				pathObject.setPathClass(pathClass);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ScriptInterpreter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ScriptInterpreter.java
@@ -74,7 +74,6 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.Tooltip;
-import javafx.scene.effect.BlendMode;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMADataImporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMADataImporter.java
@@ -540,7 +540,7 @@ class TMADataImporter {
 			core.setName(getName());
 			core.setUniqueID(getUniqueID());
 			for (String name : getMeasurementList().getMeasurementNames()) {
-				core.getMeasurementList().putMeasurement(name, getMeasurementList().getMeasurementValue(name));
+				core.getMeasurementList().put(name, getMeasurementList().get(name));
 			}
 			core.getMeasurementList().close();
 			for (Entry<String, String> entry : getMetadataMap().entrySet()) {
@@ -591,7 +591,7 @@ class TMADataImporter {
 			sb.append(entry.getKey()).append("\t").append(entry.getValue()).append("\n");
 		}
 		for (String name : core.getMeasurementList().getMeasurementNames()) {
-			sb.append(name).append("\t").append(core.getMeasurementList().getMeasurementValue(name)).append("\n");
+			sb.append(name).append("\t").append(core.getMeasurementList().get(name)).append("\n");
 		}
 		return sb.toString();
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -457,7 +457,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		}
 		// Good news! We just need a regular measurement
 		for (int i = 0; i < filterList.size(); i++)
-			values[i] = filterList.get(i).getMeasurementList().getMeasurementValue(column);
+			values[i] = filterList.get(i).getMeasurementList().get(column);
 		return values;
 	}
 	
@@ -474,7 +474,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 			else
 				return Double.NaN;
 		}
-		return pathObject.getMeasurementList().getMeasurementValue(column);
+		return pathObject.getMeasurementList().get(column);
 	}
 	
 	@Override
@@ -512,7 +512,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 
 		@Override
 		protected double computeValue() {
-			return pathObject.getMeasurementList().getMeasurementValue(name);
+			return pathObject.getMeasurementList().get(name);
 		}
 		
 	}
@@ -1845,7 +1845,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 			logger.warn("Requested measurement {} for null object! Returned empty String.", column);
 			return "";
 		}
-		double val = pathObject.getMeasurementList().getMeasurementValue(column);
+		double val = pathObject.getMeasurementList().get(column);
 		if (Double.isNaN(val))
 			return "NaN";
 		return GeneralTools.formatNumber(val, 4);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -67,7 +67,6 @@ import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.TMACoreObject;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.classes.PathClassTools;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.regions.ImagePlane;
@@ -623,7 +622,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 //			pathClasses.addAll(basePathClasses);
 
 			pathClasses.remove(null);
-			pathClasses.remove(PathClassFactory.getPathClassUnclassified());
+			pathClasses.remove(PathClass.NULL_CLASS);
 
 			Set<PathClass> parentIntensityClasses = new LinkedHashSet<>();
 			Set<PathClass> parentPositiveNegativeClasses = new LinkedHashSet<>();
@@ -640,7 +639,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 			if (!parentPositiveNegativeClasses.isEmpty()) {
 				List<PathClass> pathClassList = new ArrayList<>(parentPositiveNegativeClasses);
 				pathClassList.remove(null);
-				pathClassList.remove(PathClassFactory.getPathClassUnclassified());
+				pathClassList.remove(PathClass.NULL_CLASS);
 				Collections.sort(pathClassList);
 				for (PathClass pathClass : pathClassList) {
 					builders.add(new ClassCountMeasurementBuilder(pathClass, true));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/KaplanMeierDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/KaplanMeierDisplay.java
@@ -305,17 +305,17 @@ class KaplanMeierDisplay implements ParameterChangeListener, PathObjectHierarchy
 			for (int i = 0; i < cores.size(); i++) {
 				TMACoreObject core = cores.get(i);
 				MeasurementList ml = core.getMeasurementList();
-				survival[i] = core.getMeasurementList().getMeasurementValue(survivalColumn);
-				double censoredValue = core.getMeasurementList().getMeasurementValue(censoredColumn);
+				survival[i] = core.getMeasurementList().get(survivalColumn);
+				double censoredValue = core.getMeasurementList().get(censoredColumn);
 				boolean hasCensoredValue = !Double.isNaN(censoredValue) && (censoredValue == 0 || censoredValue == 1);
 				censored[i] = censoredValue != 0;
 				if (!hasCensoredValue) {
 					// If we don't have a censored value, ensure we mask out everything else
 					scores[i] = Double.NaN;
 					survival[i] = Double.NaN;
-				} else if (ml.containsNamedMeasurement(scoreColumn))
+				} else if (ml.containsKey(scoreColumn))
 					// Get the score if we can
-					scores[i] = ml.getMeasurementValue(scoreColumn);
+					scores[i] = ml.get(scoreColumn);
 				else {
 //					// Try to compute score if we need to
 //					Map<String, Number> map = ROIMeaningfulMeasurements.getPathClassSummaryMeasurements(core.getChildObjects(), true);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMAEntries.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMAEntries.java
@@ -433,7 +433,7 @@ class TMAEntries {
 
 		@Override
 		public void putMeasurement(String name, Number number) {
-			core.getMeasurementList().putMeasurement(name, number == null ? Double.NaN : number.doubleValue());
+			core.getMeasurementList().put(name, number == null ? Double.NaN : number.doubleValue());
 			if (imageData != null)
 				imageData.getHierarchy().fireObjectMeasurementsChangedEvent(this, Collections.singletonList(core));
 			data.updateMeasurementList();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryViewer.java
@@ -800,10 +800,10 @@ public class TMASummaryViewer {
 
 			core.putMetadataValue(TMACoreObject.KEY_UNIQUE_ID, entry.getKey());
 //			System.err.println("Putting: " + list.get(0).getMeasurement(colSurvival).doubleValue() + " LIST: " + list.size());
-			ml.putMeasurement(colSurvival, list.get(0).getMeasurementAsDouble(colSurvival));
-			ml.putMeasurement(colCensoredRequested, list.get(0).getMeasurementAsDouble(colCensored));
+			ml.put(colSurvival, list.get(0).getMeasurementAsDouble(colSurvival));
+			ml.put(colCensoredRequested, list.get(0).getMeasurementAsDouble(colCensored));
 			if (colScore != null)
-				ml.putMeasurement(colScore, score);
+				ml.put(colScore, score);
 
 			cores.add(core);
 			

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementMapper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementMapper.java
@@ -162,7 +162,7 @@ public class MeasurementMapper {
 		if (isClassProbability)
 			value = pathObject.getClassProbability();
 		else
-			value = pathObject.getMeasurementList().getMeasurementValue(measurement);
+			value = pathObject.getMeasurementList().get(measurement);
 		// Convert NaN to zero
 		if (Double.isNaN(value))
 			value = nanValue;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
@@ -38,7 +38,6 @@ import javafx.collections.ObservableSet;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.tools.MeasurementMapper;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.classes.PathClassTools;
 
 /**
@@ -502,8 +501,8 @@ public class OverlayOptions {
 	public boolean isPathClassHidden(final PathClass pathClass) {
 		if (hiddenClasses.isEmpty())
 			return false;
-		if (pathClass == null || pathClass == PathClassFactory.getPathClassUnclassified())
-			return hiddenClasses.contains(null) || hiddenClasses.contains(PathClassFactory.getPathClassUnclassified());
+		if (pathClass == null || pathClass == PathClass.NULL_CLASS)
+			return hiddenClasses.contains(null) || hiddenClasses.contains(PathClass.NULL_CLASS);
 		return hiddenClasses.contains(pathClass) || 
 				((PathClassTools.isPositiveOrGradedIntensityClass(pathClass) || PathClassTools.isNegativeClass(pathClass)) && pathClass.isDerivedClass() && isPathClassHidden(pathClass.getParentClass()));
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathHierarchyPaintingHelper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathHierarchyPaintingHelper.java
@@ -68,8 +68,6 @@ import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathTileObject;
 import qupath.lib.objects.TMACoreObject;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
 import qupath.lib.objects.classes.PathClassTools;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.objects.hierarchy.TMAGrid;
@@ -425,7 +423,7 @@ public class PathHierarchyPaintingHelper {
 						} else {
 							if ((overlayOptions.getFillAnnotations() &&
 									pathObject.isAnnotation() && 
-									pathObject.getPathClass() != PathClassFactory.getPathClass(StandardPathClasses.REGION) &&
+									pathObject.getPathClass() != PathClass.StandardPathClasses.REGION &&
 									(pathObject.getPathClass() != null || !pathObject.hasChildren()))
 									|| (pathObject.isTMACore() && overlayOptions.getShowTMACoreLabels()))
 								paintROI(pathROI, g, colorStroke, stroke, ColorToolsAwt.getMoreTranslucentColor(colorStroke), downsample);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/BrushTool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/BrushTool.java
@@ -46,8 +46,6 @@ import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.PathTileObject;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.RoiTools;
@@ -70,7 +68,7 @@ public class BrushTool extends AbstractPathROITool {
 	 * A collection of classes that should be ignored when
 	 */
 	static Set<PathClass> reservedPathClasses = Collections.singleton(
-			PathClassFactory.getPathClass(StandardPathClasses.REGION)
+			PathClass.StandardPathClasses.REGION
 			);
 	
 	double lastRequestedCursorDiameter = Double.NaN;

--- a/qupath-gui-fx/src/test/java/qupath/lib/gui/models/TestObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/test/java/qupath/lib/gui/models/TestObservableMeasurementTableData.java
@@ -35,8 +35,6 @@ import qupath.lib.images.ImageData;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
-import qupath.lib.objects.classes.PathClassFactory.StandardPathClasses;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
@@ -65,10 +63,10 @@ public class TestObservableMeasurementTableData {
 		
 			ImageData<BufferedImage> imageData = new ImageData<>(null);
 			
-			PathClass tumorClass = PathClassFactory.getPathClass(StandardPathClasses.TUMOR);
-			PathClass stromaClass = PathClassFactory.getPathClass(StandardPathClasses.STROMA);
+			PathClass tumorClass = PathClass.StandardPathClasses.TUMOR;
+			PathClass stromaClass = PathClass.StandardPathClasses.STROMA;
 	//		PathClass otherClass = PathClassFactory.getDefaultPathClass(PathClasses.OTHER);
-			PathClass artefactClass = PathClassFactory.getPathClass("Artefact");
+			PathClass artefactClass = PathClass.getInstance("Artefact");
 			PathObjectHierarchy hierarchy = imageData.getHierarchy();
 			
 			// Add a parent annotation
@@ -82,24 +80,24 @@ public class TestObservableMeasurementTableData {
 			ROI smallROI = ROIs.createRectangleROI(500, 500, 1, 1, ImagePlane.getDefaultPlane());
 			for (int i = 0; i < 100; i++) {
 				if (i < 25)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClassFactory.getNegative(tumorClass)));
+					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getNegative(tumorClass)));
 				else if (i < 50)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClassFactory.getOnePlus(tumorClass)));
+					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getOnePlus(tumorClass)));
 				else if (i < 75)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClassFactory.getTwoPlus(tumorClass)));
+					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getTwoPlus(tumorClass)));
 				else if (i < 100)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClassFactory.getThreePlus(tumorClass)));
+					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getThreePlus(tumorClass)));
 			}
 			// Create 100 stroma detections
 			for (int i = 0; i < 100; i++) {
 				if (i < 50)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClassFactory.getNegative(stromaClass)));
+					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getNegative(stromaClass)));
 				else if (i < 60)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClassFactory.getOnePlus(stromaClass)));
+					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getOnePlus(stromaClass)));
 				else if (i < 70)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClassFactory.getTwoPlus(stromaClass)));
+					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getTwoPlus(stromaClass)));
 				else if (i < 100)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClassFactory.getThreePlus(stromaClass)));
+					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getThreePlus(stromaClass)));
 			}
 			// Create 50 artefact detections
 			for (int i = 0; i < 50; i++) {
@@ -156,11 +154,11 @@ public class TestObservableMeasurementTableData {
 			PathObject parentAllred = PathObjects.createAnnotationObject(ROIs.createRectangleROI(4000, 4000, 1000, 1000, ImagePlane.getDefaultPlane()));
 			ROI newROI = ROIs.createEllipseROI(4500, 4500, 10, 10, ImagePlane.getDefaultPlane());
 			for (int i = 0; i < 100; i++)
-				parentAllred.addPathObject(PathObjects.createDetectionObject(newROI, PathClassFactory.getNegative(tumorClass)));
+				parentAllred.addPathObject(PathObjects.createDetectionObject(newROI, PathClass.getNegative(tumorClass)));
 			hierarchy.addPathObject(parentAllred);
 			model.refreshEntries();
 			assertEquals(0, model.getNumericValue(parentAllred, "Tumor: Allred score"), EPSILON);
-			parentAllred.addPathObject(PathObjects.createDetectionObject(newROI, PathClassFactory.getThreePlus(tumorClass)));
+			parentAllred.addPathObject(PathObjects.createDetectionObject(newROI, PathClass.getThreePlus(tumorClass)));
 			hierarchy.fireHierarchyChangedEvent(parentAllred);
 			model.refreshEntries();
 			assertEquals(4, model.getNumericValue(parentAllred, "Tumor: Allred score"), EPSILON);


### PR DESCRIPTION
See https://github.com/qupath/qupath/issues/1085 for more details

This involved deprecating `MeasurementList.addMeasurement(String, double)` to enforce uniqueness (so the list was really always more of a map anyway). This is important for interpreting measurements anyway.