### PR TITLE
Add private setters to QP

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -3919,5 +3919,84 @@ public class QP {
 			throw new UnsupportedOperationException("Current QuPath version " + VERSION + " is >= the specified (non-inclusive) maximum " + versionMax);			
 	}
 	
+	 
+	 
+	 /*
+	  * If Groovy finds a getXXX() it's liable to make xXX look like a variable...
+	  * then if the user tries to *create* (or set) a variable with that name, 
+	  * it will attempt to call setXXX(something).
+	  * That could then fail quietly and be confusing.
+	  * So these methods exist to make it fail noisily, and with a proposed solution.
+	  */
+	 
+	 
+	 private static void setTMACoreList(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("tMACoreList");
+	 }
+
+	 private static void setCellObjects(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("cellObjects");
+	 }
+
+	 private static void setTileObjects(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("tileObjects");
+	 }
+
+	 private static void setDetectionObjects(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("detectionObjects");
+	 }
+
+	 private static void setAnnotationObjects(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("annotationObjects");
+	 }
+
+	 private static void setAllObjects(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("allObjects");
+	 }
+
+	 private static void setCurrentHierarchy(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("currentHierarchy");
+	 }
+
+	 private static void setCurrentImageData(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("currentImageData");
+	 }
+
+	 private static void setCurrentServer(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("currentServer");
+	 }
+
+	 private static void setCurrentServerPath(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("currentServerPath");
+	 }
+
+	 private static void setProject(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("project");
+	 }
+
+	 private static void setProjectEntry(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("projectEntry");
+	 }
+
+	 private static void setCoreClasses(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("coreClasses");
+	 }
+
+	 private static void setCurrentImageName(Object o) throws UnsupportedOperationException {
+		 warnAboutSetter("currentImageName");
+	 }
+
+
+	 /**
+	  * Warn about attempt to set a property in Groovy, which really there is just a getter that isn't meant to be set.
+	  * @param name
+	  * @throws UnsupportedOperationException
+	  */
+	 private static void warnAboutSetter(String name) throws UnsupportedOperationException {
+		 logger.warn("Unsupported attempt to set {}. This can happen in a Groovy script if you use "
+				 + "'{}' as a global variable name - please use a different name instead, "
+				 + "or default a local variable with 'def {}'", name, name, name);
+		 throw new UnsupportedOperationException(name + " cannot be set!");
+	 }
 	
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ScriptInterpreter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ScriptInterpreter.java
@@ -74,11 +74,13 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.Tooltip;
+import javafx.scene.effect.BlendMode;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.Priority;
+import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 import javafx.scene.web.WebView;
@@ -89,6 +91,7 @@ import qupath.lib.gui.dialogs.Dialogs;
 import qupath.lib.gui.panes.ObjectTreeBrowser;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.scripting.QPEx;
+import qupath.lib.gui.tools.WebViews;
 import qupath.lib.images.ImageData;
 
 
@@ -256,7 +259,8 @@ class ScriptInterpreter {
 		//			});
 
 		// Command log with some color coding
-		WebView textArea = new WebView();
+		WebView textArea = WebViews.create(true);
+
 		historyText.addListener((v, o, n) -> {
 			String styleAll = "* {\n  " + 
 					"font-family: \"Courier New\", Courier, monospace;\n" + 
@@ -268,9 +272,9 @@ class ScriptInterpreter {
 			String styleWarning = ".warning {\n  " + 
 					"color: orange;\n" + 
 					"}";
-			String styleCommand = ".command {\n  " + 
-					"color: black;\n" + 
-					"}";
+//			String styleCommand = ".command {\n  " + 
+//					"color: black;\n" + 
+//					"}";
 			String styleOther = ".other {\n  " + 
 					"color: gray;\n" + 
 					"}";
@@ -290,7 +294,7 @@ class ScriptInterpreter {
 			sb.append(styleAll).append("\n");
 			sb.append(styleError).append("\n");
 			sb.append(styleWarning).append("\n");
-			sb.append(styleCommand).append("\n");
+//			sb.append(styleCommand).append("\n");
 			sb.append(styleOther).append("\n");
 			sb.append(styleVariable).append("\n");
 			sb.append("</style>").append("\n");
@@ -302,6 +306,10 @@ class ScriptInterpreter {
 			//				String content = String.format("<html><head><style>%s</style></head><body>%s</body></html>", style, n.replace("\n", "<br/>"));
 
 			textArea.getEngine().loadContent(sb.toString());
+			
+			textArea.pageFillProperty().unbind();
+			textArea.setPageFill(Color.TRANSPARENT);
+
 		});
 
 		//			TextArea textArea = new TextArea();


### PR DESCRIPTION
Purpose is to intercept attempts to do Groovy things like
```groovy
currentImageData = null
```
arising from getters creating (apparent) properties. Reasoning is explained at https://forum.image.sc/t/towards-qupath-v0-4-0-very-soon-discussing-a-possible-change/73143/4

Also make minor script interpreter fixes (although CSS still not great with styling QuPath in general, since it uses a WebView).