### PR TITLE
Support random rectangles in ROIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is a work-in-progress.
   * All objects can now have IDs
     * This aims to make it much easier to match up objects whenever some further analysis is done elsewhere (e.g. classification or clustering in Python or R)
     * See https://github.com/qupath/qupath/pull/959
+  * Much improved scripting support for classifications and measurements (https://github.com/qupath/qupath/pull/1094)
 * Support user styling via CSS (https://github.com/qupath/qupath/pull/1063)
 * Many script editor improvements, including:
   * Syntax highlighting for Markdown, JSON, YAML and XML documents
@@ -98,6 +99,8 @@ This is a work-in-progress.
 * Support passing arguments via a map to `runPlugin`, rather than only a JSON-encoded String
 * Add `difference`, `symDifference` and `subtract` methods to `RoiTools` (https://github.com/qupath/qupath/issues/995)
 * Add `ROI.updatePlane(plane)` method to move a ROI to a different z-slice or timepoint (https://github.com/qupath/qupath/issues/1052)
+* 'Classify -> Training images -> Create region annotations' supports adding regions in a selected annotation
+  * `RoiTools.createRandomRectangle()` methods created for scripting
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellMembraneDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellMembraneDetection.java
@@ -789,7 +789,7 @@ public class WatershedCellMembraneDetection extends AbstractTileableDetectionPlu
 			// TODO: Set the measurement capacity to improve efficiency
 			List<PathObject> nucleiObjects = new ArrayList<>();
 			Calibration cal = pathImage.getImage().getCalibration();
-			ImagePlane plane = pathImage.getImageRegion().getPlane();
+			ImagePlane plane = pathImage.getImageRegion().getImagePlane();
 			for (int i = 0; i < roisNuclei.size(); i++) {
 				PolygonRoi r = roisNuclei.get(i);
 				

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/SimpleTissueDetection2.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/SimpleTissueDetection2.java
@@ -246,7 +246,7 @@ public class SimpleTissueDetection2 extends AbstractDetectionPlugin<BufferedImag
 				return null;
 			
 			bp.setThreshold(127, Double.POSITIVE_INFINITY, ImageProcessor.NO_LUT_UPDATE);
-			List<PathObject> pathObjects = convertToPathObjects(bp, minArea, smoothCoordinates, imp.getCalibration(), downsample, maxHoleArea, excludeOnBoundary, singleAnnotation, pathImage.getImageRegion().getPlane(), null);
+			List<PathObject> pathObjects = convertToPathObjects(bp, minArea, smoothCoordinates, imp.getCalibration(), downsample, maxHoleArea, excludeOnBoundary, singleAnnotation, pathImage.getImageRegion().getImagePlane(), null);
 
 			if (Thread.currentThread().isInterrupted())
 				return null;

--- a/qupath-core-processing/src/main/java/qupath/imagej/processing/SimpleThresholding.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/processing/SimpleThresholding.java
@@ -258,7 +258,7 @@ public class SimpleThresholding {
 				roiIJ,
 				-request.getX()/request.getDownsample(),
 				-request.getY()/request.getDownsample(),
-				request.getDownsample(), request.getPlane());
+				request.getDownsample(), request.getImagePlane());
 	}
 
 	static ROI thresholdToROI(ImageProcessor ip, TileRequest request) {
@@ -285,7 +285,7 @@ public class SimpleThresholding {
 				roiIJ,
 				-request.getTileX(),
 				-request.getTileY(),
-				request.getDownsample(), request.getPlane());
+				request.getDownsample(), request.getImagePlane());
 	}
 	
 }

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
@@ -1013,7 +1013,7 @@ public class IJTools {
 			cal = pathImage.getImage().getCalibration();
 			downsampleFactor = pathImage.getDownsampleFactor();
 		}
-		return convertToROI(roi, cal, downsampleFactor, region.getPlane());	
+		return convertToROI(roi, cal, downsampleFactor, region.getImagePlane());	
 	}
 
 	/**

--- a/qupath-core-processing/src/main/java/qupath/opencv/DetectCytokeratinCV.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/DetectCytokeratinCV.java
@@ -216,7 +216,7 @@ public class DetectCytokeratinCV extends AbstractDetectionPlugin<BufferedImage> 
 					areaTissue.intersect(areaROI);
 
 				if (!areaTissue.isEmpty()) {
-					ROI roiTissue = RoiTools.getShapeROI(areaTissue, request.getPlane());
+					ROI roiTissue = RoiTools.getShapeROI(areaTissue, request.getImagePlane());
 					roiTissue = ShapeSimplifier.simplifyShape(roiTissue, simplifyAmount);
 					pathObjects.add(PathObjects.createAnnotationObject(roiTissue, PathClass.StandardPathClasses.STROMA));
 				}
@@ -227,7 +227,7 @@ public class DetectCytokeratinCV extends AbstractDetectionPlugin<BufferedImage> 
 					areaDAB.intersect(areaROI);
 
 				if (!areaDAB.isEmpty()) {
-					ROI roiDAB = RoiTools.getShapeROI(areaDAB, request.getPlane());
+					ROI roiDAB = RoiTools.getShapeROI(areaDAB, request.getImagePlane());
 					roiDAB = ShapeSimplifier.simplifyShape(roiDAB, simplifyAmount);
 					pathObjects.add(PathObjects.createAnnotationObject(roiDAB, PathClass.StandardPathClasses.TUMOR));
 				}

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnTools.java
@@ -707,7 +707,7 @@ public class DnnTools {
 			}
 
 			double downsample = request == null ? 1.0 : request.getDownsample();
-			ImagePlane plane = request == null ? ImagePlane.getDefaultPlane() : request.getPlane();
+			ImagePlane plane = request == null ? ImagePlane.getDefaultPlane() : request.getImagePlane();
 			double xOrigin = request == null ? 0 : request.getX();
 			double yOrigin = request == null ? 0 : request.getY();
 
@@ -784,7 +784,7 @@ public class DnnTools {
 			if (mask == null || mask.contains(x, y))
 				points.add(new Point2(x, y));
 		}
-		return ROIs.createPointsROI(points, request.getPlane());
+		return ROIs.createPointsROI(points, request.getImagePlane());
 	}
 	
 	

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
@@ -402,7 +402,7 @@ public class PixelClassifierTools {
 			var labelMap = labels;
 			pathObjects.addAll(
 					geometryMap.entrySet().parallelStream()
-						.flatMap(e -> geometryToObjects(e.getValue(), creator, labelMap.get(e.getKey()), minAreaPixels, minHoleAreaPixels, doSplit, regionRequest.getPlane()).stream())
+						.flatMap(e -> geometryToObjects(e.getValue(), creator, labelMap.get(e.getKey()), minAreaPixels, minHoleAreaPixels, doSplit, regionRequest.getImagePlane()).stream())
 						.collect(Collectors.toList())
 						);
 			

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
@@ -635,7 +635,7 @@ public class ContourTracing {
 	 */
 	public static ROI createTracedROI(Raster raster, double minThresholdInclusive, double maxThresholdInclusive, int band, RegionRequest request) {
 		var geom = createTracedGeometry(raster, minThresholdInclusive, maxThresholdInclusive, band, request);
-		return GeometryTools.geometryToROI(geom, request == null ? ImagePlane.getDefaultPlane() : request.getPlane());
+		return GeometryTools.geometryToROI(geom, request == null ? ImagePlane.getDefaultPlane() : request.getImagePlane());
 	}
 	
 	/**
@@ -651,7 +651,7 @@ public class ContourTracing {
 	 */
 	public static ROI createTracedROI(SimpleImage image, double minThresholdInclusive, double maxThresholdInclusive, RegionRequest request) {
 		var geom = createTracedGeometry(image, minThresholdInclusive, maxThresholdInclusive, request);
-		return geom == null ? null : GeometryTools.geometryToROI(geom, request == null ? ImagePlane.getDefaultPlane() : request.getPlane());
+		return geom == null ? null : GeometryTools.geometryToROI(geom, request == null ? ImagePlane.getDefaultPlane() : request.getImagePlane());
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/images/servers/TileRequest.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/TileRequest.java
@@ -24,6 +24,10 @@ package qupath.lib.images.servers;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import qupath.lib.common.LogTools;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.regions.ImageRegion;
 import qupath.lib.regions.RegionRequest;
@@ -42,6 +46,8 @@ import qupath.lib.regions.RegionRequest;
  * the full resolution image space.  They wrap a RegionRequest, because this is still used for caching purposes. 
  */
 public class TileRequest {
+	
+	private static final Logger logger = LoggerFactory.getLogger(TileRequest.class);
 			
 	private final int level;
 	private final ImageRegion tileRegion;
@@ -261,11 +267,21 @@ public class TileRequest {
 	/**
 	 * Get the ImagePlane for this request.
 	 * @return
+	 * @since v0.4.0 (replaces {@link #getPlane()} for better consistency with other classes)
 	 */
-	public ImagePlane getPlane() {
-		return tileRegion.getPlane();
+	public ImagePlane getImagePlane() {
+		return tileRegion.getImagePlane();
 	}
-	
+	/**
+	 * Get the ImagePlane for this request.
+	 * @return
+	 * @deprecated v0.4.0 use {@link #getImagePlane()} instead (changed for better consistency with other classes)
+	 */
+	@Deprecated
+	public ImagePlane getPlane() {
+		LogTools.warnOnce(logger, "TileRequest.getPlane() is deprecated in v0.4.0 - use getImagePlane() instead");
+		return getImagePlane();
+	}
 	
 	
 	@Override

--- a/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
+++ b/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
@@ -856,7 +856,7 @@ public class TileExporter  {
 			int y2 = GeneralTools.clipValue(request.getMaxY(), 0, server.getHeight());
 			
 			double downsample = request.getDownsample();
-			var request2 = RegionRequest.createInstance(server.getPath(), downsample, x, y, x2-x, y2-y, request.getPlane());
+			var request2 = RegionRequest.createInstance(server.getPath(), downsample, x, y, x2-x, y2-y, request.getImagePlane());
 			
 			img = server.readRegion(request2);
 			

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -495,7 +495,7 @@ public class PathObjectTools {
 		    for (int j = 0; j < numHorizontal; j++) {
 		        double x = numHorizontal <= 1 ? region.getMinX() + region.getWidth()/2.0 : region.getMinX() + diameterPixels / 2 + xSpacing * j;
 		        double y = numVertical <= 1 ? region.getMinY() + region.getHeight()/2.0 : region.getMinY() + diameterPixels / 2 + ySpacing * i;
-		        cores.add(PathObjects.createTMACoreObject(x, y, diameterPixels, false, region.getPlane()));
+		        cores.add(PathObjects.createTMACoreObject(x, y, diameterPixels, false, region.getImagePlane()));
 		    }
 		}
 		// Create & set the grid

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
@@ -548,6 +548,8 @@ public final class PathObjectHierarchy implements Serializable {
 	 * @return
 	 */
 	public synchronized boolean addPathObjectBelowParent(PathObject pathObjectParent, PathObject pathObject, boolean fireUpdate) {
+		if (pathObjectParent == pathObject)
+			throw new IllegalArgumentException("Cannot add a PathObject as a descendent of itself!");
 		if (pathObjectParent == null)
 			return addPathObject(pathObject, fireUpdate);
 		else

--- a/qupath-core/src/main/java/qupath/lib/regions/ImageRegion.java
+++ b/qupath-core/src/main/java/qupath/lib/regions/ImageRegion.java
@@ -25,6 +25,10 @@ package qupath.lib.regions;
 
 import java.util.Collection;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import qupath.lib.common.LogTools;
 import qupath.lib.roi.interfaces.ROI;
 
 /**
@@ -36,6 +40,8 @@ import qupath.lib.roi.interfaces.ROI;
  *
  */
 public class ImageRegion {
+	
+	private static final Logger logger = LoggerFactory.getLogger(ImageRegion.class);
 	
 	private final int x;
 	private final int y;
@@ -255,9 +261,21 @@ public class ImageRegion {
 	/**
 	 * Get the z-slice and time point for this region as an {@link ImagePlane}.
 	 * @return
+	 * @since v0.4.0 (replaces {@link #getPlane()} for better consistency with other classes)
 	 */
-	public ImagePlane getPlane() {
+	public ImagePlane getImagePlane() {
 		return ImagePlane.getPlane(getZ(), getT());
+	}
+	
+	/**
+	 * Get the z-slice and time point for this region as an {@link ImagePlane}.
+	 * @return
+	 * @deprecated v0.4.0 use {@link #getImagePlane()} instead (changed for better consistency with other classes)
+	 */
+	@Deprecated
+	public ImagePlane getPlane() {
+		LogTools.warnOnce(logger, getClass().getSimpleName() + ".getPlane() is deprecated in v0.4.0 - use getImagePlane() instead");
+		return getImagePlane();
 	}
 	
 	/* (non-Javadoc)

--- a/qupath-core/src/main/java/qupath/lib/roi/ROIs.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/ROIs.java
@@ -85,7 +85,7 @@ public class ROIs {
 	 * @return
 	 */
 	public static ROI createRectangleROI(ImageRegion region) {
-		return new RectangleROI(region.getX(), region.getY(), region.getWidth(), region.getHeight(), region.getPlane());
+		return new RectangleROI(region.getX(), region.getY(), region.getWidth(), region.getHeight(), region.getImagePlane());
 	}
 
 	/**

--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -1137,8 +1137,8 @@ public class RoiTools {
 		
 		if (random == null)
 			random = new Random();
-		double x = width == mask.getWidth() ? 0 : mask.getMinX() + random.nextDouble(mask.getWidth() - width);
-		double y = height == mask.getHeight() ? 0 : mask.getMinY() + random.nextDouble(mask.getHeight() - height);
+		double x = width == mask.getWidth() ? 0 : mask.getMinX() + random.nextDouble() * mask.getWidth() - width;
+		double y = height == mask.getHeight() ? 0 : mask.getMinY() + random.nextDouble() * mask.getHeight() - height;
 		return ROIs.createRectangleROI(x, y, width, height, mask.getImagePlane());
 	}
 	
@@ -1199,11 +1199,11 @@ public class RoiTools {
 			if (width == mask.getBoundsWidth())
 				x = mask.getBoundsX();
 			else
-				x = mask.getBoundsX() + random.nextDouble(mask.getBoundsWidth() - width);
+				x = mask.getBoundsX() + random.nextDouble() * (mask.getBoundsWidth() - width);
 			if (height == mask.getBoundsHeight())
 				y = mask.getBoundsY();
 			else
-				y = mask.getBoundsY() + random.nextDouble(mask.getBoundsHeight() - height);
+				y = mask.getBoundsY() + random.nextDouble() * (mask.getBoundsHeight() - height);
 			var rect = GeometryTools.createRectangle(x, y, width, height);
 			if (prepared.covers(rect)) {
 				success = true;

--- a/qupath-core/src/test/java/qupath/lib/regions/TestRegionRequest.java
+++ b/qupath-core/src/test/java/qupath/lib/regions/TestRegionRequest.java
@@ -73,12 +73,12 @@ public class TestRegionRequest {
 		// Change other properties
 		var request7 = request.updateZ(2);
 		assertNotEquals(request, request7);
-		assertNotEquals(request.getPlane(), request7.getPlane());
+		assertNotEquals(request.getImagePlane(), request7.getImagePlane());
 		sameRegion2D(request, request7);
 		
 		var request8 = request.updateT(2);
 		assertNotEquals(request, request8);
-		assertNotEquals(request.getPlane(), request8.getPlane());
+		assertNotEquals(request.getImagePlane(), request8.getImagePlane());
 		sameRegion2D(request, request8);
 		
 		var request9 = request.updatePath("Anything else");
@@ -116,7 +116,7 @@ public class TestRegionRequest {
 	}
 	
 	static boolean samePlane(ImageRegion r1, ImageRegion r2) {		
-		assertEquals(r1.getPlane(), r2.getPlane());
+		assertEquals(r1.getImagePlane(), r2.getImagePlane());
 		return true;
 	}
 	

--- a/qupath-core/src/test/java/qupath/lib/roi/TestRoiTools.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestRoiTools.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2021 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2021-2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -22,6 +22,9 @@
 package qupath.lib.roi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.awt.geom.AffineTransform;
 import java.io.IOException;
@@ -42,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import qupath.lib.geom.ImmutableDimension;
 import qupath.lib.io.GsonTools;
 import qupath.lib.regions.ImagePlane;
+import qupath.lib.regions.ImageRegion;
 import qupath.lib.roi.RoiTools.CombineOp;
 import qupath.lib.roi.interfaces.ROI;
 
@@ -202,6 +206,35 @@ public class TestRoiTools {
 			return geom.difference(GeometryTools.union(holeTriangles));
 		
 	}
+	
+	
+	@Test
+	void testRandomRectangles() {
+		
+		var region = ImageRegion.createInstance(1000, 2000, 300, 400, 2, 3);
+		
+		var rng = new Random(100);
+		
+		assertNotNull(RoiTools.createRandomRectangle(region, region.getWidth()-1, region.getHeight()-1, rng));
+		assertNotNull(RoiTools.createRandomRectangle(region, region.getWidth(), region.getHeight(), rng));
+		assertEquals(region.getImagePlane(), RoiTools.createRandomRectangle(region, region.getWidth()-1, region.getHeight()-1, rng).getImagePlane());
+		assertThrows(IllegalArgumentException.class, () -> RoiTools.createRandomRectangle(region, region.getWidth()+0.1, region.getHeight(), rng));
+		assertThrows(IllegalArgumentException.class, () -> RoiTools.createRandomRectangle(region, region.getWidth()+0.1, region.getHeight()+1, rng));
+
+		
+		var roi = ROIs.createEllipseROI(1000, 2000, 300, 400, ImagePlane.getPlane(3, 4));
+		
+		assertNotNull(RoiTools.createRandomRectangle(roi, roi.getBoundsWidth()/2, roi.getBoundsHeight()/2, 1000, true, rng));
+		// Are smaller, but ROI won't fit
+		assertNull(RoiTools.createRandomRectangle(roi, roi.getBoundsWidth(), roi.getBoundsHeight()/16, 1000, true, rng));
+		assertEquals(roi.getImagePlane(), RoiTools.createRandomRectangle(roi, roi.getBoundsWidth()/2, roi.getBoundsHeight()/2, 1000, true, rng).getImagePlane());
+		assertThrows(IllegalArgumentException.class, () -> RoiTools.createRandomRectangle(roi, roi.getBoundsWidth(), roi.getBoundsHeight(), 1000, true, rng));
+		assertThrows(IllegalArgumentException.class, () -> RoiTools.createRandomRectangle(roi, roi.getBoundsWidth()+0.1, roi.getBoundsHeight(), 1000, true, rng));
+		assertThrows(IllegalArgumentException.class, () -> RoiTools.createRandomRectangle(roi, roi.getBoundsWidth()+0.1, roi.getBoundsHeight()+1, 1000, true, rng));
+		
+		
+	}
+	
 	
 	
 

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
@@ -319,7 +319,7 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 				if (params.getBooleanParameterValue("getROI") && impResult.getRoi() != null) {
 					Roi roi = impResult.getRoi();
 					Calibration cal = impResult.getCalibration();
-					PathObject pathObjectNew = roi == null ? null : IJTools.convertToAnnotation(roi, cal.xOrigin, cal.yOrigin, downsampleFactor, region.getPlane());
+					PathObject pathObjectNew = roi == null ? null : IJTools.convertToAnnotation(roi, cal.xOrigin, cal.yOrigin, downsampleFactor, region.getImagePlane());
 					if (pathObjectNew != null) {
 						// If necessary, trim any returned annotation
 						if (pathROI != null && !(pathROI instanceof RectangleROI) && pathObjectNew.isAnnotation() && RoiTools.isShapeROI(pathROI) && RoiTools.isShapeROI(pathObjectNew.getROI())) {
@@ -338,7 +338,7 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 				boolean exportAsDetection = ((String) params.getChoiceParameterValue("getOverlayAs")).equals("Detections") ? true : false;
 				if (params.getBooleanParameterValue("getOverlay") && impResult.getOverlay() != null) {
 					var overlay = impResult.getOverlay();
-					List<PathObject> childObjects = QuPath_Send_Overlay_to_QuPath.createObjectsFromROIs(imp, Arrays.asList(overlay.toArray()), downsampleFactor, exportAsDetection, true, region.getPlane());
+					List<PathObject> childObjects = QuPath_Send_Overlay_to_QuPath.createObjectsFromROIs(imp, Arrays.asList(overlay.toArray()), downsampleFactor, exportAsDetection, true, region.getImagePlane());
 					if (!childObjects.isEmpty()) {
 						pathObject.addPathObjects(childObjects);
 						changes = true;

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateRegionAnnotationsCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateRegionAnnotationsCommand.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -45,8 +45,10 @@ import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.regions.ImagePlane;
+import qupath.lib.regions.ImageRegion;
 import qupath.lib.roi.ROIs;
+import qupath.lib.roi.RoiTools;
+import qupath.lib.roi.interfaces.ROI;
 
 /**
  * Command to help create annotations defining regions that will be further annotated for 
@@ -220,32 +222,81 @@ public class CreateRegionAnnotationsCommand implements Runnable {
 				return;
 			}
 			
+			// If adding 
+			PathObject parentObject = null;
+			ROI rectangle = null;
+			
 			// Determine starting location
-			double x;
-			double y;
 			switch (location) {
 			case IMAGE_CENTER:
-				x = (imageData.getServer().getWidth() - width) / 2.0;
-				y = (imageData.getServer().getHeight() - height) / 2.0;
+				double x = (imageData.getServer().getWidth() - width) / 2.0;
+				double y = (imageData.getServer().getHeight() - height) / 2.0;
+				rectangle = ROIs.createRectangleROI(x, y, width, height, viewer.getImagePlane());
 				break;
 			case RANDOM:
-				x = Math.random() * viewer.getServerWidth() - width;
-				y = Math.random() * viewer.getServerHeight() - height;
+				parentObject = imageData.getHierarchy().getSelectionModel().getSelectedObject();
+				var roi = parentObject == null ? null : parentObject.getROI();
+				if (roi != null) {
+					if (!(parentObject.isAnnotation() || parentObject.isTMACore())) {
+						logger.warn("Ignoring parent object because it's not an annotation or a TMA core");
+						parentObject = null;
+						roi = null;
+					}
+					if (!roi.isArea() || roi.isEmpty()) {
+						logger.warn("Ignoring parent object because its ROI does not define an area");
+						parentObject = null;
+						roi = null;
+					}
+				}
+				// 	If we have a selected object, add annotations within it
+				try {
+					if (roi != null) {
+						rectangle = RoiTools.createRandomRectangle(roi, width, height);
+					} else {
+						var region = ImageRegion.createInstance(0, 0, viewer.getServerWidth(), viewer.getServerHeight(), viewer.getZPosition(), viewer.getTPosition());
+						rectangle = RoiTools.createRandomRectangle(region, width, height);
+					}
+				} catch (IllegalArgumentException e) {
+					Dialogs.showErrorMessage("Create region", e.getLocalizedMessage());
+					return;
+				}
+				if (rectangle == null) {
+					Dialogs.showErrorMessage("Create region", "Unable to squeeze a rectangle of the specified size into the current ROI, sorry");
+					return;
+				}
 				break;
 			case VIEW_CENTER:
-				x = viewer.getCenterPixelX() - width / 2.0;
-				y = viewer.getCenterPixelY() - height / 2.0;
+				rectangle = ROIs.createRectangleROI(
+						viewer.getCenterPixelX() - width / 2.0,
+						viewer.getCenterPixelY() - height / 2.0,
+						width,
+						height,
+						viewer.getImagePlane());
 				break;
 			default:
-				Dialogs.showErrorMessage("Create region", "Unknowing location " + location);
+				break;
+			}
+			
+			if (rectangle == null) {
+				Dialogs.showErrorMessage("Create region", "Unable to create a rectangle region, sorry");
+				return;
+			}
+			
+			if (rectangle.getBoundsX() < 0 || rectangle.getBoundsY() < 0 || 
+					rectangle.getBoundsX() + rectangle.getBoundsWidth() > imageData.getServer().getWidth() || 
+					rectangle.getBoundsY() + rectangle.getBoundsHeight() > imageData.getServer().getHeight()) {
+				Dialogs.showErrorMessage("Create region", "Cannot create requested region - it would extend beyond the image bounds");
 				return;
 			}
 			
 			// Create an annotation
 			PathObject annotation = PathObjects.createAnnotationObject(
-					ROIs.createRectangleROI(x, y, width, height, ImagePlane.getPlane(viewer.getZPosition(), viewer.getTPosition())),
+					rectangle,
 					pathClass);
-			imageData.getHierarchy().addPathObject(annotation);
+			if (parentObject != null)
+				imageData.getHierarchy().addPathObjectBelowParent(parentObject, annotation, true);
+			else
+				imageData.getHierarchy().addPathObject(annotation);
 		}
 		
 		
@@ -268,6 +319,7 @@ public class CreateRegionAnnotationsCommand implements Runnable {
 		
 		
 	}
+	
 	
 
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/images/servers/PathHierarchyImageServer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/images/servers/PathHierarchyImageServer.java
@@ -243,7 +243,7 @@ public class PathHierarchyImageServer extends AbstractTileableImageServer implem
 					g2d,
 					imageData.isFluorescence() ? ColorToolsAwt.TRANSLUCENT_WHITE : ColorToolsAwt.TRANSLUCENT_BLACK,
 					downsampleFactor,
-					tileRequest.getPlane());
+					tileRequest.getImagePlane());
 		}
 		
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
@@ -206,7 +206,7 @@ public class HierarchyOverlay extends AbstractOverlay {
 									g2d,
 									imageData.isFluorescence() ? ColorToolsAwt.TRANSLUCENT_WHITE : ColorToolsAwt.TRANSLUCENT_BLACK,
 											downsampleFactor,
-											imageRegion.getPlane());
+											imageRegion.getImagePlane());
 				}
 				
 			} else {					


### PR DESCRIPTION
From https://forum.image.sc/t/qupath-script-for-random-square-selection/73258/3

Also update ImageRegion/TileRequest API to use `getImagePlane()` rather than `getPlane()`, for consistency with the `ROI` class and QuPathViewer.