### PR TITLE
Improved GeoJSON support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,7 @@ This is a work-in-progress.
 * JavaFX 19.0.0
 * Java Topology Suite 1.19.0
 * Groovy 4.0.5
-* Gson 2.9.1
+* Gson 2.10
 * Guava 31.1
 * ikonli 12.3.1
 * JavaCPP 1.5.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,14 @@ This is a work-in-progress.
 * Add `ROI.updatePlane(plane)` method to move a ROI to a different z-slice or timepoint (https://github.com/qupath/qupath/issues/1052)
 * 'Classify -> Training images -> Create region annotations' supports adding regions in a selected annotation
   * `RoiTools.createRandomRectangle()` methods created for scripting
+* GeoJSON improvements (https://github.com/qupath/qupath/pull/1099)
+  * Simplified representation of `PathClass`
+    * Store either `name` (single name) or `names` (array) field, and `color` (3-element int array)
+  * Flag ellipse ROIs so these can be deserialized as ellipses, not polygons
+    * A polygon representation is still stored for use in other software, if required
+  * Store measurements directly as a JSON object / map (rather than an array of name/value elements)
+  * Optionally support child objects in export
+    * Serializing the root object now involves serializing the whole hierarchy
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ groovy-core   = { module = "org.apache.groovy:groovy", version.ref = "groovy" }
 groovy-jsr223 = { module = "org.apache.groovy:groovy-jsr223", version.ref = "groovy" }
 groovy-xml    = { module = "org.apache.groovy:groovy-xml", version.ref = "groovy" }
 
-gson          = { module = "com.google.code.gson:gson", version = "2.9.1" }
+gson          = { module = "com.google.code.gson:gson", version = "2.10" }
 
 # Optionally add GeoJSON support (brings in json-simple as sub-dependency)
 # However, the use of simple-json is troublesome since it brings in an old version of junit

--- a/qupath-core/src/main/java/qupath/lib/io/GsonTools.java
+++ b/qupath-core/src/main/java/qupath/lib/io/GsonTools.java
@@ -394,10 +394,21 @@ public class GsonTools {
 				if (color != null) {
 					out.name("color");
 					var alpha = ColorTools.alpha(color);
-					if (alpha != 0 && alpha != 255)
-						out.jsonValue(String.format("[%d, %d, %d, %d]", ColorTools.red(color), ColorTools.green(color), ColorTools.blue(color), ColorTools.alpha(color)));
-					else
-						out.jsonValue(String.format("[%d, %d, %d]", ColorTools.red(color), ColorTools.green(color), ColorTools.blue(color)));
+					try {
+						if (alpha != 0 && alpha != 255)
+							out.jsonValue(String.format("[%d, %d, %d, %d]", ColorTools.red(color), ColorTools.green(color), ColorTools.blue(color), ColorTools.alpha(color)));
+						else
+							out.jsonValue(String.format("[%d, %d, %d]", ColorTools.red(color), ColorTools.green(color), ColorTools.blue(color)));
+					} catch (UnsupportedOperationException e) {
+						// TODO: Consider not trying to write json value, since it isn't always supported
+						out.beginArray();
+						out.value(ColorTools.red(color));
+						out.value(ColorTools.green(color));
+						out.value(ColorTools.blue(color));
+						if (alpha != 0 && alpha != 255)
+							ColorTools.alpha(color);
+						out.endArray();
+					}
 				}
 				out.endObject();
 				

--- a/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
@@ -269,21 +269,26 @@ class PathObjectTypeAdapters {
 			Integer color = value.getColor();
 			if (color != null) {
 				out.name("color");
-				out.beginArray();
-				out.value(ColorTools.red(color));
-				out.value(ColorTools.green(color));
-				out.value(ColorTools.blue(color));
-				out.endArray();
+				out.jsonValue(String.format("[%d, %d, %d]", ColorTools.red(color), ColorTools.green(color), ColorTools.blue(color)));
+//				out.beginArray();
+//				out.value(ColorTools.red(color));
+//				out.value(ColorTools.green(color));
+//				out.value(ColorTools.blue(color));
+//				out.endArray();
 			}
 			
+			// Write classification
 			PathClass pathClass = value.getPathClass();
 			if (pathClass != null) {
 				out.name("classification");
 				PathClassTypeAdapter.INSTANCE.write(out, pathClass);
 			}
 			
-			out.name("isLocked");
-			out.value(value.isLocked());
+			// Write locked status only if locked
+			if (value.isLocked()) {
+				out.name("isLocked");
+				out.value(true);
+			}
 			
 			if (value instanceof TMACoreObject) {
 				out.name("isMissing");
@@ -392,6 +397,7 @@ class PathObjectTypeAdapters {
 									);
 					}
 				}
+				
 				if (properties.has("classification")) {
 					pathClass = PathClassTypeAdapter.INSTANCE.fromJsonTree(properties.get("classification"));
 				}

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -203,7 +203,7 @@ public abstract class PathObject implements Externalizable {
 		if (measurementsMap == null) {
 			synchronized(this) {
 				if (measurementsMap == null)
-					measurementsMap = measurements.asMap();
+					measurementsMap = getMeasurementList().asMap();
 			}
 		}
 		return measurementsMap;


### PR DESCRIPTION
Updated GeoJSON output, while still attempting to support reading from v0.3.2.

Changes include:
* Simplified representation of `PathClass`
  * Store either `name` (single name) or `names` (array) field, and `color` (3-element int array)
* Flag ellipse ROIs so these can be deserialized as ellipses, not polygons
  * A polygon representation is still stored for use in other software, if required
* Store measurements directly as a JSON object / map (rather than an array of name/value elements)
* Optionally support child objects in export
  * Serializing the root object now involves serializing the whole hierarchy
* Update to GSON 2.10