### PR TITLE
Minor fixes

### DIFF
--- a/buildSrc/src/main/groovy/qupath.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.java-conventions.gradle
@@ -91,8 +91,8 @@ def strictJavadoc = findProperty('strictJavadoc')
 tasks.withType(Javadoc).each { javadocTask ->
     if (!strictJavadoc) {
         javadocTask.options.addStringOption('Xdoclint:none', '-quiet')
-        javadocTask.options.encoding = 'UTF-8'
     }
+   javadocTask.options.encoding = 'UTF-8'
 
     rootProject.tasks.withType(Javadoc) { rootTask ->
         rootTask.source += javadocTask.source

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -96,9 +96,7 @@ public abstract class PathObject implements Externalizable {
 	/**
 	 * Default constructor. Used for Externalizable support, not intended to be used by other consumers.
 	 */
-	public PathObject() {
-		id = UUID.randomUUID();
-	}
+	public PathObject() {}
 	
 	/**
 	 * Request the parent object. Each PathObject may have only one parent.
@@ -920,6 +918,15 @@ public abstract class PathObject implements Externalizable {
 	 * @see #updateId()
 	 */
 	public UUID getId() {
+		// Make extra sure we always have an ID when requested
+		if (id == null) {
+			synchronized (this) {
+				if (id == null) {
+					logger.debug("Generating a new UUID on request");
+					id = UUID.randomUUID();
+				}
+			}
+		}
 		return id;
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
@@ -865,7 +865,7 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 	/**
 	 * Accept any letter (including from different languages), numbers, 
 	 */
-	private static final Pattern PATTERN_NAME = Pattern.compile("[\\w\\p{L}\\d\\p{Punct}]+");
+	private static final Pattern PATTERN_NAME = Pattern.compile("[\\w\\p{L}\\d\\p{Punct} ]+");
 	
 	private static String validateNameCharacters(String name, boolean exceptOnFail) {
 		if (name.contains(DELIMITER))


### PR DESCRIPTION
- Don't warn on PathClass name with a space
- Specify UTF-8 for all javadoc tasks (including strict)
- Don't generate UUID for PathObject in constructor