### PR TITLE
Update method names in PathObjectHierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ This is a work-in-progress.
 * Add `ROI.updatePlane(plane)` method to move a ROI to a different z-slice or timepoint (https://github.com/qupath/qupath/issues/1052)
 * 'Classify -> Training images -> Create region annotations' supports adding regions within a selected annotation
   * `RoiTools.createRandomRectangle()` methods created for scripting
+* Updated method names in `PathObjectHierarchy` for better consistency (https://github.com/qupath/qupath/pull/1109)
 * GeoJSON improvements (https://github.com/qupath/qupath/pull/1099)
   * Simplified representation of `PathClass`
     * Store either `name` (single name) or `names` (array) field, and `color` (3-element int array)

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/DilateAnnotationPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/DilateAnnotationPlugin.java
@@ -246,9 +246,9 @@ public class DilateAnnotationPlugin<T> extends AbstractInteractivePlugin<T> {
 		annotation2.setColor(pathObject.getColor());
 
 		if (constrainToParent || isErosion)
-		    hierarchy.addPathObjectBelowParent(parent, annotation2, true);
+		    hierarchy.addObjectBelowParent(parent, annotation2, true);
 		else
-			hierarchy.addPathObject(annotation2);
+			hierarchy.addObject(annotation2);
 		
 	}
 	

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/FillAnnotationHolesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/FillAnnotationHolesPlugin.java
@@ -121,7 +121,7 @@ public class FillAnnotationHolesPlugin<T> extends AbstractInteractivePlugin<T> {
 			if (!toUpdate.isEmpty()) {
 				hierarchy.removeObjects(toUpdate.keySet(), true);
 				toUpdate.forEach((p, r) -> p.setROI(r));
-				hierarchy.addPathObjects(toUpdate.keySet());
+				hierarchy.addObjects(toUpdate.keySet());
 			}
 			hierarchy.getSelectionModel().selectObjects(previousSelection);
 			hierarchy.getSelectionModel().setSelectedObject(selected, true);

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/RefineAnnotationsPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/RefineAnnotationsPlugin.java
@@ -156,7 +156,7 @@ public class RefineAnnotationsPlugin<T> extends AbstractInteractivePlugin<T> {
 			if (!toUpdate.isEmpty()) {
 				hierarchy.removeObjects(toUpdate.keySet(), true);
 				toUpdate.forEach((p, r) -> p.setROI(r));
-				hierarchy.addPathObjects(toUpdate.keySet());
+				hierarchy.addObjects(toUpdate.keySet());
 			}
 			previousSelection.removeAll(toRemove);
 			if (previousSelection.size() == 1)

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SplitAnnotationsPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SplitAnnotationsPlugin.java
@@ -133,7 +133,7 @@ public class SplitAnnotationsPlugin<T> extends AbstractInteractivePlugin<T> {
 				}
 				if (pathObject.hasChildren()) {
 					for (var temp : localSplit)
-						hierarchy.addPathObjectBelowParent(pathObject, temp, false);
+						hierarchy.addObjectBelowParent(pathObject, temp, false);
 				} else 
 					pathObject.addPathObjects(localSplit);
 				toAdd.addAll(localSplit);

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -1044,7 +1044,7 @@ public class QP {
 		PathObjectHierarchy hierarchy = getCurrentHierarchy();
 		if (hierarchy == null)
 			return;
-		hierarchy.addPathObject(pathObject);
+		hierarchy.addObject(pathObject);
 	}
 	
 	/**
@@ -1070,7 +1070,7 @@ public class QP {
 		PathObjectHierarchy hierarchy = getCurrentHierarchy();
 		if (hierarchy == null)
 			return;
-		hierarchy.addPathObjects(pathObjects);
+		hierarchy.addObjects(pathObjects);
 	}
 	
 	/**
@@ -1774,7 +1774,7 @@ public class QP {
 		PathObject pathObject = PathObjects.createAnnotationObject(
 				ROIs.createRectangleROI(0, 0, server.getWidth(), server.getHeight(), ImagePlane.getPlane(z, t))
 				);
-		imageData.getHierarchy().addPathObject(pathObject);
+		imageData.getHierarchy().addObject(pathObject);
 		if (setSelected)
 			imageData.getHierarchy().getSelectionModel().setSelectedObject(pathObject);
 	}
@@ -1821,7 +1821,7 @@ public class QP {
 			transformed.add(PathObjectTools.transformObject(pathObject, transform, true, false));
 		
 		hierarchy.removeObjects(selected, true);
-		hierarchy.addPathObjects(transformed);
+		hierarchy.addObjects(transformed);
 		
 		// Set selected objects
 		var newPrimary = primary == null ? null : selected.stream().filter(p -> p.getId().equals(primary.getId())).findFirst().orElse(null);
@@ -1862,7 +1862,7 @@ public class QP {
 				.collect(Collectors.toSet());
 		var transformed = PathObjectTools.transformObjectRecursive(hierarchy.getRootObject(), transform, true, false);
 		hierarchy.clearAll();
-		hierarchy.addPathObjects(new ArrayList<>(transformed.getChildObjects()));
+		hierarchy.addObjects(new ArrayList<>(transformed.getChildObjects()));
 		
 		// Restore the selection, now with the transformed objects
 		if (!selectedIDs.isEmpty()) {
@@ -2548,7 +2548,7 @@ public class QP {
 	 */
 	public static boolean importObjectsFromFile(String path) throws FileNotFoundException, IllegalArgumentException, IOException, ClassNotFoundException {
 		var objs = PathIO.readObjects(new File(path));
-		return getCurrentHierarchy().addPathObjects(objs);
+		return getCurrentHierarchy().addObjects(objs);
 	}
 	
 	/**
@@ -3413,7 +3413,7 @@ public class QP {
 		else
 			logger.warn("Cannot assign class unambiguously - " + pathClasses.size() + " classes represented in selection");
 		hierarchy.removeObjects(merged, true);
-		hierarchy.addPathObject(pathObjectNew);
+		hierarchy.addObject(pathObjectNew);
 		hierarchy.getSelectionModel().setSelectedObject(pathObjectNew);
 		//				pathObject.removePathObjects(children);
 		//				pathObject.addPathObject(pathObjectNew);

--- a/qupath-core/src/main/java/qupath/lib/images/ImageData.java
+++ b/qupath-core/src/main/java/qupath/lib/images/ImageData.java
@@ -149,7 +149,7 @@ public class ImageData<T> implements WorkflowListener, PathObjectHierarchyListen
 		setImageType(type);
 		
 		// Add listeners for changes
-		this.hierarchy.addPathObjectListener(this);
+		this.hierarchy.addListener(this);
 		workflow.addWorkflowListener(this);
 		
 		// Discard any changes during construction

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -564,7 +564,7 @@ public class PathObjectTools {
 		var points = convertToPoints(pathObjects, preferNucleus);
 		if (deleteObjects)
 			hierarchy.removeObjects(pathObjects, true);
-		hierarchy.addPathObjects(points);
+		hierarchy.addObjects(points);
 	}
 	
 	
@@ -1021,7 +1021,7 @@ public class PathObjectTools {
 		if (toAdd.isEmpty() && toRemove.isEmpty())
 			return false;
 		hierarchy.removeObjects(toRemove, true);
-		hierarchy.addPathObjects(toAdd);
+		hierarchy.addObjects(toAdd);
 		return true;
 	}
 	
@@ -1325,7 +1325,7 @@ public class PathObjectTools {
 			return false;
 		}
 		// Add objects using the default add method (not trying to resolve location)
-		hierarchy.addPathObjects(map.values());
+		hierarchy.addObjects(map.values());
 //		// Add objects, inserting with the same parents as the originals
 //		for (var entry : map.entrySet()) {
 //			entry.getKey().getParent().addPathObject(entry.getValue());

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
@@ -115,7 +115,7 @@ class PathObjectTileCache implements PathObjectHierarchyListener {
 	public PathObjectTileCache(PathObjectHierarchy hierarchy) {
 		this.hierarchy = hierarchy;
 		if (hierarchy != null)
-			hierarchy.addPathObjectListener(this);
+			hierarchy.addListener(this);
 	}
 	
 	public void resetCache() {

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/events/PathObjectHierarchyListener.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/events/PathObjectHierarchyListener.java
@@ -25,12 +25,15 @@ package qupath.lib.objects.hierarchy.events;
 
 import java.util.EventListener;
 
+import qupath.lib.objects.hierarchy.PathObjectHierarchy;
+
 /**
- * A listener for modifications to a PathObjectHierarchy (i.e. objects added, removed, classified etc.)
+ * A listener for modifications to a {@link PathObjectHierarchy} (i.e. objects added, removed, classified etc.)
  * 
  * @author Pete Bankhead
  *
  */
+@FunctionalInterface
 public interface PathObjectHierarchyListener extends EventListener {
 	
 	/**

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools2.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools2.java
@@ -208,7 +208,7 @@ public class TestPathObjectTools2 {
 	
 	@Test
 	public void test_getRepresentedPathClasses() {
-		hierarchy.addPathObjects(Arrays.asList(po1, po2, po3, po4, po5, po6));
+		hierarchy.addObjects(Arrays.asList(po1, po2, po3, po4, po5, po6));
 		
 		var classes = PathObjectTools.getRepresentedPathClasses(hierarchy, PathAnnotationObject.class);
 		assertEquals(new HashSet<>(), classes); 

--- a/qupath-core/src/test/java/qupath/lib/objects/hierarchy/TestPathObjectHierarchy.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/hierarchy/TestPathObjectHierarchy.java
@@ -64,7 +64,7 @@ public class TestPathObjectHierarchy {
 	public void test_PathHierarchy() {
 
 		// Created new PH with listeners
-		myPH.addPathObjectListener(myPOHL);
+		myPH.addListener(myPOHL);
 		assertTrue(myPH.isEmpty());
 		
 		// Firing direct event 
@@ -80,7 +80,7 @@ public class TestPathObjectHierarchy {
 		
 		// Firing indirect events (adding/removing from hierarchy)
 		// Adding one PO with a child (so 2)
-		myPH.addPathObject(myChild1PAO);
+		myPH.addObject(myChild1PAO);
 		Collection<PathObject> POAL1 = new ArrayList<>();
 		POAL1 = myPH.getObjects(POAL1, PathAnnotationObject.class);
 		assertEquals(POAL1.size(), 2); // 1 + child
@@ -175,19 +175,19 @@ public class TestPathObjectHierarchy {
 				ROIs.createRectangleROI(900, 900, 200, 200, ImagePlane.getDefaultPlane())
 				);
 		annotationInCore.setName("Annotation in core");
-		hierarchy.addPathObject(annotationInCore);
+		hierarchy.addObject(annotationInCore);
 
 		var annotationInAnnotation = PathObjects.createAnnotationObject(
 				ROIs.createRectangleROI(950, 950, 100, 100, ImagePlane.getDefaultPlane())
 				);
 		annotationInAnnotation.setName("Annotation in " + annotationInCore.getName());
-		hierarchy.addPathObject(annotationInAnnotation);
+		hierarchy.addObject(annotationInAnnotation);
 
 		var annotationOutsideCore = PathObjects.createAnnotationObject(
 				ROIs.createRectangleROI(2000, 2000, 100, 100, ImagePlane.getDefaultPlane())
 				);
 		annotationOutsideCore.setName("Annotation outside core");
-		hierarchy.addPathObject(annotationOutsideCore);
+		hierarchy.addObject(annotationOutsideCore);
 
 		// An annotation containing the core should *not* become a parent of the core,
 		// since cores must always be directly below the root
@@ -195,7 +195,7 @@ public class TestPathObjectHierarchy {
 				ROIs.createRectangleROI(400, 400-100, 1200, 1200, ImagePlane.getDefaultPlane())
 				);
 		annotationContainingCore.setName("Annotation containing core");
-		hierarchy.addPathObject(annotationContainingCore);
+		hierarchy.addObject(annotationContainingCore);
 		
 		// Sanity check to ensure that our rectangle does indeed contain the core
 		assertTrue(annotationContainingCore.getROI().getGeometry().contains(core.getROI().getGeometry()));
@@ -214,14 +214,14 @@ public class TestPathObjectHierarchy {
 					);
 			detection.setName("Detection in " + annotation.getName());
 			mapDetections.put(detection, annotation);
-			hierarchy.addPathObject(detection);
+			hierarchy.addObject(detection);
 		}
 		// Add another detection outside of everything
 		var detectionOutside = PathObjects.createDetectionObject(
 				ROIs.createRectangleROI(4000, 4000, 5, 5, ImagePlane.getDefaultPlane())
 				);
 		detectionOutside.setName("Detection outside everything");
-		hierarchy.addPathObject(detectionOutside);
+		hierarchy.addObject(detectionOutside);
 		mapDetections.put(detectionOutside, hierarchy.getRootObject());
 
 		// Add another detection inside the core but outside of any annotations
@@ -231,7 +231,7 @@ public class TestPathObjectHierarchy {
 				);
 //		System.err.println("Centroid: " + detectionInCore.getROI().getCentroidX() + ", " + detectionInCore.getROI().getCentroidY());
 		detectionInCore.setName("Detection in core only");
-		hierarchy.addPathObject(detectionInCore);
+		hierarchy.addObject(detectionInCore);
 		mapDetections.put(detectionInCore, core);
 
 
@@ -289,26 +289,26 @@ public class TestPathObjectHierarchy {
 				ROIs.createRectangleROI(900, 900, 200, 200, ImagePlane.getDefaultPlane())
 				);
 		annotationInCore.setName("Annotation in core");
-		hierarchy.addPathObject(annotationInCore);
+		hierarchy.addObject(annotationInCore);
 
 		var annotationInAnnotation = PathObjects.createAnnotationObject(
 				ROIs.createRectangleROI(950, 950, 100, 100, ImagePlane.getDefaultPlane())
 				);
 		annotationInAnnotation.setName("Annotation in " + annotationInCore.getName());
-		hierarchy.addPathObject(annotationInAnnotation);
+		hierarchy.addObject(annotationInAnnotation);
 
 		var annotationOutsideCore = PathObjects.createAnnotationObject(
 				ROIs.createRectangleROI(2000, 2000, 100, 100, ImagePlane.getDefaultPlane())
 				);
 		annotationOutsideCore.setName("Annotation outside core");
-		hierarchy.addPathObject(annotationOutsideCore);
+		hierarchy.addObject(annotationOutsideCore);
 
 		// This was previously containing the entire TMA core - without the core, it acts as a stand-in
 		var annotationContainingCore = PathObjects.createAnnotationObject(
 				ROIs.createRectangleROI(400, 400-100, 1200, 1200, ImagePlane.getDefaultPlane())
 				);
 		annotationContainingCore.setName("Annotation stand-in for core");
-		hierarchy.addPathObject(annotationContainingCore);
+		hierarchy.addObject(annotationContainingCore);
 		
 		// Add a detection at the centroid of each annotation
 		var mapDetections = new LinkedHashMap<PathObject, PathObject>();
@@ -323,14 +323,14 @@ public class TestPathObjectHierarchy {
 					);
 			detection.setName("Detection in " + annotation.getName());
 			mapDetections.put(detection, annotation);
-			hierarchy.addPathObject(detection);
+			hierarchy.addObject(detection);
 		}
 		// Add another detection outside of everything
 		var detectionOutside = PathObjects.createDetectionObject(
 				ROIs.createRectangleROI(4000, 4000, 5, 5, ImagePlane.getDefaultPlane())
 				);
 		detectionOutside.setName("Detection outside everything");
-		hierarchy.addPathObject(detectionOutside);
+		hierarchy.addObject(detectionOutside);
 		mapDetections.put(detectionOutside, hierarchy.getRootObject());
 
 		// Add another detection inside the core but outside of any annotations
@@ -340,7 +340,7 @@ public class TestPathObjectHierarchy {
 				);
 //		System.err.println("Centroid: " + detectionInCore.getROI().getCentroidX() + ", " + detectionInCore.getROI().getCentroidY());
 		detectionInCore.setName("Detection in core only");
-		hierarchy.addPathObject(detectionInCore);
+		hierarchy.addObject(detectionInCore);
 
 
 		// Check hierarchy size

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/IJExtension.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/IJExtension.java
@@ -661,7 +661,7 @@ public class IJExtension implements QuPathExtension {
 					.map(r -> IJTools.convertToAnnotation(r, 1.0, null))
 					.collect(Collectors.toList());
 			
-			imageData.getHierarchy().addPathObjects(pathObjects);
+			imageData.getHierarchy().addObjects(pathObjects);
 			imageData.getHierarchy().getSelectionModel().selectObjects(pathObjects);
 			
 			return true;

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImportRoisCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImportRoisCommand.java
@@ -94,7 +94,7 @@ class ImportRoisCommand implements Runnable {
 		var pathObjects = rois.stream().map(r -> IJTools.convertToAnnotation(r, xOrigin, yOrigin, downsample, null)).collect(Collectors.toList());
 
 		var hierarchy = imageData.getHierarchy();
-		hierarchy.addPathObjects(pathObjects);
+		hierarchy.addObjects(pathObjects);
 		hierarchy.getSelectionModel().selectObjects(pathObjects);
 		
 	}

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateChannelTrainingImagesCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateChannelTrainingImagesCommand.java
@@ -132,7 +132,7 @@ public class CreateChannelTrainingImagesCommand implements Runnable {
 				if (initializePoints) {
 					var imageData2 = entry2.readImageData();
 					imageData2.getHierarchy()
-						.addPathObjects(Arrays.asList(
+						.addObjects(Arrays.asList(
 								PathObjects.createAnnotationObject(
 										ROIs.createPointsROI(ImagePlane.getDefaultPlane()),
 										PathClass.getInstance(channelName, channel.getColor())),

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateRegionAnnotationsCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CreateRegionAnnotationsCommand.java
@@ -294,9 +294,9 @@ public class CreateRegionAnnotationsCommand implements Runnable {
 					rectangle,
 					pathClass);
 			if (parentObject != null)
-				imageData.getHierarchy().addPathObjectBelowParent(parentObject, annotation, true);
+				imageData.getHierarchy().addObjectBelowParent(parentObject, annotation, true);
 			else
-				imageData.getHierarchy().addPathObject(annotation);
+				imageData.getHierarchy().addObject(annotation);
 		}
 		
 		

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
@@ -1469,9 +1469,9 @@ public class ObjectClassifierCommand implements Runnable {
 		public void changed(ObservableValue<? extends ImageData<BufferedImage>> source, ImageData<BufferedImage> imageDataOld,
 				ImageData<BufferedImage> imageDataNew) {
 			if (imageDataOld != null)
-				imageDataOld.getHierarchy().removePathObjectListener(this);
+				imageDataOld.getHierarchy().removeListener(this);
 			if (imageDataNew != null)
-				imageDataNew.getHierarchy().addPathObjectListener(this);
+				imageDataNew.getHierarchy().addListener(this);
 
 			invalidateClassifier();
 		}

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapDialog.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/density/DensityMapDialog.java
@@ -856,7 +856,7 @@ public class DensityMapDialog {
 					viewer.addViewerListener(this);
 					var hierarchy = viewer.getHierarchy();
 					if (hierarchy != null)
-						hierarchy.addPathObjectListener(this);
+						hierarchy.addListener(this);
 					currentViewers.add(viewer);
 					updateDensityServer(viewer);
 				}
@@ -877,10 +877,10 @@ public class DensityMapDialog {
 
 			logger.debug("ImageData changed from {} to {}", imageDataOld, imageDataNew);
 			if (imageDataOld != null)
-				imageDataOld.getHierarchy().removePathObjectListener(this);
+				imageDataOld.getHierarchy().removeListener(this);
 
 			if (imageDataNew != null) {
-				imageDataNew.getHierarchy().addPathObjectListener(this);
+				imageDataNew.getHierarchy().addListener(this);
 			}
 			updateDensityServer(viewer);
 		}

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
@@ -198,9 +198,9 @@ public class PixelClassifierPane {
 		public void changed(ObservableValue<? extends ImageData<BufferedImage>> observable,
 				ImageData<BufferedImage> oldValue, ImageData<BufferedImage> newValue) {
 			if (oldValue != null)
-				oldValue.getHierarchy().removePathObjectListener(hierarchyListener);
+				oldValue.getHierarchy().removeListener(hierarchyListener);
 			if (newValue != null)
-				newValue.getHierarchy().addPathObjectListener(hierarchyListener);
+				newValue.getHierarchy().addListener(hierarchyListener);
 			updateTitle();
 			updateAvailableResolutions(newValue);
 		}
@@ -572,7 +572,7 @@ public class PixelClassifierPane {
 		
 		qupath.imageDataProperty().addListener(imageDataListener);
 		if (qupath.getImageData() != null)
-			qupath.getImageData().getHierarchy().addPathObjectListener(hierarchyListener);
+			qupath.getImageData().getHierarchy().addListener(hierarchyListener);
 		
 		stage.focusedProperty().addListener((v, o, n) -> {
 			if (n) {
@@ -1170,7 +1170,7 @@ public class PixelClassifierPane {
 //			viewer.imageDataProperty().removeListener(imageDataListener);
 			var hierarchy = viewer.getHierarchy();
 			if (hierarchy != null)
-				hierarchy.removePathObjectListener(hierarchyListener);
+				hierarchy.removeListener(hierarchyListener);
 		}
 		featureOverlay = null;
 		overlay = null;

--- a/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_Overlay_to_QuPath.java
+++ b/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_Overlay_to_QuPath.java
@@ -135,7 +135,7 @@ public class QuPath_Send_Overlay_to_QuPath implements PlugIn {
 		List<PathObject> pathObjects = createObjectsFromROIs(imp, rois, downsample, asDetection, includeMeasurements, plane);
 		if (!pathObjects.isEmpty()) {
 			Platform.runLater(() -> {
-				hierarchy.addPathObjects(pathObjects);
+				hierarchy.addObjects(pathObjects);
 				// Select the objects, e.g. so they can be classified or otherwise updated easily
 				if (selectObjects)
 					hierarchy.getSelectionModel().selectObjects(pathObjects);

--- a/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_ROI_to_QuPath.java
+++ b/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_ROI_to_QuPath.java
@@ -81,7 +81,7 @@ public class QuPath_Send_ROI_to_QuPath implements PlugIn {
 		}
 		
 		Platform.runLater(() -> {
-			imageData.getHierarchy().addPathObject(pathObject);
+			imageData.getHierarchy().addObject(pathObject);
 			imageData.getHierarchy().getSelectionModel().setSelectedObject(pathObject);
 			viewer.setZPosition(pathObject.getROI().getZ());
 			viewer.setTPosition(pathObject.getROI().getT());

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -5100,7 +5100,7 @@ public class QuPathGUI {
 //			hierarchy.addPathObject(annotation, false);
 			
 //			// Make sure any core parent is set
-			hierarchy.addPathObjectBelowParent(coreNewParent, annotation, true);
+			hierarchy.addObjectBelowParent(coreNewParent, annotation, true);
 			
 			activeViewer.setSelectedObject(annotation);
 			return true;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/UndoRedoManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/UndoRedoManager.java
@@ -440,7 +440,7 @@ public class UndoRedoManager implements ChangeListener<QuPathViewerPlus>, QuPath
 		
 		// Stop listening for changes on the old image
 		if (imageDataOld != null) {
-			imageDataOld.getHierarchy().removePathObjectListener(this);
+			imageDataOld.getHierarchy().removeListener(this);
 		}
 		
 		// Start listening for changes on the new image... if we can
@@ -454,7 +454,7 @@ public class UndoRedoManager implements ChangeListener<QuPathViewerPlus>, QuPath
 			else
 				map.put(viewer, new SerializableUndoRedoStack<>(null));
 			// Listen for changes
-			hierarchy.addPathObjectListener(this);
+			hierarchy.addListener(this);
 		}
 		
 		refreshProperties();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -212,7 +212,7 @@ public class Commands {
 		}
 		
 		PathObject pathObject = PathObjects.createAnnotationObject(roi);
-		hierarchy.addPathObject(pathObject);
+		hierarchy.addObject(pathObject);
 		viewer.setSelectedObject(pathObject);
 		
 		// Log in the history
@@ -1008,7 +1008,7 @@ public class Commands {
 		// Remove previous objects
 		hierarchy.removeObjects(pathObjects, true);
 		if (newObject != null)
-			hierarchy.addPathObject(newObject);
+			hierarchy.addObject(newObject);
 		return true;
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPane.java
@@ -86,7 +86,7 @@ class CountingPane implements PathObjectSelectionListener, PathObjectHierarchyLi
 	
 	private Action btnAdd = new Action("Add", e -> {
 		PathObject pathObjectCounts = PathObjects.createAnnotationObject(ROIs.createPointsROI(ImagePlane.getDefaultPlane()));
-		hierarchy.addPathObject(pathObjectCounts);
+		hierarchy.addObject(pathObjectCounts);
 //		hierarchy.fireChangeEvent(pathObjectCounts.getParent());
 		hierarchy.getSelectionModel().setSelectedObject(pathObjectCounts);
 //		promptToSetProperties();
@@ -115,7 +115,7 @@ class CountingPane implements PathObjectSelectionListener, PathObjectHierarchyLi
 		for (PathClass pathClass : availableClasses) {
 			pathObjects.add(PathObjects.createAnnotationObject(ROIs.createPointsROI(plane), pathClass));
 		}
-		hierarchy.addPathObjects(pathObjects);
+		hierarchy.addObjects(pathObjects);
 	});
 	
 	
@@ -234,7 +234,7 @@ class CountingPane implements PathObjectSelectionListener, PathObjectHierarchyLi
 			return;
 		if (this.hierarchy != null) {
 			this.hierarchy.getSelectionModel().removePathObjectSelectionListener(this);
-			this.hierarchy.removePathObjectListener(this);
+			this.hierarchy.removeListener(this);
 		}
 		this.hierarchy = hierarchy;
 		PathObject objectSelected = null;
@@ -243,7 +243,7 @@ class CountingPane implements PathObjectSelectionListener, PathObjectHierarchyLi
 			PathObjectSelectionModel model = this.hierarchy.getSelectionModel();
 			model.addPathObjectSelectionListener(this);
 			objectSelected = model.getSelectedObject();
-			this.hierarchy.addPathObjectListener(this);
+			this.hierarchy.addListener(this);
 		}
 		// Update selected object in list, if suitable
 		if (objectSelected != null && PathObjectTools.hasPointROI(objectSelected))

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPanelCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPanelCommand.java
@@ -157,7 +157,7 @@ public class CountingPanelCommand implements Runnable, ChangeListener<ImageData<
 					
 					if (pointsList != null) {
 						for (PathObject points : pointsList)
-							hierarchy.addPathObject(points);
+							hierarchy.addObject(points);
 					}
 				} catch (IOException e) {
 					Dialogs.showErrorMessage("Load points error", e);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/InteractiveObjectImporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/InteractiveObjectImporter.java
@@ -253,7 +253,7 @@ public final class InteractiveObjectImporter {
 			logger.warn("{} being added - IDs not updated, so there will be duplicates!", objString);
 		}
 		
-		hierarchy.addPathObjects(pathObjects);
+		hierarchy.addObjects(pathObjects);
 		return true;
 	}
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
@@ -270,7 +270,7 @@ public class PathObjectGridView implements ChangeListener<ImageData<BufferedImag
 		
 		var currentImageData = imageDataProperty.get();
 		if (currentImageData != null) {
-			currentImageData.getHierarchy().removePathObjectListener(this);
+			currentImageData.getHierarchy().removeListener(this);
 			currentImageData = null;
 		}
 		
@@ -279,7 +279,7 @@ public class PathObjectGridView implements ChangeListener<ImageData<BufferedImag
 		
 		// Listen for changes
 		if (imageDataNew != null)
-			imageDataNew.getHierarchy().addPathObjectListener(this);
+			imageDataNew.getHierarchy().addListener(this);
 		
 		// Don't do anything if not displaying
 		if (imageDataNew == null || stage == null || !stage.isShowing())

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
@@ -709,7 +709,7 @@ class ProjectImportImagesCommand {
 			if (type != null || server != server2 || !pathObjects.isEmpty()) {
 				var imageData = new ImageData<>(server2, type);
 				if (!pathObjects.isEmpty())
-					imageData.getHierarchy().addPathObjects(pathObjects);
+					imageData.getHierarchy().addObjects(pathObjects);
 				entry.saveImageData(imageData);
 			}
 			if (server != server2)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/RigidObjectEditorCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/RigidObjectEditorCommand.java
@@ -263,7 +263,7 @@ class RigidObjectEditorCommand implements Runnable, ChangeListener<ImageData<Buf
 							GeometryTools.convertTransform(transform),
 							true, false);
 					hierarchy.clearAll();
-					hierarchy.addPathObjects(new ArrayList<>(newRoot.getChildObjects()));
+					hierarchy.addObjects(new ArrayList<>(newRoot.getChildObjects()));
 					// Need to reset the selection, so that it doesn't persist in the viewer as phantom objects
 					keepSelection = false;
 					

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SpecifyAnnotationCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SpecifyAnnotationCommand.java
@@ -312,7 +312,7 @@ class SpecifyAnnotationCommand {
 			if (cbLock.isSelected())
 				((PathAnnotationObject)annotation).setLocked(true);
 
-			hierarchy.addPathObject(annotation);
+			hierarchy.addObject(annotation);
 		});
 
 		btnAdd.setMaxWidth(Double.MAX_VALUE);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SummaryMeasurementTableCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SummaryMeasurementTableCommand.java
@@ -436,11 +436,11 @@ public class SummaryMeasurementTableCommand {
 		TableViewerListener tableViewerListener = new TableViewerListener(viewer, table);
 
 		frame.setOnShowing(e -> {
-			hierarchy.addPathObjectListener(listener);
+			hierarchy.addListener(listener);
 			viewer.addViewerListener(tableViewerListener);
 		});
 		frame.setOnHiding(e -> {
-			hierarchy.removePathObjectListener(listener);
+			hierarchy.removeListener(listener);
 			viewer.removeViewerListener(tableViewerListener);
 		});
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
@@ -272,14 +272,14 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 
 		// Deal with listeners for the current ImageData
 		if (this.hierarchy != null) {
-			hierarchy.removePathObjectListener(this);
+			hierarchy.removeListener(this);
 			hierarchy.getSelectionModel().removePathObjectSelectionListener(this);
 		}
 		this.imageData = imageData;
 		if (this.imageData != null) {
 			hierarchy = imageData.getHierarchy();
 			hierarchy.getSelectionModel().addPathObjectSelectionListener(this);
-			hierarchy.addPathObjectListener(this);
+			hierarchy.addListener(this);
 			PathObject selected = hierarchy.getSelectionModel().getSelectedObject();
 			listAnnotations.getItems().setAll(hierarchy.getAnnotationObjects());
 			hierarchy.getSelectionModel().setSelectedObject(selected);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ObjectDescriptionPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ObjectDescriptionPane.java
@@ -312,12 +312,12 @@ public class ObjectDescriptionPane<T> {
 				PathObjectHierarchy newValue) {
 			
 			if (oldValue != null) {
-				oldValue.removePathObjectListener(this);
+				oldValue.removeListener(this);
 				oldValue.getSelectionModel().removePathObjectSelectionListener(this);
 			}
 			
 			if (newValue != null) {
-				newValue.addPathObjectListener(this);
+				newValue.addListener(this);
 				newValue.getSelectionModel().addPathObjectSelectionListener(this);
 				selectedObject.set(newValue.getSelectionModel().getSelectedObject());
 				selectedObjects.setAll(newValue.getSelectionModel().getSelectedObjects());

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathObjectHierarchyView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathObjectHierarchyView.java
@@ -414,12 +414,12 @@ public class PathObjectHierarchyView implements ChangeListener<ImageData<Buffere
 	void setImageData(ImageData<BufferedImage> imageData) {
 		if (hierarchy != null) {
 			hierarchy.getSelectionModel().removePathObjectSelectionListener(this);
-			hierarchy.removePathObjectListener(this);
+			hierarchy.removeListener(this);
 		}
 		
 		this.hierarchy = imageData == null ? null : imageData.getHierarchy();
 		if (hierarchy != null) {
-			hierarchy.addPathObjectListener(this);
+			hierarchy.addListener(this);
 			hierarchy.getSelectionModel().addPathObjectSelectionListener(this);
 			treeView.setRoot(createNode(hierarchy.getRootObject()));
 		} else

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
@@ -246,13 +246,13 @@ public class SelectedMeasurementTableView implements PathObjectSelectionListener
 			ImageData<BufferedImage> imageDataNew) {
 		if (this.imageData != null) {
 			this.imageData.removePropertyChangeListener(this);
-			this.imageData.getHierarchy().removePathObjectListener(this);
+			this.imageData.getHierarchy().removeListener(this);
 			this.imageData.getHierarchy().getSelectionModel().removePathObjectSelectionListener(this);
 		}
 		this.imageData = imageDataNew;
 		if (this.imageData != null) {
 			this.imageData.addPropertyChangeListener(this);
-			this.imageData.getHierarchy().addPathObjectListener(this);
+			this.imageData.getHierarchy().addListener(this);
 			this.imageData.getHierarchy().getSelectionModel().addPathObjectSelectionListener(this);
 		}
 		logger.trace("Image data set to {}", imageData);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/KaplanMeierDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/KaplanMeierDisplay.java
@@ -192,7 +192,7 @@ class KaplanMeierDisplay implements ParameterChangeListener, PathObjectHierarchy
 	public KaplanMeierDisplay(final PathObjectHierarchy hierarchy, final String scoreColumn, final String survivalColumn, final String censoredColumn) {
 		this.hierarchy = hierarchy;
 		if (this.hierarchy != null)
-			this.hierarchy.addPathObjectListener(this);
+			this.hierarchy.addListener(this);
 		this.scoreColumn = scoreColumn;
 		this.survivalColumn = survivalColumn;
 		this.censoredColumn = censoredColumn;
@@ -217,7 +217,7 @@ class KaplanMeierDisplay implements ParameterChangeListener, PathObjectHierarchy
 
 		frame.setOnCloseRequest(e -> {
 			if (hierarchy != null)
-				hierarchy.removePathObjectListener(KaplanMeierDisplay.this);
+				hierarchy.removeListener(KaplanMeierDisplay.this);
 			panelParams.removeParameterChangeListener(KaplanMeierDisplay.this);
 			frame.hide();
 		});
@@ -260,12 +260,12 @@ class KaplanMeierDisplay implements ParameterChangeListener, PathObjectHierarchy
 	 */
 	public void setHierarchy(final PathObjectHierarchy hierarchy, final String survivalKey, final String censoredKey) {
 		if (this.hierarchy != null)
-			this.hierarchy.removePathObjectListener(this);
+			this.hierarchy.removeListener(this);
 		this.survivalColumn = survivalKey;
 		this.censoredColumn = censoredKey;
 		this.hierarchy = hierarchy;
 		if (this.hierarchy != null)
-			this.hierarchy.addPathObjectListener(this);
+			this.hierarchy.addListener(this);
 		generatePlot();
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryViewer.java
@@ -1217,11 +1217,11 @@ public class TMASummaryViewer {
 	 */
 	public void setTMAEntriesFromImageData(final ImageData<BufferedImage> imageData) {
 		if (this.imageData != null) {
-			this.imageData.getHierarchy().removePathObjectListener(hierarchyListener);
+			this.imageData.getHierarchy().removeListener(hierarchyListener);
 		}
 		if (imageData != null) {
 			this.imageData = imageData;
-			this.imageData.getHierarchy().addPathObjectListener(hierarchyListener);
+			this.imageData.getHierarchy().addListener(hierarchyListener);
 			setTMAEntries(getEntriesForTMAData(imageData));
 			stage.setTitle("TMA Viewer: " + ServerTools.getDisplayableImageName(imageData.getServer()));
 		}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -1528,7 +1528,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 		// Remove listeners for previous hierarchy
 		ImageData<BufferedImage> imageDataOld = this.imageDataProperty.get();
 		if (imageDataOld != null) {
-			imageDataOld.getHierarchy().removePathObjectListener(this);
+			imageDataOld.getHierarchy().removeListener(this);
 			imageDataOld.getHierarchy().getSelectionModel().removePathObjectSelectionListener(this);
 		}
 		
@@ -1616,7 +1616,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 
 		if (imageDataNew != null) {
 			//			hierarchyPainter = new PathHierarchyPainter(hierarchy);
-			hierarchy.addPathObjectListener(this);
+			hierarchy.addListener(this);
 			hierarchy.getSelectionModel().addPathObjectSelectionListener(this);
 		}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/AbstractPathROITool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/AbstractPathROITool.java
@@ -225,7 +225,7 @@ abstract class AbstractPathROITool extends AbstractPathTool {
 				if (currentROI.isEmpty()) {
 					pathObject = null;
 				} else
-					hierarchy.addPathObject(pathObject); // Ensure object is within the hierarchy
+					hierarchy.addObject(pathObject); // Ensure object is within the hierarchy
 			} else {
 				ROI roiNew = refineROIByParent(pathObject.getROI());
 				if (roiNew.isEmpty()) {
@@ -233,7 +233,7 @@ abstract class AbstractPathROITool extends AbstractPathTool {
 					pathObject = null;
 				} else {
 					((PathAnnotationObject)pathObject).setROI(roiNew);
-					hierarchy.addPathObjectBelowParent(getCurrentParent(), pathObject, true);
+					hierarchy.addObjectBelowParent(getCurrentParent(), pathObject, true);
 				}
 			}
 			if (pathObject != null)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/MoveTool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/MoveTool.java
@@ -302,9 +302,9 @@ public class MoveTool extends AbstractPathTool {
 //						PathObject parentPrevious = pathObject.getParent();
 						hierarchy.removeObjectWithoutUpdate(pathObject, true);
 						if (getCurrentParent() == null || !PathPrefs.clipROIsForHierarchyProperty().get() || e.isShiftDown())
-							hierarchy.addPathObject(pathObject);
+							hierarchy.addObject(pathObject);
 						else
-							hierarchy.addPathObjectBelowParent(getCurrentParent(), pathObject, true);
+							hierarchy.addObjectBelowParent(getCurrentParent(), pathObject, true);
 //						PathObject parentNew = pathObject.getParent();
 //						if (parentPrevious == parentNew)
 //							hierarchy.fireHierarchyChangedEvent(this, parentPrevious);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/PointsTool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/PointsTool.java
@@ -249,7 +249,7 @@ public class PointsTool extends AbstractPathTool {
 			points = ROIs.createPointsROI(xx, yy, viewerPlane);
 			
 			currentObject = (PathROIObject)PathObjects.createAnnotationObject(points,  PathPrefs.autoSetAnnotationClassProperty().get());
-			viewer.getHierarchy().addPathObject(currentObject);
+			viewer.getHierarchy().addObject(currentObject);
 			viewer.setSelectedObject(currentObject);
 			
 //			viewer.createAnnotationObject(points);

--- a/qupath-gui-fx/src/test/java/qupath/lib/gui/models/TestObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/test/java/qupath/lib/gui/models/TestObservableMeasurementTableData.java
@@ -104,7 +104,7 @@ public class TestObservableMeasurementTableData {
 				parent.addPathObject(PathObjects.createDetectionObject(smallROI, artefactClass));
 			}
 			
-			hierarchy.addPathObject(parent);
+			hierarchy.addObject(parent);
 			
 			ObservableMeasurementTableData model = new ObservableMeasurementTableData();
 			model.setImageData(imageData, Collections.singletonList(parent));
@@ -145,7 +145,7 @@ public class TestObservableMeasurementTableData {
 			
 			// Add a new parent that completely contains the current object, and confirm complete scores agree
 			PathObject parentNew = PathObjects.createAnnotationObject(ROIs.createRectangleROI(0, 0, 2000, 2000, ImagePlane.getDefaultPlane()));
-			hierarchy.addPathObject(parentNew);
+			hierarchy.addObject(parentNew);
 			model.refreshEntries();
 			assertEquals(135, model.getNumericValue(parent, "Stroma + Tumor: H-score"), EPSILON);
 			assertEquals(135, model.getNumericValue(parentNew, "Stroma + Tumor: H-score"), EPSILON);
@@ -155,7 +155,7 @@ public class TestObservableMeasurementTableData {
 			ROI newROI = ROIs.createEllipseROI(4500, 4500, 10, 10, ImagePlane.getDefaultPlane());
 			for (int i = 0; i < 100; i++)
 				parentAllred.addPathObject(PathObjects.createDetectionObject(newROI, PathClass.getNegative(tumorClass)));
-			hierarchy.addPathObject(parentAllred);
+			hierarchy.addObject(parentAllred);
 			model.refreshEntries();
 			assertEquals(0, model.getNumericValue(parentAllred, "Tumor: Allred score"), EPSILON);
 			parentAllred.addPathObject(PathObjects.createDetectionObject(newROI, PathClass.getThreePlus(tumorClass)));


### PR DESCRIPTION
Mostly improve symmetry and consistency:` addObject` instead of `addPathObject`, because removing uses `removeObject` and not `removePathObject`.

Also, QP uses `addObject` rather than `addPathObject`.

Along the way, update names of add/remove methods for listeners as well.