### PR TITLE
Update PathObject method names

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
@@ -193,7 +193,7 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 		double estimatedSpots;
 
 		// We assume that after this processing, any previous sub-cellular objects should be removed
-		pathObject.clearPathObjects();
+		pathObject.clearChildObjects();
 
 		// Ensure we have no existing subcellular detection measurements - if we do, remove them
 		String[] existingMeasurements = pathObject.getMeasurementList().getMeasurementNames().stream().filter(n -> n.startsWith("Subcellular:")).toArray(n -> new String[n]);
@@ -382,8 +382,8 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 			measurementList.put("Subcellular: " + channelName +  ": Num clusters", clusterObjects.size());
 
 			// Add spots
-			pathObject.addPathObjects(spotObjects);
-			pathObject.addPathObjects(clusterObjects);
+			pathObject.addChildObjects(spotObjects);
+			pathObject.addChildObjects(clusterObjects);
 
 		}
 		return true;

--- a/qupath-core-processing/src/main/java/qupath/lib/algorithms/TilerPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/algorithms/TilerPlugin.java
@@ -175,8 +175,8 @@ public class TilerPlugin<T> extends AbstractDetectionPlugin<T> {
 			if (wasCancelled)
 				return;
 			
-			parentObject.clearPathObjects();
-			parentObject.addPathObjects(tiles);
+			parentObject.clearChildObjects();
+			parentObject.addChildObjects(tiles);
 			if (parentObject.isAnnotation())
 				((PathAnnotationObject)parentObject).setLocked(true);
 			imageData.getHierarchy().fireHierarchyChangedEvent(this, parentObject);

--- a/qupath-core-processing/src/main/java/qupath/lib/analysis/heatmaps/DensityMaps.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/analysis/heatmaps/DensityMaps.java
@@ -667,7 +667,7 @@ public class DensityMaps {
 				else if (hotspots.size() < nHotspots) {
 					logger.warn("Only {}/{} hotspots could be found in {}", hotspots.size(), nHotspots, parent);
 				}
-				parent.addPathObjects(hotspots);
+				parent.addChildObjects(hotspots);
 			}
 			
 			hierarchy.fireHierarchyChangedEvent(DensityMaps.class);

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
@@ -133,7 +133,7 @@ public class SmoothFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 			@Override
 			public void run() {
 				try {
-					if (!parentObject.hasChildren())
+					if (!parentObject.hasChildObjects())
 						return;
 	//				System.out.println("Smoothing with FWHM " +fwhmPixels);
 					// TODO: MAKE A MORE ELEGANT LIST!!!!
@@ -404,12 +404,12 @@ public class SmoothFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 		if (hierarchy.getTMAGrid() != null) {
 			logger.info("Smoothing using TMA cores");
 			for (TMACoreObject core : hierarchy.getTMAGrid().getTMACoreList()) {
-				if (core.hasChildren())
+				if (core.hasChildObjects())
 					parents.add(core);
 			}
 		} else {
 			for (PathObject pathObject : hierarchy.getSelectionModel().getSelectedObjects()) {
-				if (pathObject.isAnnotation() && pathObject.hasChildren())
+				if (pathObject.isAnnotation() && pathObject.hasChildObjects())
 					parents.add(pathObject);
 			}			
 			if (!parents.isEmpty())

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SplitAnnotationsPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SplitAnnotationsPlugin.java
@@ -131,11 +131,11 @@ public class SplitAnnotationsPlugin<T> extends AbstractInteractivePlugin<T> {
 					annotation.setLocked(pathObject.isLocked());
 					localSplit.add(annotation);
 				}
-				if (pathObject.hasChildren()) {
+				if (pathObject.hasChildObjects()) {
 					for (var temp : localSplit)
 						hierarchy.addObjectBelowParent(pathObject, temp, false);
 				} else 
-					pathObject.addPathObjects(localSplit);
+					pathObject.addChildObjects(localSplit);
 				toAdd.addAll(localSplit);
 			}
 			if (toAdd.isEmpty() && toRemove.isEmpty())

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/TileClassificationsToAnnotationsPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/TileClassificationsToAnnotationsPlugin.java
@@ -213,7 +213,7 @@ public class TileClassificationsToAnnotationsPlugin<T> extends AbstractDetection
 							pathROINew = RoiTools.getShapeROI(new Area(path), ImagePlane.getDefaultPlane());
 						pathSingleAnnotation = PathObjects.createAnnotationObject(pathROINew, pathClass);
 						if (!deleteTiles)
-							pathSingleAnnotation.addPathObjects(tiles);
+							pathSingleAnnotation.addChildObjects(tiles);
 					}
 				}
 				
@@ -253,7 +253,7 @@ public class TileClassificationsToAnnotationsPlugin<T> extends AbstractDetection
 //							PathObjectTools.containsObject(pathSingleAnnotation, childObject)
 							PathObject annotation = PathObjects.createAnnotationObject(shape, pathClass);
 							if (!deleteTiles)
-								annotation.addPathObjects(children);
+								annotation.addChildObjects(children);
 							pathAnnotations.add(annotation);
 						}
 					}
@@ -281,9 +281,9 @@ public class TileClassificationsToAnnotationsPlugin<T> extends AbstractDetection
 		public void taskComplete(boolean wasCancelled) {
 			if (!wasCancelled && !Thread.currentThread().isInterrupted()) {
 				if (params.getBooleanParameterValue("deleteTiles"))
-					parentObject.clearPathObjects();
+					parentObject.clearChildObjects();
 				if (pathAnnotations != null && !pathAnnotations.isEmpty())
-					parentObject.addPathObjects(pathAnnotations);
+					parentObject.addChildObjects(pathAnnotations);
 				imageData.getHierarchy().fireHierarchyChangedEvent(parentObject);
 			}
 			pathAnnotations = null;

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -3544,7 +3544,7 @@ public class QP {
 		// Create the new ROI
 		ROI shapeNew = GeometryTools.geometryToROI(geometry, plane);
 		PathObject pathObjectNew = PathObjects.createAnnotationObject(shapeNew);
-		parent.addPathObject(pathObjectNew);
+		parent.addChildObject(pathObjectNew);
 		hierarchy.fireHierarchyChangedEvent(parent);	
 		hierarchy.getSelectionModel().setSelectedObject(pathObjectNew);
 		return true;

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
@@ -244,9 +244,9 @@ public class PixelClassifierTools {
 		for (var entry : map.entrySet()) {
 			var parent = entry.getKey();
 			var children = entry.getValue();
-			if (clearExisting && parent.hasChildren())
-				parent.clearPathObjects();
-			parent.addPathObjects(children);
+			if (clearExisting && parent.hasChildObjects())
+				parent.clearChildObjects();
+			parent.addChildObjects(children);
 			if (!parent.isRootObject())
 				parent.setLocked(true);
 		}

--- a/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathObjectTypeAdapters.java
@@ -350,7 +350,7 @@ class PathObjectTypeAdapters {
 				}
 			}
 			
-			if (doHierarchy && value.hasChildren()) {
+			if (doHierarchy && value.hasChildObjects()) {
 				out.name("children");
 				out.beginArray();
 				for (var child : value.getChildObjectsAsArray()) {
@@ -532,7 +532,7 @@ class PathObjectTypeAdapters {
 			}
 			
 			if (childObjects != null)
-				pathObject.addPathObjects(childObjects);
+				pathObject.addChildObjects(childObjects);
 			
 			return pathObject;
 		}

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -232,7 +232,7 @@ public abstract class PathObject implements Externalizable {
 			else
 				return String.format(" (%d points)", nPoints);
 		}
-		if (!hasChildren())
+		if (!hasChildObjects())
 			return "";
 		int nChildren = nChildObjects();
 		int nDescendants = PathObjectTools.countDescendants(this);
@@ -289,14 +289,26 @@ public abstract class PathObject implements Externalizable {
 	/**
 	 * Add an object to the child list of this object.
 	 * @param pathObject
+	 * @since v0.4.0
 	 */
-	public synchronized void addPathObject(PathObject pathObject) {
+	public synchronized void addChildObject(PathObject pathObject) {
 		if (pathObject instanceof PathRootObject) //J
 			throw new IllegalArgumentException("PathRootObject cannot be added as child to another PathObject"); //J 
-		addPathObjectImpl(pathObject);
+		addChildObjectImpl(pathObject);
 	}
 	
-	private synchronized void addPathObjectImpl(PathObject pathObject) {
+	/**
+	 * Legacy method to add a single child object.
+	 * @param pathObject
+	 * @deprecated since v0.4.0, replaced by {@link #addChildObject(PathObject)}
+	 */
+	@Deprecated
+	public void addPathObject(PathObject pathObject) {
+		LogTools.warnOnce(logger, "addPathObject(Collection) is deprecated - use addChildObject(Collection) instead");
+		addChildObject(pathObject);
+	}
+	
+	private synchronized void addChildObjectImpl(PathObject pathObject) {
 		ensureChildList(nChildObjects() + 1);
 		// Make sure the object is removed from any other parent
 		if (pathObject.parent != this) {
@@ -311,7 +323,7 @@ public abstract class PathObject implements Externalizable {
 	}
 
 	
-	private synchronized void addPathObjectsImpl(Collection<? extends PathObject> pathObjects) {
+	private synchronized void addChildObjectsImpl(Collection<? extends PathObject> pathObjects) {
 		if (pathObjects == null || pathObjects.isEmpty())
 			return;
 		ensureChildList(nChildObjects() + pathObjects.size());
@@ -386,83 +398,33 @@ public abstract class PathObject implements Externalizable {
 		list.removeAll(toRemove);
 	}
 	
-//	/**
-//	 * Remove all items from a list, but optionally using a (temporary) set 
-//	 * to improve performance.
-//	 * 
-//	 * @param list
-//	 * @param toRemove
-//	 */
-//	private static <T> void removeAllQuickly(List<T> list, Collection<T> toRemove) {
-//		// This is rather implementation-specific, based on how ArrayLists do their object removal.
-//		// In some implementations it might be better to switch the list to a set temporarily?
-//		int size = 10;
-//		if (list.size() > size || toRemove.size() > size) {
-//			var tempSet = new LinkedHashSet<>(list);
-//			tempSet.removeAll(toRemove);
-//			list.clear();
-//			list.addAll(tempSet);
-//		} else {
-//			if (!(toRemove instanceof Set)  && toRemove.size() > size) {
-//				toRemove = new HashSet<>(toRemove);
-//			}
-//			list.removeAll(toRemove);
-//		}
-////		list.removeAll(toRemove);
-//	}
-	
-	
-//	public void addPathObjects(int index, Collection<? extends PathObject> pathObjects) {
-//		if (pathObjects == null || pathObjects.isEmpty())
-//			return;
-//		ensureChildList(pathObjects.size());
-//		// Make sure the object is removed from any other parent
-//		Iterator<? extends PathObject> iter = pathObjects.iterator();
-//		boolean isChildList = false;
-//		PathObject previousParent = null;
-//		while (iter.hasNext()) {
-//			PathObject pathObject = iter.next();
-//			previousParent = pathObject.parent;
-//			if (pathObject.parent != this) {
-//				// Remove objects from previous parent
-//				if (previousParent != null && previousParent.childList != null) {
-//					// Check if we were given the list directly... if so, remove using the iterator
-////					if (pathObjects == previousParent.childList)
-//					isChildList = pathObjects.equals(previousParent.childList);
-//					if (!isChildList) {
-//						// Should be able to remove from previous parent without a concurrent exception
-////						logger.info("Calling remove " + pathObject);
-//						previousParent.childList.remove(pathObject);
-//					}
-//				}
-//				// Set the parent
-//				pathObject.parent = this;
-//			}
-//		}
-////		logger.info("Adding all " + pathObjects.size());
-//		childList.addAll(index, pathObjects);
-//		// If we have all the children of a pathObject, clear that objects children
-//		if (isChildList)
-//			previousParent.childList.clear();
-//		
-////		for (PathObject pathObject : pathObjects)
-////			addPathObject(index++, pathObject);
-//	}
-	
 	/**
 	 * Add a collection of objects to the child list of this object.
 	 * @param pathObjects
+	 * @since v0.4.0
 	 */
-	public synchronized void addPathObjects(Collection<? extends PathObject> pathObjects) {
-		addPathObjectsImpl(pathObjects);
+	public synchronized void addChildObjects(Collection<? extends PathObject> pathObjects) {
+		addChildObjectsImpl(pathObjects);
+	}
+	
+	/**
+	 * Legacy method to add child objects.
+	 * @param pathObjects
+	 * @deprecated since v0.4.0, replaced by {@link #addChildObjects(Collection)}
+	 */
+	@Deprecated
+	public void addPathObjects(Collection<? extends PathObject> pathObjects) {
+		LogTools.warnOnce(logger, "addPathObjects(Collection) is deprecated - use addChildObjects(Collection) instead");
+		addChildObjects(pathObjects);
 	}
 
 	/**
 	 * Remove a single object from the child list of this object.
 	 * @param pathObject
+	 * @since v0.4.0
 	 */
-	public void removePathObject(PathObject pathObject) {
-		if (!hasChildren())
+	public void removeChildObject(PathObject pathObject) {
+		if (!hasChildObjects())
 			return;
 		if (pathObject.parent == this)
 			pathObject.parent = null; //.setParent(null);
@@ -470,11 +432,23 @@ public abstract class PathObject implements Externalizable {
 	}
 	
 	/**
+	 * Legacy method to remove a single child object.
+	 * @param pathObject
+	 * @deprecated since v0.4.0, replaced by {@link #removeChildObject(PathObject)}
+	 */
+	@Deprecated
+	public void removePathObject(PathObject pathObject) {
+		LogTools.warnOnce(logger, "removePathObject(PathObject) is deprecated - use removeChildObject(PathObject) instead");
+		removeChildObject(pathObject);
+	}
+	
+	/**
 	 * Remove multiple objects from the child list of this object.
 	 * @param pathObjects
+	 * @since v0.4.0
 	 */
-	public synchronized void removePathObjects(Collection<PathObject> pathObjects) {
-		if (!hasChildren())
+	public synchronized void removeChildObjects(Collection<PathObject> pathObjects) {
+		if (!hasChildObjects())
 			return;
 		for (PathObject pathObject : pathObjects) {
 			if (pathObject.parent == this)
@@ -486,10 +460,22 @@ public abstract class PathObject implements Externalizable {
 	}
 	
 	/**
-	 * Remove all child objects.
+	 * Legacy method to remove specified child objects.
+	 * @param pathObjects 
+	 * @deprecated since v0.4.0, replaced by {@link #removeChildObjects(Collection)}
 	 */
-	public void clearPathObjects() {
-		if (!hasChildren())
+	@Deprecated
+	public void removePathObjects(Collection<PathObject> pathObjects) {
+		LogTools.warnOnce(logger, "removePathObjects(Collection) is deprecated - use removeChildObjects(Collection) instead");
+		removeChildObjects(pathObjects);
+	}
+	
+	/**
+	 * Remove all child objects.
+	 * @since v0.4.0
+	 */
+	public void clearChildObjects() {
+		if (!hasChildObjects())
 			return;
 		synchronized (childList) {
 			for (PathObject pathObject : childList) {
@@ -498,6 +484,16 @@ public abstract class PathObject implements Externalizable {
 			}
 			childList.clear();
 		}
+	}
+	
+	/**
+	 * Legacy method to remove all child objects.
+	 * @deprecated since v0.4.0, replaced by {@link #clearChildObjects()}
+	 */
+	@Deprecated
+	public void clearPathObjects() {
+		LogTools.warnOnce(logger, "clearPathObjects() is deprecated, use clearChildObjects() instead");
+		clearChildObjects();
 	}
 	
 	/**
@@ -520,7 +516,7 @@ public abstract class PathObject implements Externalizable {
 	 * @see #nChildObjects()
 	 */
 	public int nDescendants() {
-		if (!hasChildren())
+		if (!hasChildObjects())
 			return 0;
 		// This could be used if needed - but with childList being synchronized I think it isn't necessary
 //		var childArray = getChildObjectsAsArray();
@@ -534,9 +530,21 @@ public abstract class PathObject implements Externalizable {
 	/**
 	 * Check if this object has children, or if its child object list is empty.
 	 * @return
+	 * @since v0.4.0, replaces {@link #hasChildren()} for more consistent naming
 	 */
-	public boolean hasChildren() {
+	public boolean hasChildObjects() {
 		return childList != null && !childList.isEmpty();
+	}
+	
+	/**
+	 * Legacy method to check for child objects.
+	 * @return
+	 * @deprecated since v0.4.0, replaced by {@link #hasChildObjects()}
+	 */
+	@Deprecated
+	public boolean hasChildren() {
+		LogTools.warnOnce(logger, "hasChildren() is deprecated - use hasChildObjects() instead");
+		return hasChildObjects();
 	}
 	
 	/**
@@ -636,7 +644,7 @@ public abstract class PathObject implements Externalizable {
 	 * @return
 	 */
 	public Collection<PathObject> getChildObjects() {
-		if (!hasChildren())
+		if (!hasChildObjects())
 			return Collections.emptyList();
 		return cachedUnmodifiableChildren;
 	}
@@ -650,7 +658,7 @@ public abstract class PathObject implements Externalizable {
 	public Collection<PathObject> getChildObjects(Collection<PathObject> children) {
 		if (children == null)
 			return getChildObjects();
-		if (!hasChildren())
+		if (!hasChildObjects())
 			return children;
 		children.addAll(childList);
 		return children;
@@ -663,14 +671,14 @@ public abstract class PathObject implements Externalizable {
 	 * @return collection containing all descendant object (the same as {@code descendants} if provided)
 	 */
 	public Collection<PathObject> getDescendantObjects(Collection<PathObject> descendants) {
-		if (!hasChildren())
+		if (!hasChildObjects())
 			return Collections.emptyList();
 		if (descendants == null)
 			descendants = new ArrayList<>();
 //		descendants.addAll(childList);
 		for (var child : childList) {
 			descendants.add(child);
-			if (child.hasChildren())
+			if (child.hasChildObjects())
 				child.getDescendantObjects(descendants);
 		}
 		return descendants;
@@ -678,6 +686,7 @@ public abstract class PathObject implements Externalizable {
 	
 	/**
 	 * Get a defensive copy of child objects as an array.
+	 * <p>
 	 * Why? Well perhaps you want to iterate through it and {@link #getChildObjects()} may result in synchronization problems if 
 	 * the list is modified by another thread. In such a case a defensive copy may already be required, and it is more efficient to request 
 	 * it here.

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -860,7 +860,7 @@ public class PathObjectTools {
 	 * @return
 	 */
 	public static Collection<PathObject> getDescendantObjects(PathObject pathObject, Collection<PathObject> pathObjects, Class<? extends PathObject> cls) {
-		if (pathObject == null || !pathObject.hasChildren())
+		if (pathObject == null || !pathObject.hasChildObjects())
 			return pathObjects == null ? Collections.emptyList() : pathObjects;
 		
 		if (pathObjects == null)
@@ -882,7 +882,7 @@ public class PathObjectTools {
 			if (cls == null || cls.isInstance(childObject)) {
 				pathObjects.add(childObject);
 			}
-			if (childObject.hasChildren())
+			if (childObject.hasChildObjects())
 				addPathObjectsRecursively(childObject.getChildObjectsAsArray(), pathObjects, cls);
 		}
 	}
@@ -1178,13 +1178,13 @@ public class PathObjectTools {
 	public static PathObject transformObjectRecursive(PathObject pathObject, AffineTransform transform, boolean copyMeasurements, boolean createNewIDs) {
 		var newObj = transformObject(pathObject, transform, copyMeasurements, createNewIDs);
 		// Parallelization can help
-		if (pathObject.hasChildren()) {
+		if (pathObject.hasChildObjects()) {
 			var newChildObjects = pathObject.getChildObjects()
 				.parallelStream()
 				.map(p -> transformObjectRecursive(p, transform, copyMeasurements, createNewIDs))
 				.collect(Collectors.toList());
 			
-			newObj.addPathObjects(newChildObjects);
+			newObj.addChildObjects(newChildObjects);
 //			for (var child: pathObject.getChildObjects()) {
 //				newObj.addPathObject(transformObjectRecursive(child, transform, copyMeasurements, createNewIDs));
 //			}

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
@@ -121,7 +121,7 @@ public final class PathObjectHierarchy implements Serializable {
 	 * @return
 	 */
 	public synchronized boolean isEmpty() {
-		return (tmaGrid == null || tmaGrid.nCores() == 0) && !rootObject.hasChildren();// && featureMaps.isEmpty();
+		return (tmaGrid == null || tmaGrid.nCores() == 0) && !rootObject.hasChildObjects();// && featureMaps.isEmpty();
 	}
 	
 	/**
@@ -375,9 +375,9 @@ public final class PathObjectHierarchy implements Serializable {
 				// Beware that we could have 'orphaned' detections
 				if (possibleParent.isTMACore())
 					possibleParent.getParent().getChildObjects().stream().filter(p -> p.isDetection()).forEach(previousChildren::add);
-				possibleParent.addPathObject(pathObject);
+				possibleParent.addChildObject(pathObject);
 				if (!previousChildren.isEmpty()) {
-					pathObject.addPathObjects(filterObjectsForROI(pathObject.getROI(), previousChildren));
+					pathObject.addChildObjects(filterObjectsForROI(pathObject.getROI(), previousChildren));
 				}
 				
 				// Notify listeners of changes, if required
@@ -428,15 +428,15 @@ public final class PathObjectHierarchy implements Serializable {
 		}
 
 		// Can't keep children if there aren't any
-		boolean hasChildren = pathObject.hasChildren();
+		boolean hasChildren = pathObject.hasChildObjects();
 		
-		pathObjectParent.removePathObject(pathObject);
+		pathObjectParent.removeChildObject(pathObject);
 
 		// Assign the children to the parent object, if necessary
 		if (keepChildren && hasChildren) {
 			// We create a new array list because getPathObjectList returns an unmodifiable collection
 //			List<PathObject> list = new ArrayList<>(pathObject.getPathObjectList());
-			pathObjectParent.addPathObjects(pathObject.getChildObjects());
+			pathObjectParent.addChildObjects(pathObject.getChildObjects());
 //			pathObject.clearPathObjects(); // Clear child objects, just in case
 		}
 		if (fireEvent) {
@@ -485,7 +485,7 @@ public final class PathObjectHierarchy implements Serializable {
 		for (Entry<PathObject, List<PathObject>> entry : map.entrySet()) {
 			PathObject parent = entry.getKey();
 			List<PathObject> children = entry.getValue();
-			parent.removePathObjects(children);
+			parent.removeChildObjects(children);
 			if (keepChildren) {
 				for (PathObject child : children)
 					childrenToKeep.addAll(child.getChildObjects());
@@ -538,7 +538,7 @@ public final class PathObjectHierarchy implements Serializable {
 	
 	// TODO: Be very cautious about this!!!!  Use of tileCache inside a synchronized method might lead to deadlocks?
 	private synchronized boolean addPathObjectToList(PathObject pathObjectParent, PathObject pathObject, boolean fireChangeEvents) {
-		pathObjectParent.addPathObject(pathObject);
+		pathObjectParent.addChildObject(pathObject);
 		// Notify listeners of changes, if required
 		if (fireChangeEvents)
 			fireObjectAddedEvent(this, pathObject);
@@ -679,7 +679,7 @@ public final class PathObjectHierarchy implements Serializable {
 	 * Remove all objects from the hierarchy.
 	 */
 	public synchronized void clearAll() {
-		getRootObject().clearPathObjects();
+		getRootObject().clearChildObjects();
 		tmaGrid = null;
 		fireHierarchyChangedEvent(getRootObject());
 	}

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
@@ -180,7 +180,7 @@ class PathObjectTileCache implements PathObjectHierarchyListener {
 		}
 		
 		// Add the children
-		if (includeChildren && !(pathObject instanceof TemporaryObject) && pathObject.hasChildren()) {
+		if (includeChildren && !(pathObject instanceof TemporaryObject) && pathObject.hasChildObjects()) {
 			for (PathObject child : pathObject.getChildObjectsAsArray())
 				addToCache(child, includeChildren, limitToClass);
 		}

--- a/qupath-core/src/main/java/qupath/lib/plugins/AbstractTileableDetectionPlugin.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/AbstractTileableDetectionPlugin.java
@@ -142,7 +142,7 @@ public abstract class AbstractTileableDetectionPlugin<T> extends AbstractDetecti
 		AtomicInteger countdown = new AtomicInteger(pathROIs.size());
 		for (ROI pathROI : pathROIs) {
 			ParallelTileObject tile = new ParallelTileObject(manager, pathROI, imageData.getHierarchy(), countdown);
-			parentObject.addPathObject(tile);
+			parentObject.addChildObject(tile);
 			for (ParallelTileObject tileTemp : tileList) {
 				if (tileTemp.suggestNeighbor(tile))
 					tile.suggestNeighbor(tileTemp);
@@ -174,8 +174,8 @@ public abstract class AbstractTileableDetectionPlugin<T> extends AbstractDetecti
 		public void setTiles(Collection<ParallelTileObject> tiles) {
 			this.tiles = new ArrayList<>(tiles);
 			countdown = new AtomicInteger(tiles.size());
-			this.parent.clearPathObjects();
-			this.parent.addPathObjects(tiles);
+			this.parent.clearChildObjects();
+			this.parent.addChildObjects(tiles);
 		}
 		
 		public void tileComplete(PathObject tile, boolean wasCancelled) {
@@ -187,17 +187,17 @@ public abstract class AbstractTileableDetectionPlugin<T> extends AbstractDetecti
 		}
 		
 		private void postprocess() {
-			parent.clearPathObjects();
+			parent.clearChildObjects();
 			if (wasCancelled) {
 				// If anything was cancelled, then replace the original objects
-				parent.addPathObjects(originalChildObjects);
+				parent.addChildObjects(originalChildObjects);
 			} else {
 				// Add the objects from all the children
 				for (var tile : tiles) {
 					tile.resolveOverlaps();
-					parent.addPathObjects(tile.getChildObjects());
+					parent.addChildObjects(tile.getChildObjects());
 				}
-				if (parent.hasChildren())
+				if (parent.hasChildObjects())
 					parent.setLocked(true);
 			}
 //			hierarchy.fireObjectsChangedEvent(this, Collections.singletonList(parent));

--- a/qupath-core/src/main/java/qupath/lib/plugins/DetectionPluginTools.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/DetectionPluginTools.java
@@ -147,14 +147,14 @@ public class DetectionPluginTools {
 			try {
 //				// Tile objects handle their own completion
 				if (parentObject instanceof ParallelTileObject) {
-					parentObject.clearPathObjects();
-					parentObject.addPathObjects(pathObjectsDetected);
+					parentObject.clearChildObjects();
+					parentObject.addChildObjects(pathObjectsDetected);
 					((ParallelTileObject)parentObject).setComplete(wasCancelled);
 				} else {
 					if (!wasCancelled) {
-						parentObject.clearPathObjects();
+						parentObject.clearChildObjects();
 						if (pathObjectsDetected != null) {
-							parentObject.addPathObjects(pathObjectsDetected);
+							parentObject.addChildObjects(pathObjectsDetected);
 							tryToSetObjectLock(parentObject, !pathObjectsDetected.isEmpty());
 						}
 						imageData.getHierarchy().fireObjectsChangedEvent(this, Collections.singletonList(parentObject));

--- a/qupath-core/src/main/java/qupath/lib/plugins/ParallelTileObject.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/ParallelTileObject.java
@@ -293,12 +293,12 @@ public class ParallelTileObject extends PathTileObject implements TemporaryObjec
 					double threshold = 0.1;
 					if (firstArea >= secondArea) {
 						if (intersectionArea / secondArea > threshold) {
-							second.removePathObject(secondObject);
+							second.removeChildObject(secondObject);
 							nRemoved++;
 						}
 					} else {
 						if (intersectionArea / firstArea > threshold) {
-							first.removePathObject(firstObject);
+							first.removeChildObject(firstObject);
 							nRemoved++;
 							break;
 						}
@@ -355,11 +355,11 @@ public class ParallelTileObject extends PathTileObject implements TemporaryObjec
 						parallelObjects.add(temp);
 					}
 				}
-				parent.removePathObjects(parallelObjects);
+				parent.removeChildObjects(parallelObjects);
 				for (PathObject temp : parallelObjects)
-					parent.addPathObjects(temp.getChildObjects());
+					parent.addChildObjects(temp.getChildObjects());
 
-				if (parent.hasChildren() && parent instanceof PathROIObject)
+				if (parent.hasChildObjects() && parent instanceof PathROIObject)
 					((PathROIObject)parent).setLocked(true);
 
 				hierarchy.fireHierarchyChangedEvent(parent);

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectMethods.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectMethods.java
@@ -89,27 +89,27 @@ class TestPathObjectMethods {
 	}
 	//@Test
 	public void test_addPathObject(PathObject myPO, PathObject tPO, Integer nchildren) {
-		myPO.addPathObject(tPO);
+		myPO.addChildObject(tPO);
 		assertEquals((Integer)myPO.nChildObjects(), nchildren);
 	}
 	//@Test
 	public void test_addPathObjects(PathObject myPO, Collection<PathObject> colPO, Integer nchildren) {
-		myPO.addPathObjects(colPO);
+		myPO.addChildObjects(colPO);
 		assertEquals((Integer)myPO.nChildObjects(), nchildren);
 	}
 	//@Test
 	public void test_removePathObject(PathObject myPO, PathObject tPO, Integer nchildren) {
-		myPO.removePathObject(tPO);
+		myPO.removeChildObject(tPO);
 		assertEquals((Integer)myPO.nChildObjects(), nchildren);
 	}
 	//@Test
 	public void test_removePathObjects(PathObject myPO, Collection<PathObject> colPO, Integer nchildren) {
-		myPO.removePathObjects(colPO);
+		myPO.removeChildObjects(colPO);
 		assertEquals((Integer)myPO.nChildObjects(), nchildren);
 	}
 	//@Test
 	public void test_clearPathObjects(PathObject myPO, Integer nchildren) {
-		myPO.clearPathObjects();
+		myPO.clearChildObjects();
 		assertEquals((Integer)myPO.nChildObjects(), nchildren);
 	}
 	//@Test

--- a/qupath-core/src/test/java/qupath/lib/objects/hierarchy/TestPathObjectHierarchy.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/hierarchy/TestPathObjectHierarchy.java
@@ -73,8 +73,8 @@ public class TestPathObjectHierarchy {
 		myPOHL.setFiredState(0);
 		
 		// Creating structure of POs
-		myChild1PAO.addPathObject(myChild3PAO);
-		myPRO.addPathObject(myChild1PAO);
+		myChild1PAO.addChildObject(myChild3PAO);
+		myPRO.addChildObject(myChild1PAO);
 		assertEquals(myPRO.nChildObjects(), 1);
 		assertEquals(myChild1PAO.getParent(), myPRO);
 		

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
@@ -312,8 +312,8 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 				
 				
 				boolean changes = false;
-				if (params.getBooleanParameterValue("clearObjects") && pathObject.hasChildren()) {
-					pathObject.clearPathObjects();
+				if (params.getBooleanParameterValue("clearObjects") && pathObject.hasChildObjects()) {
+					pathObject.clearChildObjects();
 					changes = true;
 				}
 				if (params.getBooleanParameterValue("getROI") && impResult.getRoi() != null) {
@@ -328,7 +328,7 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 						}
 						// Only add if we have something
 						if (pathObjectNew.getROI() instanceof LineROI || !pathObjectNew.getROI().isEmpty()) {
-							pathObject.addPathObject(pathObjectNew);
+							pathObject.addChildObject(pathObjectNew);
 							//			imageData.getHierarchy().addPathObject(IJHelpers.convertToPathObject(imp, imageData.getServer(), imp.getRoi(), downsampleFactor, false), true);
 							changes = true;
 						}
@@ -340,7 +340,7 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 					var overlay = impResult.getOverlay();
 					List<PathObject> childObjects = QuPath_Send_Overlay_to_QuPath.createObjectsFromROIs(imp, Arrays.asList(overlay.toArray()), downsampleFactor, exportAsDetection, true, region.getImagePlane());
 					if (!childObjects.isEmpty()) {
-						pathObject.addPathObjects(childObjects);
+						pathObject.addChildObjects(childObjects);
 						changes = true;
 					}
 //					for (Roi roi : impResult.getOverlay().toArray()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathObjectHierarchyView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathObjectHierarchyView.java
@@ -478,7 +478,7 @@ public class PathObjectHierarchyView implements ChangeListener<ImageData<Buffere
 						assert child != value;
 						if (child.isTMACore())
 							tmaCores.add(child);
-						else if (child.isAnnotation() || child.hasChildren())
+						else if (child.isAnnotation() || child.hasChildObjects())
 							sortable.add(child);
 						else if (includeDetections)
 							others.add(child);
@@ -505,7 +505,7 @@ public class PathObjectHierarchyView implements ChangeListener<ImageData<Buffere
 		public boolean isLeaf() {
 			if (isLeaf == null) {
 				var pathObject = getValue();
-				if (!pathObject.hasChildren())
+				if (!pathObject.hasChildObjects())
 					isLeaf = true;
 				else if (PathPrefs.detectionTreeDisplayModeProperty().get() != DetectionTreeDisplayModes.NONE) {
 					isLeaf = false;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -666,7 +666,7 @@ public class GuiTools {
 		// Deselect first
 		hierarchy.getSelectionModel().deselectObject(pathObjectSelected);
 
-		if (pathObjectSelected.hasChildren()) {
+		if (pathObjectSelected.hasChildObjects()) {
 			int nDescendants = PathObjectTools.countDescendants(pathObjectSelected);
 			String message = nDescendants == 1 ? "Keep descendant object?" : String.format("Keep %d descendant objects?", nDescendants);
 			Dialogs.DialogButton confirm = Dialogs.showYesNoCancelDialog("Delete object", message);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathHierarchyPaintingHelper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathHierarchyPaintingHelper.java
@@ -424,7 +424,7 @@ public class PathHierarchyPaintingHelper {
 							if ((overlayOptions.getFillAnnotations() &&
 									pathObject.isAnnotation() && 
 									pathObject.getPathClass() != PathClass.StandardPathClasses.REGION &&
-									(pathObject.getPathClass() != null || !pathObject.hasChildren()))
+									(pathObject.getPathClass() != null || !pathObject.hasChildObjects()))
 									|| (pathObject.isTMACore() && overlayOptions.getShowTMACoreLabels()))
 								paintROI(pathROI, g, colorStroke, stroke, ColorToolsAwt.getMoreTranslucentColor(colorStroke), downsample);
 							else
@@ -440,7 +440,7 @@ public class PathHierarchyPaintingHelper {
 			for (PathObject childObject : pathObject.getChildObjectsAsArray()) {
 				// Only call the painting method if required
 				ROI childROI = childObject.getROI();
-				if ((childROI != null && boundsDisplayed.intersects(childROI.getBoundsX(), childROI.getBoundsY(), childROI.getBoundsWidth(), childROI.getBoundsHeight())) || childObject.hasChildren())
+				if ((childROI != null && boundsDisplayed.intersects(childROI.getBoundsX(), childROI.getBoundsY(), childROI.getBoundsWidth(), childROI.getBoundsHeight())) || childObject.hasChildObjects())
 					painted = paintObject(childObject, paintChildren, g, boundsDisplayed, overlayOptions, selectionModel, downsample) | painted;
 			}
 		}

--- a/qupath-gui-fx/src/test/java/qupath/lib/gui/models/TestObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/test/java/qupath/lib/gui/models/TestObservableMeasurementTableData.java
@@ -80,28 +80,28 @@ public class TestObservableMeasurementTableData {
 			ROI smallROI = ROIs.createRectangleROI(500, 500, 1, 1, ImagePlane.getDefaultPlane());
 			for (int i = 0; i < 100; i++) {
 				if (i < 25)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getNegative(tumorClass)));
+					parent.addChildObject(PathObjects.createDetectionObject(smallROI, PathClass.getNegative(tumorClass)));
 				else if (i < 50)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getOnePlus(tumorClass)));
+					parent.addChildObject(PathObjects.createDetectionObject(smallROI, PathClass.getOnePlus(tumorClass)));
 				else if (i < 75)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getTwoPlus(tumorClass)));
+					parent.addChildObject(PathObjects.createDetectionObject(smallROI, PathClass.getTwoPlus(tumorClass)));
 				else if (i < 100)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getThreePlus(tumorClass)));
+					parent.addChildObject(PathObjects.createDetectionObject(smallROI, PathClass.getThreePlus(tumorClass)));
 			}
 			// Create 100 stroma detections
 			for (int i = 0; i < 100; i++) {
 				if (i < 50)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getNegative(stromaClass)));
+					parent.addChildObject(PathObjects.createDetectionObject(smallROI, PathClass.getNegative(stromaClass)));
 				else if (i < 60)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getOnePlus(stromaClass)));
+					parent.addChildObject(PathObjects.createDetectionObject(smallROI, PathClass.getOnePlus(stromaClass)));
 				else if (i < 70)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getTwoPlus(stromaClass)));
+					parent.addChildObject(PathObjects.createDetectionObject(smallROI, PathClass.getTwoPlus(stromaClass)));
 				else if (i < 100)
-					parent.addPathObject(PathObjects.createDetectionObject(smallROI, PathClass.getThreePlus(stromaClass)));
+					parent.addChildObject(PathObjects.createDetectionObject(smallROI, PathClass.getThreePlus(stromaClass)));
 			}
 			// Create 50 artefact detections
 			for (int i = 0; i < 50; i++) {
-				parent.addPathObject(PathObjects.createDetectionObject(smallROI, artefactClass));
+				parent.addChildObject(PathObjects.createDetectionObject(smallROI, artefactClass));
 			}
 			
 			hierarchy.addObject(parent);
@@ -127,7 +127,7 @@ public class TestObservableMeasurementTableData {
 	
 			// Check tumor H-score unaffected when tumor detections added without intensity classification
 			for (int i = 0; i < 10; i++)
-				parent.addPathObject(PathObjects.createDetectionObject(smallROI, tumorClass));
+				parent.addChildObject(PathObjects.createDetectionObject(smallROI, tumorClass));
 			hierarchy.fireHierarchyChangedEvent(this);
 			model.refreshEntries();
 	//		model.setImageData(imageData, Collections.singletonList(parent));
@@ -154,11 +154,11 @@ public class TestObservableMeasurementTableData {
 			PathObject parentAllred = PathObjects.createAnnotationObject(ROIs.createRectangleROI(4000, 4000, 1000, 1000, ImagePlane.getDefaultPlane()));
 			ROI newROI = ROIs.createEllipseROI(4500, 4500, 10, 10, ImagePlane.getDefaultPlane());
 			for (int i = 0; i < 100; i++)
-				parentAllred.addPathObject(PathObjects.createDetectionObject(newROI, PathClass.getNegative(tumorClass)));
+				parentAllred.addChildObject(PathObjects.createDetectionObject(newROI, PathClass.getNegative(tumorClass)));
 			hierarchy.addObject(parentAllred);
 			model.refreshEntries();
 			assertEquals(0, model.getNumericValue(parentAllred, "Tumor: Allred score"), EPSILON);
-			parentAllred.addPathObject(PathObjects.createDetectionObject(newROI, PathClass.getThreePlus(tumorClass)));
+			parentAllred.addChildObject(PathObjects.createDetectionObject(newROI, PathClass.getThreePlus(tumorClass)));
 			hierarchy.fireHierarchyChangedEvent(parentAllred);
 			model.refreshEntries();
 			assertEquals(4, model.getNumericValue(parentAllred, "Tumor: Allred score"), EPSILON);


### PR DESCRIPTION
Refer to child objects consistently as child objects, rather than switch to sometimes calling them path objects.

This means updating the add/remove/clear methods, but get remains unchanged.