### PR TITLE
Show annotations outside the image bounds

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
@@ -168,8 +168,12 @@ public class HierarchyOverlay extends AbstractOverlay {
 			shapeRegion = AwtTools.getBounds(imageRegion);
 		var boundsDisplayed = shapeRegion.getBounds();
 		
+		// Note: the following was commented out for v0.4.0, because objects becoming invisible 
+		// when outside the image turned out to be problematic more than helpful
+		
 		// Ensure the bounds do not extend beyond what the server actually contains
-		boundsDisplayed = boundsDisplayed.intersection(serverBounds);
+//		boundsDisplayed = boundsDisplayed.intersection(serverBounds);
+		
 		if (boundsDisplayed.width <= 0 || boundsDisplayed.height <= 0)
 			return;
 


### PR DESCRIPTION
Not painting annotations that are entirely outside the image bounds turned out to be more confusing than helpful, particularly when applying transforms to objects