### PR TITLE
Improve TMA support for object transforms and json serialization

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
@@ -402,7 +402,7 @@ class QuPathTypeAdapters {
 			
 			MeasurementList measurements = value.getMeasurementList();
 			if (flattenProperties) {
-				// Flatting properties probably not a good idea!
+				// Flattening properties probably not a good idea!
 				
 				// Add measurements
 				if (!measurements.isEmpty()) {
@@ -600,8 +600,7 @@ class QuPathTypeAdapters {
 			
 			if (measurementList != null && !measurementList.isEmpty()) {
 				try (var ml = pathObject.getMeasurementList()) {
-					for (int i = 0; i < measurementList.size(); i++)
-						ml.putAll(measurementList);
+					ml.putAll(measurementList);
 				}
 			}
 			if (pathClass != null)

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -1124,8 +1124,9 @@ public class PathObjectTools {
 			newObject = PathObjects.createAnnotationObject(roi, pathClass, null);
 		} else if (pathObject instanceof PathRootObject) {
 			newObject = new PathRootObject();
-		} else if (pathObject instanceof TMACoreObject && roi instanceof EllipseROI) {
+		} else if (pathObject instanceof TMACoreObject) {
 			var core = (TMACoreObject)pathObject;
+			// TODO: Consider supporting non-ellipse ROIs for TMA cores
 			newObject = PathObjects.createTMACoreObject(roi.getBoundsX(), roi.getBoundsY(), roi.getBoundsWidth(), roi.getBoundsHeight(), core.isMissing());
 		} else
 			throw new UnsupportedOperationException("Unable to transform object " + pathObject);


### PR DESCRIPTION
* Support TMA grids when applying an affine transform to all objects via `QP.transformAllObjects` (although the ROIs must still be ellipses)
* Fix hierarchy json support to include TMA grid
* Fix inefficiency in deserializing measurement lists from json