### PR TITLE
Improved object handling & new commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,13 @@ This is a work-in-progress.
   * Store measurements directly as a JSON object / map (rather than an array of name/value elements)
   * Optionally support child objects in export
     * Serializing the root object now involves serializing the whole hierarchy
+* Add copy & paste options for objects
+  * Copy selected objects or all annotations to the system clipboard, as GeoJSON
+  * Paste objects from the clipboard, optionally positioning them on the current viewer plane
+  * Paste selected objects to the current viewer plane (to easily duplicate objects across z-slices/timepoints)
+* Creating a full image annotation with 'selection mode' turned on selects all objects in the current plane
+  * New command 'Objects -> Select... -> Select objects on current plane' can achieve the same when not using selection mode
+
 
 ### Bugs fixed
 * Reading from Bio-Formats blocks forever when using multiple series outside a project (https://github.com/qupath/qupath/issues/894)

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -81,6 +81,7 @@ import qupath.lib.classifiers.pixel.PixelClassifier;
 import qupath.lib.color.ColorDeconvolutionStains;
 import qupath.lib.common.ColorTools;
 import qupath.lib.common.GeneralTools;
+import qupath.lib.common.LogTools;
 import qupath.lib.common.Timeit;
 import qupath.lib.common.Version;
 import qupath.lib.images.ImageData;
@@ -1708,9 +1709,132 @@ public class QP {
 	 * Create an annotation for the entire width and height of the current image data, on the default plane (z-slice, time point).
 	 * 
 	 * @param setSelected if true, select the object that was created after it is added to the hierarchy
+	 * @deprecated v0.4.0 use {@link #createFullImageAnnotation(boolean)} instead
 	 */
+	@Deprecated
 	public static void createSelectAllObject(final boolean setSelected) {
+		LogTools.warnOnce(logger, "createSelectAllObject(boolean) is deprecated, use createFullImageAnnotation(boolean) instead");
 		createSelectAllObject(setSelected, 0, 0);
+	}
+	
+	/**
+	 * Create an annotation for the entire width and height of the current image data, on the default plane (z-slice, time point).
+	 * 
+	 * @param setSelected if true, select the object that was created after it is added to the hierarchy
+	 * @param z z-slice index for the annotation
+	 * @param t timepoint index for the annotation
+	 * @deprecated v0.4.0 use {@link #createFullImageAnnotation(boolean, int, int)} instead
+	 */
+	@Deprecated
+	public static void createSelectAllObject(final boolean setSelected, int z, int t) {
+		LogTools.warnOnce(logger, "createSelectAllObject(boolean, int, int) is deprecated, use createFullImageAnnotation(boolean, int, int) instead");
+		ImageData<?> imageData = getCurrentImageData();
+		if (imageData == null)
+			return;
+		ImageServer<?> server = imageData.getServer();
+		PathObject pathObject = PathObjects.createAnnotationObject(
+				ROIs.createRectangleROI(0, 0, server.getWidth(), server.getHeight(), ImagePlane.getPlane(z, t))
+				);
+		imageData.getHierarchy().addObject(pathObject);
+		if (setSelected)
+			imageData.getHierarchy().getSelectionModel().setSelectedObject(pathObject);
+	}
+	
+	/**
+	 * Create annotation around the full image for the current image, on all z-slices and timepoints.
+	 * @param setSelected if true, set the annotations to be selected when they are created
+	 * @return the annotations that were created, or an empty list if no image data was available
+	 * @since v0.4.0
+	 * @see #createAllFullImageAnnotations(ImageData, boolean)
+	 */
+	public static List<PathObject> createAllFullImageAnnotations(boolean setSelected) {
+		return createAllFullImageAnnotations(getCurrentImageData(), setSelected);
+	}
+	
+	
+	/**
+	 * Create annotation around the full image for the specified image, on all z-slices and timepoints.
+	 * @param imageData the image data
+	 * @param setSelected if true, set the annotations to be selected when they are created
+	 * @return the annotations that were created, or an empty list if no image data was available
+	 * @since v0.4.0
+	 */
+	public static List<PathObject> createAllFullImageAnnotations(ImageData<?> imageData, boolean setSelected) {
+		if (imageData == null)
+			return Collections.emptyList();
+		ImageServer<?> server = imageData.getServer();
+		List<PathObject> annotations = new ArrayList<>();
+		for (int t = 0; t < server.nTimepoints(); t++) {
+			for (int z = 0; z < server.nZSlices(); z++) {
+				PathObject pathObject = PathObjects.createAnnotationObject(
+						ROIs.createRectangleROI(0, 0, server.getWidth(), server.getHeight(), ImagePlane.getPlane(z, t))
+						);
+				annotations.add(pathObject);
+			}			
+		}
+		imageData.getHierarchy().addObjects(annotations);
+		if (setSelected)
+			imageData.getHierarchy().getSelectionModel().setSelectedObjects(annotations, annotations.get(0));
+		return annotations;
+	}
+	
+	
+	/**
+	 * Create an annotation around the full image for the current image, on the default (first) z-slice and timepoint.
+	 * @param setSelected if true, set the annotation to be selected when it is created
+	 * @return the annotation that was created, or null if no image data was available
+	 * @since v0.4.0
+	 * @see #createFullImageAnnotation(boolean, int, int)
+	 * @see #createFullImageAnnotation(ImageData, boolean)
+	 */
+	public static PathObject createFullImageAnnotation(boolean setSelected) {
+		return createFullImageAnnotation(getCurrentImageData(), setSelected);
+	}
+	
+	/**
+	 * Create an annotation around the full image for the current image, on the specified z-slice and timepoint.
+	 * @param setSelected if true, set the annotation to be selected when it is created
+	 * @param z z-slice (0-based index)
+	 * @param t timepoint (0-based index)
+	 * @return the annotation that was created, or null if no image data was available
+	 * @since v0.4.0
+	 * @see #createFullImageAnnotation(ImageData, boolean, int, int)
+	 */
+	public static PathObject createFullImageAnnotation(boolean setSelected, int z, int t) {
+		return createFullImageAnnotation(getCurrentImageData(), setSelected, z, t);		
+	}
+	
+	/**
+	 * Create an annotation around the full image for the specified image, on the default (first) z-slice and timepoint.
+	 * @param imageData the image data for which the annotation should be added
+	 * @param setSelected if true, set the annotation to be selected when it is created
+	 * @return the annotation that was created, or null if no image data was available
+	 * @since v0.4.0
+	 */
+	public static PathObject createFullImageAnnotation(ImageData<?> imageData, boolean setSelected) {
+		return createFullImageAnnotation(imageData, setSelected, 0, 0);
+	}
+	
+	/**
+	 * Create an annotation around the full image for the specified image, on the specified z-slice and timepoint.
+	 * @param imageData the image data for which the annotation should be added
+	 * @param setSelected if true, set the annotation to be selected when it is created
+	 * @param z z-slice (0-based index)
+	 * @param t timepoint (0-based index)
+	 * @return the annotation that was created, or null if no image data was available
+	 * @since v0.4.0
+	 */
+	public static PathObject createFullImageAnnotation(ImageData<?> imageData, boolean setSelected, int z, int t) {
+		if (imageData == null)
+			return null;
+		ImageServer<?> server = imageData.getServer();
+		PathObject pathObject = PathObjects.createAnnotationObject(
+				ROIs.createRectangleROI(0, 0, server.getWidth(), server.getHeight(), ImagePlane.getPlane(z, t))
+				);
+		imageData.getHierarchy().addObject(pathObject);
+		if (setSelected)
+			imageData.getHierarchy().getSelectionModel().setSelectedObject(pathObject);
+		return pathObject;
 	}
 
 	/**
@@ -1760,27 +1884,7 @@ public class QP {
 	public static ImageServer<BufferedImage> buildServer(URI uri, String... args) throws IOException {
 		return ImageServers.buildServer(uri, args);
 	}
-	
-	
-	/**
-	 * Create an annotation for the entire width and height of the current image data, on the default plane (z-slice, time point).
-	 * 
-	 * @param setSelected if true, select the object that was created after it is added to the hierarchy
-	 * @param z z-slice index for the annotation
-	 * @param t timepoint index for the annotation
-	 */
-	public static void createSelectAllObject(final boolean setSelected, int z, int t) {
-		ImageData<?> imageData = getCurrentImageData();
-		if (imageData == null)
-			return;
-		ImageServer<?> server = imageData.getServer();
-		PathObject pathObject = PathObjects.createAnnotationObject(
-				ROIs.createRectangleROI(0, 0, server.getWidth(), server.getHeight(), ImagePlane.getPlane(z, t))
-				);
-		imageData.getHierarchy().addObject(pathObject);
-		if (setSelected)
-			imageData.getHierarchy().getSelectionModel().setSelectedObject(pathObject);
-	}
+
 	
 //	public static boolean removeObjectsOutsideImage() {
 //		return removeObjectsOutsideImage(getCurrentServer(), getCurrentHierarchy());

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -4056,6 +4056,60 @@ public class QP {
 	}
 	
 	 
+	 /**
+	  * Remove objects that are entirely outside the current image.
+	  * @return true if objects were removed, false otherwise
+	  * @since v0.4.0
+	  * @see #removeObjectsOutsideImage(ImageData, boolean)
+	  */
+	 public static boolean removeObjectsOutsideImage() {
+		 return removeObjectsOutsideImage(getCurrentImageData());
+	 }
+	 
+	 /**
+	  * Remove objects that are entirely or partially outside the current image.
+	  * @param ignoreIntersecting if true, ignore objects that are intersecting the image bounds; if false, remove these intersecting objects too
+	  * @return true if objects were removed, false otherwise
+	  * @since v0.4.0
+	  * @see #removeObjectsOutsideImage(ImageData, boolean)
+	  */
+	 public static boolean removeObjectsOutsideImage(boolean ignoreIntersecting) {
+		 return removeObjectsOutsideImage(getCurrentImageData(), ignoreIntersecting);
+	 }
+
+	 /**
+	  * Remove objects that are entirely or outside the specified image.
+	  * @param imageData the image data, including a hierarchy and server to use
+	  * @return true if objects were removed, false otherwise
+	  * @since v0.4.0
+	  * @see #removeObjectsOutsideImage(ImageData, boolean)
+	  */
+	 public static boolean removeObjectsOutsideImage(ImageData<?> imageData) {
+		 return removeObjectsOutsideImage(imageData, true);		 
+	 }
+
+	 /**
+	  * Remove objects that are entirely or partially outside the specified image.
+	  * @param imageData the image data, including a hierarchy and server to use
+	  * @param ignoreIntersecting if true, ignore objects that are intersecting the image bounds; if false, remove these intersecting objects too
+	  * @return true if objects were removed, false otherwise
+	  * @since v0.4.0
+	  * @see #removeObjectsOutsideImage(ImageData, boolean)
+	  */
+	 public static boolean removeObjectsOutsideImage(ImageData<?> imageData, boolean ignoreIntersecting) {
+		 Objects.requireNonNull(imageData, "Hierarchy must not be null!");
+		 var hierarchy = imageData.getHierarchy();
+		 var server = imageData.getServer();
+		 var toRemove = PathObjectTools.findObjectsOutsideImage(hierarchy.getAllObjects(false), server, ignoreIntersecting);
+		 if (toRemove.isEmpty())
+			 return false;
+		 hierarchy.removeObjects(toRemove, true);
+		 hierarchy.getSelectionModel().deselectObjects(toRemove);
+		 return true;
+	 }
+	 
+	 
+	 
 	 
 	 /*
 	  * If Groovy finds a getXXX() it's liable to make xXX look like a variable...

--- a/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
@@ -442,7 +442,7 @@ class QuPathTypeAdapters {
 			}
 			
 			if (doHierarchy && value.hasChildObjects()) {
-				out.name("children");
+				out.name("childObjects");
 				out.beginArray();
 				for (var child : value.getChildObjectsAsArray()) {
 					write(out, child);
@@ -546,8 +546,9 @@ class QuPathTypeAdapters {
 					// Allow 'type' to be used as an alias
 					type = properties.get("type").getAsString();
 				}
-				if (properties.has("children") && properties.get("children").isJsonArray()) {
-					var children = properties.get("children").getAsJsonArray();
+				var childObjectsName = properties.has("childObjects") ? "childObjects" : "children";
+				if (properties.has(childObjectsName) && properties.get(childObjectsName).isJsonArray()) {
+					var children = properties.get(childObjectsName).getAsJsonArray();
 					childObjects = new ArrayList<>();
 					for (var child : children) {
 						var childObject = parseObject(child.getAsJsonObject());

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -46,13 +46,13 @@ import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
-import org.locationtech.jts.geom.util.AffineTransformation;
 import org.locationtech.jts.index.strtree.STRtree;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import qupath.lib.geom.Point2;
 import qupath.lib.images.ImageData;
+import qupath.lib.images.servers.ImageServer;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.classes.PathClassTools;
@@ -61,7 +61,7 @@ import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.objects.hierarchy.TMAGrid;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.regions.ImageRegion;
-import qupath.lib.roi.EllipseROI;
+import qupath.lib.regions.RegionRequest;
 import qupath.lib.roi.LineROI;
 import qupath.lib.roi.PointsROI;
 import qupath.lib.roi.RoiTools;
@@ -310,6 +310,78 @@ public class PathObjectTools {
 		//			return true;
 	}
 
+	/**
+	 * Get all the objects with ROIs that are outside the bounds of an image.
+	 * @param pathObjects the input objects to check
+	 * @param server the image to check
+	 * @param ignoreIntersecting if true, consider objects that overlap the image boundary to be inside (and therefore don't include them in the output); 
+	 *                           if false, consider them to be outside and include them in the output
+	 * @return a filtered list of the input object containing those considered outside the image
+	 * @since v0.4.0
+	 * @see #findObjectsOutsideRegion(Collection, ImageRegion, boolean)
+	 * @see #findObjectsOutsideRegion(Collection, ImageRegion, int, int, int, int, boolean)
+	 */
+	public static List<PathObject> findObjectsOutsideImage(Collection<? extends PathObject> pathObjects, ImageServer<?> server, boolean ignoreIntersecting) {
+		return findObjectsOutsideRegion(pathObjects, 
+				RegionRequest.createInstance(server), 0, server.nZSlices(), 0, server.nTimepoints(), ignoreIntersecting);
+	}
+	
+	/**
+	 * Get all the objects in a collection that are outside a defined region.
+	 * @param pathObjects input objects to check
+	 * @param region 2D region
+	 * @param ignoreIntersecting if true, consider objects that overlap the region boundary to be inside (and therefore don't include them in the output); 
+	 *                           if false, consider them to be outside and include them in the output
+	 * @return a filtered list of the input object containing those considered outside the region
+	 * @since v0.4.0
+	 * @see #findObjectsOutsideRegion(Collection, ImageRegion, int, int, int, int, boolean)
+	 */
+	public static List<PathObject> findObjectsOutsideRegion(Collection<? extends PathObject> pathObjects, ImageRegion region, boolean ignoreIntersecting) {
+		return findObjectsOutsideRegion(pathObjects, region, region.getZ(), region.getZ()+1, region.getT(), region.getT()+1, ignoreIntersecting);
+	}
+	
+	/**
+	 * Get all the objects in a collection that are outside a defined region, expanded for multiple z-slices and timepoints.
+	 * @param pathObjects input objects to check
+	 * @param region 2D region
+	 * @param minZ minimum z for the region (inclusive)
+	 * @param maxZ maximum z for the region (exclusive)
+	 * @param minT minimum t for the region (inclusive)
+	 * @param maxT maximum t for the region (exclusive)
+	 * @param ignoreIntersecting if true, consider objects that overlap the region boundary to be inside (and therefore don't include them in the output); 
+	 *                           if false, consider them to be outside and include them in the output
+	 * @return a filtered list of the input object containing those considered outside the region
+	 * @since v0.4.0
+	 * @see #findObjectsOutsideRegion(Collection, ImageRegion, boolean)
+	 */
+	public static List<PathObject> findObjectsOutsideRegion(Collection<? extends PathObject> pathObjects, ImageRegion region, int minZ, int maxZ, int minT, int maxT, boolean ignoreIntersecting) {
+		return pathObjects
+				.stream()
+				.filter(p -> !checkRegionContainsROI(p.getROI(), region, minZ, maxZ, minT, maxT, ignoreIntersecting))
+				.collect(Collectors.toList());
+	}
+	
+	
+	private static boolean checkRegionContainsROI(ROI roi, ImageRegion region, int minZ, int maxZ, int minT, int maxT, boolean ignoreIntersecting) {
+		if (roi == null)
+			return false;
+		if (roi.getZ() < minZ || roi.getZ() >= maxZ || roi.getT() < minT || roi.getT() >= maxT)
+			return false;
+		boolean regionContainsBounds = region.getX() <= roi.getBoundsX() && 
+				region.getY() <= roi.getBoundsY() &&
+				region.getMaxX() >= roi.getBoundsX() + roi.getBoundsWidth() &&
+				region.getMaxY() >= roi.getBoundsY() + roi.getBoundsHeight();
+		if (regionContainsBounds)
+			return true;
+		else if (ignoreIntersecting)
+			// Ensure planes match (since we've already handled that)
+			return RoiTools.intersectsRegion(roi.updatePlane(region.getImagePlane()), region);
+		else {
+			return false;
+		}
+	}
+	
+	
 	
 	/**
 	 * Get a user-friendly name for a specific type of PathObject, based on its Java class.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
@@ -173,7 +173,12 @@ class Menus {
 				"If the clipboard contents are GeoJSON objects, the objects will be pasted to the current image. "
 				+ "Otherwise, any text found will be shown in a the script editor.")
 //		@ActionAccelerator("shortcut+v") // No shortcut because it gets fired too often
-		public final Action PASTE = createAction(() -> Commands.pasteFromClipboard(qupath));
+		public final Action PASTE = createAction(() -> Commands.pasteFromClipboard(qupath, false));
+
+		@ActionMenu("Paste to current plane")
+		@ActionDescription("Paste GeoJSON objects from the system clipboard to the current z-slice and timepoint, if possible.\n" + 
+				"New object IDs will be generated if needed.")
+		public final Action PASTE_TO_PLANE = createAction(() -> Commands.pasteFromClipboard(qupath, true));
 
 		
 		public final Action SEP_1 = ActionTools.createSeparator();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
@@ -139,8 +139,12 @@ class Menus {
 		@ActionMenu("Copy to clipboard...>Selected objects")
 		@ActionDescription("Copy the selected objects to the system clipboard as GeoJSON.")
 //		@ActionAccelerator("shortcut+c")
-		public final Action COPY_SELECTED_OBJECTS = qupath.createImageDataAction(imageData -> Commands.copyObjectsToClipboard(qupath, imageData));
-//
+		public final Action COPY_SELECTED_OBJECTS = qupath.createImageDataAction(imageData -> Commands.copySelectedObjectsToClipboard(imageData));
+
+		@ActionMenu("Copy to clipboard...>Annotation objects")
+		@ActionDescription("Copy all annotation objects to the system clipboard as GeoJSON.")
+		public final Action COPY_ANNOTATION_OBJECTS = qupath.createImageDataAction(imageData -> Commands.copyAnnotationsToClipboard(imageData));
+
 		@ActionMenu("Copy to clipboard...>")
 		public final Action SEP_00 = ActionTools.createSeparator();
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
@@ -175,10 +175,16 @@ class Menus {
 //		@ActionAccelerator("shortcut+v") // No shortcut because it gets fired too often
 		public final Action PASTE = createAction(() -> Commands.pasteFromClipboard(qupath, false));
 
-		@ActionMenu("Paste to current plane")
+		@ActionMenu("Paste clipboard objects on current plane")
 		@ActionDescription("Paste GeoJSON objects from the system clipboard to the current z-slice and timepoint, if possible.\n" + 
-				"New object IDs will be generated if needed.")
+				"New object IDs will be generated if needed to avoid duplicates.")
 		public final Action PASTE_TO_PLANE = createAction(() -> Commands.pasteFromClipboard(qupath, true));
+
+		@ActionDescription("Copy the selected objects and paste them on the current plane (z-slice and timepoint visible in the viewer).\n"
+				+ "This avoids using the system clipboard. It is intended to help transfer annotations quickly across multidimensional images.")
+		@ActionMenu("Paste selected objects on current plane")
+		@ActionAccelerator("shortcut+shift+v")
+		public final Action ANNOTATION_COPY_TO_PLANE = qupath.createViewerAction(viewer -> Commands.copySelectedAnnotationsToCurrentPlane(viewer));
 
 		
 		public final Action SEP_1 = ActionTools.createSeparator();
@@ -520,10 +526,14 @@ class Menus {
 
 		@ActionMenu("Select...>")
 		public final Action SEP_3 = ActionTools.createSeparator();
-
+		
 		@ActionDescription("Select objects based upon their classification.")
 		@ActionMenu("Select...>Select objects by classification")
 		public final Action SELECT_BY_CLASSIFICATION = qupath.createImageDataAction(imageData -> Commands.promptToSelectObjectsByClassification(qupath, imageData));
+
+		@ActionDescription("Select all objects on the current plane visiible in the viewer.")
+		@ActionMenu("Select...>Select objects on current plane")
+		public final Action SELECT_BY_PLANE = qupath.createViewerAction(viewer -> Commands.selectObjectsOnCurrentPlane(viewer));
 
 		@ActionDescription("Lock all currently selected objects.")
 		@ActionMenu("Lock...>Lock selected objects")
@@ -581,10 +591,10 @@ class Menus {
 		public final Action RIGID_OBJECT_EDITOR = qupath.createImageDataAction(imageData -> Commands.editSelectedAnnotation(qupath));
 		
 		@ActionDescription("Duplicate the selected annotations.")
-		@ActionMenu("Annotations...>Duplicate annotations")
+		@ActionMenu("Annotations...>Duplicate selected annotations")
 		@ActionAccelerator("shift+d")
 		public final Action ANNOTATION_DUPLICATE = qupath.createImageDataAction(imageData -> Commands.duplicateSelectedAnnotations(imageData));
-		
+
 		@ActionDescription("Transfer the last annotation to the current image. "
 				+ "This can be used to bring annotations from one viewer to another, or to recover "
 				+ "an annotation that has just been deleted.")

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
@@ -638,6 +638,15 @@ class Menus {
 				+ "This removes vertices that are considered unnecessary, using a specified amplitude tolerance.")
 		@ActionMenu("Annotations...>Simplify shape")
 		public final Action SIMPLIFY_SHAPE = qupath.createImageDataAction(imageData -> Commands.promptToSimplifySelectedAnnotations(imageData, 1.0));
+		
+		
+		@ActionDescription("Update all object IDs to ensure they are unique.")
+		@ActionMenu("Refresh object IDs")
+		public final Action REFRESH_OBJECT_IDS = qupath.createImageDataAction(imageData -> Commands.refreshObjectIDs(imageData, false));
+
+		@ActionDescription("Update all duplicate object IDs to ensure they are unique.")
+		@ActionMenu("Refresh duplicate object IDs")
+		public final Action REFRESH_DUPLICATE_OBJECT_IDS = qupath.createImageDataAction(imageData -> Commands.refreshObjectIDs(imageData, true));
 
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/Menus.java
@@ -571,8 +571,8 @@ class Menus {
 		public final Action SEP_6 = ActionTools.createSeparator();
 
 		@ActionDescription("Interactively translate and/or rotate the current selected annotation.")
-		@ActionMenu("Annotations...>Transform annotation")
-		@ActionAccelerator("shortcut+shift+alt+r")
+		@ActionMenu("Annotations...>Transform annotations")
+		@ActionAccelerator("shortcut+shift+t")
 		public final Action RIGID_OBJECT_EDITOR = qupath.createImageDataAction(imageData -> Commands.editSelectedAnnotation(qupath));
 		
 		@ActionDescription("Duplicate the selected annotations.")
@@ -698,7 +698,7 @@ class Menus {
 
 		@ActionDescription("Show a list containing recently-used commands.")
 		@ActionMenu("Show recent commands")
-		@ActionAccelerator("shift+shortcut+up")
+		@ActionAccelerator("shortcut+p")
 		public final Action RECENT_COMMAND_LIST = Commands.createSingleStageAction(() -> CommandFinderTools.createRecentCommandsDialog(qupath));
 
 		public final Action SEP_0 = ActionTools.createSeparator();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -1772,6 +1772,28 @@ public class Commands {
 		MiniViewers.createDialog(viewer, true).show();
 	}
 	
+	
+	/**
+	 * Refresh object IDs to ensure uniqueness.
+	 * @param imageData
+	 * @param duplicatesOnly only refresh IDs that are duplicates of other IDs
+	 */
+	public static void refreshObjectIDs(ImageData<?> imageData, boolean duplicatesOnly) {
+		 if (imageData == null)
+			 return;
+		 var hierarchy = imageData.getHierarchy();
+		 if (duplicatesOnly) {
+			 QP.refreshDuplicateIDs(hierarchy);
+			 imageData.getHistoryWorkflow().addStep(
+					 new DefaultScriptableWorkflowStep("Refresh duplicate IDs", "refreshDuplicateIDs()"));
+		 } else {
+			 QP.refreshIDs(hierarchy);
+			 imageData.getHistoryWorkflow().addStep(
+					 new DefaultScriptableWorkflowStep("Refresh duplicate IDs", "refreshIDs()"));			 
+		 }
+	}
+	
+	
 	/**
 	 * Show a dialog to import object(s) from a file.
 	 * @param qupath

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/InteractiveObjectImporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/InteractiveObjectImporter.java
@@ -249,7 +249,7 @@ public final class InteractiveObjectImporter {
 			for (var toAdd : flatSet) {
 				toAdd.refreshID();
 			}
-		} else if (!containsDuplicates) {
+		} else if (containsDuplicates) {
 			logger.warn("{} being added - IDs not updated, so there will be duplicates!", objString);
 		}
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/RigidObjectEditorCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/RigidObjectEditorCommand.java
@@ -65,15 +65,12 @@ import qupath.lib.gui.viewer.overlays.PathOverlay;
 import qupath.lib.gui.viewer.tools.PathTools;
 import qupath.lib.images.ImageData;
 import qupath.lib.objects.PathObject;
-import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathROIObject;
 import qupath.lib.plugins.workflow.DefaultScriptableWorkflowStep;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.regions.ImageRegion;
 import qupath.lib.roi.GeometryTools;
-import qupath.lib.roi.PolylineROI;
 import qupath.lib.roi.ROIs;
 import qupath.lib.roi.interfaces.ROI;
 import qupath.lib.scripting.QP;
@@ -118,13 +115,6 @@ class RigidObjectEditorCommand implements Runnable, ChangeListener<ImageData<Buf
 	 */
 	PathObject getSelectedObject(final QuPathViewer viewer) {
 		return viewer.getSelectedObject();
-	}
-	
-	
-	private boolean isSuitableAnnotation(PathObject pathObject) {
-		return pathObject  instanceof PathAnnotationObject
-//				&& pathObject.isEditable()
-				&& (pathObject.hasROI() && pathObject.getROI().isArea() || pathObject.getROI() instanceof PolylineROI);
 	}
 	
 
@@ -457,10 +447,10 @@ class RigidObjectEditorCommand implements Runnable, ChangeListener<ImageData<Buf
 						transformer.theta -= thetaIncrement;
 						event.consume();
 					} else 	if (code == KeyCode.UP) {
-						transformer.theta += thetaIncrement/10.0;
+						transformer.theta -= thetaIncrement/10.0;
 						event.consume();
 					} else if (code == KeyCode.DOWN) {
-						transformer.theta -= thetaIncrement/10.0;
+						transformer.theta += thetaIncrement/10.0;
 						event.consume();
 					}
 				} else {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SummaryMeasurementTableCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SummaryMeasurementTableCommand.java
@@ -421,7 +421,7 @@ public class SummaryMeasurementTableCommand {
 				}
 				if (imageData != null)
 					displayedName.set(ServerTools.getDisplayableImageName(imageData.getServer()));
-				if (event.isAddedOrRemovedEvent())
+				if (event.isStructureChangeEvent())
 					model.setImageData(imageData, imageData.getHierarchy().getObjects(null, type));
 				else
 					model.refreshEntries();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/CommandFinderTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/CommandFinderTools.java
@@ -81,6 +81,7 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
@@ -284,6 +285,10 @@ public class CommandFinderTools {
 
 		FilteredList<CommandEntry> commands = new FilteredList<>(menuManager.getRecentCommands());
 		TableView<CommandEntry> table = createCommandTable(commands);
+		// Don't make recent command sortable
+		for (var col : table.getColumns())
+			col.setSortable(false);
+		
 		TextField textField = createTextField(table, commands, false, stage, null);
 		textField.setPromptText("Search recent commands");
 
@@ -326,7 +331,7 @@ public class CommandFinderTools {
 		});
 
 		table.setOnMouseClicked(e -> {
-			if (e.getClickCount() > 1) {
+			if (e.getClickCount() > 1 && !(e.getTarget() instanceof TableColumnHeader)) {
 				runSelectedCommand(table.getSelectionModel().getSelectedItem());
 			}
 		});
@@ -387,7 +392,7 @@ public class CommandFinderTools {
 		});
 
 		table.setOnMouseClicked(e -> {
-			if (e.getClickCount() > 1) {
+			if (e.getClickCount() > 1 && !(e.getTarget() instanceof TableColumnHeader)) {
 				if (runSelectedCommand(table.getSelectionModel().getSelectedItem())) {
 					if (cbAutoClose.isSelected()) {
 						stage.hide();


### PR DESCRIPTION
* Scriptable commands to
  * Remove and/or clip objects outside the image bounds
  * Refresh all/duplicate IDs
  * Copy selected/clipboard objects to the current viewer plane
* Minor GeoJSON change (`childObjects` rather than `children`)