### PR TITLE
Improve z/t index handling, object display & painting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,12 @@ This is a work-in-progress.
   * Copy selected objects or all annotations to the system clipboard, as GeoJSON
   * Paste objects from the clipboard, optionally positioning them on the current viewer plane
   * Paste selected objects to the current viewer plane (to easily duplicate objects across z-slices/timepoints)
-* Include z-index and time-index in measurement tables of z-stacks and time series
+* Make z-index and time-index more visible
+  * Show in measurement tables and the annotation list
+* Remove ROI shape from `PathObject.toString()` (and therefore list cells) in favor of showing z/t indexes
+  * Shape is usually evident from ROI icons & can still be seen in measurement tables
+* Make annotation list sorting more predictable
+  * Uses (in order) time index, z-index, string representation, ROI location, UUID
 * Creating a full image annotation with 'selection mode' turned on selects all objects in the current plane
   * New command 'Objects -> Select... -> Select objects on current plane' can achieve the same when not using selection mode
 
@@ -147,6 +152,7 @@ This is a work-in-progress.
 * The colors used in pie chart legends were sometimes incorrect (https://github.com/qupath/qupath/issues/1062)
 * Delaunay connection lines could be broken or slow to display (https://github.com/qupath/qupath/pull/1069)
 * Attempting to add a row or column to a TMA grid with a single core produced weird results
+* The brush/wand tools could sometimes modify annotations selected on a different image plane
 
 ### Changes through Bio-Formats 6.11.0
 * Bio-Formats 6.11.0 brings several important new features to QuPath, including:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ This is a work-in-progress.
   * Copy selected objects or all annotations to the system clipboard, as GeoJSON
   * Paste objects from the clipboard, optionally positioning them on the current viewer plane
   * Paste selected objects to the current viewer plane (to easily duplicate objects across z-slices/timepoints)
+* Include z-index and time-index in measurement tables of z-stacks and time series
 * Creating a full image annotation with 'selection mode' turned on selects all objects in the current plane
   * New command 'Objects -> Select... -> Select objects on current plane' can achieve the same when not using selection mode
 

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -236,18 +236,10 @@ public abstract class PathObject implements Externalizable {
 			return "";
 		int nChildren = nChildObjects();
 		int nDescendants = PathObjectTools.countDescendants(this);
+		String objString = nDescendants == 1 ? " object)" : " objects)";
 		if (nChildren == nDescendants)
-			return " (" + nChildren + " objects)";
-		return " (" + (nChildren) + "/" + nDescendants + " objects)";
-//		if (nDescendants == 1)
-//			return " - 1 descendant";
-//		else
-//			return " - " + nDescendants + " descendant";
-//		
-//		if (childList.size() == 1)
-//			return " - 1 object";
-//		else
-//			return " - " + childList.size() + " objects";
+			return " (" + nChildren + objString;
+		return " (" + (nChildren) + "/" + nDescendants + objString;
 	}
 
 	@Override
@@ -259,14 +251,26 @@ public abstract class PathObject implements Externalizable {
 			sb.append(getName());
 		else
 			sb.append(PathObjectTools.getSuitableName(getClass(), false));
-			
-		// ROI
-		if (!isCell() && hasROI())
-			sb.append(" (").append(getROI().getRoiName()).append(")");
 		
 		// Classification
 		if (getPathClass() != null)
 			sb.append(" (").append(getPathClass().toString()).append(")");
+
+		// ROI
+		if (hasROI()) {
+			var roi = getROI();
+			if (roi.getZ() > 0 || roi.getT() > 0) {
+				if (roi.getZ() > 0) {
+					sb.append(" (z=").append(roi.getZ());
+					if (roi.getT() > 0) {
+						sb.append(", t=").append(roi.getT());
+					}
+					sb.append(")");
+				} else {
+					sb.append("(t=").append(roi.getT()).append(")");
+				}
+			}
+		}
 		
 		// Number of descendants
 		sb.append(objectCountPostfix());

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -246,11 +246,12 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		}
 
 		// New v0.4.0: include z and time indices
-		if (containsMultiZ || (imageData != null && imageData.getServer().nZSlices() > 1)) {
+		var imageServer = imageData == null ? null : imageData.getServer();
+		if (containsMultiZ || (imageServer != null && imageServer.nZSlices() > 1)) {
 			builderMap.put("Z index", new ZSliceMeasurementBuilder());
 		}
 
-		if (containsMultiT || (imageData != null && imageData.getServer().nTimepoints() > 1)) {
+		if (containsMultiT || (imageServer != null && imageServer.nTimepoints() > 1)) {
 			builderMap.put("Time index", new TimepointMeasurementBuilder());
 		}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
@@ -27,6 +27,8 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -411,18 +413,17 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 		if (disableUpdates.get())
 			return;
 
-		Collection<PathObject> newList = hierarchy.getObjects(new HashSet<>(), PathAnnotationObject.class);
+		// Create a sorted list of annotations
+		List<PathObject> newList = new ArrayList<>(hierarchy.getObjects(new HashSet<>(), PathAnnotationObject.class));
+		Collections.sort(newList, annotationListComparator);
+				
 		pathClassPane.getListView().refresh();
 		// If the lists are the same, we just need to refresh the appearance (because e.g. classifications or measurements now differ)
 		// For some reason, 'equals' alone wasn't behaving nicely (perhaps due to ordering?)... so try a more manual test instead
-//		if (newList.equals(listAnnotations.getItems())) {
-		if (newList.size() == listAnnotations.getItems().size() && newList.containsAll(listAnnotations.getItems())) {
+		if (newList.equals(listAnnotations.getItems())) {
 			// Don't refresh unless there is good reason to believe the list should appear different now
 			// This was introduced due to flickering as annotations were dragged
 			// TODO: Reconsider when annotation list is refreshed
-			
-//			listAnnotations.setStyle(".list-cell:empty {-fx-background-color: white;}");
-			
 //			if (event.getEventType() == HierarchyEventType.CHANGE_CLASSIFICATION || event.getEventType() == HierarchyEventType.CHANGE_MEASUREMENTS || (event.getStructureChangeBase() != null && event.getStructureChangeBase().isPoint()) || PathObjectTools.containsPointObject(event.getChangedObjects()))
 			if (!event.isChanging())
 				listAnnotations.refresh();
@@ -435,5 +436,16 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 		listAnnotations.getItems().setAll(newList);
 		suppressSelectionChanges = lastChanging;
 	}
+	
+	
+	static Comparator<PathObject> annotationListComparator = Comparator.nullsFirst(Comparator
+				.comparingInt((PathObject p) -> p.hasROI() ? p.getROI().getT() : -1)
+				.thenComparingInt(p -> p.hasROI() ? p.getROI().getZ() : -1)
+				.thenComparing(p -> p.toString())
+				.thenComparingDouble(p -> p.hasROI() ? p.getROI().getBoundsY(): -1)
+				.thenComparingDouble(p -> p.hasROI() ? p.getROI().getBoundsX(): -1)
+				.thenComparing(p -> p.getID().toString())
+				);
+	
 	
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathHierarchyPaintingHelper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathHierarchyPaintingHelper.java
@@ -450,7 +450,7 @@ public class PathHierarchyPaintingHelper {
 	
 
 	private static void paintROI(ROI pathROI, Graphics2D g, Color colorStroke, Stroke stroke, Color colorFill, double downsample) {
-		if (pathROI == null)
+		if (pathROI == null || pathROI.isEmpty())
 			return;
 //		pathROI.draw(g, colorStroke, colorFill);
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/AbstractPathROITool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/AbstractPathROITool.java
@@ -223,6 +223,14 @@ abstract class AbstractPathROITool extends AbstractPathTool {
 		} else {
 			if (!requestParentClipping(e)) {
 				if (currentROI.isEmpty()) {
+					// We may be removing an object that was already removed from the hierarchy (during editing) 
+					// - if so, we need to notify listeners somehow
+					if (pathObject != null) {
+						if (pathObject.getParent() == null)
+							hierarchy.fireHierarchyChangedEvent(this);
+						else
+							hierarchy.removeObject(pathObject, true);
+					}
 					pathObject = null;
 				} else
 					hierarchy.addObject(pathObject); // Ensure object is within the hierarchy

--- a/qupath-gui-fx/src/test/java/qupath/lib/gui/measure/TestObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/test/java/qupath/lib/gui/measure/TestObservableMeasurementTableData.java
@@ -21,7 +21,7 @@
  * #L%
  */
 
-package qupath.lib.gui.models;
+package qupath.lib.gui.measure;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -30,7 +30,6 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import qupath.lib.gui.measure.ObservableMeasurementTableData;
 import qupath.lib.images.ImageData;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjects;


### PR DESCRIPTION
* Include z/t index in measurement tables (if non-zero)
* Don't show ROI type in `PathObjecttoString()`, but do show non-zero z-index and t-index.
* Make annotation list order more predictable
* Fix bug that meant brush/wand could edit an annotation on a different plane, if it was selected
* Ensure annotations are removed if they have an empty ROI after brush/wand editing
* Don't paint objects with an empty ROI