### PR TITLE
Fix exception type in GeometryTools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ This is a work-in-progress.
 * Delaunay connection lines could be broken or slow to display (https://github.com/qupath/qupath/pull/1069)
 * Attempting to add a row or column to a TMA grid with a single core produced weird results
 * The brush/wand tools could sometimes modify annotations selected on a different image plane
+* NPE if GeometryTools.refineAreas() is called with a non-area geometry (https://github.com/qupath/qupath/issues/1060)
 
 ### Changes through Bio-Formats 6.11.0
 * Bio-Formats 6.11.0 brings several important new features to QuPath, including:

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -639,7 +639,7 @@ public class GeometryTools {
     	@SuppressWarnings("unchecked")
 		var polygons = (List<Polygon>)PolygonExtracter.getPolygons(geometry);
     	if (polygons.isEmpty())
-    		return null;
+    		return geometry.getFactory().createPolygon();
     	var filtered = polygons
     			.stream()
     			.filter(g -> externalRingArea(g) >= minArea)
@@ -710,27 +710,26 @@ public class GeometryTools {
     
     
     /**
-     * Remove small fragments and fill interior rings within a Geometry.
+     * Remove small fragments and fill small interior rings within a Geometry.
+     * <p>
+     * Note that any modifications to the geometry will result in points and lines being stripped away, 
+     * leaving only polygons.
      * 
      * @param geometry input geometry to refine
      * @param minSizePixels minimum area of a fragment to keep (the area of interior rings for polygons will be ignored)
      * @param minHoleSizePixels minimum size of an interior hole to keep
-     * @return the refined geometry (possibly the original unchanged), or null if the changes resulted in the Geometry disappearing
+     * @return the refined geometry (possibly the original unchanged), or empty geometry if the changes resulted in the Geometry disappearing
      * 
      * @see #removeFragments(Geometry, double)
      * @see #removeInteriorRings(Geometry, double)
-	 * @throws IllegalArgumentException if the input geometry isn't polygonal
      */
-    public static Geometry refineAreas(Geometry geometry, double minSizePixels, double minHoleSizePixels) throws IllegalArgumentException {
+    public static Geometry refineAreas(Geometry geometry, double minSizePixels, double minHoleSizePixels) {
     	
-    	
-    	if (!(geometry instanceof Polygonal)) {
-    		throw new IllegalArgumentException("Can't refine areas for a non-polygonal geometry " + geometry);
-    	}
-		
     	if (minSizePixels <= 0 && minHoleSizePixels <= 0)
 			return geometry;
-    	
+
+    	geometry = ensurePolygonal(geometry);
+
     	var geom2 = geometry;
 		
 //    	// Fill interior rings first

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -719,8 +719,14 @@ public class GeometryTools {
      * 
      * @see #removeFragments(Geometry, double)
      * @see #removeInteriorRings(Geometry, double)
+	 * @throws IllegalArgumentException if the input geometry isn't polygonal
      */
-    public static Geometry refineAreas(Geometry geometry, double minSizePixels, double minHoleSizePixels) {
+    public static Geometry refineAreas(Geometry geometry, double minSizePixels, double minHoleSizePixels) throws IllegalArgumentException {
+    	
+    	
+    	if (!(geometry instanceof Polygonal)) {
+    		throw new IllegalArgumentException("Can't refine areas for a non-polygonal geometry " + geometry);
+    	}
 		
     	if (minSizePixels <= 0 && minHoleSizePixels <= 0)
 			return geometry;

--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -378,20 +378,17 @@ public class RoiTools {
 	 * @param roi the ROI to refine
 	 * @param minAreaPixels the minimum size of a fragment to retain
 	 * @param minHoleAreaPixels the minimum size of a hole to retain, or -1 if all holes should be retained
-	 * @return an updated ROI - or null if the modifications caused the ROI to disappear
-	 * @throws IllegalArgumentException if the input ROI doesn't define an area
+	 * @return an updated ROI - which may be empty if the modifications caused the ROI to disappear
 	 * @see GeometryTools#refineAreas(Geometry, double, double)
 	 */
-	public static ROI removeSmallPieces(ROI roi, double minAreaPixels, double minHoleAreaPixels) throws IllegalArgumentException {
-		if (!roi.isArea())
-			throw new IllegalArgumentException("Only area ROIs supported!");
+	public static ROI removeSmallPieces(ROI roi, double minAreaPixels, double minHoleAreaPixels) {
 		
 		logger.trace("Removing small pieces from {} (min = {}, max = {})", roi, minAreaPixels, minHoleAreaPixels);
 		
 		// We can't have holes if we don't have an AreaROI
 		if (roi instanceof RectangleROI || roi instanceof EllipseROI || roi instanceof LineROI || roi instanceof PolylineROI) {
 			if (roi.getArea() < minAreaPixels)
-				return null;
+				return ROIs.createEmptyROI(roi.getImagePlane());
 			else
 				return roi;
 		}
@@ -401,7 +398,7 @@ public class RoiTools {
 		if (geometry == geometry2)
 			return roi;
 		if (geometry2 == null)
-			return null;
+			return ROIs.createEmptyROI(roi.getImagePlane());
 		return GeometryTools.geometryToROI(geometry2, roi.getImagePlane());
 	}
 

--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -378,10 +378,11 @@ public class RoiTools {
 	 * @param roi the ROI to refine
 	 * @param minAreaPixels the minimum size of a fragment to retain
 	 * @param minHoleAreaPixels the minimum size of a hole to retain, or -1 if all holes should be retained
-	 * @return
+	 * @return an updated ROI - or null if the modifications caused the ROI to disappear
+	 * @throws IllegalArgumentException if the input ROI doesn't define an area
 	 * @see GeometryTools#refineAreas(Geometry, double, double)
 	 */
-	public static ROI removeSmallPieces(ROI roi, double minAreaPixels, double minHoleAreaPixels) {
+	public static ROI removeSmallPieces(ROI roi, double minAreaPixels, double minHoleAreaPixels) throws IllegalArgumentException {
 		if (!roi.isArea())
 			throw new IllegalArgumentException("Only area ROIs supported!");
 		

--- a/qupath-core/src/test/java/qupath/lib/roi/TestRoiTools.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestRoiTools.java
@@ -22,6 +22,7 @@
 package qupath.lib.roi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -114,6 +115,27 @@ public class TestRoiTools {
 		
 		
 	}
+	
+	
+	@Test
+	public void testRemoveSmallRegions() {
+		
+		var roi = ROIs.createRectangleROI(0, 0, 20, 20, ImagePlane.getDefaultPlane());
+		
+		assertEquals(roi, RoiTools.removeSmallPieces(roi, 10, 10));
+		assertFalse(RoiTools.removeSmallPieces(roi, 10, 10).isEmpty());
+		assertTrue(RoiTools.removeSmallPieces(roi, 500, 0).isEmpty());
+		
+		var line = ROIs.createLineROI(0, 0, 100, 100, ImagePlane.getDefaultPlane());
+		assertEquals(line, RoiTools.removeSmallPieces(line, 0, 0)); // Unchanged
+		assertTrue(RoiTools.removeSmallPieces(line, 50, 0).isEmpty());
+
+		var points = ROIs.createPointsROI(10, 10, ImagePlane.getDefaultPlane());
+		assertEquals(points, RoiTools.removeSmallPieces(points, 0, 0)); // Unchanged
+		assertTrue(RoiTools.removeSmallPieces(points, 50, 0).isEmpty());
+
+	}
+	
 	
 	
 	/**


### PR DESCRIPTION
Addresses https://github.com/qupath/qupath/issues/1060 by throwing an IllegalArgumentException if a non-polygonal geometry is passed to `GeometryTools.refineAreas()`