### PR TITLE
Make analysis pane tabs undockable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This is a work-in-progress.
 * 'Rotate annotation' command renamed to 'Transform annotation'
   * Optionally apply transform to *all* objects, not just the selected annotation
 * Support user styling via CSS (https://github.com/qupath/qupath/pull/1063)
+* Tabs in the 'Annotation pane' can be undocked to become separate windows
+  * Right-click on 'Project', 'Image', 'Annotations' etc. and choose 'Undock tab' 
 * Many script editor improvements, including:
   * Syntax highlighting for Markdown, JSON, YAML and XML documents
   * Added 'Replace/Next' and 'Replace all' features to Find window (https://github.com/qupath/qupath/pull/898)

--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -892,8 +892,8 @@ public final class GeneralTools {
 	 * @param extractor function used to convert each element of the collection to a String representation
 	 */
 	public static <T> void smartStringSort(Collection<T> collection, Function<T, String> extractor) {
-		for (var temp : collection)
-			System.err.println(new StringPartsSorter<T>(temp, temp.toString()));
+//		for (var temp : collection)
+//			System.err.println(new StringPartsSorter<T>(temp, temp.toString()));
 		var list = collection.stream().map(c -> new StringPartsSorter<>(c, extractor.apply(c))).sorted().map(s -> s.obj).collect(Collectors.toList());
 		collection.clear();
 		collection.addAll(list);

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -1247,7 +1247,6 @@ public class PathObjectTools {
 	 * Apply a transform to the ROI of a PathObject, creating a new object of the same type with the new ROI.
 	 * @param pathObject the object to transform; this will be unchanged
 	 * @param roiTransformer the ROI transform to apply
-	 * @param transform optional affine transform; if {@code null}, this effectively acts to duplicate the object
 	 * @param copyMeasurements if true, the measurements and metadata maps of the new object will be populated with those from the pathObject
 	 * @param createNewIDs if true, create new IDs for each copied object; otherwise, retain the same ID.
 	 * @return

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -166,9 +166,13 @@ public class Commands {
 		if (hierarchy == null)
 			return;
 		
-		if (!Dialogs.showConfirmDialog("Resolve hierarchy",
-				"Are you sure you want to resolve object relationships?\n" +
-				"For large object hierarchies this can take a long time.")) {
+		int nObjects = hierarchy.getAllObjects(false).size();
+		String message = "Are you sure you want to resolve object relationships?";
+		if (nObjects > 100) {
+			message += "\nFor large object hierarchies this can take a long time.";
+		}
+		
+		if (!Dialogs.showConfirmDialog("Resolve hierarchy", message)) {
 			return;
 		}
 		hierarchy.resolveHierarchy();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -183,8 +183,10 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		boolean containsRoot = false;
 		boolean containsMultiZ = false;
 		boolean containsMultiT = false;
+		boolean containsROIs = false;
 		List<PathObject> pathObjectListCopy = new ArrayList<>(list);
 		for (PathObject temp : pathObjectListCopy) {
+			containsROIs = containsROIs || temp.hasROI();
 			if (temp instanceof PathAnnotationObject) {
 //				if (temp.hasChildren())
 //					containsParentAnnotations = true;
@@ -247,11 +249,11 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 
 		// New v0.4.0: include z and time indices
 		var imageServer = imageData == null ? null : imageData.getServer();
-		if (containsMultiZ || (imageServer != null && imageServer.nZSlices() > 1)) {
+		if (containsMultiZ || (containsROIs && imageServer != null && imageServer.nZSlices() > 1)) {
 			builderMap.put("Z index", new ZSliceMeasurementBuilder());
 		}
 
-		if (containsMultiT || (imageServer != null && imageServer.nTimepoints() > 1)) {
+		if (containsMultiT || (containsROIs && imageServer != null && imageServer.nTimepoints() > 1)) {
 			builderMap.put("Time index", new TimepointMeasurementBuilder());
 		}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -30,6 +30,7 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -1247,7 +1248,9 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 							children.add(new ProjectTreeRowItem(row));
 						}
 					} else {
-						children.addAll(getAllMetadataValues(metadataKey).stream()
+						var values = new ArrayList<>(getAllMetadataValues(metadataKey));
+						GeneralTools.smartStringSort(values);
+						children.addAll(values.stream()
 								.map(value -> new ProjectTreeRowItem(new MetadataRow(value)))
 								.collect(Collectors.toList()));
 					}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -92,6 +92,8 @@ import javafx.scene.control.Slider;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.SpinnerValueFactory.DoubleSpinnerValueFactory;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;
@@ -101,6 +103,7 @@ import javafx.scene.image.WritableImage;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
@@ -1676,6 +1679,43 @@ public class GuiTools {
 			}
 		}
 
+	}
+
+
+
+	/**
+	 * Make a tab undockable, via a context menu available on right-click.
+	 * When undocked, the tab will become a floating window.
+	 * If the window is closed, it will be added back to its original tab pane.
+	 * @param tab
+	 * @since v0.4.0
+	 */
+	public static void makeTabUndockable(Tab tab) {
+		var miUndock = new MenuItem("Undock tab");
+		var popup = new ContextMenu(miUndock);
+		tab.setContextMenu(popup);
+		miUndock.setOnAction(e -> {
+			var tabPane = tab.getTabPane();
+			var parent = tabPane.getScene() == null ? null : tabPane.getScene().getWindow();
+			
+			double width = tabPane.getWidth();
+			double height = tabPane.getHeight();
+			tabPane.getTabs().remove(tab);
+			var stage = new Stage();
+			stage.initOwner(parent);
+			stage.setTitle(tab.getText());
+			var content = tab.getContent();
+			tab.setContent(null);
+			var tabContent = new BorderPane(content);
+			stage.setScene(new Scene(tabContent, width, height));
+			stage.show();
+			
+			stage.setOnCloseRequest(e2 -> {
+				tabContent.getChildren().remove(tabContent);
+				tab.setContent(content);
+				tabPane.getTabs().add(tab);
+			});
+		});
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/PaneTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/PaneTools.java
@@ -62,6 +62,10 @@ public class PaneTools {
 		var tooltip = tooltipText == null ? null : new Tooltip(tooltipText);
 		
 		for (var n : nodes) {
+			if (n == null) {
+				col++;
+				continue;
+			}
 			if (lastNode == n) {
 				Integer span = GridPane.getColumnSpan(n);
 				if (span == null)


### PR DESCRIPTION
Improved annotation tab pane behavior:
* Right-click on a tab to undock it & create a separate window
* Restore docked tab by closing the window
* Drag to rearrange tabs

Note that the dock status and window position isn't persistent, so will need to be reset each time.

Also a few other minor fixes, including improved sorting of image entries under the 'Project' tab.

Related to https://forum.image.sc/t/feature-request-project-tab-sorting/73792

![qupath-undock](https://user-images.githubusercontent.com/4690904/201408819-e3c653a1-893f-4a57-96fe-290739105c1c.jpg)
