### PR TITLE
Simplify setting accelerators for menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,8 @@ This is a work-in-progress.
 * Panning with synchronized viewers now corrects for different rotations
 * Multi-view commands now available through 'View' menu (and not only right-clicking a viewer)
   * These make it possible to create grid of viewers, to work with multiple images simultaneously
+* Simplify setting new accelerators (key combinations) via scripts
+  * Example: `getQuPath().setAccelerator("File>Open...", "shift+o")`
 
 
 ### Bugs fixed


### PR DESCRIPTION
Aims to avoid needing the more tortured logic of https://gist.github.com/petebankhead/63a6d2e93b7ce704e57eefb6885010fa

In a script, now simply call something like
```groovy
getQuPath().setAccelerator("File>Open...", "shift+o")
```

Relates to https://forum.image.sc/t/feature-request-windows-with-favorite-menu-items/72721