### PR TITLE
Fix code styling, emoji in yaml

### DIFF
--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -304,6 +304,8 @@ public class RichScriptEditor extends DefaultScriptEditor {
 				String baseStyle = n.getBaseStyle();
 				if (baseStyle != null && !baseStyle.isBlank())
 					codeArea.setStyle(baseStyle);
+				else
+					codeArea.setStyle(null);
 				StyleSpans<Collection<String>> changes = n.computeEditorStyles(codeArea.getText());
 				codeArea.setStyleSpans(0, changes);
 				codeArea.requestFocus(); // Seems necessary to trigger the update when switching between scripts

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/stylers/YamlStyler.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/stylers/YamlStyler.java
@@ -67,9 +67,10 @@ public class YamlStyler implements ScriptStyler {
 		var visitor = new StyleSpanVisitor(text);
 		
 		try {
+			int incValue = 0;
 			for (var event : yaml.parse(new StringReader(text))) {
-				int startInd = event.getStartMark().getIndex();
-				int endInd = event.getEndMark().getIndex();
+				int startInd = incValue + event.getStartMark().getIndex();
+				int endInd = incValue + event.getEndMark().getIndex();
 				
 				visitor.appendStyle(startInd);
 				
@@ -95,6 +96,15 @@ public class YamlStyler implements ScriptStyler {
 					if (event instanceof ScalarEvent) {
 						var scalar = (ScalarEvent)event;
 						var value = scalar.getValue();
+						
+						// Unsure about this!
+						// It seems to address problems with emoji, which are used in bioimage.io (for example)
+						int inc = value.length() - Character.codePointCount(value, 0, value.length());
+						if (inc > 0) {
+							endInd += inc;
+							incValue += inc;
+						}
+						
 						if (isNumeric(value))
 							style = "number";
 					}


### PR DESCRIPTION
Fix regression that got 'stuck' on a sans-serif font after switching to markdown. Improve yaml styling to handle codepoints for scalar values. This helps support emoji.