### PR TITLE
In recent projects menu, added paths tooltips and fixed OS dependent separators

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -1535,7 +1535,6 @@ public class GuiTools {
 					continue;
 				String name = getNameFromURI(uri);
 				name = "..." + File.separator + name;
-				//MenuItem item = new MenuItem(name);
 				CustomMenuItem item = new CustomMenuItem(new Label(name));
 				Tooltip tooltip = new Tooltip(Paths.get(uri).normalize().toString());
 				Tooltip.install(item.getContent(), tooltip);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -29,6 +29,7 @@ import java.awt.Transparency;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.net.URI;
 import java.text.NumberFormat;
 import java.text.ParsePosition;
@@ -88,6 +89,7 @@ import javafx.scene.control.ListView;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
+import javafx.scene.control.CustomMenuItem;
 import javafx.scene.control.Slider;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SpinnerValueFactory;
@@ -1496,7 +1498,7 @@ public class GuiTools {
 		// Strip extension if we have one
 		if (path.length == 1)
 			return name;
-		return path[path.length-2] + "/" + name;
+		return path[path.length-2] + File.separator + name;
 	}
 	
 	
@@ -1532,8 +1534,11 @@ public class GuiTools {
 				if (uri == null)
 					continue;
 				String name = getNameFromURI(uri);
-				name = ".../" + name;
-				MenuItem item = new MenuItem(name);
+				name = "..." + File.separator + name;
+				//MenuItem item = new MenuItem(name);
+				CustomMenuItem item = new CustomMenuItem(new Label(name));
+				Tooltip tooltip = new Tooltip(Paths.get(uri).normalize().toString());
+				Tooltip.install(item.getContent(), tooltip);
 				item.setOnAction(event -> consumer.accept(uri));
 				menuRecent.getItems().add(item);
 			}


### PR DESCRIPTION
Hello,

this PR is to make it easier to recognise which QuPath project is which in the "Recent projects..." menu:

![image](https://user-images.githubusercontent.com/3523902/202584032-3a8aec80-cbea-4893-aaa6-513047c0acfd.png)

If you let your mouse pointer sit over one of the shorten project paths, a tooltip appears with the full project path.

Also, since I'm on Windows, I changed the hard-coded slashes to `File.separator` so they become OS dependent (i.e. '/' on Linux or Mac, and '\\' on Windows).

Cheers,
Egor