### PR TITLE
Improve percentile calculations & normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,8 +108,6 @@ The following is a long-yet-non-exhaustive list of changes & improvements.
 
 
 ### Core improvements
-* Reduced use of Java serialization
-  * Serialization filters now used to better control deserialized classes
 * All objects can now have IDs
   * This aims to make it much easier to match up objects whenever some further analysis is done elsewhere (e.g. classification or clustering in Python or R)
   * See https://github.com/qupath/qupath/pull/959
@@ -124,6 +122,12 @@ The following is a long-yet-non-exhaustive list of changes & improvements.
   * Switched `BufferedImageTools.resize` to use ImageJ internally
 * Use `-Djts.overlay=ng` system property by default with Java Topology Suite
   * This should resolve many occurrences of the dreaded `TopologyException` when manipulating ROIs & geometries
+* Reduced use of Java serialization
+  * Serialization filters now used to better control deserialized classes
+* Improved percentile calculations in `OpenCVTools`
+  * Output changed to match with NumPy, R and other software
+  * Performance should be much improved when calculating percentiles from large arrays
+* `ImageOps` now supports both per-channel and joint percentile normalization
 
 
 ### Code & scripting improvements

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
@@ -47,6 +47,8 @@ import java.util.stream.Collectors;
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_imgproc;
 import org.apache.commons.math3.stat.descriptive.rank.Percentile;
+import org.apache.commons.math3.stat.descriptive.rank.Percentile.EstimationType;
+import org.apache.commons.math3.stat.ranking.NaNStrategy;
 import org.bytedeco.javacpp.IntPointer;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerScope;
@@ -83,6 +85,7 @@ import qupath.lib.analysis.images.SimpleImages;
 import qupath.lib.color.ColorModelFactory;
 import qupath.lib.common.ColorTools;
 import qupath.lib.common.GeneralTools;
+import qupath.lib.common.ThreadTools;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.PixelType;
 import qupath.lib.objects.PathObject;
@@ -923,23 +926,61 @@ public class OpenCVTools {
 	}
 	
 	/**
+	 * Create a {@link Percentile} instance with default configuration.
+	 * <p>
+	 * This uses {@link EstimationType#R_7} as the estimation type, 
+	 * because this corresponds to the default ('linear') method used 
+	 * within NumPy.
+	 * <p>
+	 * See the <a href="https://numpy.org/doc/stable/reference/generated/numpy.percentile.html">NumPy docs</a>  
+	 * and also <a href="https://commons.apache.org/proper/commons-math/javadocs/api-3.6.1/org/apache/commons/math3/stat/descriptive/rank/Percentile.EstimationType.html">
+	 * Apache Commons Math</a>.
+	 * 
+	 * @return
+	 */
+	static Percentile createPercentile() {
+		return new Percentile()
+				.withEstimationType(EstimationType.R_7)
+				.withNaNStrategy(NaNStrategy.REMOVED);
+	}
+	
+	
+	/**
 	 * Get percentile values for all pixels in a Mat, ignoring NaNs.
+	 * <p>
+	 * Note that the behavior of this method was changed for v0.4.0 to
+	 * match NumPy's 'linear' method to calculate percentiles 
+	 * (which is NumPy's current default at the time of writing).
+	 * 
 	 * @param mat
-	 * @param percentiles requested percentiles, {@code 0 < percentile <= 100}
+	 * @param percentiles requested percentiles (must be between 0 and 100)
 	 * @return percentile values, in the same order as the input percentiles
+	 * 
+	 * @implSpec here, providing 0 or 100 should return the minimum or maximum respectively.
+	 * @implNote this was rewritten for improved performance in v0.4.0
 	 */
 	public static double[] percentiles(Mat mat, double... percentiles) {
+		boolean doParallel = OpenCVTools.totalPixels(mat) > 1_000_000 && ThreadTools.getParallelism() > 2;
+		// Sorting will almost certainly hurt performance unless parallel & we need multiple percentiles
+		boolean doSort = doParallel && percentiles.length > 5;
+		return percentilesStream(mat, doParallel, doSort, percentiles);
+	}
+	
+	/**
+	 * Legacy percentiles method before v0.4.0 (slower)
+	 * @param mat
+	 * @param percentiles
+	 * @return
+	 */
+	static double[] percentilesSorted(Mat mat, double... percentiles) {
 		double[] result = new double[percentiles.length];
 		if (result.length == 0)
 			return result;
 		
 		int n = (int)totalPixels(mat);
-//		var matSorted = new Mat();
-//		var mat2 = mat.reshape(1, n);
-//		opencv_core.sort(mat2, matSorted, opencv_core.CV_SORT_ASCENDING + opencv_core.CV_SORT_EVERY_COLUMN);
 		
-		var percentile = new Percentile();
-		
+		var percentile = createPercentile();
+				
 		// Sort, then strip NaNs
 		double[] values = OpenCVTools.extractDoubles(mat);
 		Arrays.sort(values);
@@ -951,27 +992,67 @@ public class OpenCVTools {
 		}
 		if (n < values.length)
 			values = Arrays.copyOf(values, n);
+
+		double minValue = Double.NaN;
+		boolean minSet = false;
 		
 		// Set data
 		// We can't rely on Percentile to strip NaNs (it appears not to)
 		percentile.setData(values);
-		for (int i = 0; i < percentiles.length; i++)
-			result[i] = percentile.evaluate(percentiles[i]);
+		for (int i = 0; i < percentiles.length; i++) {
+			if (percentiles[i] == 0.0) {
+				if (!minSet) {
+					minValue = Arrays.stream(values).filter(d -> !Double.isNaN(d)).min().orElse(Double.NaN);
+					minSet = true;
+				}
+				result[i] = minValue;
+			} else
+				result[i] = percentile.evaluate(percentiles[i]);
+		}
 		return result;
+	}
+	
+	/**
+	 * Stream-based percentile method.
+	 * @param mat
+	 * @param doParallel
+	 * @param doSort
+	 * @param percentiles
+	 * @return
+	 * @since v0.4.0
+	 */
+	static double[] percentilesStream(Mat mat, boolean doParallel, boolean doSort, double... percentiles) {
+		double[] result = new double[percentiles.length];
+		if (result.length == 0)
+			return result;
 		
-//		int n = (int)mat.total();
-//		var mat2 = mat.reshape(1, n);
-//		var matSorted = new Mat();
-//		
-//		opencv_core.sort(mat2, matSorted, opencv_core.CV_SORT_ASCENDING + opencv_core.CV_SORT_EVERY_COLUMN);
-//		try (var idx = matSorted.createIndexer()) {
-//			for (int i = 0; i < result.length; i++) {
-//				long ind = (long)(percentiles[i] / 100.0 * (n - 1));
-//				result[i] = idx.getDouble(ind);
-//			}
-//		}
-//		matSorted.release();
-//		return result;
+		var percentile = createPercentile();
+				
+		// Create a customized stream to filter out NaNs, optionally using sorting & parallelization
+		double[] values = OpenCVTools.extractDoubles(mat);
+		var stream = Arrays.stream(values);
+		if (doParallel)
+			stream = stream.parallel();
+		if (doSort)
+			stream = stream.sorted();
+		values = stream.filter(d -> !Double.isNaN(d)).toArray();
+
+		double minValue = Double.NaN;
+		boolean minSet = false;
+		
+		// Set data - NaNs should be stripped beforehand, since they aren't here (despite what the docs might suggest)
+		percentile.setData(values);
+		for (int i = 0; i < percentiles.length; i++) {
+			if (percentiles[i] == 0.0) {
+				if (!minSet) {
+					minValue = Arrays.stream(values).filter(d -> !Double.isNaN(d)).min().orElse(Double.NaN);
+					minSet = true;
+				}
+				result[i] = minValue;
+			} else
+				result[i] = percentile.evaluate(percentiles[i]);
+		}
+		return result;
 	}
 	
 	


### PR DESCRIPTION
* Switch `OpenCVTools` percentile method to match NumPy (can give different results!)
* Improve percentile performance by using streams & avoiding array sort
* Add tests for percentiles