### PR TITLE
Optionally use pre-compiled scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ The following is a long-yet-non-exhaustive list of changes & improvements.
   * If the filter text doesn't contain `|`, just filter by image name (the previous behavior)
   * If the filter text contains `|`, additionally split on `|` and check that all tokens are either contained in the image name, or in a metadata text in the format `key=value`
   * For example, a search `.tif|source=imagej` would look for images that contain both `.tif` and `source=imagej` either in their name or metadata
+* New 'Run -> Use compiled scripts' option to reuse compiled versions of a script where possible
+  * This can improve performance (slightly...) when re-running scripts many times
+  * This is an experimental feature, currently turned off by default - please be on the lookout for any unexpected behavior
 
 
 ### New & improved commands

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/ScriptParameters.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/ScriptParameters.java
@@ -58,6 +58,8 @@ public class ScriptParameters {
 	
 	private boolean requestHierarchyUpdate = true;
 	
+	private boolean useCompiled = false;
+	
 	private Writer writer;
 	private Writer errorWriter;
 	
@@ -195,6 +197,20 @@ public class ScriptParameters {
 	}
 	
 	/**
+	 * Request that any script should be compiled before being evaluated, 
+	 * and previously compiled versions reused when possible.
+	 * <p>
+	 * This is not always supported, but where it is it may improve performance
+	 * if the same script is evaluated many times.
+	 * It may also mean that any errors are caught earlier.
+	 * <p>
+	 * @return
+	 */
+	public boolean useCompiled() {
+		return useCompiled;
+	}
+	
+	/**
 	 * Request whether to fire an update event for the object hierarchy, if an image data 
 	 * object is available.
 	 * <p>
@@ -242,6 +258,8 @@ public class ScriptParameters {
 		
 		private Project<?> project;
 		private ImageData<?> imageData;
+		
+		private boolean useCompiled = false;
 		
 		private Writer writer;
 		private Writer errorWriter;
@@ -397,6 +415,17 @@ public class ScriptParameters {
 		}
 		
 		/**
+		 * Request that the script is compiled before being evaluated, 
+		 * or a previously compiled version is used where available.
+		 * @param useCompiled
+		 * @return
+		 */
+		public Builder useCompiled(boolean useCompiled) {
+			this.useCompiled = useCompiled;
+			return this;
+		}
+		
+		/**
 		 * Build the {@link ScriptParameters} with the current options.
 		 * @return
 		 * @throws IllegalArgumentException if neither file nor script are set
@@ -419,6 +448,8 @@ public class ScriptParameters {
 			params.errorWriter = this.errorWriter == null ? new PrintWriter(System.err) : this.errorWriter;
 			
 			params.requestHierarchyUpdate = this.requestHierarchyUpdate;
+			
+			params.useCompiled = useCompiled;
 			
 			params.args = this.args;
 			params.batchSize = this.batchSize;


### PR DESCRIPTION
New option in `ScriptParameters` and under the 'Run' menu of the script editor.

Because the `ScriptEngine` is reused, it seems *possible* that information could leak from one invocation of the script to the next. I couldn't find any way to do this, since a new `ScriptContext` is provided each time - but it remains an experimental off-by-default option until we're confident it behaves well.

I've noticed some small performance improvements (fractions of a second) by avoiding the need to create a new script engine and compile the script again each time - but it remains to be seen if these become more worthwhile for more complex scripts.