### PR TITLE
Yet more dark mode fixes

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CellIntensityClassificationCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CellIntensityClassificationCommand.java
@@ -43,7 +43,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
-import javafx.scene.paint.Color;
 import qupath.lib.analysis.stats.Histogram;
 import qupath.lib.common.ColorTools;
 import qupath.lib.common.ThreadTools;
@@ -142,13 +141,12 @@ public class CellIntensityClassificationCommand implements Runnable {
 		
 		singleThreshold.addListener((v, o, n) -> {
 			chartWrapper.clearThresholds();
-			Color color = Color.rgb(0, 0, 0, 0.2);
 			if (!n) {
 				for (int i = 0; i < sliders.size(); i++) {
-					chartWrapper.addThreshold(sliders.get(i).valueProperty(), color);
+					chartWrapper.addThreshold(sliders.get(i).valueProperty());
 				}
 			} else
-				chartWrapper.addThreshold(sliders.get(0).valueProperty(), color);
+				chartWrapper.addThreshold(sliders.get(0).valueProperty());
 		});
 
 		selectedMeasurement.addListener((v, o, n) -> {
@@ -171,8 +169,7 @@ public class CellIntensityClassificationCommand implements Runnable {
 				
 				// Add first threshold to histogram
 				if (i == 0) {
-					Color color = Color.rgb(0, 0, 0, 0.2);
-					chartWrapper.addThreshold(sliders.get(i).valueProperty(), color);
+					chartWrapper.addThreshold(sliders.get(i).valueProperty());
 				}
 			}
 		});

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SingleMeasurementClassificationCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SingleMeasurementClassificationCommand.java
@@ -233,7 +233,7 @@ public class SingleMeasurementClassificationCommand implements Runnable {
 			
 			var chartWrapper = new ThresholdedChartWrapper(histogramPane.getChart());
 			chartWrapper.setIsInteractive(true);
-			chartWrapper.addThreshold(sliderThreshold.valueProperty(), Color.rgb(0, 0, 0, 0.2));
+			chartWrapper.addThreshold(sliderThreshold.valueProperty());
 			
 			histogramPane.getChart().getYAxis().setTickLabelsVisible(false);
 			histogramPane.getChart().setAnimated(false);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramPanelFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramPanelFX.java
@@ -399,7 +399,7 @@ public class HistogramPanelFX {
 		private NumberAxis xAxis, yAxis;
 		private Pane pane = new Pane();
 		
-		private DoubleProperty lineWidth = new SimpleDoubleProperty(3);
+		private DoubleProperty lineWidth = new SimpleDoubleProperty(2);
 		
 		private BooleanProperty isInteractive = new SimpleBooleanProperty(false);
 		
@@ -510,6 +510,14 @@ public class HistogramPanelFX {
 			return addThreshold(new SimpleDoubleProperty(x), color);
 		}
 		
+		/**
+		 * Add a threshold value.
+		 * @param d
+		 * @return
+		 */
+		public ObservableNumberValue addThreshold(final ObservableNumberValue d) {
+			return addThreshold(d, null);
+		}
 		
 		/**
 		 * Add a threshold value with its display color.
@@ -517,10 +525,15 @@ public class HistogramPanelFX {
 		 * @param color
 		 * @return
 		 */
-		public ObservableNumberValue addThreshold(final ObservableNumberValue d, final Color color) {
+		private ObservableNumberValue addThreshold(final ObservableNumberValue d, final Color color) {
 			Line line = new Line();
+			line.getStyleClass().add("qupath-histogram-line");
 			if (color != null)
 				line.setStroke(color);
+			else
+				line.setStyle("-fx-stroke: ladder(-fx-background, "
+						+ "derive(-fx-background, 30%) 49%, "
+						+ "derive(-fx-background, -30%) 50%);");
 			line.strokeWidthProperty().bind(lineWidth);
 
 			// Bind the requested x position of the line to the 'actual' coordinate within the parent

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -348,6 +348,7 @@ public class BrightnessContrastCommand implements Runnable, ChangeListener<Image
 				}
 				sliderMin.setValue(sliderMin.getMin());
 				sliderMax.setValue(sliderMax.getMax());
+				sliderGamma.setValue(1.0);
 		});
 		
 		Stage dialog = new Stage();
@@ -899,9 +900,8 @@ public class BrightnessContrastCommand implements Runnable, ChangeListener<Image
 		sliderMax.setDisable(false);
 		
 		chartWrapper.getThresholds().clear();
-		Color color = Color.rgb(0, 0, 0, 0.2);
-		chartWrapper.addThreshold(sliderMin.valueProperty(), color);
-		chartWrapper.addThreshold(sliderMax.valueProperty(), color);
+		chartWrapper.addThreshold(sliderMin.valueProperty());
+		chartWrapper.addThreshold(sliderMax.valueProperty());
 		chartWrapper.setIsInteractive(true);
 //		chartWrapper.getThresholds().setAll(sliderMin.valueProperty(), sliderMax.valueProperty());
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/KaplanMeierDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/KaplanMeierDisplay.java
@@ -84,7 +84,6 @@ import qupath.lib.gui.charts.ChartTools;
 import qupath.lib.gui.charts.HistogramPanelFX;
 import qupath.lib.gui.charts.HistogramPanelFX.ThresholdedChartWrapper;
 import qupath.lib.gui.dialogs.ParameterPanelFX;
-import qupath.lib.gui.tools.ColorToolsFX;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.TMACoreObject;
@@ -566,7 +565,7 @@ class KaplanMeierDisplay implements ParameterChangeListener, PathObjectHierarchy
 			histogramPanel.getChart().setAnimated(false);
 			histogramWrapper = new ThresholdedChartWrapper(histogramPanel.getChart());
 			for (ObservableNumberValue val : threshProperties)
-				histogramWrapper.addThreshold(val, ColorToolsFX.getCachedColor(240, 0, 0, 128));
+				histogramWrapper.addThreshold(val);
 			histogramWrapper.getPane().setPrefHeight(150);
 			paneHistogram.add(histogramWrapper.getPane(), 0, 0);
 			Tooltip.install(histogramPanel.getChart(), new Tooltip("Distribution of scores"));
@@ -592,7 +591,7 @@ class KaplanMeierDisplay implements ParameterChangeListener, PathObjectHierarchy
 			//				chartPValues.getYAxis().setAutoRanging(false);
 			pValuesWrapper = new ThresholdedChartWrapper(chartPValues);
 			for (ObservableNumberValue val : threshProperties)
-				pValuesWrapper.addThreshold(val, ColorToolsFX.getCachedColor(240, 0, 0, 128));
+				pValuesWrapper.addThreshold(val);
 
 			pValuesWrapper.getPane().setPrefHeight(150);
 			paneHistogram.add(pValuesWrapper.getPane(), 0, 1);

--- a/qupath-gui-fx/src/main/resources/css/dark.css
+++ b/qupath-gui-fx/src/main/resources/css/dark.css
@@ -21,6 +21,30 @@
     
     -qp-script-error-color: rgb(255, 60, 60);
     -qp-script-string-color: rgb(255, 240, 60);
+    
+     -fx-box-border: ladder(
+        -fx-color,
+        black 20%,
+        derive(-fx-color,15%) 30%
+    );
+    
+    -fx-mark-color: ladder(
+        -fx-color,
+        rgb(200, 200, 200) 30%,
+        derive(-fx-color,-63%) 31%
+    );
+    
+    -fx-mark-highlight-color: ladder(
+        -fx-color,
+        derive(-fx-color,80%) 60%,
+        rgb(200, 200, 200) 70%
+    );
+    
+/*     -fx-text-box-border: ladder(
+        -fx-background,
+        black 10%,
+        derive(-fx-background, 15%) 30%
+    ); */
 }
 
 .code-area * {
@@ -42,6 +66,32 @@
     -fx-blend-mode: soft-light;
 }
 
+/* .slider {
+	-fx-control-inner-background: derive(-fx-base, 25%);
+} */
+
+.check-box > .box,
+.radio-button > .radio {
+	-fx-outer-border: derive(-fx-color,40%);
+}
+
 .slider {
 	-fx-control-inner-background: derive(-fx-base, 25%);
+}
+
+.slider .thumb {
+    -fx-background-color:
+        linear-gradient(to bottom, derive(-fx-text-box-border, 60%), derive(-fx-text-box-border, 30%)),
+        -fx-inner-border,
+        -fx-body-color;
+}
+
+.table-view,
+.tree-table-view {
+    -fx-table-header-border-color: -fx-box-border;
+    -fx-table-cell-border-color: derive(-fx-color,20%);
+}
+
+.axis {
+    AXIS_COLOR: derive(-fx-background,40%);
 }


### PR DESCRIPTION
Includes fixing display of threshold lines on histograms (which were previously stuck to being dark gray).

Attempt to make checkboxes more visible in dark mode, and switch the table cell outlines to be light rather than dark.