### PR TITLE
DnnModel improvements and other bug fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,9 @@ task mergedJavadocs(type: Javadoc,
 	options.links 'https://javadoc.io/doc/org.locationtech.jts/jts-core/1.19.0/'
 	options.links 'https://javadoc.io/doc/net.imagej/ij/1.53t/'
 	options.links 'https://javadoc.scijava.org/Bio-Formats/'
+	options.links 'https://javadoc.io/doc/ai.djl/api/0.19.0/index.html'
 	
+	// Don't fail on error, because this happened too often due to a javadoc link being temporarily down
 	failOnError = false
 
 }

--- a/buildSrc/src/main/groovy/qupath.djl-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.djl-conventions.gradle
@@ -45,13 +45,44 @@ dependencies {
 		    implementation "ai.djl.tensorflow:tensorflow-model-zoo:$djlVersion"
 	}
     
-    if ('tflite' in djlEngines) {
-	    implementation "ai.djl.tflite:tflite-engine:$djlVersion"
+	if ('onnx' in djlEngines || 'onnxruntime' in djlEngines) {
+	    implementation "ai.djl.onnxruntime:onnxruntime-engine:$djlVersion"
 	    // No model zoo available
+	}
+
+	if ('paddlepaddle' in djlEngines) {
+	    implementation "ai.djl.paddlepaddle:paddlepaddle-engine:$djlVersion"
+	    if ('paddlepaddle' in djlZoos)
+		    implementation "ai.djl.paddlepaddle:paddlepaddle-model-zoo:$djlVersion"
 	}
 	
 	if ('onnx' in djlEngines || 'onnxruntime' in djlEngines) {
 	    implementation "ai.djl.onnxruntime:onnxruntime-engine:$djlVersion"
+	    // No model zoo available
+	}
+	
+	if ('xgboost' in djlEngines) {
+	    implementation "ai.djl.ml.xgboost:xgboost:$djlVersion"
+	    // No model zoo available
+	}
+	
+	if ('lightgbm' in djlEngines) {
+	    implementation "ai.djl.ml.lightgbm:lightgbm:$djlVersion"
+	    // No model zoo available
+	}
+	
+	if ('tensorrt' in djlEngines) {
+	    implementation "ai.djl.tensorrt:tensorrt:$djlVersion"
+	    // No model zoo available
+	}
+
+    if ('tflite' in djlEngines || 'tensorflowlite' in djlEngines) {
+	    implementation "ai.djl.tflite:tflite-engine:$djlVersion"
+	    // No model zoo available
+	}
+	
+	if ('dlr' in djlEngines || 'neodlr' in djlEngines) {
+	    implementation "ai.djl.dlr:dlr-engine:$djlVersion"
 	    // No model zoo available
 	}
 }

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -134,6 +134,8 @@ import qupath.lib.roi.GeometryTools;
 import qupath.lib.roi.ROIs;
 import qupath.lib.roi.RoiTools;
 import qupath.lib.roi.interfaces.ROI;
+import qupath.opencv.dnn.DnnModelParams;
+import qupath.opencv.dnn.DnnModels;
 import qupath.opencv.dnn.DnnTools;
 import qupath.opencv.io.OpenCVTypeAdapters;
 import qupath.opencv.ml.objects.OpenCVMLClassifier;
@@ -297,6 +299,8 @@ public class QP {
 			OpenCVTools.class,
 			NumpyTools.class,
 			DnnTools.class,
+			DnnModels.class,
+			DnnModelParams.class,
 			TileExporter.class,
 			LabeledImageServer.class,
 			ServerTools.class,

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModelBuilder.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModelBuilder.java
@@ -1,0 +1,44 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.opencv.dnn;
+
+/**
+ * Builder to create a {@link DnnModel} from {@link DnnModelParams}.
+ * This exists to allow different implementations to be added via extensions.
+ * 
+ * @author Pete Bankhead
+ *
+ * @param <T>
+ * @since v0.4.0
+ */
+public interface DnnModelBuilder<T> {
+	
+	/**
+	 * Build a {@link DnnModel} if possible, or return null otherwise.
+	 * This should return null quickly whenever it is known that the model cannot be built.
+	 * @param params
+	 * @return
+	 */
+	public DnnModel<T> buildModel(DnnModelParams params);
+	
+}

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModelParams.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModelParams.java
@@ -1,0 +1,386 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.opencv.dnn;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parameters to build a {@link DnnModel}.
+ * These are used via {@link DnnModels#buildModel(DnnModelParams)}.
+ * <p>
+ * Many parameters are optional.
+ * However as many as are available should be set, to maximize the chances 
+ * of a {@link DnnModelBuilder} being available to build a model from the parameters.
+ * <p>
+ * <b>Warning!</b> The API for this class is unstable; it is likely to change in 
+ * future releases.
+ * 
+ * @author Pete Bankhead
+ * @since v0.4.0
+ */
+public class DnnModelParams {
+	
+	/**
+	 * Default name to identify TensorFlow.
+	 */
+	public static final String FRAMEWORK_TENSORFLOW = "TensorFlow";
+	
+	/**
+	 * Default name to identify TensorFlow Lite.
+	 */
+	public static final String FRAMEWORK_TF_LITE = "TFLite";
+	
+	/**
+	 * Default name to identify ONNX Runtime.
+	 */
+	public static final String FRAMEWORK_ONNX_RUNTIME = "OnnxRuntime";
+	
+	/**
+	 * Default name to identify OpenCV DNN.
+	 */
+	public static final String FRAMEWORK_OPENCV_DNN = "OpenCV DNN";
+	
+	/**
+	 * Default name to identify PyTorch.
+	 */
+	public static final String FRAMEWORK_PYTORCH = "PyTorch";
+	
+	/**
+	 * Default name to identify MXNet.
+	 */
+	public static final String FRAMEWORK_MXNET = "MxNet";
+
+	
+	
+	private static final Logger logger = LoggerFactory.getLogger(DnnModelParams.class);
+
+	private String framework;
+	
+	private String layout;
+	private List<URI> uris;
+	
+	private boolean lazyInitialize = false;
+	
+	private Map<String, DnnShape> inputs;
+	private Map<String, DnnShape> outputs;
+	
+	private DnnModelParams(DnnModelParams params) {
+		if (params == null) {
+			logger.debug("Creating default model params");
+			return;
+		}
+		logger.debug("Creating model params from {}", params);
+		this.framework = params.getFramework();
+		this.layout = params.getLayout();
+		this.uris = Collections.unmodifiableList(new ArrayList<>(params.getURIs()));
+		this.inputs = params.inputs == null ? null : Collections.unmodifiableMap(new LinkedHashMap<>(params.getInputs()));
+		this.outputs = params.outputs == null ? null : Collections.unmodifiableMap(new LinkedHashMap<>(params.getOutputs()));
+		this.lazyInitialize = params.lazyInitialize;
+	}
+	
+	/**
+	 * Get the name of the deep learning framework that may be used.
+	 * If null, consumers may try to infer this from any URIs.
+	 * @return
+	 */
+	public String getFramework() {
+		return framework;
+	}
+	
+	/**
+	 * Get the URIs associated with the model (e.g. weights and/or config files).
+	 * @return
+	 */
+	public List<URI> getURIs() {
+		return uris == null ? Collections.emptyList() : Collections.unmodifiableList(uris);
+	}
+	
+	/**
+	 * Get the requested inputs and their shapes.
+	 * @return the inputs, if known, or null otherwise
+	 */
+	public Map<String, DnnShape> getInputs() {
+		if (inputs == null)
+			return null;
+		return Collections.unmodifiableMap(inputs);
+	}
+
+	/**
+	 * Get the expected outputs and their shapes.
+	 * @return the outputs, if known, or null otherwise
+	 */
+	public Map<String, DnnShape> getOutputs() {
+		if (outputs == null)
+			return null;
+		return Collections.unmodifiableMap(outputs);
+	}
+
+	public String getLayout() {
+		return layout;
+	}
+	
+	/**
+	 * Request that any model is loaded lazily on demand.
+	 * <p>
+	 * This can be useful to avoid blocking at some inopportune point in the code, 
+	 * but means that any exceptions associated with model initialization will 
+	 * probably not be thrown until the model is used.
+	 * @return
+	 */
+	public boolean requestLazyInitialize() {
+		return lazyInitialize;
+	}
+	
+	/**
+	 * Create a new params builder, initialized with the values from existing 
+	 * params.
+	 * @param params
+	 * @return a new builder
+	 */
+	public static Builder builder(DnnModelParams params) {
+		return new Builder(params);
+	}
+
+	/**
+	 * Create a new params builder, with default values.
+	 * @return a new builder
+	 */
+	public static Builder builder() {
+		return builder(null);
+	}
+	
+	
+
+	/**
+	 * Builder for {@link DnnModelParams}.
+	 */
+	public static class Builder {
+		
+		private static final Logger logger = LoggerFactory.getLogger(Builder.class);
+		
+		private DnnModelParams params;
+		
+		private Builder(DnnModelParams params) {
+			this.params = new DnnModelParams(params);
+		}
+		
+		/**
+		 * Specify the URIs as files. These will be appended to any existing URIs.
+		 * @param files
+		 * @return
+		 */
+		public Builder files(File... files) {
+			return URIs(Arrays.stream(files).map(f -> f.toPath().toUri()).collect(Collectors.toList()));
+		}
+		
+		/**
+		 * Specify the URIs as path objects. These will be appended to any existing URIs.
+		 * @param paths
+		 * @return
+		 */
+		public Builder paths(Path... paths) {
+			return URIs(Arrays.stream(paths).map(p -> p.toUri()).collect(Collectors.toList()));
+		}
+		
+		/**
+		 * Specify the URIs. These will be appended to any existing URIs.
+		 * @param uris
+		 * @return
+		 */
+		public Builder URIs(URI... uris) {
+			return URIs(Arrays.asList(uris));
+		}
+		
+		/**
+		 * Specify the URIs as a collection. These will be appended to any existing URIs.
+		 * @param uris
+		 * @return
+		 */
+		public Builder URIs(Collection<URI> uris) {
+			if (params.uris == null)
+				params.uris = new ArrayList<>(uris);
+			else
+				params.uris.addAll(uris);
+			return this;
+		}
+		
+		/**
+		 * Optionally request lazy initialization.
+		 * @param lazyInitialize
+		 * @return
+		 */
+		public Builder lazyInitialize(boolean lazyInitialize) {
+			params.lazyInitialize = lazyInitialize;
+			return this;
+		}
+		
+		/**
+		 * Specify the deep learning framework that can use the model.
+		 * <p>
+		 * It is recommended to use one of the default names available as static variables
+		 * in {@link DnnModelParams}.
+		 * However, an extension might use some other unique identifier to ensure that it is 
+		 * used in preference to some other implementation.
+		 * @param framework
+		 * @return
+		 */
+		public Builder framework(String framework) {
+			params.framework = framework;
+			return this;
+		}
+		
+		public Builder layout(String layout) {
+			params.layout = layout;
+			return this;
+		}
+		
+		/**
+		 * Specify the shape for a single input, with the default input name.
+		 * @param shape
+		 * @return
+		 */
+		public Builder inputShape(long... shape) {
+			return input(DnnModel.DEFAULT_INPUT_NAME, DnnShape.of(shape));
+		}
+		
+		/**
+		 * Specify the shape as a long array for a single input with a specified name.
+		 * @param name
+		 * @param shape
+		 * @return
+		 */
+		public Builder input(String name, long... shape) {
+			return input(name, DnnShape.of(shape));
+		}
+		
+		/**
+		 * Specify the shape for a single input with a specified name.
+		 * @param name
+		 * @param shape
+		 * @return
+		 */
+		public Builder input(String name, DnnShape shape) {
+			if (name == null)
+				name = DnnModel.DEFAULT_INPUT_NAME;
+			return inputs(Collections.singletonMap(name, shape));
+		}
+		
+		/**
+		 * Specify the shapes for one or more inputs.
+		 * @param inputs
+		 * @return
+		 */
+		public Builder inputs(Map<String, DnnShape> inputs) {
+			if (inputs == null) {
+				logger.warn("Provided inputs were null");
+				return this;
+			}
+			if (inputs.isEmpty()) {
+				logger.warn("Provided inputs were empty");
+				return this;
+			}
+			if (params.inputs == null)
+				params.inputs = new LinkedHashMap<>(inputs);
+			else
+				params.inputs.putAll(inputs);
+			return this;
+		}
+
+		/**
+		 * Specify the shape for a single output, with the default output name.
+		 * @param shape
+		 * @return
+		 */
+		public Builder outputShape(long... shape) {
+			return output(DnnModel.DEFAULT_OUTPUT_NAME, DnnShape.of(shape));
+		}
+
+		/**
+		 * Specify the shape as a long array for a single named output.
+		 * @param name 
+		 * @param shape
+		 * @return
+		 */
+		public Builder output(String name, long... shape) {
+			return output(name, DnnShape.of(shape));
+		}
+
+		/**
+		 * Specify the shape for a single named output.
+		 * @param name 
+		 * @param shape
+		 * @return
+		 */
+		public Builder output(String name, DnnShape shape) {
+			if (name == null)
+				name = DnnModel.DEFAULT_OUTPUT_NAME;
+			return outputs(Collections.singletonMap(name, shape));
+		}
+
+		/**
+		 * Specify the shapes for one or more outputs.
+		 * These will be added to any existing outputs.
+		 * @param outputs
+		 * @return
+		 */
+		public Builder outputs(Map<String, DnnShape> outputs) {
+			if (outputs == null) {
+				logger.warn("Provided outputs were null");
+				return this;
+			}
+			if (outputs.isEmpty()) {
+				logger.warn("Provided outputs were empty");
+				return this;
+			}
+			if (params.outputs == null)
+				params.outputs = new LinkedHashMap<>(outputs);
+			else
+				params.outputs.putAll(outputs);
+			return this;
+		}
+		
+		/**
+		 * Build the params.
+		 * @return
+		 */
+		public DnnModelParams build() {
+			return new DnnModelParams(params);
+		}
+		
+	}
+	
+	
+}

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModels.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModels.java
@@ -1,0 +1,120 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.opencv.dnn;
+
+import java.util.ServiceLoader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import qupath.lib.classifiers.object.ObjectClassifiers;
+import qupath.lib.io.GsonTools;
+import qupath.lib.io.GsonTools.SubTypeAdapterFactory;
+
+/**
+ * Helper class for building new {@linkplain DnnModel DnnModels}.
+ * <p>
+ * This includes a {@link ServiceLoader} to support adding new implementations 
+ * via extensions.
+ * 
+ * @author Pete Bankhead
+ * @since v0.4.0
+ */
+public class DnnModels {
+	
+	private static final Logger logger = LoggerFactory.getLogger(DnnModels.class);
+	
+	@SuppressWarnings("rawtypes")
+	private static final SubTypeAdapterFactory<DnnModel> dnnAdapter;
+	
+	@SuppressWarnings("rawtypes")
+	private static final SubTypeAdapterFactory<BlobFunction> blobAdapter;
+	
+	@SuppressWarnings("rawtypes")
+	private static final SubTypeAdapterFactory<PredictionFunction> predictionAdapter;
+	
+	static {
+		
+		blobAdapter = GsonTools.createSubTypeAdapterFactory(BlobFunction.class, "blob_fun")
+				.registerSubtype(DefaultBlobFunction.class);
+		
+		predictionAdapter = GsonTools.createSubTypeAdapterFactory(PredictionFunction.class, "prediction_fun");
+		
+		dnnAdapter = GsonTools.createSubTypeAdapterFactory(DnnModel.class, "dnn_model")
+				.registerSubtype(DefaultDnnModel.class)
+				.registerSubtype(OpenCVDnn.class);
+		
+		ObjectClassifiers.ObjectClassifierTypeAdapterFactory.registerSubtype(OpenCVModelObjectClassifier.class);
+		ObjectClassifiers.ObjectClassifierTypeAdapterFactory.registerSubtype(DnnObjectClassifier.class);
+
+		GsonTools.getDefaultBuilder()
+				.registerTypeAdapterFactory(blobAdapter)
+				.registerTypeAdapterFactory(predictionAdapter)
+				.registerTypeAdapterFactory(dnnAdapter);
+		
+	}
+	
+	
+	/**
+	 * Register a new {@link DnnModel} class for JSON serialization/deserialization.
+	 * @param <T>
+	 * @param subtype
+	 * @param name
+	 */
+	@SuppressWarnings("rawtypes")
+	public static <T extends DnnModel> void registerDnnModel(Class<T> subtype, String name) {
+		if (name == null || name.isBlank())
+			dnnAdapter.registerSubtype(subtype);
+		else
+			dnnAdapter.registerSubtype(subtype, name);
+	}
+	
+	
+	@SuppressWarnings("rawtypes")
+	private static ServiceLoader<DnnModelBuilder> serviceLoader = ServiceLoader.load(DnnModelBuilder.class);
+	
+	
+	/**
+	 * Build a {@link DnnModel} from the given parameters.
+	 * This queries all available {@linkplain DnnModelBuilder DnnModelBuilders} through a service loader.
+	 * @param <T>
+	 * @param params
+	 * @return a new DnnModel, or null if no model could be built
+	 */
+	public static <T> DnnModel<T> buildModel(DnnModelParams params) {
+		synchronized (serviceLoader) {
+			for (DnnModelBuilder<?> builder : serviceLoader) {
+				try {
+					var model = builder.buildModel(params);
+					if (model != null)
+						return (DnnModel<T>)model;
+				} catch (Exception e) {
+					logger.error(e.getLocalizedMessage(), e);
+				}
+			}
+		}
+		return null;
+	}
+	
+
+}

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnTools.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2021 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2021-2022 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -58,12 +58,10 @@ import org.bytedeco.opencv.opencv_dnn.SegmentationModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import qupath.lib.classifiers.object.ObjectClassifiers;
 import qupath.lib.common.GeneralTools;
+import qupath.lib.common.LogTools;
 import qupath.lib.geom.Point2;
 import qupath.lib.images.servers.ImageServer;
-import qupath.lib.io.GsonTools;
-import qupath.lib.io.GsonTools.SubTypeAdapterFactory;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.classes.PathClass;
@@ -83,64 +81,37 @@ public class DnnTools {
 	
 	private static final Logger logger = LoggerFactory.getLogger(DnnTools.class);
 	
-	@SuppressWarnings("rawtypes")
-	private static final SubTypeAdapterFactory<DnnModel> dnnAdapter;
-	
-	@SuppressWarnings("rawtypes")
-	private static final SubTypeAdapterFactory<BlobFunction> blobAdapter;
-	
-	@SuppressWarnings("rawtypes")
-	private static final SubTypeAdapterFactory<PredictionFunction> predictionAdapter;
-	
-	static {
-		
-		blobAdapter = GsonTools.createSubTypeAdapterFactory(BlobFunction.class, "blob_fun")
-				.registerSubtype(DefaultBlobFunction.class);
-		
-		predictionAdapter = GsonTools.createSubTypeAdapterFactory(PredictionFunction.class, "prediction_fun");
-		
-		dnnAdapter = GsonTools.createSubTypeAdapterFactory(DnnModel.class, "dnn_model")
-				.registerSubtype(DefaultDnnModel.class)
-				.registerSubtype(OpenCVDnn.class);
-		
-		ObjectClassifiers.ObjectClassifierTypeAdapterFactory.registerSubtype(OpenCVModelObjectClassifier.class);
-		ObjectClassifiers.ObjectClassifierTypeAdapterFactory.registerSubtype(DnnObjectClassifier.class);
-
-		GsonTools.getDefaultBuilder()
-				.registerTypeAdapterFactory(blobAdapter)
-				.registerTypeAdapterFactory(predictionAdapter)
-				.registerTypeAdapterFactory(dnnAdapter);
-		
-	}
-	
-	
 	/**
 	 * Register a new {@link DnnModel} class for JSON serialization/deserialization.
 	 * @param <T>
 	 * @param subtype
 	 * @param name
+	 * @deprecated since v0.4.0; use {@link DnnModels#registerDnnModel(Class, String)} instead.
 	 */
 	@SuppressWarnings("rawtypes")
+	@Deprecated
 	public static <T extends DnnModel> void registerDnnModel(Class<T> subtype, String name) {
-		if (name == null || name.isBlank())
-			dnnAdapter.registerSubtype(subtype);
-		else
-			dnnAdapter.registerSubtype(subtype, name);
+		LogTools.warnOnce(logger, "DnnTools.registerDnnModel is deprecated - use DnnModels.registerDnnModel instead");
+		DnnModels.registerDnnModel(subtype, name);
 	}
 	
 	
 	/**
-	 * Initiative building and configurating an {@link OpenCVDnn}.
+	 * Initiative building and configuring an {@link OpenCVDnn}.
+	 * <p>
+	 * Note that {@link DnnModels#buildModel(DnnModelParams)} should generally be used instead 
+	 * to create an arbitrary {@link DnnModel}, since it can potentially use different libraries 
+	 * or frameworks.
 	 * 
 	 * @param modelPath
 	 * @return
 	 * @apiNote since {@link OpenCVDnn} is used to build other things (e.g. a {@link Net}, a {@link Model}), 
 	 *          this is, rather inelegantly, a builder for a builder. However the difference is that, once you have 
 	 *          an {@link OpenCVDnn}, configuration is fixed.
+	 * @see DnnModels#buildModel(DnnModelParams)
 	 */
 	public static OpenCVDnn.Builder builder(String modelPath) {
 		return OpenCVDnn.builder(modelPath);
-				
 	}
 	
 	

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVDnnModelBuilder.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVDnnModelBuilder.java
@@ -1,0 +1,81 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.opencv.dnn;
+
+import java.nio.file.Paths;
+import java.util.Set;
+
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.bytedeco.opencv.opencv_dnn.Net;
+
+import qupath.lib.common.GeneralTools;
+
+/**
+ * A {@link DnnModelBuilder} implementation that uses OpenCV's DNN module 
+ * to build a {@link Net}.
+ * 
+ * @author Pete Bankhead
+ * @since v0.4.0
+ */
+public class OpenCVDnnModelBuilder implements DnnModelBuilder<Mat> {
+	
+	private static Set<String> weightsExtensions = Set.of(".pb", ".onnx", ".caffemodel", ".t7", ".net", ".weights", ".bin");
+	private static Set<String> configExtensions = Set.of(".prototxt", ".pbtxt", ".cfg", ".xml");
+	
+	
+	private boolean canBuild(DnnModelParams params) {
+		// We need URIs - but can only handle 1 or 2
+		var uris = params.getURIs();
+		if (uris.isEmpty() || uris.size() > 2)
+			return false;
+		// Check framework
+		var framework = params.getFramework();
+		if (framework != null)
+			return DnnModelParams.FRAMEWORK_OPENCV_DNN.equalsIgnoreCase(framework);
+		// If the framework isn't specified to be something else, 
+		// estimate if we can handle it
+		for (var uri : params.getURIs()) {
+			// We need a local file path
+			var path = GeneralTools.toPath(uri);
+			if (path == null)
+				return false;
+			var ext = GeneralTools.getExtension(path.getFileName().toString()).orElse("").toLowerCase();
+			if (!weightsExtensions.contains(ext) && !configExtensions.contains(ext))
+				return false;
+		}
+		// We can but try
+		return true;
+	}
+
+	@Override
+	public DnnModel<Mat> buildModel(DnnModelParams params) {
+		if (!canBuild(params))
+			return null;
+		var uris = params.getURIs();
+		var builder = OpenCVDnn.builder(Paths.get(uris.get(0)).toAbsolutePath().toString());
+		if (uris.size() > 1)
+			builder = builder.config(uris.get(1));
+		
+		return builder.build();
+	}
+	
+}

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/PredictionFunction.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/PredictionFunction.java
@@ -84,7 +84,7 @@ public interface PredictionFunction<T> {
 	 * <p>
 	 * Often, this is a singleton map with key {@link #DEFAULT_INPUT_NAME} for functions that take a single input.
 	 * <p>
-	 * If the shape is know, the axis order is typically NCHW.
+	 * If the shape is known, the axis order is typically NCHW.
 	 * NCHW is used by OpenCV https://docs.opencv.org/4.5.2/d6/d0f/group__dnn.html#ga29f34df9376379a603acd8df581ac8d7
 	 * and also by PyTorch; for TensorFlow some rearrangement may be needed.
 	 * 

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
@@ -39,6 +39,7 @@ import qupath.lib.classifiers.pixel.PixelClassifier;
 import qupath.lib.classifiers.pixel.PixelClassifierMetadata;
 import qupath.lib.images.servers.ColorTransforms;
 import qupath.lib.images.servers.PixelCalibration;
+import qupath.lib.images.servers.PixelType;
 import qupath.lib.images.servers.ColorTransforms.ColorTransform;
 import qupath.lib.images.servers.ImageServerMetadata.ChannelType;
 import qupath.lib.objects.classes.PathClass;
@@ -200,15 +201,6 @@ public class PatchClassifierParams {
 			}
 		}
 		
-		var metadata = new PixelClassifierMetadata.Builder()
-				.inputShape(params.getPatchWidth(), params.getPatchHeight())
-				.classificationLabels(params.getOutputClasses())
-				.setChannelType(params.getOutputChannelType())
-				.inputResolution(params.getInputResolution())
-				.inputPadding(pad)
-				//				.set(params.getOutputPixelType()) // TODO: Add this if required
-				.build();
-
 		var dataOp = ImageOps.buildImageDataOp(params.getInputChannels());
 		var ops = new ArrayList<ImageOp>();
 		if (params.getPreprocessing() != null)
@@ -219,8 +211,18 @@ public class PatchClassifierParams {
 
 		if (params.getPostprocessing() != null)
 			ops.addAll(params.getPostprocessing());
-
+		
 		dataOp = dataOp.appendOps(ops.toArray(ImageOp[]::new));
+		
+		var metadata = new PixelClassifierMetadata.Builder()
+				.inputShape(params.getPatchWidth(), params.getPatchHeight())
+				.classificationLabels(params.getOutputClasses())
+				.setChannelType(params.getOutputChannelType())
+				.inputResolution(params.getInputResolution())
+				.inputPadding(pad)
+				.outputPixelType(dataOp.getOutputType(PixelType.FLOAT32))
+				.build();
+
 
 		return PixelClassifiers.createClassifier(dataOp, metadata);
 

--- a/qupath-core-processing/src/main/resources/META-INF/services/qupath.opencv.dnn.DnnModelBuilder
+++ b/qupath-core-processing/src/main/resources/META-INF/services/qupath.opencv.dnn.DnnModelBuilder
@@ -1,0 +1,1 @@
+qupath.opencv.dnn.OpenCVDnnModelBuilder

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
@@ -1159,16 +1159,17 @@ public class ContourTracing {
 		var channelType = server.getMetadata().getChannelType();
 		int h = img.getHeight();
 		int w = img.getWidth();
+		var nChannels = server.nChannels();
 		
 		// If we have probabilities, then the 'true' classification is the one with the highest values.
 		// If we have classifications, then the 'true' classification is the value of the pixel (which is expected to have a single band).
-		boolean doClassification = channelType == ImageServerMetadata.ChannelType.PROBABILITY || channelType == ImageServerMetadata.ChannelType.CLASSIFICATION;
+		boolean doClassification = (channelType == ImageServerMetadata.ChannelType.PROBABILITY && nChannels > 1) || channelType == ImageServerMetadata.ChannelType.CLASSIFICATION;
 		if (doClassification) {
 			SimpleImage image;
+			// If we have probability & more than one channel, we take the channel with the highest probability (i.e. softmax)
 			if (channelType == ImageServerMetadata.ChannelType.PROBABILITY) {
 				// Convert probabilities to classifications
 				var raster = img.getRaster();
-				var nChannels = server.nChannels();
 				float[] output = new float[w * h];
 				for (int y = 0; y < h; y++) {
 					for (int x = 0; x < w; x++) {

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierUI.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierUI.java
@@ -261,6 +261,12 @@ public class PixelClassifierUI {
 		Objects.requireNonNull(imageData);
 		Objects.requireNonNull(classifier);
 		
+		var detections = imageData.getHierarchy().getDetectionObjects();
+		if (detections.isEmpty()) {
+			Dialogs.showErrorMessage("Classify detections", "This command only support classifying detections, sorry");
+			return false;
+		}
+		
 		PixelClassifierTools.classifyDetectionsByCentroid(imageData, classifier);
 		if (classifierName != null) {
 			imageData.getHistoryWorkflow().addStep(

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/WelcomeStage.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/WelcomeStage.java
@@ -45,12 +45,10 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
-import javafx.scene.paint.Color;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
 import javafx.scene.text.TextFlow;
 import javafx.stage.Stage;
-import javafx.stage.StageStyle;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.prefs.PathPrefs.AutoUpdateType;
 import qupath.lib.gui.prefs.QuPathStyleManager;
@@ -242,8 +240,12 @@ class WelcomeStage {
 		pane.setBottom(paneOptions);
 		pane.setPadding(new Insets(10));
 		
-		stage.setScene(new Scene(pane, Color.TRANSPARENT));
-		stage.initStyle(StageStyle.UNDECORATED);
+		// Transparent undecorated stage looked pretty good on recent macOS,
+		// but not on Windows 10 (because there was no drop shadow)
+//		stage.setScene(new Scene(pane, Color.TRANSPARENT));
+//		stage.initStyle(StageStyle.UNDECORATED);
+		stage.setScene(new Scene(pane));
+		stage.setTitle("Welcome");
 		GuiTools.makeDraggableStage(stage);
 		stage.getScene().setOnMouseClicked(e -> {
 			if (e.getClickCount() == 2) {


### PR DESCRIPTION
* Enable new `DnnModel` implementations to be added via extensions (using a `ServiceLoader`)
* Make all DeepJavaLibrary engines available when building via gradle properties
* Handle single-channel probability predictions as if they are multichannel when creating objects
  * Without this, the 'softmax' assumption would mean that everything was treated as 'detected' since there was no higher channel available
* Store all actions added with `installActions`, so they can be found again via `QuPathGUI.lookupActionByText(String)`
* Add title to startup message (because otherwise drop shadow missing on Windows)