### PR TITLE
More fixes

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/CellTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/CellTools.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -92,9 +93,12 @@ public class CellTools {
 	 * Results are returned as a new list of cells.
 	 * @param cells input cells
 	 * @return a new list of cells, potentially containing some of the original cells and other adjusted cells
+	 * 
+	 * @implNote It is <b>not</b> guaranteed that the cells that are output will be in the same order as the 
+	 *           input collection. This behavior may change in the future.
 	 */
 	public static List<PathObject> constrainCellOverlaps(Collection<? extends PathObject> cells) {
-		var map = new HashMap<PathObject, Geometry>();
+		var map = new LinkedHashMap<PathObject, Geometry>();
 		for (var cell : cells) {
 			if (!cell.isCell()) {
 				logger.warn("{} is not a cell - will be skipped!", cell);
@@ -112,12 +116,15 @@ public class CellTools {
 	 * @param distance the maximum distance (in pixels) to expand each nucleus
 	 * @param nucleusScale the maximum size of the cell relative to the nucleus (ignored if &le; 1).
 	 * @return cell objects derived from the supplied detections. This may have fewer entries if not all detections could be used successfully.
+	 * 
+	 * @implNote It is <b>not</b> guaranteed that the cells that are output will be in the same order as the 
+	 *           input collection. This behavior may change in the future.
 	 */
 	public static List<PathObject> detectionsToCells(Collection<? extends PathObject> detections, double distance, double nucleusScale) {
 		
 		var transform = new AffineTransformation();
 		
-		var map = new HashMap<PathObject, Geometry>();
+		var map = new LinkedHashMap<PathObject, Geometry>();
 		for (var detection : detections) {
 			var roiNucleus = PathObjectTools.getROI(detection, true);
 			var geomNucleus = roiNucleus.getGeometry();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/BrushTool.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/BrushTool.java
@@ -350,6 +350,9 @@ public class BrushTool extends AbstractPathROITool {
 		if (requestPixelSnapping())
 			shapeDrawn = GeometryTools.roundCoordinates(shapeDrawn);
 		
+		// Make sure we don't have any linestrings/points
+		shapeDrawn = GeometryTools.ensurePolygonal(shapeDrawn);
+		
 		lastPoint = p;
 		try {
 			if (shapeROI != null) {


### PR DESCRIPTION
* Occasional exception when using wand tool (GeometryCollection created inadvertently)
* Tooltip obscuring popup menu in the project pane
* Document that the output of some `CellTools` methods might be different from what's expected
  * See https://forum.image.sc/t/delaunaytools-using-area-geometries-instead-of-points-as-seeds/74539/5