### PR TITLE
Improve support for Apple silicon

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,7 +9,7 @@
  * <p>
  *     gradlew.bat clean jpackage
  * <p>
- * NOTE: This build requires OpenJDK 16 (since it contains jpackage).
+ * NOTE: This build requires OpenJDK 17+ (since it contains jpackage).
  * Gradle's toolchain options are used to overcome this: if you run gradlew with a different JDK,
  * gradle will use a different JDK for building QuPath itself (downloading it if necessary).
  */
@@ -34,5 +34,5 @@ gradlePlugin {
 
 dependencies {
     // Make Gradle plugin available to limit platform jars
-    implementation 'org.bytedeco:gradle-javacpp:1.5.7'
+    implementation 'org.bytedeco:gradle-javacpp:1.5.8'
 }

--- a/buildSrc/src/main/groovy/qupath.common-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.common-conventions.gradle
@@ -60,20 +60,6 @@ if ("32".equals(System.getProperty("sun.arch.data.model"))) {
     logger.warn("You may at least need to replace the OpenSlide dlls with 32-bit versions from https://openslide.org/download/")
 }
 
-// Check if we are running using Apple Silicon
-//String osName = System.properties['os.name']?.toLowerCase()
-String osArch = System.properties['os.arch']
-def isAppleSilicon = platform == 'mac' && osArch == 'aarch64'
-if (isAppleSilicon) {
-    project.logger.warn("""
-Apple Silicon support is experimental and incomplete!
-I will try to build anyway, but note that:
-- I may need to use a SNAPSHOT version of OpenCV (subject to change on each build)
-- Parts of the software relying on native libraries are unlikely to work (including OpenSlide)
-If you want to avoid these messages, please use a JDK for x86_64.
-	""".trim())
-}
-
 
 /*
  * Preserve the version number

--- a/buildSrc/src/main/groovy/qupath.djl-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.djl-conventions.gradle
@@ -16,6 +16,12 @@ else if (djlEnginesProp == "none")
 else
 	djlEngines = djlEnginesProp.split(",").collect(e -> e.toLowerCase().strip()).findAll(e -> !e.isBlank())
 
+// Check for Apple Silicon - TensorFlow currently doesn't work there
+if ('tensorflow' in djlEngines && properties['platform.shortName'] == 'mac' && System.properties['os.arch'] == 'aarch64') {
+	println 'TensorFlow is not supported on Apple Silicon - engine will not be added'
+	djlEngines.remove('tensorflow')
+}
+	
 def djlApi = !djlEngines.isEmpty() || project.findProperty('djl.api')
 
 def djlZoosProp = project.findProperty('djl.zoos') ?: "all"

--- a/buildSrc/src/main/java/io/github/qupath/gradle/PlatformPlugin.java
+++ b/buildSrc/src/main/java/io/github/qupath/gradle/PlatformPlugin.java
@@ -30,6 +30,7 @@ public class PlatformPlugin implements Plugin<Project> {
     public enum Platform {
         WINDOWS("windows", "win", "natives-windows", "ico", "msi"),
         MAC("macosx", "mac", "natives-osx", "icns", "pkg"),
+        MAC_AARCH64("macosx", "mac", "natives-mac-aarch64", "icns", "pkg"),
         LINUX("linux", "linux", "natives-linux", "png", "deb"),
         UNKNOWN(null, null, null, null, null);
         
@@ -106,9 +107,11 @@ public class PlatformPlugin implements Plugin<Project> {
             return Platform.WINDOWS;
         else if (os.indexOf("nix") >= 0 || os.indexOf("nux") >= 0)
             return Platform.LINUX;
-        else if (os.indexOf("mac") >= 0)
+        else if (os.indexOf("mac") >= 0) {
+        	if ("aarch64".equalsIgnoreCase(System.getProperty("os.arch")))
+        		return Platform.MAC_AARCH64;
             return Platform.MAC;
-        else
+        } else
             return Platform.UNKNOWN;
     }
     

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
@@ -25,6 +25,8 @@ package qupath.lib.images.servers;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -355,7 +357,9 @@ public interface ImageServerBuilder<T> {
 			} else {
 				return (ImageServer<T>)ImageServers.buildServer(uri, args);
 			}
-			String msg = "Unable to build ImageServer for " + uri + " (args=" + Arrays.asList(args) + ")";
+			String msg = "Unable to build ImageServer for " + URLDecoder.decode(uri.toString(), StandardCharsets.UTF_8);
+			if (args != null && args.length > 0)
+				msg += " (args=" + Arrays.asList(args) + ")";
 			if (providerClassName != null) {
 				if (!failedWithRequestedProvider)
 					msg += " - I couldn't find " + providerClassName;

--- a/qupath-extension-bioformats/build.gradle
+++ b/qupath-extension-bioformats/build.gradle
@@ -15,6 +15,11 @@ if (versionOverride) {
 	bioformatsVersion = versionOverride
 }
 
+String nativesClassifier = properties['platform.classifier']
+if (nativesClassifier == 'natives-mac-aarch64') {
+	println "WARNING! Bio-Formats does not fully support Apple Silicon (some .ndpi images are known to fail)"
+}
+
 
 dependencies {
 	// This can be used to include bioformats_package.jar - however it causes warnings with SLF4J

--- a/qupath-extension-openslide/build.gradle
+++ b/qupath-extension-openslide/build.gradle
@@ -9,12 +9,23 @@ archivesBaseName = 'qupath-extension-openslide'
 description = "QuPath extension to support image reading using OpenSlide."
 
 String nativesClassifier = properties['platform.classifier']
+def openslidePath = project.findProperty("openslide")
 
 dependencies {
   implementation project(':qupath-core')
 
-  implementation "org.openslide:openslide:3.4.1_2"
-  if (nativesClassifier != null)
-    implementation "org.openslide:openslide:3.4.1_2:${nativesClassifier}"
+  if (openslidePath) {
+	  implementation files(openslidePath)
+  } else {
+	  if (nativesClassifier == 'natives-mac-aarch64') {
+		  println "QuPath + OpenSlide isn't supported on Apple Silicon - please build with -Popenslide=/path/to/openslide.jar"
+		  implementation "org.openslide:openslide:3.4.1_2"
+	  } else {
+		  // 'Normal' approach to using OpenSlide
+		  implementation "org.openslide:openslide:3.4.1_2"
+		  if (nativesClassifier != null)
+		    implementation "org.openslide:openslide:3.4.1_2:${nativesClassifier}"
+	  }
+  }
 
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
@@ -1000,7 +1000,7 @@ public class Dialogs {
 			// There's sometimes annoying visual bug in dark mode that results in a white/light 
 			// thin line at the bottom of the dialog - padding seems to fix it
 			if (Insets.EMPTY.equals(dialog.getDialogPane().getPadding()))
-				dialog.getDialogPane().setStyle("-fx-padding: 1px;");
+				dialog.getDialogPane().setStyle("-fx-background-insets: -1; -fx-padding: 1px;");
 			
 			return dialog;
 		}


### PR DESCRIPTION
Improve build scripts for building using Apple silicon
* Avoid including TensorFlow & OpenSlide (which won't work)
* Support a -Popenslide=/path/to/openslide.jar preference to create a build that uses a local openslide jar
* Give more informative error if (when) OpenSlide can't be found

Without a custom build, installing with homebrew and including `libopenslide-jni.jnilib` in the app directory can also work (assuming it contains links to its dependencies).