### PR TITLE
Show ImageLocation Panel on Max Border Pixels

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -2704,7 +2704,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 		if (server == null)
 			return "";
 		String units;
-		if (xx < 0 || yy < 0 || xx > server.getWidth()-1 || yy > server.getHeight()-1)
+		if (xx < 0 || yy < 0 || xx > server.getWidth() || yy > server.getHeight())
 			return "";
 
 		double xDisplay = xx;


### PR DESCRIPTION
At the moment, the ImageLocation overlay panel doesn't show when the cursor is at the maximum x or y values:

<img width="1383" alt="image" src="https://user-images.githubusercontent.com/1779056/216098397-13a67159-a732-4e98-b749-41fafed20eff.png">

This pull request makes it visible:

<img width="1474" alt="image" src="https://user-images.githubusercontent.com/1779056/216098787-95232144-7bf4-4341-8508-cf28f0646079.png">
