### PR TITLE
Further Brightness/Contrast improvements

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramPanelFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramPanelFX.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javafx.scene.layout.Border;
+import javafx.scene.layout.BorderPane;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -398,7 +400,7 @@ public class HistogramPanelFX {
 		
 		private XYChart<Number, Number> chart;
 		private NumberAxis xAxis, yAxis;
-		private Pane pane = new Pane();
+		private BorderPane pane = new BorderPane();
 		
 		private DoubleProperty lineWidth = new SimpleDoubleProperty(2);
 		
@@ -417,9 +419,10 @@ public class HistogramPanelFX {
 			this.chart = chart;
 			this.xAxis = (NumberAxis)chart.getXAxis();
 			this.yAxis = (NumberAxis)chart.getYAxis();
-			pane.getChildren().add(chart);
-	        chart.prefWidthProperty().bind(pane.widthProperty());
-	        chart.prefHeightProperty().bind(pane.heightProperty());
+//			pane.getChildren().add(chart);
+			pane.setCenter(chart);
+//	        chart.prefWidthProperty().bind(pane.prefWidthProperty());
+//	        chart.prefHeightProperty().bind(pane.prefHeightProperty());
 
 	        thresholds.addListener(new ListChangeListener<>() {
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramPanelFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramPanelFX.java
@@ -96,7 +96,7 @@ public class HistogramPanelFX {
 			public void onChanged(Change<? extends HistogramData> c) {
 				while (c.next()) {
 					// Pattern taken from https://docs.oracle.com/javase/8/javafx/api/javafx/collections/ListChangeListener.Change.html
-					// Hower I only really need to worry about adding/removing (I hope)
+					// However I only really need to worry about adding/removing (I hope)
 					if (c.wasPermutated()) {
 						for (int i = c.getFrom(); i < c.getTo(); ++i) {
 							//permutate
@@ -251,7 +251,8 @@ public class HistogramPanelFX {
 		 */
 		private void setColor(final Color color) {
 			this.colorStroke = color;
-			this.colorFill = color == null ? null : Color.color(color.getRed(), color.getGreen(), color.getBlue(), color.getOpacity()/4);			
+			this.colorFill = color == null ? null :
+					Color.color(color.getRed(), color.getGreen(), color.getBlue(), color.getOpacity()/4);
 		}
 		
 		/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramPanelFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/HistogramPanelFX.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -419,31 +419,18 @@ public class HistogramPanelFX {
 			this.chart = chart;
 			this.xAxis = (NumberAxis)chart.getXAxis();
 			this.yAxis = (NumberAxis)chart.getYAxis();
-//			pane.getChildren().add(chart);
 			pane.setCenter(chart);
-//	        chart.prefWidthProperty().bind(pane.prefWidthProperty());
-//	        chart.prefHeightProperty().bind(pane.prefHeightProperty());
+	        thresholds.addListener(this::handleLineListChange);
+		}
 
-	        thresholds.addListener(new ListChangeListener<>() {
-
-				@Override
-				public void onChanged(ListChangeListener.Change<? extends ObservableNumberValue> c) {
-					while (c.next()) {
-						if (c.wasPermutated()) {
-							continue;
-						} else {
-							for (ObservableNumberValue removedItem : c.getRemoved()) {
-								pane.getChildren().remove(vLines.remove(removedItem));
-							}
-//	        				pane.getChildren().removeAll(c.getRemoved());
-//	        				for (ObservableNumberValue addedItem : c.getAddedSubList()) {
-//	        					addThreshold(addedItem.getValue().doubleValue());
-//	        				}
-						}
+		private void handleLineListChange(ListChangeListener.Change<? extends ObservableNumberValue> c) {
+			while (c.next()) {
+				if (!c.wasPermutated()) {
+					for (ObservableNumberValue removedItem : c.getRemoved()) {
+						pane.getChildren().remove(vLines.remove(removedItem));
 					}
 				}
-			});
-	        
+			}
 		}
 		
 		/**
@@ -614,13 +601,13 @@ public class HistogramPanelFX {
 					);
 
 			// We can only bind both ways if we have a writable value
-			if (d instanceof WritableNumberValue) {
+			if (d instanceof WritableNumberValue writableNumberValue) {
 				line.setOnMouseDragged(e -> {
 					if (isInteractive()) {
 						double xNew = xAxis.getValueForDisplay(xAxis.sceneToLocal(e.getSceneX(), e.getSceneY()).getX()).doubleValue();
 						xNew = Math.max(xNew, xAxis.getLowerBound());
 						xNew = Math.min(xNew, xAxis.getUpperBound());
-						((WritableNumberValue)d).setValue(xNew);
+						writableNumberValue.setValue(xNew);
 					}
 				});
 				

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -856,8 +856,7 @@ public class BrightnessContrastCommand implements Runnable {
 				histogramPanel.getHistogramData().setAll(data);
 			} else
 				histogramPanel.getHistogramData().clear();
-		}
-		else {
+		} else {
 			// Any animation is slightly nicer if we can modify the current data, rather than creating a new one
 			if (histogramPanel.getHistogramData().size() == 1) {
 				Color color = infoSelected.getColor() == null ? ColorToolsFX.TRANSLUCENT_BLACK_FX : ColorToolsFX.getCachedColor(infoSelected.getColor());
@@ -897,7 +896,7 @@ public class BrightnessContrastCommand implements Runnable {
 		}
 		
 		histogramPanel.getChart().getXAxis().setTickLabelsVisible(true);
-		histogramPanel.getChart().getXAxis().setLabel("Pixel value");
+//		histogramPanel.getChart().getXAxis().setLabel("Pixel value");
 		histogramPanel.getChart().getYAxis().setTickLabelsVisible(true);
 //		histogramPanel.getChart().getYAxis().setLabel("Frequency");
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -239,10 +239,9 @@ public class BrightnessContrastCommand implements Runnable {
 		histogramPanel.getChart().setAnimated(false);
 		var chartPane = chartWrapper.getPane();
 		chartPane.setPrefWidth(200);
-//		chartPane.setPrefHeight(100);
-//		pane.add(chartPane, 0, row++);
-//		GridPane.setVgrow(chartPane, Priority.ALWAYS);
-		pane.add(histogramPanel.getChart(), 0, row++);
+		chartPane.setPrefHeight(150);
+		pane.add(chartPane, 0, row++);
+//		pane.add(histogramPanel.getChart(), 0, row++);
 
 		Pane paneSliders = createSliderPane();
 		paneSliders.prefWidthProperty().bind(pane.widthProperty());
@@ -880,17 +879,18 @@ public class BrightnessContrastCommand implements Runnable {
 		if (infoSelected != null)
 			xAxis.setTickUnit(infoSelected.getMaxAllowed() - infoSelected.getMinAllowed());
 		
-		// Don't use the first or last count if it's an outlier
+		// Don't use the first or last count if it's an outlier & we have many bins
 		NumberAxis yAxis = (NumberAxis)histogramPanel.getChart().getYAxis();
-		if (infoSelected != null && histogram != null) {
-			long maxCount = 0L;
+		if (infoSelected != null && histogram != null && histogram.nBins() > 10) {
+			long maxCountExcludingEndBins = 0L;
 			for (int i = 1; i < histogram.nBins()-1; i++)
-				maxCount = Math.max(maxCount, histogram.getCountsForBin(i));
-			if (maxCount == 0)
-				maxCount = histogram.getMaxCount();
-			yAxis.setAutoRanging(false);
-			yAxis.setLowerBound(0);
-			yAxis.setUpperBound((double)maxCount / histogram.getCountSum());
+				maxCountExcludingEndBins = Math.max(maxCountExcludingEndBins, histogram.getCountsForBin(i));
+			double outlierThreshold = maxCountExcludingEndBins * 4;
+			if (histogram.getMaxCount() > outlierThreshold) {
+				yAxis.setAutoRanging(false);
+				yAxis.setLowerBound(0);
+				yAxis.setUpperBound((double)outlierThreshold / histogram.getCountSum());
+			}
 		}
 
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -77,7 +77,6 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
-import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
 import javafx.stage.Stage;

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -56,3 +56,26 @@
     -fx-background-color: -fx-base;
     -fx-text-fill: -fx-text-base-color;
 }
+
+/* Style a minimal colorpicker (just a clickable square) */
+.minimal-color-picker {
+  -fx-color-label-visible: false;
+  -fx-background-color: null;
+}
+
+.minimal-color-picker > .color-picker-label {
+  -fx-padding: 0;
+}
+
+.minimal-color-picker:hover {
+  -fx-effect: dropshadow(two-pass-box , rgba(0, 0, 0, 0.2), 5, 0.0 , 0, 2);
+}
+
+.minimal-color-picker:focused {
+  -fx-background-color: null;
+  -fx-background-radius: 0;
+}
+
+.minimal-color-picker > .color-picker-label > .picker-color > .picker-color-rect {
+  -fx-stroke: null;
+}


### PR DESCRIPTION
Summary of changes in this PR (and recent ones):
* Add checkbox to the top of the 'Show' column to show/hide all
* Replace color rectangles with minimal color pickers (that look the same, but respond to clicks)
* Automatically bring text field into focus when double-clicking to set a channel name
* Rename columns
* Reorder the lower controls
* Support regular expressions in the channel name filter for advanced filtering (optional)

Before (left) and after (right).

<img width="200" alt="Brightness:Contrast before changes" src="https://github.com/qupath/qupath/assets/4690904/dd6ead11-38f0-44fa-97e3-2c6dd96bdef2">

<img width="200" alt="Brightness:Contrast dialog updated" src="https://github.com/qupath/qupath/assets/4690904/fe8ac8b8-4ec3-46cc-a708-4d7a11c2d864">