### PR TITLE
Fix enabling B/C table for RGB images

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -1499,7 +1499,7 @@ public class BrightnessContrastCommand implements Runnable {
 				this.customColors = null;
 			// Minimal color picker - just a small, clickable colored square
 			colorPicker = new ColorPicker();
-			colorPicker.getStyleClass().addAll("button", "minimal-color-picker");
+			colorPicker.getStyleClass().addAll("button", "minimal-color-picker", "always-opaque");
 			colorPicker.valueProperty().addListener(this::handleColorChange);
 			setGraphic(colorPicker);
 			setEditable(true);
@@ -1522,7 +1522,7 @@ public class BrightnessContrastCommand implements Runnable {
 			Integer rgb = item.getColor();
 			// Can only set the color for direct, non-RGB channels
 			boolean canChangeColor = rgb != null && item instanceof DirectServerChannelInfo;
-			setDisable(!canChangeColor);
+			colorPicker.setDisable(!canChangeColor);
 			colorPicker.setOnShowing(null);
 			if (rgb == null) {
 				colorPicker.setValue(Color.TRANSPARENT);

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -79,3 +79,12 @@
 .minimal-color-picker > .color-picker-label > .picker-color > .picker-color-rect {
   -fx-stroke: null;
 }
+
+/* Set opacity for 1, even if the control is disabled (usually sets opacity to 0.4) */
+.always-opaque,
+.always-opaque:hover,
+.always-opaque:focused,
+.always-opaque:disabled,
+.always-opaque:disabled > * {
+  -fx-opacity: 1;
+}


### PR DESCRIPTION
Regression accidentally disabled the entire cell, not the colorpicker... but then disabling the colorpicker also resulted in changing its opacity, which was bad too. This attempts to fix both issues.