### PR TITLE
make getNameWithoutExtension return value consistent

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -296,8 +296,7 @@ public final class GeneralTools {
 	 * {@link #getExtension(File)}
 	 */
 	public static String getNameWithoutExtension(String name) {
-		var ext = getExtension(name).orElse(null);
-		return ext ==  null ? name : name.substring(0, name.length() - ext.length());
+		return getNameWithoutExtension(new File(name));
 	}
 	
 	/**

--- a/qupath-core/src/test/java/qupath/lib/common/TestGeneralTools.java
+++ b/qupath-core/src/test/java/qupath/lib/common/TestGeneralTools.java
@@ -79,6 +79,7 @@ public class TestGeneralTools {
 		for (String ext : Arrays.asList(".ext", ".tif", ".ome.tiff", ".tar.gz", ".ome.tif")) {
 			File file = new File(baseName + ext);
 			String parsed = GeneralTools.getExtension(file).orElse(null);
+			assertEquals(GeneralTools.getNameWithoutExtension(file.getAbsolutePath()), GeneralTools.getNameWithoutExtension(file.getAbsoluteFile()));
 			assertEquals(ext, parsed);
 			assertEquals(baseName, GeneralTools.getNameWithoutExtension(file));
 			assertEquals(baseName, GeneralTools.getNameWithoutExtension(file.getPath()));


### PR DESCRIPTION
`GeneralTools.getNameWithoutExtension(String)` returns the whole string without the extension for absolute path, while
`GeneralTools.getNameWithoutExtension(File)` returns only the file name part without the extension. eg: `/home/demo/myfile.tif`, the former method returns `/home/demo/myfile` while the latter one returns `myfile`. This commit make them return `myfile` for consistent. A test is also added.