### PR TITLE
Add changelistener to downsamplefactor

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
@@ -309,6 +309,9 @@ class ToolBarComponent {
 			setMaxWidth(60);
 			setTextAlignment(TextAlignment.CENTER);
 			setOnMouseEntered(e -> refreshMagnificationTooltip());
+			viewer.downsampleFactor().addListener((v, o, n) -> {
+				setText(GuiTools.getMagnificationString(viewer));
+			});
 			setOnMouseClicked(e -> {
 				if (e.getClickCount() == 2)
 					promptToUpdateMagnification();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -644,9 +644,12 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 			repaint();
 		}
 	};
-	
-	
-	
+
+	public DoubleProperty downsampleFactor() {
+		return downsampleFactor;
+	}
+
+
 	static class ListenerManager {
 		
 		private List<ListenerHandler> handlers = new ArrayList<>();


### PR DESCRIPTION
This probably only come in handy in weird edge cases like clicking the "adjust zoom to fit images to viewer" button when zoomed in.

Maybe a binding would be more suitable, though