### PR TITLE
Use collectors toList instead of bare toList in refreshExtensions

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionManager.java
@@ -177,7 +177,7 @@ public class ExtensionManager {
 		if (showNotification) {
 			// A bit convoluted... but try to show new servers that have been loaded by comparing with the past
 			List<String> serverBuilders = serverBuildersBefore.stream().map(s -> s.getName()).toList();
-			List<String> serverBuildersUpdated = ImageServerProvider.getInstalledImageServerBuilders().stream().map(s -> s.getName()).collect(Collectors.toList());
+			List<String> serverBuildersUpdated = ImageServerProvider.getInstalledImageServerBuilders().stream().map(s -> s.getName()).collect(Collectors.toCollection(ArrayList::new));
 			serverBuildersUpdated.removeAll(serverBuilders);
 			for (String builderName : serverBuildersUpdated) {
 				Dialogs.showInfoNotification("Image server loaded",  builderName);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionManager.java
@@ -41,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -175,7 +177,7 @@ public class ExtensionManager {
 		if (showNotification) {
 			// A bit convoluted... but try to show new servers that have been loaded by comparing with the past
 			List<String> serverBuilders = serverBuildersBefore.stream().map(s -> s.getName()).toList();
-			List<String> serverBuildersUpdated = ImageServerProvider.getInstalledImageServerBuilders().stream().map(s -> s.getName()).toList();
+			List<String> serverBuildersUpdated = ImageServerProvider.getInstalledImageServerBuilders().stream().map(s -> s.getName()).collect(Collectors.toList());
 			serverBuildersUpdated.removeAll(serverBuilders);
 			for (String builderName : serverBuildersUpdated) {
 				Dialogs.showInfoNotification("Image server loaded",  builderName);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -189,8 +189,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 						handleURLDrop(viewer2, url);
 					}
 	        	} catch (IOException e) {
-					Dialogs.showErrorMessage("Drag & Drop", e.getLocalizedMessage());
-	        		
+					Dialogs.showErrorMessage("Drag & Drop", e);
 	        	} finally {
 	        		taskRunning = false;
 	        	}


### PR DESCRIPTION
Problem: `refreshExtensions` always throws `UnsupportedOperationException`, even if it succeeds.
Solution: use `Collectors.toList()` instead of the `Stream` `toList` method (which should be equivalent anyways imo...).

From: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/stream/Stream.html#toList()

> The returned List is unmodifiable; calls to any mutator method will always cause UnsupportedOperationException to be thrown.