### PR TITLE
Fix PathClass singleton creation when a derived PathClass is requested

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
@@ -825,6 +825,10 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 		// This can occur during deserialization
 		if (!pathClass.isDerivedClass() && pathClass.getName() == null)
 			return NULL_CLASS;
+		if (pathClass.isDerivedClass()) {
+			PathClass parent = getSingleton(pathClass.getParentClass());
+			pathClass = PathClass.getInstance(parent, pathClass.getName(), pathClass.getColor());
+		}
 		var previous = existingClasses.putIfAbsent(createCacheString(pathClass), pathClass);
 		return previous == null ? pathClass : previous;
 	}


### PR DESCRIPTION
When opening a project with derived classes in QuPath 0.4.0+, it currently wrongly adds them to `existingClasses`.

This simple PR aims to fix this