### PR TITLE
Support non-finite measurement values in geojson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This is a work-in-progress for the next QuPath release.
 
 ### Bugs fixed
 * Rendered image export does not support opacity (https://github.com/qupath/qupath/issues/1292)
+* Cannot import GeoJSON with NaN measurements (https://github.com/qupath/qupath/issues/1293)
 
 ### Dependency updates
 * DeepJavaLibrary 0.21.0


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/1293

Also serialize non-finite measurements as strings `"NaN", "Infinity", "-Infinity" since these are not valid json numbers.

See discussion at https://stackoverflow.com/questions/1423081/json-left-out-infinity-and-nan-json-status-in-ecmascript