### PR TITLE
Replace all uses of Files.exist(path) with path.toFile().exists()

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -4052,7 +4052,7 @@ public class QP {
 			if (classifier == null) {
 				try {
 					var path = Paths.get(name);
-					if (Files.exists(path))
+					if (path.toFile().exists())
 						classifier = ObjectClassifiers.readClassifier(path);
 				} catch (Exception e) {
 					exception = e;
@@ -4097,7 +4097,7 @@ public class QP {
 		}
 		try {
 			var path = Paths.get(name);
-			if (Files.exists(path))
+			if (path.toFile().exists())
 				return DensityMaps.loadDensityMap(path);
 		} catch (Exception e) {
 			exception = e;
@@ -4278,7 +4278,7 @@ public class QP {
 		}
 		try {
 			var path = Paths.get(name);
-			if (Files.exists(path))
+			if (path.toFile().exists())
 				pixelClassifier = PixelClassifiers.readClassifier(path);
 		} catch (Exception e) {
 			exception = e;

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/BioimageIoTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/BioimageIoTools.java
@@ -124,13 +124,13 @@ public class BioimageIoTools {
 					// We can't currently handle zipped weights - so see if we can find unzipped weights
 					if (relativeSource.toLowerCase().endsWith(".zip")) {
 						pathWeights = basePath.resolve(relativeSource.substring(0, relativeSource.length()-4));
-						if (!Files.exists(pathWeights)) {
+						if (!pathWeights.toFile().exists()) {
 							logger.warn("Please unzip the model weights to {}", pathWeights);
 							continue;
 						}
 					} else {
 						pathWeights = basePath.resolve(relativeSource);
-						if (!Files.exists(pathWeights)) {
+						if (!pathWeights.toFile().exists()) {
 							logger.warn("Can't find model weights at {}", pathWeights);
 							continue;
 						}

--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -124,9 +124,9 @@ public final class GeneralTools {
 		// v0.2, less reliable way
 		if (version == null) {
 			var path = Paths.get("VERSION");
-			if (!Files.exists(path))
+			if (!path.toFile().exists())
 				path = Paths.get("app/VERSION");
-			if (Files.exists(path)) {
+			if (path.toFile().exists()) {
 				try {
 					version = Files.readString(path);
 				} catch (IOException e) {

--- a/qupath-core/src/main/java/qupath/lib/images/servers/FileFormatInfo.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/FileFormatInfo.java
@@ -184,7 +184,7 @@ public class FileFormatInfo {
 				return;
 			}
 			Path path = GeneralTools.toPath(uri);
-			if (!Files.exists(path)) {
+			if (!path.toFile().exists()) {
 				return;
 			}
 			File file = path.toFile();

--- a/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
+++ b/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
@@ -687,7 +687,7 @@ public class TileExporter  {
 				data.labels = labelList;
 			}
 			var pathJson = Paths.get(dirOutput, imageName + "-tiles.json");
-			if (Files.exists(pathJson)) {
+			if (pathJson.toFile().exists()) {
 				logger.warn("Overwriting existing JSON file {}", pathJson);
 			}
 			try (var writer = Files.newBufferedWriter(pathJson, StandardCharsets.UTF_8)) {

--- a/qupath-core/src/main/java/qupath/lib/io/PathIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathIO.java
@@ -600,7 +600,7 @@ public class PathIO {
 //			if (uris.size() == 1) {
 //				var uri = uris.iterator().next();
 //				var serverPath = GeneralTools.toPath(uri);
-//				if (serverPath != null && Files.exists(serverPath))
+//				if (serverPath != null && serverPath.toFile().exists())
 //					path = serverPath.toFile().getAbsolutePath();
 //				else
 //					path = uri.toString();

--- a/qupath-core/src/main/java/qupath/lib/io/UriUpdater.java
+++ b/qupath-core/src/main/java/qupath/lib/io/UriUpdater.java
@@ -406,7 +406,7 @@ public class UriUpdater<T extends UriResource> {
 							Objects.equals(pathItem.getRoot(), pathPrevious.getRoot())
 							) {
 						Path pathRelative = pathBase.resolve(pathPrevious.relativize(pathItem));
-						if (Files.exists(pathRelative)) {
+						if (pathRelative.toFile().exists()) {
 							URI uri2 = pathRelative.normalize().toUri().normalize();
 							replacements.put(item, new SingleUriItem(uri2));
 							count++;
@@ -535,7 +535,7 @@ public class UriUpdater<T extends UriResource> {
 		public UriStatus getStatus() {
 			if (path == null)
 				return UriStatus.UNKNOWN;
-			if (Files.exists(path))
+			if (path.toFile().exists())
 				return UriStatus.EXISTS;
 			return UriStatus.MISSING;
 		}

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -643,7 +643,7 @@ class DefaultProject implements Project<BufferedImage> {
 		
 		private Path getEntryPath(boolean create) throws IOException {
 			var path = getEntryPath();
-			if (create && !Files.exists(path))
+			if (create && !path.toFile().exists())
 				Files.createDirectories(path);
 			return path;
 		}
@@ -691,7 +691,7 @@ class DefaultProject implements Project<BufferedImage> {
 			if (server == null)
 				return null;
 			ImageData<BufferedImage> imageData = null;
-			if (Files.exists(path)) {
+			if (path.toFile().exists()) {
 				try (var stream = Files.newInputStream(path)) {
 					imageData = PathIO.readImageData(stream, null, server, BufferedImage.class);
 					imageData.setLastSavedPath(path.toString(), true);
@@ -703,7 +703,7 @@ class DefaultProject implements Project<BufferedImage> {
 			// See https://github.com/qupath/qupath/issues/512
 			if (imageData == null) {
 				var pathBackup = getBackupImageDataPath();
-				if (Files.exists(pathBackup)) {
+				if (pathBackup.toFile().exists()) {
 					try (var stream = Files.newInputStream(pathBackup)) {
 						imageData = PathIO.readImageData(stream, null, server, BufferedImage.class);
 						imageData.setLastSavedPath(pathBackup.toString(), true);
@@ -733,7 +733,7 @@ class DefaultProject implements Project<BufferedImage> {
 			
 			// If we already have a file, back it up first
 			var pathBackup = getBackupImageDataPath();
-			if (Files.exists(pathData))
+			if (pathData.toFile().exists())
 				Files.move(pathData, pathBackup, StandardCopyOption.REPLACE_EXISTING);
 			
 			// Set the entry property, if needed
@@ -753,11 +753,11 @@ class DefaultProject implements Project<BufferedImage> {
 				imageData.setLastSavedPath(pathData.toString(), true);
 				timestamp = Files.getLastModifiedTime(pathData).toMillis();
 				// Delete backup file if it exists
-				if (Files.exists(pathBackup))
+				if (pathBackup.toFile().exists())
 					Files.delete(pathBackup);
 			} catch (IOException e) {
 				// Try to restore the backup
-				if (Files.exists(pathBackup)) {
+				if (pathBackup.toFile().exists()) {
 					logger.warn("Exception writing image file - attempting to restore {} from backup", pathData);
 					Files.move(pathBackup, pathData, StandardCopyOption.REPLACE_EXISTING);				
 				}
@@ -794,7 +794,7 @@ class DefaultProject implements Project<BufferedImage> {
 		@Override
 		public synchronized PathObjectHierarchy readHierarchy() throws IOException {
 			var path = getImageDataPath();
-			if (Files.exists(path)) {
+			if (path.toFile().exists()) {
 				try (var stream = Files.newInputStream(path)) {
 					return PathIO.readHierarchy(stream);
 				}
@@ -828,7 +828,7 @@ class DefaultProject implements Project<BufferedImage> {
 		@Override
 		public synchronized BufferedImage getThumbnail() throws IOException {
 			var path = getThumbnailPath();
-			if (Files.exists(path)) {
+			if (path.toFile().exists()) {
 				try (var stream = Files.newInputStream(path)) {
 					return ImageIO.read(stream);
 				}
@@ -847,7 +847,7 @@ class DefaultProject implements Project<BufferedImage> {
 		
 		synchronized boolean moveDataToTrash() {
 			Path path = getEntryPath();
-			if (!Files.exists(path))
+			if (!path.toFile().exists())
 				return true;
 			if (Desktop.isDesktopSupported()) {
 				var desktop = Desktop.getDesktop();

--- a/qupath-core/src/main/java/qupath/lib/projects/ResourceManager.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/ResourceManager.java
@@ -172,7 +172,7 @@ public class ResourceManager {
 		@Override
 		public boolean remove(String name) throws IOException {
 			var path = getPathForName(name, true);
-			if (path != null && Files.exists(path)) {
+			if (path != null && path.toFile().exists()) {
 				logger.debug("Deleting resource '{}' from {}", name, path);
 				GeneralTools.deleteFile(path.toFile(), true);
 				return true;
@@ -187,7 +187,7 @@ public class ResourceManager {
 		@Override
 		public T get(String name) throws IOException {
 			var path = getPathForName(name, true);
-			if (path != null && Files.exists(path)) {
+			if (path != null && path.toFile().exists()) {
 				logger.debug("Reading resource '{}' from {}", name, path);
 				return readFromFile(path);
 			}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
@@ -98,7 +98,7 @@ public class ExtensionClassLoader extends URLClassLoader {
 			logger.debug("Extensions directory is null - no extensions will be loaded");
 			return;
 		}
-		if (!Files.exists(dirExtensions)) {
+		if (!dirExtensions.toFile().exists()) {
 			logger.debug("No extensions directory exists at {}", dirExtensions);
 			return;			
 		}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionManager.java
@@ -216,7 +216,7 @@ public class ExtensionManager {
 			dir = extensionClassLoader.getExtensionDirectory();
 		}
 		// Create directory if we need it
-		if (!Files.exists(dir)) {
+		if (!dir.toFile().exists()) {
 			logger.info("Creating extensions directory: {}", dir);
 			try {
 				Files.createDirectories(dir);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/FileCopier.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/FileCopier.java
@@ -146,11 +146,11 @@ public class FileCopier {
 				return dir.toPath();
 			var path = dir.toPath().resolve(outputPath);
 			// We are free to create user subdirectories without prompts
-			if (!Files.exists(path))
+			if (!path.toFile().exists())
 				Files.createDirectories(path);
 			return path;
 		} else if (outputPath != null){
-			if (!Files.exists(outputPath)) {
+			if (!outputPath.toFile().exists()) {
 				if (Dialogs.showYesNoDialog(title, "Create directory\n" + outputPath))
 					Files.createDirectories(outputPath);
 				else
@@ -206,7 +206,7 @@ public class FileCopier {
 		default:
 			long nExisting = paths.stream()
 				.map(p -> dir.resolve(p.getFileName()))
-				.filter(p -> Files.exists(p))
+				.filter(p -> p.toFile().exists())
 				.count();
 			if (nExisting == 0) {
 				overwriteExisting = true;
@@ -232,7 +232,7 @@ public class FileCopier {
 				logger.info("Skipping {} (source and destination are the same)", source);
 				continue;
 			}
-			if (overwriteExisting || !Files.exists(destination)) {
+			if (overwriteExisting || !destination.toFile().exists()) {
 				try {
 					logger.info("Copying {} -> {}", source, destination);
 					Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/JavadocViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/JavadocViewer.java
@@ -531,7 +531,7 @@ public class JavadocViewer {
 			if (Files.isDirectory(baseDir)) {
 				// Handle javadoc directories
 				var file = baseDir.resolve(indexName);
-				if (Files.exists(file))
+				if (file.toFile().exists())
 					return parseJavadocSearchItems(file, cls);
 				else
 					throw new IOException("Unable to find index file " + file);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -1289,7 +1289,7 @@ public class QuPathGUI {
 					var urisUpdated = new HashMap<URI, URI>();
 					for (var uri : uris) {
 						var pathUri = GeneralTools.toPath(uri);
-						if (pathUri != null && Files.exists(pathUri)) {
+						if (pathUri != null && pathUri.toFile().exists()) {
 							urisUpdated.put(uri, uri);
 							continue;
 						}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/UserDirectoryManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/UserDirectoryManager.java
@@ -250,7 +250,7 @@ public class UserDirectoryManager {
 	 * @throws IllegalArgumentException if the path is not null, but does not represent a valid, existing directory
 	 */
 	public void setUserPath(Path path) throws IllegalArgumentException {
-		if (path != null && Files.exists(path)) {
+		if (path != null && path.toFile().exists()) {
 			if (!Files.isDirectory(path)) {
 				throw new IllegalArgumentException("User path " + path + " exists, but is not a directory!");
 			}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -335,7 +335,7 @@ public class PathPrefs {
 			Path path = getConfigPath();
 			if (path == null)
 				return false;
-			return Files.exists(path) && Files.isWritable(path);
+			return path.toFile().exists() && Files.isWritable(path);
 		} catch (Exception e) {
 			logger.error("Error trying to find config file", e);
 			return false;
@@ -415,7 +415,7 @@ public class PathPrefs {
 					// With jpackage 15+, this should work
 					String memory = "java-options=-Xmx" + n.intValue() + "M";
 					Path config = getConfigPath();
-					if (config == null || !Files.exists(config)) {
+					if (config == null || !config.toFile().exists()) {
 						logger.error("Cannot find config file!");
 						return;
 					}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/QuPathStyleManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/QuPathStyleManager.java
@@ -276,7 +276,7 @@ public class QuPathStyleManager {
 		int nInstalled = 0;
 		try {
 			// If we have a user directory, add a CSS subdirectory if needed
-			if (pathCss != null && !Files.exists(pathCss)) {
+			if (pathCss != null && !pathCss.toFile().exists()) {
 				if (Files.isDirectory(pathCss.getParent()))
 					Files.createDirectory(pathCss);
 			}
@@ -297,7 +297,7 @@ public class QuPathStyleManager {
 					logger.warn("Can't copy CSS - source and target files are the same!");
 					continue;
 				}
-				if (Files.exists(target)) {
+				if (target.toFile().exists()) {
 					// Check if we want to overwrite - if so, retain the response so we don't 
 					// have to prompt multiple times if there are multiple files
 					if (overwriteExisting == null) {


### PR DESCRIPTION
I did this with `egrep -rl "Files\.exists\(\w+\)" | xargs sed -E -i 's/Files\.exists\((\w+)\)/\1.toFile().exists()/g'` so there's a non-zero chance I missed some usages (anything with a method or field access in the something of `Files.exists(something)` will be missed) and a small chance I broke something, but I didn't want the regex to get too complex.

Based on apparently slow performance, see
https://rules.sonarsource.com/java/RSPEC-3725/

https://github.com/qupath/qupath-extension-wsinfer/pull/30
https://github.com/qupath/qupath/issues/1154#issuecomment-1327044045