### PR TITLE
Handle z & t in 'synchronize viewers'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is a work-in-progress for the next QuPath release.
 * ProjectCommands.promptToImportImages always returns an empty list (https://github.com/qupath/qupath/issues/1251)
 * PathIO doesn't restore backup if writing ImageData fails (https://github.com/qupath/qupath/issues/1252)
 * Scripts open with the caret at the bottom of the text rather than the top (https://github.com/qupath/qupath/issues/1258)
+* 'Synchronize viewers' ignores z and t positions (https://github.com/qupath/qupath/issues/1220)
 
 ### Dependency updates
 * Bio-Formats 7.0.0


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/1220 - to an extent.

This uses a very simple approach by calculating changes to the z and t position in the main viewer, and then adding these changes to the z and t values for the viewers to be synchronized - and then clipping to the actual range of z and t values supported by the image in viewer being synchronized.

That should work nicely when synchronizing across stacks with identical dimensions, using the same z and t indices. But where dimensions or indices don't match, then out-of-range clipping can cause the relative difference between the main and synchronizing viewer to squeeze down to zero.

I'm not at all convinced that's the ideal behavior, but it should be better than ignoring z and t entirely (as is currently the case).