### PR TITLE
Add task to export icons & command descriptions

### DIFF
--- a/qupath-gui-fx/build.gradle
+++ b/qupath-gui-fx/build.gradle
@@ -3,8 +3,6 @@ plugins {
   id 'qupath.publishing-conventions'
   id 'java-library'
 
-//  id "io.freefair.lombok" version "8.0.1"
-
   alias(libs.plugins.javafx)
 }
 
@@ -24,6 +22,7 @@ dependencies {
   api libs.controlsfx
 
   implementation libs.snakeyaml
+  implementation libs.picocli
   
   implementation libs.jfxtras
   implementation libs.commons.text
@@ -46,4 +45,22 @@ javafx {
 	           "javafx.web",
 	           "javafx.swing"]
 	configuration = 'api'
+}
+
+/**
+ * Export all icons from the icon factory (useful for documentation).
+ */
+task exportDocs(type: JavaExec) {
+    description "Export icons and command descriptions for documentation"
+    group "QuPath"
+
+    dependsOn('compileJava')
+    def docsDir = rootProject.layout.getBuildDirectory().dir('qupath-docs').get().getAsFile()
+    doFirst {
+        println "Making docs dir in ${docsDir.getAbsolutePath()}"
+        docsDir.mkdirs()
+    }
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'qupath.lib.gui.tools.DocGenerator'
+    args docsDir.getAbsolutePath(), "--all"
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -245,7 +245,7 @@ public class QuPathGUI {
 	 * 
 	 * @param stage a stage to use for the main QuPath window
 	 */
-	private QuPathGUI(final Stage stage, final HostServices hostServices) {
+	private QuPathGUI(final Stage stage, final HostServices hostServices, boolean showStage) {
 		super();
 		
 		this.stage = stage;
@@ -303,8 +303,10 @@ public class QuPathGUI {
 		// Remove this to only accept drag-and-drop into a viewer
 		TMACommands.installDragAndDropHandler(this);
 
-		timeit.checkpoint("Showing");
-		stage.show();
+		if (showStage) {
+			timeit.checkpoint("Showing");
+			stage.show();
+		}
 
 		// Install extensions
 		timeit.checkpoint("Adding extensions");
@@ -373,9 +375,18 @@ public class QuPathGUI {
 		}
 		if (stage == null)
 			stage = new Stage();
-		return new QuPathGUI(stage, hostServices);
+		return new QuPathGUI(stage, hostServices, true);
 	}
 
+	/**
+	 * Create a new QuPath instance that is not visible (i.e. its stage is not shown).
+	 * @return
+	 * @throws IllegalStateException
+	 */
+	public static QuPathGUI createHiddenInstance() throws IllegalStateException {
+		var stage = new Stage();
+		return new QuPathGUI(stage, null, false);
+	}
 
 
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/DocGenerator.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/DocGenerator.java
@@ -1,0 +1,137 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2023 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.tools;
+
+import javafx.application.Platform;
+import javafx.embed.swing.SwingFXUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import qupath.lib.gui.QuPathGUI;
+
+import javax.imageio.ImageIO;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Command line tool to export icons and markdown documentation for QuPath commands.
+ */
+@CommandLine.Command(name = "DocGenerator", subcommands = {CommandLine.HelpCommand.class})
+public class DocGenerator implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(DocGenerator.class);
+
+    @CommandLine.Parameters(index = "0", description = "Output directory", defaultValue = ".")
+    private Path outputDir;
+
+    @CommandLine.Option(names = {"--icon-dir"}, description = "Name of directory to export icons to", defaultValue = "icons")
+    private String iconDirName = "icons";
+
+    @CommandLine.Option(names = {"--markdown-file"}, description = "Name of markdown file to export", defaultValue = "commands.md")
+    private String markdownFileName = "commands.md";
+
+    @CommandLine.Option(names = {"-s", "--icon-size"}, description = "Size of icons to export", defaultValue = "128")
+    private int iconSize = 128;
+
+    @CommandLine.Option(names = {"-i", "--icons"}, description = "Export icons")
+    private boolean doIcons = false;
+
+    @CommandLine.Option(names = {"-m", "--markdown"}, description = "Export markdown file with command descriptions")
+    private boolean doMarkdown = false;
+
+    @CommandLine.Option(names = {"-a", "--all"}, description = "Export all supported documentation files")
+    private boolean doAll = false;
+
+    @Override
+    public void run() {
+        if (Platform.isFxApplicationThread()) {
+            doExports();
+        } else {
+            Platform.startup(() -> {
+                doExports();
+                Platform.runLater(Platform::exit);
+            });
+        }
+    }
+
+    private void doExports() {
+        if (!doAll && !doIcons && !doMarkdown) {
+            logger.info("Nothing selected to export!");
+            return;
+        }
+        if (outputDir == null || !Files.isDirectory(outputDir)) {
+            logger.error("Please specify a valid output directory (that exists)");
+            return;
+        }
+        if (doAll || doIcons) {
+            try {
+                var dirIcons = outputDir.resolve(iconDirName);
+                System.out.println(dirIcons);
+                System.out.println(logger);
+                logger.info("Exporting icons to {}", dirIcons);
+                if (!Files.exists(dirIcons))
+                    Files.createDirectory(dirIcons);
+                exportIcons(dirIcons);
+            } catch (IOException e) {
+                logger.error("Failed to export icons", e);
+            }
+        }
+        if (doAll || doMarkdown) {
+            try {
+                var pathMarkdown = outputDir.resolve(markdownFileName);
+                logger.info("Exporting markdown to {}", pathMarkdown);
+                exportMarkdown(pathMarkdown);
+            } catch (IOException e) {
+                logger.error("Failed to export markdown", e);
+            }
+        }
+    }
+
+    private void exportIcons(Path outputDir) throws IOException  {
+        for (IconFactory.PathIcons icon : IconFactory.PathIcons.values()) {
+            var image = IconFactory.createIconImage(icon, iconSize);
+            var img = SwingFXUtils.fromFXImage(image, null);
+            ImageIO.write(img, "PNG", outputDir.resolve(icon + ".png").toFile());
+        }
+    }
+
+    private void exportMarkdown(Path outputFile) throws IOException  {
+        var qupath = QuPathGUI.getInstance();
+        if (qupath == null) {
+            logger.debug("Creating new QuPath instance");
+            qupath = QuPathGUI.createHiddenInstance();
+        }
+        logger.info("Writing markdown to {}", outputFile);
+        try (var writer = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8)) {
+            CommandFinderTools.menusToMarkdown(qupath, writer);
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
+    public static void main(String[] args) {
+        new CommandLine(new DocGenerator()).execute(args);
+    }
+
+}


### PR DESCRIPTION
Add new task `gradlew exportDocs`.

This creates `build/qupath-docs` containing
* `commands.md` - a markdown description of commands and associated descriptions
* `icons` - a collection of PNG images for the main icons used within QuPath.

The expectation is that both of these may be useful in generating the main QuPath docs.