### PR TITLE
Update ViewTrackerControlPane.java

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/recording/ViewTrackerControlPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/recording/ViewTrackerControlPane.java
@@ -153,7 +153,7 @@ public class ViewTrackerControlPane implements Runnable {
 		this.qupath = qupath;
 		viewer = qupath.getViewer();
 		trackersList = FXCollections.observableArrayList(getExistingRecordings(qupath, viewer.getImageData()));
-		
+
 		// Create listener that will be triggered for every imageData change
 		imageDataListener = (v, o, n) -> {
 			// Stop recording (if recording)
@@ -559,10 +559,11 @@ public class ViewTrackerControlPane implements Runnable {
 			});
 			
 			dialog.show();
+
+			// Remove the arrow in the TitledPane
+			titledPane.lookup(".arrow").setVisible(false);
 		}
 		
-		// Remove the arrow in the TitledPane
-		titledPane.lookup(".arrow").setVisible(false);
 	}
 	
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/recording/ViewTrackerControlPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/recording/ViewTrackerControlPane.java
@@ -518,7 +518,7 @@ public class ViewTrackerControlPane implements Runnable {
 			dialog.initOwner(qupath.getStage());
 			dialog.setTitle("Tracking");
 			
-			StackPane pane = new StackPane(mainPane);
+			BorderPane pane = new BorderPane(mainPane);
 			dialog.setScene(new Scene(pane));
 
 			// Necessary for window resizing when expanding the TitledPane


### PR DESCRIPTION
Fix exception when trying to open view tracking twice. More refactoring should be done in the future to avoid the use of the static dialog.