### PR TITLE
Extract masked pixels

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
@@ -2678,8 +2678,11 @@ public class OpenCVTools {
 			opencv_core.extractChannel(mask, maskChannel, channel);
 		}
 
-		if (inputChannel.total() != maskChannel.total()) {
-			throw new IllegalArgumentException("The input and the mask must have the same dimensions");
+		if (inputChannel.rows() != maskChannel.rows()) {
+			throw new IllegalArgumentException("The input and the mask don't have the same number of rows");
+		}
+		if (inputChannel.cols() != maskChannel.cols()) {
+			throw new IllegalArgumentException("The input and the mask don't have the same number of columns");
 		}
 
 		int height = inputChannel.rows();

--- a/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
@@ -702,13 +702,16 @@ public class TestOpenCVTools {
 
 	@Test
 	public void testPixelExtractionWithMask() {
-		int circleRadius = 1;
-		Mat mat = OpenCVTools.createDisk(circleRadius, false);
-		Mat mask = mat.clone();
+		try (PointerScope scope = new PointerScope()) {
+			int circleRadius = 200;
+			Mat mat = OpenCVTools.createDisk(circleRadius, false);
+			Mat mask = mat.clone();
 
-		float[] maskedPixels = OpenCVTools.extractMaskedPixels(mat, mask, 0);
+			float[] maskedPixels = OpenCVTools.extractMaskedPixels(mat, mask, 0);
 
-		assertTrue(mean(OpenCVTools.extractFloats(mat)) < 1 && mean(maskedPixels) == 1);
+			assertTrue(mean(OpenCVTools.extractFloats(mat)) < 1);
+			assertEquals(1, mean(maskedPixels));
+		}
 	}
 
 	private float mean(float[] array) {

--- a/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
@@ -699,6 +699,29 @@ public class TestOpenCVTools {
 			}
 		}
 	}
+
+	@Test
+	public void testPixelExtractionWithMask() {
+		int circleRadius = 1;
+		Mat mat = OpenCVTools.createDisk(circleRadius, false);
+		Mat mask = mat.clone();
+
+		float[] maskedPixels = OpenCVTools.extractMaskedPixels(mat, mask, 0);
+
+		assertTrue(mean(OpenCVTools.extractFloats(mat)) < 1 && mean(maskedPixels) == 1);
+	}
+
+	private float mean(float[] array) {
+		if (array.length == 0) {
+			return 0;
+		} else {
+			float sum = 0;
+			for (float element: array) {
+				sum += element;
+			}
+			return sum / array.length;
+		}
+	}
 	
 
 }

--- a/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
@@ -707,7 +707,7 @@ public class TestOpenCVTools {
 			Mat mat = OpenCVTools.createDisk(circleRadius, false);
 			Mat mask = mat.clone();
 
-			float[] maskedPixels = OpenCVTools.extractMaskedPixels(mat, mask, 0);
+			float[] maskedPixels = OpenCVTools.extractMaskedFloats(mat, mask, 0);
 
 			assertTrue(mean(OpenCVTools.extractFloats(mat)) < 1);
 			assertEquals(1, mean(maskedPixels));

--- a/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -701,7 +702,7 @@ public class TestOpenCVTools {
 	}
 
 	@Test
-	public void testPixelExtractionWithMask() {
+	public void testFloatPixelExtractionWithMaskOnSingleChannelImage() {
 		try (PointerScope scope = new PointerScope()) {
 			int circleRadius = 200;
 			Mat mat = OpenCVTools.createDisk(circleRadius, false);
@@ -714,12 +715,78 @@ public class TestOpenCVTools {
 		}
 	}
 
+	@Test
+	public void testFloatPixelExtractionWithMaskOnMultiChannelImage() {
+		try (PointerScope scope = new PointerScope()) {
+			var image = new BufferedImage(3, 3, BufferedImage.TYPE_INT_ARGB);
+			var graphics = image.createGraphics();
+			graphics.setColor(Color.GREEN);
+			graphics.fillOval(0, 0, image.getWidth(), image.getHeight());
+			graphics.dispose();
+			Mat mat = OpenCVTools.imageToMat(image);
+			Mat mask = mat.clone();
+
+			float[] maskedRedPixels = OpenCVTools.extractMaskedFloats(mat, mask, 0);
+			float[] maskedGreenPixels = OpenCVTools.extractMaskedFloats(mat, mask, 1);
+
+			assertTrue(mean(OpenCVTools.extractFloats(mat)) < 255);
+			assertEquals(0, mean(maskedRedPixels));
+			assertEquals(255, mean(maskedGreenPixels));
+		}
+	}
+
 	private float mean(float[] array) {
 		if (array.length == 0) {
 			return 0;
 		} else {
 			float sum = 0;
 			for (float element: array) {
+				sum += element;
+			}
+			return sum / array.length;
+		}
+	}
+
+	@Test
+	public void testDoublePixelExtractionWithMaskOnSingleChannelImage() {
+		try (PointerScope scope = new PointerScope()) {
+			int circleRadius = 200;
+			Mat mat = OpenCVTools.createDisk(circleRadius, false);
+			Mat mask = mat.clone();
+
+			double[] maskedPixels = OpenCVTools.extractMaskedDoubles(mat, mask, 0);
+
+			assertTrue(mean(OpenCVTools.extractDoubles(mat)) < 1);
+			assertEquals(1, mean(maskedPixels));
+		}
+	}
+
+	@Test
+	public void testDoublePixelExtractionWithMaskOnMultiChannelImage() {
+		try (PointerScope scope = new PointerScope()) {
+			var image = new BufferedImage(3, 3, BufferedImage.TYPE_INT_ARGB);
+			var graphics = image.createGraphics();
+			graphics.setColor(Color.GREEN);
+			graphics.fillOval(0, 0, image.getWidth(), image.getHeight());
+			graphics.dispose();
+			Mat mat = OpenCVTools.imageToMat(image);
+			Mat mask = mat.clone();
+
+			double[] maskedRedPixels = OpenCVTools.extractMaskedDoubles(mat, mask, 0);
+			double[] maskedGreenPixels = OpenCVTools.extractMaskedDoubles(mat, mask, 1);
+
+			assertTrue(mean(OpenCVTools.extractDoubles(mat)) < 255);
+			assertEquals(0, mean(maskedRedPixels));
+			assertEquals(255, mean(maskedGreenPixels));
+		}
+	}
+
+	private double mean(double[] array) {
+		if (array.length == 0) {
+			return 0;
+		} else {
+			double sum = 0;
+			for (double element: array) {
 				sum += element;
 			}
 			return sum / array.length;


### PR DESCRIPTION
New method (+ corresponding test) to extract pixels from a ROI using OpenCV.
 
It extracts pixels from the input with non-zero values in the corresponding mask, limited to the requested (zero-based) channel index. The mask doesn't have to be multichannel; it could be, but also could be just a single channel that should be applied to all channels.
 
The corresponding unit test generates a binary image of a circle, and then duplicate it to use as the main input image. It checks if the mean value is 1 with the mask, and less than 1 without it.