### PR TITLE
Improve working with multiple displays and slide labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This is a work-in-progress for the next QuPath release.
 * Scripts open with the caret at the bottom of the text rather than the top (https://github.com/qupath/qupath/issues/1258)
 * 'Synchronize viewers' ignores z and t positions (https://github.com/qupath/qupath/issues/1220)
 * Menubars and shortcuts are confused when ImageJ is open but QuPath is in focus in macOS (https://github.com/qupath/qupath/issues/6)
+* Slide label can be too big for the screen (https://github.com/qupath/qupath/issues/1263)
+* Slide label doesn't update as expected when changing the image (https://github.com/qupath/qupath/issues/1246)
 
 ### Dependency updates
 * Bio-Formats 7.0.0

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/ActionTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/ActionTools.java
@@ -327,10 +327,12 @@ public class ActionTools {
 		
 		// Get accessible fields corresponding to actions
 		for (var f : cls.getDeclaredFields()) {
-			if (Modifier.isStatic(f.getModifiers()) || !f.canAccess(obj)) {
+			if (Modifier.isStatic(f.getModifiers())) {// || !f.canAccess(obj)) {
 				continue;
 			}
 			try {
+				if (!f.canAccess(obj))
+					f.setAccessible(true);
 				var value = f.get(obj);
 				if (value instanceof Action) {
 					var action = (Action)value;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SimpleImageViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SimpleImageViewer.java
@@ -260,8 +260,9 @@ public class SimpleImageViewer {
     }
 
     private String getCurrentTile() {
-        if (image.get() == null)
-            return resources.getString("SimpleImageViewer.noImage");
+        // We use a placeholder now - so let's retain the title
+//        if (image.get() == null)
+//            return resources.getString("SimpleImageViewer.noImage");
         String name = imageName.get();
         if (name == null || name.isEmpty())
             return resources.getString("SimpleImageViewer.noTitle");

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SimpleImageViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SimpleImageViewer.java
@@ -1,0 +1,458 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2023 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.lib.gui.panes;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.DoubleBinding;
+import javafx.beans.binding.StringBinding;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.value.ObservableValue;
+import javafx.embed.swing.SwingFXUtils;
+import javafx.scene.Scene;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+import org.controlsfx.control.action.Action;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.fx.dialogs.Dialogs;
+import qupath.fx.dialogs.FileChoosers;
+import qupath.fx.localization.LocalizedResourceManager;
+import qupath.lib.awt.common.BufferedImageTools;
+import qupath.lib.display.ChannelDisplayInfo;
+import qupath.lib.display.ImageDisplay;
+import qupath.lib.gui.actions.ActionTools;
+import qupath.lib.gui.actions.annotations.ActionAccelerator;
+import qupath.lib.gui.actions.annotations.ActionConfig;
+import qupath.lib.gui.localization.QuPathResources;
+import qupath.lib.gui.prefs.PathPrefs;
+import qupath.lib.gui.prefs.SystemMenuBar;
+import qupath.lib.gui.tools.MenuTools;
+import qupath.lib.images.ImageData;
+import qupath.lib.images.servers.WrappedBufferedImageServer;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.concurrent.Callable;
+
+/**
+ * A simple viewer for a single image, with options to save or copy.
+ * <p>
+ *     This is primarily intended for RGB images, but can also be used for other types after
+ *     applying automatic brightness/contrast settings.
+ * </p>
+ * <p>
+ *     This stores (and can be updated with) a {@link BufferedImage} or a JavaFX {@link Image},
+ *     because both serve different purposes can be useful in different contexts.
+ * </p>
+ *
+ * @since v0.5.0
+ */
+public class SimpleImageViewer {
+
+    private static final Logger logger = LoggerFactory.getLogger(SimpleImageViewer.class);
+
+    private Stage stage;
+
+    private LocalizedResourceManager resources = QuPathResources.getLocalizedResourceManager();
+
+    private MenuBar menubar;
+    private BorderPane pane;
+    private ImageView imageView;
+    private ContextMenu contextMenu;
+
+    private BooleanProperty isNon8BitImage = new SimpleBooleanProperty(false);
+
+    private DoubleProperty saturation = new SimpleDoubleProperty();
+
+    private BooleanProperty expandToWindow = new SimpleBooleanProperty(false);
+
+    private ReadOnlyObjectWrapper<String> imageName = new ReadOnlyObjectWrapper();
+    private ReadOnlyObjectWrapper<BufferedImage> img = new ReadOnlyObjectWrapper<>();
+    private ReadOnlyObjectWrapper<Image> image = new ReadOnlyObjectWrapper<>();
+
+    @ActionConfig("SimpleImageViewer.Action.copy")
+    @ActionAccelerator("shortcut+c")
+    private Action actionCopy = ActionTools.createAction(this::handleCopyToClipboard);
+
+    @ActionConfig("SimpleImageViewer.Action.close")
+    @ActionAccelerator("shortcut+w")
+    private Action actionClose = ActionTools.createAction(this::handleClose);
+
+    @ActionConfig("SimpleImageViewer.Action.save")
+    @ActionAccelerator("shortcut+shift+s")
+    private Action actionSave = ActionTools.createAction(this::handleSaveImage);
+
+    @ActionConfig("SimpleImageViewer.Action.saturation")
+    private Action actionSaturation = ActionTools.createAction(this::handleSetSaturation);
+
+    @ActionConfig("SimpleImageViewer.Action.expandToWindow")
+    private Action actionExpandToWindow = ActionTools.createSelectableAction(expandToWindow);
+
+    /**
+     * Create a new simple image viewer.
+     * The stage will be created, but not shown.
+     */
+    public SimpleImageViewer() {
+        initialize();
+    }
+
+    private void initialize() {
+        pane = new BorderPane();
+        pane.setStyle("-fx-background-color: black;");
+
+        saturation.bind(PathPrefs.autoBrightnessContrastSaturationPercentProperty());
+        saturation.addListener(this::handleSaturationChanged);
+
+        initializeActions();
+        initializeImageView();
+        initializeMenuBar();
+        initializeContextMenu();
+
+        stage = new Stage();
+        stage.titleProperty().bind(createTitleBinding());
+        var scene = new Scene(pane);
+        pane.prefWidthProperty().bind(scene.widthProperty());
+        pane.prefHeightProperty().bind(scene.heightProperty());
+        stage.setScene(scene);
+    }
+
+    private void initializeActions() {
+        ActionTools.getAnnotatedActions(this); // Applies annotations for configuration
+        actionSave.disabledProperty().bind(img.isNull());
+        actionCopy.disabledProperty().bind(image.isNull());
+        actionSaturation.disabledProperty().bind(isNon8BitImage.not());
+    }
+
+    private void initializeImageView() {
+        imageView = new ImageView();
+        imageView.fitWidthProperty().bind(createFitImageBinding(this::computeFitWidth));
+        imageView.fitHeightProperty().bind(createFitImageBinding(this::computeFitHeight));
+        imageView.setPreserveRatio(true);
+        imageView.imageProperty().bind(image);
+        pane.setCenter(imageView);
+    }
+
+    private Double computeFitWidth() {
+        var imageFX = image.get();
+        if (imageFX != null && !expandToWindow.get())
+            return Math.min(pane.getWidth(), imageFX.getWidth());
+        return pane.getWidth();
+    }
+
+    private Double computeFitHeight() {
+        var imageFX = image.get();
+        if (imageFX != null && !expandToWindow.get())
+            return Math.min(pane.getHeight(), imageFX.getHeight());
+        return pane.getHeight();
+    }
+
+    private DoubleBinding createFitImageBinding(Callable<Double> func) {
+        return Bindings.createDoubleBinding(
+                func, pane.widthProperty(), pane.heightProperty(), expandToWindow);
+    }
+
+    private void initializeMenuBar() {
+        menubar = new MenuBar();
+        menubar.getMenus().addAll(
+                createFileMenu(),
+                createEditMenu(),
+                createViewMenu());
+        SystemMenuBar.manageMainMenuBar(menubar);
+        pane.setTop(menubar);
+    }
+
+    private StringBinding createTitleBinding() {
+        return Bindings.createStringBinding(this::getCurrentTile, image, imageName, PathPrefs.defaultLocaleDisplayProperty());
+    }
+
+    private String getCurrentTile() {
+        if (image.get() == null)
+            return resources.getString("SimpleImageViewer.noImage");
+        String name = imageName.get();
+        if (name == null || name.isEmpty())
+            return resources.getString("SimpleImageViewer.noTitle");
+        return name;
+    }
+
+    private Menu createFileMenu() {
+        return MenuTools.createMenu(
+                "Menu.File",
+                actionSave,
+                actionClose
+        );
+    }
+
+    private Menu createEditMenu() {
+        return MenuTools.createMenu(
+                "Menu.Edit",
+                actionCopy
+        );
+    }
+
+    private Menu createViewMenu() {
+        return MenuTools.createMenu(
+                "Menu.View",
+                actionExpandToWindow,
+                actionSaturation
+        );
+    }
+
+    private void initializeContextMenu() {
+        contextMenu = new ContextMenu();
+        MenuItem miCopy = ActionTools.createMenuItem(actionCopy);
+
+        MenuItem miExpandToWindow = ActionTools.createMenuItem(actionExpandToWindow);
+
+        MenuItem miSaturation = ActionTools.createMenuItem(actionSaturation);
+        miSaturation.visibleProperty().bind(actionSaturation.disabledProperty().not());
+
+        contextMenu.getItems().addAll(
+                miCopy,
+                miExpandToWindow,
+                miSaturation
+        );
+        pane.setOnContextMenuRequested(e -> contextMenu.show(pane, e.getScreenX(), e.getScreenY()));
+    }
+
+    /**
+     * Get the percentage of any non-8-bit image that should be saturated when applying auto contrast settings.
+     * @return
+     * @implNote by default, this is (unidirectionally) bound to {@link PathPrefs#autoBrightnessContrastSaturationPercentProperty()}
+     * and so must be unbound before making changes.
+     * Alternatively, use {@link #setSaturationPercent(double)} and the unbinding will be performed automatically.
+     */
+    public DoubleProperty saturationPercentProperty() {
+        return saturation;
+    }
+
+    /**
+     * Get the percentage of pixels to use when applying auto contrast settings to a non-8-bit image.
+     * @return
+     */
+    public double getSaturationPercent() {
+        return saturation.get();
+    }
+
+    /**
+     * Set the percentage of pixels to use when applying auto contrast settings to a non-8-bit image.
+     * @param percent
+     * @implNote this will unbind the property from {@link PathPrefs#autoBrightnessContrastSaturationPercentProperty()}
+     */
+    public void setSaturationPercent(double percent) {
+        saturation.unbind();
+        saturation.set(percent);
+    }
+
+    /**
+     * Get the property indicating whether the image should grow to fill the window (while maintaining its
+     * aspect ratio).
+     * If false, the image will grow no larger than its preferred width and height.
+     * @return
+     */
+    public BooleanProperty expandToWindowProperty() {
+        return expandToWindow;
+    }
+
+    /**
+     * Query whether the image is allowed to expand beyond its preferred width and height to fill the window.
+     * If false, the image will grow no larger than its preferred width and height.
+     * @return
+     */
+    public boolean getExpandToWindow() {
+        return expandToWindow.get();
+    }
+
+    /**
+     * Control whether the image should be allowed to expand beyond its preferred width and height to fill the window.
+     * If false, the image will grow no larger than its preferred width and height.
+     * @param limit
+     */
+    public void setExpandToWindow(boolean limit) {
+        expandToWindow.set(limit);
+    }
+
+    /**
+     * Get the stage used to display the image.
+     * @return
+     */
+    public Stage getStage() {
+        return stage;
+    }
+
+    private void handleClose() {
+        stage.close();
+    }
+
+    private void handleSaveImage() {
+        String name = imageName.get();
+        File fileOutput = FileChoosers.
+                promptToSaveFile(stage, null,
+                        name == null || name.isEmpty() ? null : new File(name),
+                        FileChoosers.createExtensionFilter("PNG", ".png"));
+        if (fileOutput != null) {
+            try {
+                ImageIO.write(img.get(), "PNG", fileOutput);
+            } catch (Exception e) {
+                Dialogs.showErrorMessage("Save image",
+                        "Error saving " + fileOutput.getName() + "\n" + e.getLocalizedMessage());
+            }
+        }
+    }
+
+    private void handleCopyToClipboard() {
+        ClipboardContent content = new ClipboardContent();
+        content.putImage(image.get());
+        Clipboard.getSystemClipboard().setContent(content);
+    }
+
+    /**
+     * Update the image using a JavaFX image.
+     * @param name
+     * @param image
+     */
+    public void updateImage(String name, Image image) {
+        this.image.set(image);
+        this.img.set(convertToBufferedImage(image));
+        this.imageName.set(name);
+        this.isNon8BitImage.set(requiresAutoContrast(img.get()));
+    }
+
+    /**
+     * Update the image using a buffered image.
+     * @param name
+     * @param img
+     */
+    public void updateImage(String name, BufferedImage img) {
+        this.img.set(img);
+        this.image.set(convertToFXImage(img));
+        this.imageName.set(name);
+        this.isNon8BitImage.set(requiresAutoContrast(img));
+    }
+
+    /**
+     * Get a read-only property indicating the name of the image.
+     * @return
+     */
+    public ReadOnlyObjectProperty<String> imageNameProperty() {
+        return imageName.getReadOnlyProperty();
+    }
+
+    /**
+     * Get the name of the image.
+     * @return
+     */
+    public String getName() {
+        return imageName.get();
+    }
+
+    /**
+     * Get a read-only property representing the JavaFX image.
+     * @return
+     */
+    public ReadOnlyObjectProperty<Image> imageProperty() {
+        return image.getReadOnlyProperty();
+    }
+
+    /**
+     * Get the JavaFX image.
+     * @return
+     */
+    public Image getImage() {
+        return image.get();
+    }
+
+    /**
+     * Get a read-only property representing the buffered image.
+     * @return
+     */
+    public ReadOnlyObjectProperty<BufferedImage> bufferedImageProperty() {
+        return img.getReadOnlyProperty();
+    }
+
+    /**
+     * Get the buffered image.
+     * @return
+     */
+    public BufferedImage getBufferedImage() {
+        return img.get();
+    }
+
+    private BufferedImage convertToBufferedImage(Image image) {
+        if (image == null)
+            return null;
+        return SwingFXUtils.fromFXImage(image, null);
+    }
+
+    private static boolean requiresAutoContrast(BufferedImage img) {
+        if (img == null || BufferedImageTools.is8bitColorType(img.getType()) || img.getType() == BufferedImage.TYPE_BYTE_GRAY)
+            return false;
+        else
+            return true;
+    }
+
+    private Image convertToFXImage(BufferedImage imgBuffered) {
+        if (imgBuffered == null)
+            return null;
+        if (requiresAutoContrast(imgBuffered)) {
+            // Non-RGB images probably need to have contrast settings applied before they can be visualized.
+            // By wrapping the image, we avoid slow z-stack/time series requests & determine brightness & contrast just from one plane.
+            var wrappedServer = new WrappedBufferedImageServer("Dummy", imgBuffered);
+            var imageDisplay = new ImageDisplay(new ImageData<>(wrappedServer));
+            for (ChannelDisplayInfo info : imageDisplay.selectedChannels()) {
+                imageDisplay.autoSetDisplayRange(info, saturation.get()/100.0);
+            }
+            imgBuffered = imageDisplay.applyTransforms(imgBuffered, null);
+        }
+        return SwingFXUtils.toFXImage(imgBuffered, null);
+    }
+
+    private void handleSetSaturation() {
+        Double percent = Dialogs.showInputDialog(
+                "Set saturation",
+                "Set saturation percentage", saturation.get());
+        if (percent != null && Double.isFinite(percent) && percent >= 0 && percent < 100) {
+            setSaturationPercent(percent);
+        }
+    }
+
+    private void handleSaturationChanged(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
+        if (isNon8BitImage.get())
+            updateImage(imageName.get(), img.get());
+    }
+
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SlideLabelView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SlideLabelView.java
@@ -76,6 +76,11 @@ public class SlideLabelView implements ChangeListener<ImageData<BufferedImage>> 
 		stage = simpleImageViewer.getStage();
 		stage.initOwner(qupath.getStage());
 
+		if (simpleImageViewer.getImage() == null) {
+			stage.setWidth(240);
+			stage.setHeight(240);
+		}
+
 		showing.addListener((v, o, n) -> {
 			if (n) {
 				if (!stage.isShowing()) {
@@ -97,12 +102,7 @@ public class SlideLabelView implements ChangeListener<ImageData<BufferedImage>> 
 		if (showing.get()) {
 			Platform.runLater(() -> {
 				updateLabel(qupath.getImageData());
-				if (simpleImageViewer.getImage() == null) {
-					stage.setWidth(240);
-					stage.setHeight(240);
-				}
 				GuiTools.showWithScreenSizeConstraints(stage, 0.8);
-				stage.sizeToScene();
 			});
 		}
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SlideLabelView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SlideLabelView.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -23,30 +23,22 @@
 
 package qupath.lib.gui.panes;
 
-import java.awt.image.BufferedImage;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
-import javafx.embed.swing.SwingFXUtils;
-import javafx.scene.Scene;
-import javafx.scene.control.ContextMenu;
-import javafx.scene.control.Label;
-import javafx.scene.control.MenuItem;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.scene.input.Clipboard;
-import javafx.scene.input.ClipboardContent;
-import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.prefs.PathPrefs;
+import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
+
+import java.awt.image.BufferedImage;
 
 /**
  * A simple viewer for a slide label, tied to the current viewer.
@@ -59,9 +51,13 @@ public class SlideLabelView implements ChangeListener<ImageData<BufferedImage>> 
 	private static Logger logger = LoggerFactory.getLogger(SlideLabelView.class);
 	
 	private QuPathGUI qupath;
-	private Stage dialog;
+
+	private SimpleImageViewer simpleImageViewer;
+	private Stage stage;
+
 	private BooleanProperty showing = PathPrefs.createPersistentPreference("showSlideLabel", false);
-	private BorderPane pane = new BorderPane();
+
+	private StringProperty placeholderText = new SimpleStringProperty();
 	
 	/**
 	 * Constructor.
@@ -73,23 +69,25 @@ public class SlideLabelView implements ChangeListener<ImageData<BufferedImage>> 
 	}
 	
 	private void createDialog() {
-		dialog = new Stage();
-		dialog.initOwner(qupath.getStage());
-		dialog.setTitle("Label");
-		dialog.setScene(new Scene(pane, 400, 400));
-		
+		simpleImageViewer = new SimpleImageViewer();
+
+		simpleImageViewer.placeholderTextProperty().bind(placeholderText);
+
+		stage = simpleImageViewer.getStage();
+		stage.initOwner(qupath.getStage());
+
 		showing.addListener((v, o, n) -> {
 			if (n) {
-				if (!dialog.isShowing())
-					dialog.show();
+				if (!stage.isShowing()) {
+					GuiTools.showWithScreenSizeConstraints(stage, 0.8);
+				}
 			} else {
-				if (dialog.isShowing())
-					dialog.hide();
+				if (stage.isShowing())
+					stage.hide();
 			}
 		});
 		
-		
-		dialog.showingProperty().addListener((v, o, n) -> {
+		stage.showingProperty().addListener((v, o, n) -> {
 			if (n)
 				updateLabel(qupath.getImageData());
 			showing.set(n);
@@ -97,7 +95,15 @@ public class SlideLabelView implements ChangeListener<ImageData<BufferedImage>> 
 		
 		
 		if (showing.get()) {
-			Platform.runLater(() -> dialog.show());
+			Platform.runLater(() -> {
+				updateLabel(qupath.getImageData());
+				if (simpleImageViewer.getImage() == null) {
+					stage.setWidth(240);
+					stage.setHeight(240);
+				}
+				GuiTools.showWithScreenSizeConstraints(stage, 0.8);
+				stage.sizeToScene();
+			});
 		}
 	}
 	
@@ -106,7 +112,7 @@ public class SlideLabelView implements ChangeListener<ImageData<BufferedImage>> 
 	 * @return
 	 */
 	public BooleanProperty showingProperty() {
-		if (dialog == null)
+		if (stage == null)
 			createDialog();
 		return showing;
 	}
@@ -117,70 +123,46 @@ public class SlideLabelView implements ChangeListener<ImageData<BufferedImage>> 
 	}
 	
 	private void updateLabel(final ImageData<BufferedImage> imageData) {
-		if (dialog == null || !dialog.isShowing())
+		if (stage == null || !stage.isShowing())
 			return;
 		
-		// Try to get a label image
-		Image imgLabel = null;
-		String message = "No label available";
-		if (imageData != null) {
-			ImageServer<BufferedImage> server = imageData.getServer();
-			if (server != null) {
-				var associatedNames = server.getAssociatedImageList();
-				if (!associatedNames.isEmpty()) {
-					try {
-						// Try to get a label from the associated images
-						// We start by looking for associated names equal to or containing label, and eventually broaden out to allow other associated images 
-						// as better than displaying nothing at all (since they might actually be label images).
-						// Adapted because of https://github.com/qupath/qupath/issues/643
-						String labelName = server.getAssociatedImageList().stream().filter(n -> n.toLowerCase().trim().equals("label")).findFirst().orElse(null);
-						if (labelName == null)
-							labelName = server.getAssociatedImageList().stream().filter(n -> n.toLowerCase().trim().contains("(label)")).findFirst().orElse(null);
-						if (labelName == null)
-							labelName = server.getAssociatedImageList().stream().filter(n -> n.toLowerCase().trim().contains("label")).findFirst().orElse(null);
-						if (labelName == null)
-							labelName = server.getAssociatedImageList().stream().filter(n -> n.toLowerCase().trim().contains("macro")).findFirst().orElse(null);
-						if (labelName == null)
-							labelName = associatedNames.get(0);
-						imgLabel = SwingFXUtils.toFXImage(server.getAssociatedImage(labelName), null);
-					} catch (Exception e) {
-						logger.error("Unable to read label from {}", server.getPath());
-					}
-				}
-			}
-		} else
-			message = "No image open in the current viewer";
-
-		// Update the component
-		if (imgLabel == null)
-			pane.setCenter(new Label(message));
-		else {
-			
-			ContextMenu popup = new ContextMenu();
-			MenuItem copyItem = new MenuItem("Copy");
-			var content = new ClipboardContent();
-			content.putImage(imgLabel);
-			copyItem.setOnAction(e -> {
-				Clipboard.getSystemClipboard().setContent(content);
-			});
-			popup.getItems().add(copyItem);
-			
-			ImageView view = new ImageView(imgLabel);
-			view.setPreserveRatio(true);
-			view.fitWidthProperty().bind(pane.widthProperty());
-			view.fitHeightProperty().bind(pane.heightProperty());
-			pane.setCenter(view);
-			
-			view.setOnMousePressed(e -> {
-				if (e.isPopupTrigger())
-					popup.show(view, e.getScreenX(), e.getScreenY());
-			});
-			view.setOnMouseReleased(e -> {
-				if (e.isPopupTrigger())
-					popup.show(view, e.getScreenX(), e.getScreenY());
-			});
-			
+		ImageServer<BufferedImage> server = imageData == null ? null : imageData.getServer();
+		if (server == null) {
+			placeholderText.set("No image open in the current viewer");
+			simpleImageViewer.resetImage();
+		} else {
+			String labelName = searchForLabelName(server);
+			if (labelName == null) {
+				placeholderText.set("No label found");
+				simpleImageViewer.resetImage();
+			} else
+				simpleImageViewer.updateImage(labelName, server.getAssociatedImage(labelName));
 		}
+	}
+
+	/**
+	 * Try to get the name of an associated label image.
+	 * @param server
+	 * @return
+	 */
+	private static String searchForLabelName(ImageServer<?> server) {
+		// Try to get a label from the associated images
+		// We start by looking for associated names equal to or containing label, and eventually broaden out to allow other associated images
+		// as better than displaying nothing at all (since they might actually be label images).
+		// Adapted because of https://github.com/qupath/qupath/issues/643
+		var associatedNames = server.getAssociatedImageList();
+		if (associatedNames.isEmpty())
+			return null;
+		String labelName = associatedNames.stream().filter(n -> n.toLowerCase().trim().equals("label")).findFirst().orElse(null);
+		if (labelName == null)
+			labelName = associatedNames.stream().filter(n -> n.toLowerCase().trim().contains("(label)")).findFirst().orElse(null);
+		if (labelName == null)
+			labelName = associatedNames.stream().filter(n -> n.toLowerCase().trim().contains("label")).findFirst().orElse(null);
+		if (labelName == null)
+			labelName = associatedNames.stream().filter(n -> n.toLowerCase().trim().contains("macro")).findFirst().orElse(null);
+		if (labelName == null)
+			labelName = associatedNames.get(0);
+		return labelName;
 	}
 
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -74,6 +74,7 @@ import qupath.lib.color.ColorDeconvolutionStains;
 import qupath.lib.color.ColorDeconvolutionStains.DefaultColorDeconvolutionStains;
 import qupath.lib.color.StainVector;
 import qupath.lib.common.ColorTools;
+import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.actions.ActionTools;
 import qupath.lib.gui.commands.Commands;
@@ -96,11 +97,13 @@ import qupath.lib.roi.RoiTools.CombineOp;
 import qupath.lib.roi.interfaces.ROI;
 
 import javax.swing.SwingUtilities;
+import java.awt.AWTException;
 import java.awt.Desktop;
 import java.awt.Desktop.Action;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.Transparency;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -504,8 +507,7 @@ public class GuiTools {
 			double height = scene.getHeight();
 			try {
 				// For reasons I do not understand, this occasionally throws an ArrayIndexOutOfBoundsException
-				return new Robot().getScreenCapture(null,
-						x, y, width, height, false);
+				return createScreenCapture(x, y, width, height, GeneralTools.isMac());
 			} catch (Exception e) {
 				logger.error("Unable to make main window screenshot, will resort to trying to crop a full screenshot instead", e);
 				var img2 = makeSnapshotFX(qupath, viewer, GuiTools.SnapshotType.FULL_SCREENSHOT);
@@ -513,14 +515,46 @@ public class GuiTools {
 						(int)x, (int)y, (int)width, (int)height);
 			}
 		case FULL_SCREENSHOT:
-			var screen = Screen.getPrimary();
+			// Make the screenshot of the screen containing QuPath, if possible
+			var screen = stage == null ? Screen.getPrimary() : FXUtils.getScreen(stage);
 			var bounds = screen.getBounds();
-			return new Robot().getScreenCapture(null,
-					bounds.getMinX(), bounds.getMinY(), bounds.getWidth(), bounds.getHeight());
+			return createScreenCapture(bounds.getMinX(), bounds.getMinY(), bounds.getWidth(), bounds.getHeight(), GeneralTools.isMac());
 		default:
 			throw new IllegalArgumentException("Unknown snapshot type " + type);
 		}
 	}
+
+
+	/**
+	 * Make a screen capture, optionally preferring AWT over JavaFX.
+	 * The reason to use AWT sometimes is that macOS (at least) can sometimes given different colors - see
+	 * https://github.com/qupath/qupath/issues/1309
+	 * <p>
+	 * @param x
+	 * @param y
+	 * @param width
+	 * @param height
+	 * @param preferAwt
+	 * @return
+	 * @implNote We make the assumption here that the screen coordinates used with JavaFX and AWT are compatible.
+	 */
+	private static WritableImage createScreenCapture(double x, double y, double width, double height, boolean preferAwt) {
+		if (preferAwt) {
+			try {
+				logger.debug("Attempting screen capture with AWT");
+				var img = new java.awt.Robot().createScreenCapture(
+						new Rectangle2D.Double(x, y, width, height).getBounds()
+				);
+				return SwingFXUtils.toFXImage(img, null);
+			} catch (AWTException e) {
+				logger.warn("Exception attempting AWT screen capture");
+				logger.debug(e.getMessage(), e);
+			}
+		}
+		return new Robot().getScreenCapture(null, x, y, width, height);
+	}
+
+
 
 	/**
 	 * Make a snapshot (image) showing what is currently displayed in a QuPath window

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -1350,4 +1350,45 @@ public class GuiTools {
 	}
 
 
+	/**
+	 * Show a stage, while ensuring that it cannot be larger than the screen size.
+	 * The screen is determined from the stage itself, its owner, or is the primary screen.
+	 * <p>
+	 *     This method is useful when there is a risk that an initial stage size is too big for the screen,
+	 *     but we do not want to prevent the user from resizing freely afterwards.
+	 * </p>
+	 * @param stage
+	 * @param proportion
+	 * @see #showWithSizeConstraints(Stage, double, double)
+	 */
+	public static void showWithScreenSizeConstraints(Stage stage, double proportion) {
+		Screen screen = FXUtils.getScreen(stage);
+		if (screen == null && stage.getOwner() != null)
+			screen = FXUtils.getScreen(stage.getOwner());
+		if (screen == null)
+			screen = Screen.getPrimary();
+		showWithSizeConstraints(stage,
+				screen.getVisualBounds().getWidth() * proportion,
+						screen.getVisualBounds().getHeight() * proportion);
+	}
+
+	/**
+	 * Show a stage, while ensuring that it cannot be larger the maximum dimensions provided
+	 * This effectively sets the maximum dimensions of the stage, shows it, and then restores the previous maximum dimensions.
+	 * @param stage
+	 * @param maxWidth
+	 * @param maxHeight
+	 * @see #showWithScreenSizeConstraints(Stage, double)
+	 */
+	public static void showWithSizeConstraints(Stage stage, double maxWidth, double maxHeight) {
+		double previousMaxWidth = stage.getMaxWidth();
+		double previousMaxHeight = stage.getMaxHeight();
+		stage.setMaxWidth(Math.min(previousMaxWidth, maxWidth));
+		stage.setMaxHeight(Math.min(previousMaxHeight, maxHeight));
+		stage.show();
+		stage.setMaxWidth(previousMaxWidth);
+		stage.setMaxHeight(previousMaxHeight);
+	}
+
+
 }

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -676,6 +676,7 @@ SimpleImageViewer.Action.saturation = Set saturation
 SimpleImageViewer.Action.saturation.description = Set the saturation to improve the contrast for non-8-bit images
 SimpleImageViewer.Action.expandToWindow = Expand to fit window
 SimpleImageViewer.Action.expandToWindow.description = Allow the image to grow to fit the window. Otherwise, the image will be constrained to be no larger than its preferred size.
+SimpleImageViewer.placeholderText = No image available
 SimpleImageViewer.noImage = No image
 SimpleImageViewer.noTitle = Untitled image
 

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -665,6 +665,21 @@ Action.Processing.Classify.splitTrainValidationTest = Split project train/valida
 Action.Processing.Classify.splitTrainValidationTest.description = Split images within a project into training, validation and test sets
 
 
+# Simple image viewer
+SimpleImageViewer.Action.close = Close
+SimpleImageViewer.Action.close.description = Close the image window
+SimpleImageViewer.Action.copy = Copy
+SimpleImageViewer.Action.copy.description = Copy the image to the clipboard
+SimpleImageViewer.Action.save = Save As
+SimpleImageViewer.Action.save.description = Save the image
+SimpleImageViewer.Action.saturation = Set saturation
+SimpleImageViewer.Action.saturation.description = Set the saturation to improve the contrast for non-8-bit images
+SimpleImageViewer.Action.expandToWindow = Expand to fit window
+SimpleImageViewer.Action.expandToWindow.description = Allow the image to grow to fit the window. Otherwise, the image will be constrained to be no larger than its preferred size.
+SimpleImageViewer.noImage = No image
+SimpleImageViewer.noTitle = Untitled image
+
+
 # Preferences
 Prefs.Appearance = Appearance
 Prefs.General = General


### PR DESCRIPTION
* Fix https://github.com/qupath/qupath/issues/1263
* Fix https://github.com/qupath/qupath/issues/1309 (by using AWT instead of JavaFX for screenshot)
* Address https://github.com/qupath/qupath/issues/1246

Reduced duplication in the code used to display slide labels. This is now rewritten, and adds an option to specify the saturation percentage for non-8-bit images. This can help with making label content visible in awkward cases (e.g. many .czi images).