### PR TITLE
Fix minor view tracker bugs

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/recording/ViewTrackerAnalysisCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/recording/ViewTrackerAnalysisCommand.java
@@ -203,7 +203,8 @@ final class ViewTrackerAnalysisCommand implements Runnable {
 				
 				zSlider.setValue(frame.getZ());
 				tSlider.setValue(frame.getT());
-				timeSlider.setValue(frame.getTimestamp());
+				// Slider now updates automatically via binding to playback
+//				timeSlider.setValue(frame.getTimestamp());
 				
 				slideOverview.paintCanvas(o.getZ() != frame.getZ() || o.getT() != frame.getT(), false);
 			});
@@ -308,8 +309,10 @@ final class ViewTrackerAnalysisCommand implements Runnable {
 					slideOverview.paintCanvas();
 					
 					playback.doStartPlayback();
+					timeSlider.valueProperty().bind(playback.playbackTimeProperty());
 				} else {
 					// If already playing, pause the playback where it currently is
+					timeSlider.valueProperty().unbind();
 					playback.doStopPlayback();
 				}
 			});
@@ -319,9 +322,12 @@ final class ViewTrackerAnalysisCommand implements Runnable {
 			btnRewind.setOnAction(e -> {
 				boolean isPlaying = playback.isPlaying();
 				playback.doStopPlayback();
+				timeSlider.valueProperty().unbind();
 				timeSlider.setValue(tracker.getFrame(0).getTimestamp());
-				if (isPlaying)
+				if (isPlaying) {
 					playback.doStartPlayback();
+					timeSlider.valueProperty().bind(playback.playbackTimeProperty());
+				}
 			});
 			
 			// If we have a total of 0 or 1 frame in recording, disable playback

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/recording/ViewTrackerControlPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/recording/ViewTrackerControlPane.java
@@ -310,9 +310,12 @@ public class ViewTrackerControlPane implements Runnable {
 		btnPane.addRow(0, exportBtn, deleteBtn, btnMore);
 		
 		// Disable all buttons if no recording is selected, disable 'Export' and 'More' if multiple selection
-		exportBtn.disableProperty().bind(Bindings.or(Bindings.equal(Bindings.size(table.getSelectionModel().getSelectedItems()), 1).not(), isAnalysisOpened));
-		deleteBtn.disableProperty().bind(Bindings.or(table.getSelectionModel().selectedItemProperty().isNull(), isAnalysisOpened));
-		btnMore.disableProperty().bind(Bindings.or(Bindings.equal(Bindings.size(table.getSelectionModel().getSelectedItems()), 1).not(), isAnalysisOpened));
+		exportBtn.disableProperty().bind(
+				playing.or(Bindings.or(Bindings.equal(Bindings.size(table.getSelectionModel().getSelectedItems()), 1).not(), isAnalysisOpened)));
+		deleteBtn.disableProperty().bind(
+				playing.or(Bindings.or(table.getSelectionModel().selectedItemProperty().isNull(), isAnalysisOpened)));
+		btnMore.disableProperty().bind(
+				playing.or(Bindings.or(Bindings.equal(Bindings.size(table.getSelectionModel().getSelectedItems()), 1).not(), isAnalysisOpened)));
 		
 		// Disable playback button if no ViewTracker or multiple ViewTrackers are selected
 		actionPlayback.disabledProperty().bind(Bindings.size(table.getSelectionModel().getSelectedItems()).isNotEqualTo(1).or(recordingMode).or(isAnalysisOpened));


### PR DESCRIPTION
* Prevent opening the recording analysis after already pressing playback (since playing simultaneously in both resulting in a very flashy outcome)
* Enable the timeline slider in the recording analysis pane to move more smoothly, rather than frame by frame