### PR TITLE
Improve use of Preferences

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/PathClassManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/PathClassManager.java
@@ -137,7 +137,7 @@ class PathClassManager {
 	
 	/**
 	 * Load PathClasses from preferences.
-	 * Note that this also sets the color of any PathClass that is loads,
+	 * Note that this also sets the color of any PathClass that is loaded,
 	 * and is really only intended for use when initializing.
 	 * 
 	 * @return

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/UpdateManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/UpdateManager.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import javafx.beans.property.LongProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,9 @@ import qupath.fx.utils.GridPaneUtils;
 class UpdateManager {
 	
 	private static final Logger logger = LoggerFactory.getLogger(UpdateManager.class);
-	
+
+	private static LongProperty lastUpdateCheck = PathPrefs.createPersistentPreference("lastUpdateCheck", -1L);
+
 	private QuPathGUI qupath;
 	
 	private UpdateManager(QuPathGUI qupath) {
@@ -141,7 +144,7 @@ class UpdateManager {
 				logger.debug(e.getLocalizedMessage(), e);
 			}
 		}
-		PathPrefs.getUserPreferences().putLong("lastUpdateCheck", System.currentTimeMillis());
+		lastUpdateCheck.set(System.currentTimeMillis());
 		
 		// If we couldn't determine the version, tell the user only if this isn't the automatic check
 		if (projectUpdates.isEmpty()) {
@@ -241,8 +244,8 @@ class UpdateManager {
 
 		// Don't run auto-update check again if we already checked within the last hour
 		long currentTime = System.currentTimeMillis();
-		long lastUpdateCheck = PathPrefs.getUserPreferences().getLong("lastUpdateCheck", 0);
-		double diffHours = (double)(currentTime - lastUpdateCheck) / (60L * 60L * 1000L);
+		long lastUpdateCheckMillis = lastUpdateCheck.get();
+		double diffHours = (double)(currentTime - lastUpdateCheckMillis) / (60L * 60L * 1000L);
 		if (diffHours < 12) {
 			logger.debug("Skipping update check (I already checked recently)");
 			return;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -466,8 +466,17 @@ public class PathPrefs {
 	
 	/**
 	 * Get the {@link Preferences} object for storing user preferences.
+	 * <p>
+	 *     Note that the preferences object returned by this method must not be retained and reused,
+	 *     because it may be invalidated by a call to {@link #resetPreferences()}.
+	 *     Rather, as far as possible other methods of this class should be used rather than accessing the
+	 *     {@link Preferences} directly.
+	 * </p>
 	 * @return
+	 * @deprecated since v0.5.0 - avoid direct use of the {@link Preferences} object, since this may be invalidated by
+	 *             a call to {@link #resetPreferences()}
 	 */
+	@Deprecated
 	public static Preferences getUserPreferences() {
 		return MANAGER.getPreferences();
 	}
@@ -1525,6 +1534,18 @@ public class PathPrefs {
 	 */
 	public static DoubleProperty createPersistentPreference(final String name, final double defaultValue) {
 		return MANAGER.createPersistentDoubleProperty(name, defaultValue);
+	}
+
+
+	/**
+	 * Create a persistent property, which is one that will be saved to/reloaded from the user preferences.
+	 *
+	 * @param name
+	 * @param defaultValue
+	 * @return
+	 */
+	public static LongProperty createPersistentPreference(final String name, final long defaultValue) {
+		return MANAGER.createPersistentLongProperty(name, defaultValue);
 	}
 
 	


### PR DESCRIPTION
Fixes to coincide with https://github.com/qupath/qupath-fxtras/pull/11 Deprecate direct access to the `Preferences` object, since this can be invalidated by a call to reset (and then stops being usable).