### PR TITLE
Reduce memory use, improve pixel classification measurement performance

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/OpenCVPixelClassifier.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/OpenCVPixelClassifier.java
@@ -124,8 +124,6 @@ class OpenCVPixelClassifier implements PixelClassifier, UriResource {
 	        // Create & return BufferedImage
 	        BufferedImage imgResult = OpenCVTools.matToBufferedImage(matResult, colorModelLocal);
 	
-//	        // Return memory as quickly as we can
-//	        scope.deallocate();
 	        return imgResult;
     	} finally {
 //        	System.gc(); // Shouldn't be needed if deallocate is used?

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -592,37 +592,7 @@ public class PixelClassifierTools {
 	 * @return true if measurements were added, false otherwise
 	 */
 	public static boolean addMeasurements(Collection<? extends PathObject> objectsToMeasure, PixelClassificationMeasurementManager manager, String measurementID) {
-		
-		if (measurementID == null || measurementID.isBlank())
-			measurementID = "";
-		else {
-			measurementID = measurementID.strip();
-			if (measurementID.endsWith(":"))
-				measurementID += " ";
-			else
-				measurementID += ": ";			
-		}
-		
-		
-		int n = objectsToMeasure.size();
-		int i = 0;
-		
-		for (var pathObject : objectsToMeasure) {
-			i++;
-			if (n < 100 || n % 100 == 0)
-				logger.debug("Measured {}/{}", i, n);
-			try (var ml = pathObject.getMeasurementList()) {
-				for (String name : manager.getMeasurementNames()) {
-					Number value = manager.getMeasurementValue(pathObject, name, false);
-					double val = value == null ? Double.NaN : value.doubleValue();
-					ml.put(measurementID + name, val);
-				}
-			}
-			// We really want to lock objects so we don't end up with wrong measurements
-			if (!pathObject.isRootObject())
-				pathObject.setLocked(true);
-		}
-		return true;
+		return manager.addMeasurements(objectsToMeasure, measurementID);
 	}
 	
 

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
@@ -422,8 +422,10 @@ public class OpenCVTools {
 			} else {
 				opencv_core.merge(new MatVector(channels.toArray(Mat[]::new)), dest);
 			}
-//			scope.deallocate();
 		}
+
+		if (logger.isTraceEnabled())
+			logger.trace("Merged channels: {}", Arrays.stream(dest.createIndexer().sizes()).mapToObj(l -> l).toList());
 
 		return dest;
 	}

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ui/LoadResourceCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ui/LoadResourceCommand.java
@@ -131,9 +131,7 @@ public final class LoadResourceCommand<S> implements Runnable {
 		var cachedServers = new WeakHashMap<ImageData<BufferedImage>, ImageServer<BufferedImage>>();
 		var overlay = PixelClassificationOverlay.create(qupath.getOverlayOptions(), cachedServers, new ColorModelRenderer(null));
 		overlay.setMaxThreads(nThreads);
-		for (var viewer : qupath.getAllViewers())
-			viewer.setCustomPixelLayerOverlay(overlay);
-		
+
 		var comboClassifiers = new ComboBox<String>();
 		try {
 			updateAvailableItems(comboClassifiers.getItems());
@@ -170,8 +168,17 @@ public final class LoadResourceCommand<S> implements Runnable {
 		selectedResource.addListener((v, o, n) -> {
 			cachedServers.clear();
 			updateServers(n, cachedServers);
+
+			for (var viewer : qupath.getAllViewers()) {
+				if (n != null) {
+					viewer.resetCustomPixelLayerOverlay();;
+					viewer.setCustomPixelLayerOverlay(overlay);
+				} else
+					viewer.resetCustomPixelLayerOverlay();;
+			}
 		});
-		
+
+
 		// Add file chooser
 		var menu = new ContextMenu();
 		var miLoadClassifier = new MenuItem("Import from files");

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
@@ -285,6 +285,7 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 			hierarchy.getSelectionModel().setSelectedObject(selected);
 		} else {
 			listAnnotations.getItems().clear();
+			hierarchy = null;
 		}
 		hasImageData.set(this.imageData != null);
 		pathClassPane.refresh();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
@@ -217,19 +217,6 @@ public class SelectedMeasurementTableView implements PathObjectSelectionListener
 			tableMeasurements.refresh();
 			delayedUpdate = false;
 		}
-
-//		// Check if objects are outside hierarchy
-//		if (imageData != null) {
-//			for (PathObject pathObject : getSelectedObjectList()) {
-//				if (PathObjectTools.hierarchyContainsObject(imageData.getHierarchy(), pathObject)) {
-//					tableModel.setImageData(this.imageData, getSelectedObjectList());
-//					tableMeasurements.refresh();
-//					return;
-//				}
-//			}
-//		}
-//		tableModel.setImageData(null, getSelectedObjectList());
-//		tableMeasurements.refresh();
 	}
 
 	@Override

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -1522,7 +1522,10 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 	public void setImageData(ImageData<BufferedImage> imageDataNew) {
 		if (this.imageDataProperty.get() == imageDataNew)
 			return;
-		
+
+		// We want to stop caching the hierarchy
+		hierarchyOverlay.resetImageData();
+
 		imageDataChanging.set(true);
 		
 		// Remove listeners for previous hierarchy

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
@@ -115,6 +115,17 @@ public class HierarchyOverlay extends AbstractOverlay {
 			overlayServer = new PathHierarchyImageServer(imageData, getOverlayOptions());
 		}
 	}
+
+
+	/**
+	 * Reset the last image data.
+	 * The hierarchy overlay stores the last-seen image data internally to assist with caching, but retaining a reference
+	 * too long could become a memory leak.
+	 */
+	public void resetImageData() {
+		this.imageData = null;
+		updateOverlayServer();
+	}
 	
 
 	@Override

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathDraggingROIToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathDraggingROIToolEventHandler.java
@@ -77,8 +77,10 @@ abstract class AbstractPathDraggingROIToolEventHandler extends AbstractPathROITo
 		
 		var viewer = getViewer();
 		PathObject selectedObject = viewer.getSelectedObject();
-		if (selectedObject == null)
+		if (selectedObject == null) {
+			resetConstrainingObjects();
 			return;
+		}
 		
 		RoiEditor editor = viewer.getROIEditor();
 		
@@ -93,11 +95,8 @@ abstract class AbstractPathDraggingROIToolEventHandler extends AbstractPathROITo
 			} else {
 				commitObjectToHierarchy(e, selectedObject);
 			}
-//			editor.ensureHandlesUpdated();
-//			editor.resetActiveHandle();
-//			if (PathPrefs.getReturnToMoveMode())
-//				modes.setMode(Modes.MOVE);
 		}
+		resetConstrainingObjects();
 	}
 	
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathROIToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathROIToolEventHandler.java
@@ -140,14 +140,14 @@ abstract class AbstractPathROIToolEventHandler extends AbstractPathToolEventHand
 		// If we are double-clicking & we don't have a polygon, see if we can access a ROI
 		if (!PathPrefs.selectionModeProperty().get() && e.getClickCount() > 1) {
 			// Reset parent... for now
-			resetConstrainedAreaParent();		
-			tryToSelect(xx, yy, e.getClickCount()-2, false);
+			resetConstrainingObjects();
+			ToolUtils.tryToSelect(viewer, xx, yy, e.getClickCount()-2, false);
 			e.consume();
 			return;
 		}
 
 		// Set the current parent object based on the first click
-		setConstrainedAreaParent(hierarchy, xx, yy, Collections.emptyList());
+		updatingConstrainingObjects(viewer, xx, yy, Collections.emptyList());
 		
 		// Create a new annotation
 		PathObject pathObject = createNewAnnotation(e, xx, yy);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPolyROIToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPolyROIToolEventHandler.java
@@ -91,6 +91,7 @@ abstract class AbstractPolyROIToolEventHandler extends AbstractPathROIToolEventH
 					((PathROIObject)currentObject).setROI(roiUpdated);
 				}
 				commitObjectToHierarchy(e, currentObject);
+				resetConstrainingObjects();
 			}
 		}
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
@@ -207,7 +207,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 		if (!PathPrefs.selectionModeProperty().get() && (multipleClicks || (createNew && !e.isShiftDown()))) {
 			// See if, rather than creating something, we can instead reactivate a current object
 			if (multipleClicks) {
-				PathObject objectSelectable = getSelectableObject(p.getX(), p.getY(), e.getClickCount() - 1);
+				PathObject objectSelectable = ToolUtils.getSelectableObject(viewer, p.getX(), p.getY(), e.getClickCount() - 1);
 				if (objectSelectable != null && objectSelectable.isEditable() && objectSelectable.hasROI() && objectSelectable.getROI().isArea()) {
 					createNew = false;
 					viewer.setSelectedObject(objectSelectable);
@@ -217,7 +217,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 					currentObject = null;
 				}
 			} else if (!PathPrefs.selectionModeProperty().get()) {
-					List<PathObject> listSelectable = getSelectableObjectList(p.getX(), p.getY());
+					List<PathObject> listSelectable = ToolUtils.getSelectableObjectList(viewer, p.getX(), p.getY());
 					PathObject objectSelectable = null;
 					for (int i = listSelectable.size()-1; i >= 0; i--) {
 						PathObject temp = listSelectable.get(i);
@@ -255,7 +255,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 //					.orElseGet(() -> null);
 //		}
 //		setConstrainedAreaParent(hierarchy, parent, currentObject);
-		setConstrainedAreaParent(hierarchy, xx, yy, Collections.singleton(currentObject));
+		updatingConstrainingObjects(viewer, xx, yy, Collections.singleton(currentObject));
 
 		
 		// Need to remove the object from the hierarchy while editing it
@@ -276,7 +276,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 		lastPoint = p;
 	}
 	
-	
+
 	
 	
 	@Override
@@ -432,9 +432,11 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 		if (currentObject != null) {
 			commitObjectToHierarchy(e, currentObject);
 		}
-		
+
 		lastPoint = null;
 		this.currentObject = null;
+
+		resetConstrainingObjects();
 	}
 	
 	
@@ -466,7 +468,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 		
 		// See if we're on top of a tile
 		if (useTiles) {
-			List<PathObject> listSelectable = getSelectableObjectList(x, y);
+			List<PathObject> listSelectable = ToolUtils.getSelectableObjectList(getViewer(), x, y);
 			for (PathObject temp : listSelectable) {
 //				if ((temp instanceof PathDetectionObject) && temp.getROI() instanceof PathArea)
 				if (temp instanceof PathTileObject && temp.hasROI() && temp.getROI().isArea() && !(temp.getROI() instanceof RectangleROI)) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/MoveToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/MoveToolEventHandler.java
@@ -303,6 +303,9 @@ public class MoveToolEventHandler extends AbstractPathToolEventHandler {
 		
 		// Make sure we don't have a previous point (to prevent weird dragging artefacts)
 		pDragging = null;
+
+		// Reset any constraining objects
+		resetConstrainingObjects();
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/ToolUtils.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/ToolUtils.java
@@ -1,0 +1,110 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
+ * Contact: IP Management (ipmanagement@qub.ac.uk)
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.lib.gui.viewer.tools.handlers;
+
+import qupath.lib.gui.viewer.QuPathViewer;
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.PathObjectTools;
+import qupath.lib.objects.hierarchy.PathObjectHierarchy;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Static methods for use with PathTool event handlers.
+ * Extracted here to reduce the complexity of the event handler code (slightly).
+ */
+class ToolUtils {
+
+    /**
+     * Try to select an object with a ROI overlapping a specified coordinate.
+     * If there is no object found, the current selected object will be reset (to null).
+     *
+     * @param x
+     * @param y
+     * @param searchCount - how far up the hierarchy to go, i.e. how many parents to check if objects overlap
+     * @param addToSelection
+     * @return true if any object was selected
+     */
+    static boolean tryToSelect(QuPathViewer viewer, double x, double y, int searchCount, boolean addToSelection) {
+        return tryToSelect(viewer, x, y, searchCount, addToSelection, false);
+    }
+
+    static boolean tryToSelect(QuPathViewer viewer, double x, double y, int searchCount, boolean addToSelection, boolean toggleSelection) {
+        PathObjectHierarchy hierarchy = viewer == null ? null : viewer.getHierarchy();
+        if (hierarchy == null)
+            return false;
+        PathObject pathObject = getSelectableObject(viewer, x, y, searchCount);
+        if (toggleSelection && hierarchy.getSelectionModel().getSelectedObject() == pathObject)
+            hierarchy.getSelectionModel().deselectObject(pathObject);
+        else
+            viewer.setSelectedObject(pathObject, addToSelection);
+        // Reset selection if we have nothing
+        if (pathObject == null && addToSelection)
+            viewer.setSelectedObject(null);
+        return pathObject != null;
+    }
+
+    /**
+     * Determine which object would be selected by a click in this location - but do not actually apply the selection.
+     *
+     * @param viewer
+     * @param x
+     * @param y
+     * @param searchCount how far up the hierarchy to go, i.e. how many parents to check if objects overlap
+     * @return the object that would be selected
+     */
+    static PathObject getSelectableObject(QuPathViewer viewer, double x, double y, int searchCount) {
+        List<PathObject> pathObjectList = getSelectableObjectList(viewer, x, y);
+        if (pathObjectList == null || pathObjectList.isEmpty())
+            return null;
+        int ind = searchCount % pathObjectList.size();
+        return pathObjectList.get(ind);
+    }
+
+    /**
+     * Get a list of all selectable objects overlapping the specified x, y coordinates, ordered by depth in the hierarchy
+     * @param x
+     * @param y
+     * @return
+     */
+    static List<PathObject> getSelectableObjectList(QuPathViewer viewer, double x, double y) {
+        PathObjectHierarchy hierarchy = viewer == null ? null : viewer.getHierarchy();
+        if (hierarchy == null)
+            return Collections.emptyList();
+
+        Collection<PathObject> pathObjects = PathObjectTools.getObjectsForLocation(
+                hierarchy, x, y, viewer.getZPosition(), viewer.getTPosition(), viewer.getMaxROIHandleSize());
+        if (pathObjects.isEmpty())
+            return Collections.emptyList();
+        List<PathObject> pathObjectList = new ArrayList<>(pathObjects);
+        if (pathObjectList.size() == 1)
+            return pathObjectList;
+        Collections.sort(pathObjectList, PathObjectHierarchy.HIERARCHY_COMPARATOR);
+        return pathObjectList;
+    }
+}


### PR DESCRIPTION
Numerous changes aiming to reduce memory use, including:
* Preventing objects (and object hierarchies) from being retained for a time after an image has been closed
* Improving the efficiency of `ImageOps` with padding
* Parallelising pixel classification measurements

The last two of these should improve pixel classification generally, and making measurements in particular.

It is the proposed fix for https://github.com/qupath/qupath/issues/1322

I obtained some rough timings using *Run for project* with 3 images and an extreme pixel classifier with 250 output channels:

```groovy
setImageType('BRIGHTFIELD_H_E');
setColorDeconvolutionStains('{"Name" : "H&E default", "Stain 1" : "Hematoxylin", "Values 1" : "0.65111 0.70119 0.29049", "Stain 2" : "Eosin", "Values 2" : "0.2159 0.8012 0.5581", "Background" : " 255 255 255"}');
clearAllObjects();
resetSelection();
//createAnnotationsFromPixelClassifier("My threshold", 0.0, 0.0, "INCLUDE_IGNORED", "SPLIT") // Alternative option
createAnnotationsFromPixelClassifier("My threshold", 0.0, 0.0, "INCLUDE_IGNORED")
selectAnnotations();
addPixelClassifierMeasurements("Busy classifier", "Busy classifier")
println getAnnotationObjects().measurements
```

With larger images / ROIs, the changes can result in huge speed improvements (tested using M1 Max, macOS 13.5.2):

### v0.5.0-SNAPSHOT

```
INFO: Starting script at Fri Sep 15 13:54:32 BST 2023
INFO: [[Busy classifier: Stroma %:57.11750411987305, Busy classifier: Stroma area µm^2:3.7282948E7, Busy classifier: Tumor %:42.88249588012695, Busy classifier: Tumor area µm^2:2.799117E7]]
INFO: Total run time: 14.97 seconds
INFO: Starting script at Fri Sep 15 13:54:47 BST 2023
INFO: [[Busy classifier: Stroma %:24.72903823852539, Busy classifier: Stroma area µm^2:122532.3984375, Busy classifier: Tumor %:75.27095794677734, Busy classifier: Tumor area µm^2:372967.65625]]
INFO: Total run time: 0.42 seconds
INFO: Starting script at Fri Sep 15 13:54:48 BST 2023
INFO: [[Busy classifier: Stroma %:42.06702423095703, Busy classifier: Stroma area µm^2:2.7533646E7, Busy classifier: Tumor %:57.93297576904297, Busy classifier: Tumor area µm^2:3.7918208E7]]
INFO: Total run time: 9.97 seconds
```

## v0.4.4
```
INFO: Starting script at Fri Sep 15 13:57:43 BST 2023
INFO: [[Busy classifier: Stroma %:57.11750411987305, Busy classifier: Stroma area µm^2:3.7282948E7, Busy classifier: Tumor %:42.88249588012695, Busy classifier: Tumor area µm^2:2.799117E7]]
INFO: Total run time: 78.18 seconds
INFO: Starting script at Fri Sep 15 13:59:01 BST 2023
INFO: [[Busy classifier: Stroma %:24.72903823852539, Busy classifier: Stroma area µm^2:122532.3984375, Busy classifier: Tumor %:75.27095794677734, Busy classifier: Tumor area µm^2:372967.65625]]
INFO: Total run time: 0.49 seconds
INFO: Starting script at Fri Sep 15 13:59:02 BST 2023
INFO: [[Busy classifier: Stroma %:42.06702423095703, Busy classifier: Stroma area µm^2:2.7533646E7, Busy classifier: Tumor %:57.93297576904297, Busy classifier: Tumor area µm^2:3.7918208E7]]
INFO: Total run time: 74.90 seconds
```