### PR TITLE
Support info messages / badges

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
 import org.controlsfx.control.decoration.Decorator;
 import org.controlsfx.control.decoration.GraphicDecoration;
 import org.slf4j.Logger;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
@@ -23,6 +23,7 @@ package qupath.lib.gui.actions;
 
 import static qupath.lib.gui.actions.ActionTools.createAction;
 
+import javafx.collections.ListChangeListener;
 import org.controlsfx.control.action.Action;
 
 import qupath.lib.gui.QuPathGUI;
@@ -117,8 +118,11 @@ public class CommonActions {
 		PROJECT_NEW = createAction(() -> Commands.promptToCreateProject(qupath));
 		PROJECT_OPEN = createAction(() -> Commands.promptToOpenProject(qupath));
 		PROJECT_ADD_IMAGES = createAction(() -> ProjectCommands.promptToImportImages(qupath));
-		
-		BRIGHTNESS_CONTRAST = ActionTools.createAction(new BrightnessContrastCommand(qupath));
+
+		var brightnessCommand = new BrightnessContrastCommand(qupath);
+		BRIGHTNESS_CONTRAST = ActionTools.createAction(brightnessCommand);
+		ActionTools.installWarningsBadge(BRIGHTNESS_CONTRAST,  brightnessCommand.warningString());
+
 		COUNTING_PANEL = ActionTools.createAction(new CountingPanelCommand(qupath));
 		TMA_ADD_NOTE = qupath.createImageDataAction(imageData -> TMACommands.promptToAddNoteToSelectedCores(imageData));
 		CONVEX_POINTS = ActionTools.createSelectableAction(PathPrefs.showPointHullsProperty());
@@ -135,6 +139,13 @@ public class CommonActions {
 		
 		// This has the effect of applying the annotations
 		ActionTools.getAnnotatedActions(this);
+	}
+
+	private void handleBrightnessContrastWarnings(ListChangeListener.Change<? extends String> change) {
+		if (change.getList().isEmpty())
+			BRIGHTNESS_CONTRAST.getProperties().remove("WARNINGS");
+		else
+			BRIGHTNESS_CONTRAST.getProperties().put("WARNINGS", change.getList().size());
 	}
 	
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
@@ -121,7 +121,7 @@ public class CommonActions {
 
 		var brightnessCommand = new BrightnessContrastCommand(qupath);
 		BRIGHTNESS_CONTRAST = ActionTools.createAction(brightnessCommand);
-		ActionTools.installWarningsBadge(BRIGHTNESS_CONTRAST,  brightnessCommand.warningString());
+		ActionTools.installInfoMessage(BRIGHTNESS_CONTRAST,  brightnessCommand.infoMessage());
 
 		COUNTING_PANEL = ActionTools.createAction(new CountingPanelCommand(qupath));
 		TMA_ADD_NOTE = qupath.createImageDataAction(imageData -> TMACommands.promptToAddNoteToSelectedCores(imageData));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/InfoMessage.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/InfoMessage.java
@@ -1,0 +1,142 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2023 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.lib.gui.actions;
+
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.value.ObservableStringValue;
+
+/**
+ * An informative message that shoudl be shown to the user.
+ */
+public class InfoMessage {
+
+    /**
+     * The type of message, which can be used for styling.
+     */
+    public enum MessageType {
+        /**
+         * Information only.
+         */
+        INFO,
+        /**
+         * Warning.
+         */
+        WARN,
+        /**
+         * Error or exception.
+         */
+        ERROR
+    }
+
+    private MessageType badgeType;
+
+    private ReadOnlyStringProperty text;
+
+    private InfoMessage(MessageType badgeType, ObservableStringValue text) {
+        this.badgeType = badgeType;
+        var wrapper = new ReadOnlyStringWrapper();
+        wrapper.bind(text);
+        this.text = wrapper.getReadOnlyProperty();
+    }
+
+    /**
+     * Create an information message.
+     * @param text
+     * @return
+     */
+    public static InfoMessage info(ObservableStringValue text) {
+        return new InfoMessage(MessageType.INFO, text);
+    }
+
+    /**
+     * Create an information message with static text.
+     * @param text
+     * @return
+     */
+    public static InfoMessage info(String text) {
+        return new InfoMessage(MessageType.INFO, new SimpleStringProperty(text));
+    }
+
+    /**
+     * Create a warning message.
+     * @param text
+     * @return
+     */
+    public static InfoMessage warning(ObservableStringValue text) {
+        return new InfoMessage(MessageType.WARN, text);
+    }
+
+    /**
+     * Create a warning message with static text.
+     * @param text
+     * @return
+     */
+    public static InfoMessage warning(String text) {
+        return new InfoMessage(MessageType.WARN, new SimpleStringProperty(text));
+    }
+
+    /**
+     * Create a error message.
+     * @param text
+     * @return
+     */
+    public static InfoMessage error(ObservableStringValue text) {
+        return new InfoMessage(MessageType.ERROR, text);
+    }
+
+    /**
+     * Create a error messagew ith static text.
+     * @param text
+     * @return
+     */
+    public static InfoMessage error(String text) {
+        return new InfoMessage(MessageType.ERROR, new SimpleStringProperty(text));
+    }
+
+    /**
+     * Read only property containing the message text.
+     * @return
+     */
+    public ReadOnlyStringProperty textProperty() {
+        return text;
+    }
+
+    /**
+     * Text of the message.
+     * @return
+     */
+    public String getText() {
+        return text.get();
+    }
+
+    /**
+     * Type of the message.
+     * @return
+     */
+    public MessageType getMessageType() {
+        return badgeType;
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -28,8 +28,8 @@ import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.ObjectBinding;
+import javafx.beans.binding.ObjectExpression;
 import javafx.beans.binding.StringBinding;
-import javafx.beans.binding.StringExpression;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -95,6 +95,7 @@ import qupath.lib.display.ChannelDisplayInfo;
 import qupath.lib.display.DirectServerChannelInfo;
 import qupath.lib.display.ImageDisplay;
 import qupath.lib.gui.QuPathGUI;
+import qupath.lib.gui.actions.InfoMessage;
 import qupath.lib.gui.charts.HistogramChart;
 import qupath.lib.gui.charts.HistogramChart.HistogramData;
 import qupath.lib.gui.charts.ChartThresholdPane;
@@ -136,7 +137,7 @@ public class BrightnessContrastCommand implements Runnable {
 	/**
 	 * Style used for labels that display warning text.
 	 */
-	private static final String WARNING_STYLE = "-fx-text-fill: -qp-script-error-color;";
+	private static final String WARNING_STYLE = "-fx-text-fill: -qp-script-warn-color;";
 
 	private static final double BUTTON_SPACING = 5;
 
@@ -201,6 +202,8 @@ public class BrightnessContrastCommand implements Runnable {
 //			dialog = createDialog();
 		dialog.show();
 		updateShowTableColumnHeader();
+		if (table.getSelectionModel().isEmpty())
+			table.getSelectionModel().select(getCurrentInfo());
 	}
 
 	private void initializeColorPicker() {
@@ -425,13 +428,13 @@ public class BrightnessContrastCommand implements Runnable {
 
 	private ObservableList<String> warningList = FXCollections.observableArrayList();
 
-	private StringExpression warningString = Bindings.createStringBinding(() -> {
+	private ObjectExpression<InfoMessage> infoMessage = Bindings.createObjectBinding(() -> {
 		if (warningList.isEmpty())
 			return null;
 		if (warningList.size() == 1)
-			return "1 warning";
+			return InfoMessage.warning("1 warning");
 		else
-			return warningList.size() + " warnings";
+			return InfoMessage.warning(warningList.size() + " warnings");
 	}, warningList);
 
 	/**
@@ -439,8 +442,8 @@ public class BrightnessContrastCommand implements Runnable {
 	 * This can be used to notify the user that something is amiss, even if the dialog is not open.
 	 * @return a string expression that evaluates to the warning text, or null if there are no warnings
 	 */
-	public StringExpression warningString() {
-		return warningString;
+	public ObjectExpression infoMessage() {
+		return infoMessage;
 	}
 
 

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -11,7 +11,7 @@
 
   -qp-script-error-color: ladder(-qp-script-background-color, red 30%, darkred 50%, red 70%);
 
-  -qp-script-warn-color: ladder(-qp-script-background-color, orange 30%, darkorange 50%, orange 70%);
+  -qp-script-warn-color: darkorange; /* ladder(-qp-script-background-color, darkorange 30%, orange 50%, darkorange 70%); */
 
   -qp-script-info-color: -qp-script-text-color;
 
@@ -92,4 +92,20 @@
 .always-opaque:disabled,
 .always-opaque:disabled > * {
   -fx-opacity: 1;
+}
+
+.info-message {
+  -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.5), 1, 0, 0, 0);
+}
+
+.info-message.warn {
+  -fx-fill: -qp-script-warn-color;
+}
+
+.info-message.error {
+  -fx-fill: -qp-script-error-color;
+}
+
+.info-message.info {
+  -fx-fill: -qp-script-debug-color;
 }


### PR DESCRIPTION
Initial support for commands that can result in a badge appearing on a toolbar button (or other node).

The eventual plan is to use this to draw attention to errors/warnings that may not otherwise be visible to the user.