### PR TITLE
Fix typo in DragDrop listener and move strings to resourceBundle

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -180,11 +180,8 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 					if (files != null) {
 				        logger.debug("Files dragged onto {}", source);
 						handleFileDrop(viewer2, files);
-					} else if (url != null) {
-						logger.debug("URL dragged onto {}", source);
-						handleURLDrop(viewer2, url);
-					} else if (string != null) {
-						logger.debug("String/URL dragged onto {}", source);
+					} else if (url != null || string != null) {
+						logger.debug("URL/String dragged onto {}", source);
 						handleURLDrop(viewer2, url);
 					}
 	        	} catch (IOException e) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -132,7 +132,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
     	} else if (type == DragEvent.DRAG_OVER) {
     		// Start drag/drop
     		var dragboard = event.getDragboard();
-    		if (dragboard.hasFiles() || dragboard.hasUrl()) {
+    		if (dragboard.hasFiles() || dragboard.hasUrl() || dragboard.hasString()) {
     			event.acceptTransferModes(TransferMode.COPY);
                 event.consume();
                 return;
@@ -171,8 +171,9 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
         
         var files = dragboard.hasFiles() ? new ArrayList<>(dragboard.getFiles()) : null;
         var url = dragboard.getUrl();
+		var string = dragboard.getString();
         var viewer2 = viewer;
-        if (files != null || url != null) {
+        if (files != null || url != null || string != null) {
 	        invokeLater(() -> {
 	        	taskRunning = true;
 	        	try {
@@ -181,6 +182,9 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 						handleFileDrop(viewer2, files);
 					} else if (url != null) {
 						logger.debug("URL dragged onto {}", source);
+						handleURLDrop(viewer2, url);
+					} else if (string != null) {
+						logger.debug("String/URL dragged onto {}", source);
 						handleURLDrop(viewer2, url);
 					}
 	        	} catch (IOException e) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -26,7 +26,13 @@ package qupath.lib.gui.viewer;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -65,10 +71,6 @@ import qupath.lib.gui.scripting.DefaultScriptEditor;
 
 /**
  * Drag and drop support for main QuPath application, which can support a range of different object types (Files, URLs, Strings,..)
- * 
- * @author Pete Bankhead
- * @author Melvin Gelbard
- *
  */
 public class DragDropImportListener implements EventHandler<DragEvent> {
 	
@@ -79,7 +81,8 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 	private List<DropHandler<File>> dropHandlers = new ArrayList<>();
 	
 	/**
-	 * Flag to indeicate
+	 * Flag to indicate that a task is currently running, and events should be dropped until it is finished
+	 * (e.g. a dialog is showing and we need a response)
 	 */
 	private boolean taskRunning = false;
 	
@@ -527,7 +530,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
      *
      */
      @FunctionalInterface
-    public static interface DropHandler<T> {
+    public interface DropHandler<T> {
     	 
     	/**
     	 * Handle drop onto a viewer.
@@ -538,7 +541,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
     	 * @param list the dropped objects
     	 * @return true if the handler processed the drop event
     	 */
-    	public boolean handleDrop(final QuPathViewer viewer, final List<T> list);
+    	boolean handleDrop(final QuPathViewer viewer, final List<T> list);
     	
     }
     

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -878,3 +878,24 @@ Prefs.BioFormats.alwaysUseExtensions.description = Request that Bio-Formats is a
 Prefs.BioFormats.skipExtensions = Never use Bio-Formats for specified image extensions
 Prefs.BioFormats.skipExtensions.description = Request that Bio-Formats is never the file reader used for images with specific extensions; enter as a list with spaces between each entry
 
+## Drag & drop messages
+DragDrop = Drag & Drop
+DragDrop.loadData = Load data
+DragDrop.loadMessage = Please drag the file onto a specific viewer to open!
+DragDrop.openImage = Open image
+DragDrop.importObjects = Import objects
+DragDrop.openData = Open data
+DragDrop.chooseData = What do you want to do with the data file?
+DragDrop.chooseDataOptions = "You can\n 1. Open the image in the current viewer\n 2. Import objects and add them to the current image.
+DragDrop.selectProject = Select project
+DragDrop.selectProjectToOpen = Select project to open
+DragDrop.createProject = Create project
+DragDrop.createProjectForEmptyDirectory = Create project for empty directory?
+DragDrop.TMAGridImport = TMA grid import
+DragDrop.TMAGridImportImageError = Please open an image first before importing a de-arrayed TMA grid!
+DragDrop.TMAGridSetHierarchy = "Set TMA grid for existing hierarchy?"
+DragDrop.TMAGridParseError = Could not parse TMA grid from %s
+DragDrop.specificViewer = Please drag the file on a specific viewer to open!
+DragDrop.projectForMultipleFiles = Could not handle multiple file drop - if you want to handle multiple images, you need to create a project first
+DragDrop.couldNotHandleFiles = Sorry, I couldn't figure out what to do with these files - try opening one at a time
+DragDrop.couldNotHandleFile = Sorry, I couldn't figure out what to do with %s


### PR DESCRIPTION
The typo was "Please drag the file only a specific viewer to open", but I figured if I was fixing it I may as well plop the GUI strings into the resources as well.

Obviously not even close to urgent