### PR TITLE
Add error badge to log toolbar button

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -161,7 +161,8 @@ import qupath.lib.scripting.languages.ExecutableLanguage;
 import qupath.lib.scripting.languages.ScriptLanguage;
 import qupath.lib.gui.scripting.DefaultScriptEditor;
 import qupath.lib.gui.scripting.QPEx;
-
+import qupath.ui.logviewer.ui.main.LogMessageCounts;
+import qupath.ui.logviewer.ui.main.LogViewer;
 
 
 /**
@@ -330,6 +331,9 @@ public class QuPathGUI {
 		// Populating the scripting menu is slower, so delay it until now
 		populateScriptingMenu(getMenu(QuPathResources.getString("Menu.Automate"), false));
 		SystemMenuBar.manageMainMenuBar(menuBar);
+
+		stage.setMinWidth(600);
+		stage.setMinHeight(400);
 
 		logger.debug("{}", timeit.stop());
 	}
@@ -2643,11 +2647,12 @@ public class QuPathGUI {
 	
 	
 	/**
-	 * Show the log window associated with this QuPath instance.
+	 * Get the log viewer associated with this QuPath instance.
+	 * @return
 	 * @since v0.5.0
 	 */
-	public void showLogWindow() {
-		logViewerCommand.run();
+	public LogViewerCommand getLogViewerCommand() {
+		return logViewerCommand;
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
@@ -26,6 +26,8 @@ import static qupath.lib.gui.actions.ActionTools.createAction;
 import javafx.collections.ListChangeListener;
 import org.controlsfx.control.action.Action;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.actions.annotations.ActionAccelerator;
 import qupath.lib.gui.actions.annotations.ActionConfig;
@@ -47,6 +49,8 @@ import qupath.lib.gui.tools.IconFactory.PathIcons;
  * @since v0.5.0
  */
 public class CommonActions {
+
+	private static final Logger logger = LoggerFactory.getLogger(CommonActions.class);
 	
 	@ActionConfig("Action.File.Project.createProject")
 	public final Action PROJECT_NEW;
@@ -126,7 +130,20 @@ public class CommonActions {
 		COUNTING_PANEL = ActionTools.createAction(new CountingPanelCommand(qupath));
 		TMA_ADD_NOTE = qupath.createImageDataAction(imageData -> TMACommands.promptToAddNoteToSelectedCores(imageData));
 		CONVEX_POINTS = ActionTools.createSelectableAction(PathPrefs.showPointHullsProperty());
-		SHOW_LOG = ActionTools.createAction(() -> qupath.showLogWindow());
+
+		// The log viewer should already exist - in which case we can use it to support info messages
+		var logviewer = qupath.getLogViewerCommand();
+		if (logviewer == null) {
+			// Log a warning (but who will see it?!)
+			logger.warn("Log viewer not available! Will attempt to load lazily.");
+			SHOW_LOG = ActionTools.createAction(() -> qupath.getLogViewerCommand().show());
+		} else {
+			SHOW_LOG = ActionTools.createAction(() -> logviewer.show());
+			var counts = logviewer.getLogMessageCounts();
+			if (counts != null)
+				ActionTools.installInfoMessage(SHOW_LOG, logviewer.getInfoMessage());
+		}
+
 		SHOW_ANALYSIS_PANE = ActionTools.createSelectableAction(qupath.showAnalysisPaneProperty());
 		PREFERENCES = Commands.createSingleStageAction(() -> Commands.createPreferencesDialog(qupath));
 		SHOW_OBJECT_DESCRIPTIONS = Commands.createSingleStageAction(() -> Commands.createObjectDescriptionsDialog(qupath));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/InfoMessage.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/InfoMessage.java
@@ -22,13 +22,19 @@
 
 package qupath.lib.gui.actions;
 
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.ReadOnlyIntegerWrapper;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.value.ObservableNumberValue;
 import javafx.beans.value.ObservableStringValue;
 
 /**
- * An informative message that shoudl be shown to the user.
+ * An informative message that should be shown to the user.
  */
 public class InfoMessage {
 
@@ -54,11 +60,16 @@ public class InfoMessage {
 
     private ReadOnlyStringProperty text;
 
-    private InfoMessage(MessageType badgeType, ObservableStringValue text) {
+    private ReadOnlyObjectProperty<Number> count;
+
+    private InfoMessage(MessageType badgeType, ObservableStringValue text, ObservableNumberValue count) {
         this.badgeType = badgeType;
         var wrapper = new ReadOnlyStringWrapper();
         wrapper.bind(text);
         this.text = wrapper.getReadOnlyProperty();
+        var wrapperCount = new ReadOnlyObjectWrapper<Number>();
+        wrapperCount.bind(count.map(c -> c != null && c.intValue() < 0 ? null : c.intValue()));
+        this.count = wrapperCount.getReadOnlyProperty();
     }
 
     /**
@@ -67,7 +78,7 @@ public class InfoMessage {
      * @return
      */
     public static InfoMessage info(ObservableStringValue text) {
-        return new InfoMessage(MessageType.INFO, text);
+        return info(text, new SimpleIntegerProperty(-1));
     }
 
     /**
@@ -76,7 +87,42 @@ public class InfoMessage {
      * @return
      */
     public static InfoMessage info(String text) {
-        return new InfoMessage(MessageType.INFO, new SimpleStringProperty(text));
+        return info(text, -1);
+    }
+
+    /**
+     * Create an information message with a count.
+     * @param text
+     * @param count
+     * @return
+     */
+    public static InfoMessage info(ObservableStringValue text, ObservableNumberValue count) {
+        return new InfoMessage(MessageType.INFO, text, count);
+    }
+
+    /**
+     * Create an information message with static text and a count.
+     * @param text
+     * @param count
+     * @return
+     */
+    public static InfoMessage info(String text, int count) {
+        return info(new SimpleStringProperty(text), new SimpleIntegerProperty(count));
+    }
+
+    /**
+     * Create a information message to show a count of messages.
+     * @param count
+     * @return
+     */
+    public static InfoMessage info(ObservableNumberValue count) {
+        return info(Bindings.createStringBinding(() -> {
+            int value = count.intValue();
+            if (value == 1)
+                return "1 message";
+            else
+                return value + " messages";
+        }), count);
     }
 
     /**
@@ -85,7 +131,7 @@ public class InfoMessage {
      * @return
      */
     public static InfoMessage warning(ObservableStringValue text) {
-        return new InfoMessage(MessageType.WARN, text);
+        return warning(text, new SimpleIntegerProperty(-1));
     }
 
     /**
@@ -94,26 +140,99 @@ public class InfoMessage {
      * @return
      */
     public static InfoMessage warning(String text) {
-        return new InfoMessage(MessageType.WARN, new SimpleStringProperty(text));
+        return warning(text, -1);
     }
 
     /**
-     * Create a error message.
+     * Create a warning message with a count.
+     * @param text
+     * @param count
+     * @return
+     */
+    public static InfoMessage warning(ObservableStringValue text, ObservableNumberValue count) {
+        return new InfoMessage(MessageType.WARN, text, count);
+    }
+
+    /**
+     * Create a warning message to show a count of warnings.
+     * @param count
+     * @return
+     */
+    public static InfoMessage warning(ObservableNumberValue count) {
+        return new InfoMessage(MessageType.WARN,
+                Bindings.createStringBinding(() -> {
+                    int value = count.intValue();
+                    if (value == 1)
+                        return "1 warning";
+                    else
+                        return value + " warnings";
+                }), count);
+    }
+
+    /**
+     * Create a warning message with static text and a count.
+     * @param text
+     * @param count
+     * @return
+     */
+    public static InfoMessage warning(String text, int count) {
+        return warning(new SimpleStringProperty(text), new SimpleIntegerProperty(count));
+    }
+
+
+    /**
+     * Create an error message.
      * @param text
      * @return
      */
     public static InfoMessage error(ObservableStringValue text) {
-        return new InfoMessage(MessageType.ERROR, text);
+        return error(text, new SimpleIntegerProperty(-1));
     }
 
     /**
-     * Create a error messagew ith static text.
+     * Create an error message with static text.
      * @param text
      * @return
      */
     public static InfoMessage error(String text) {
-        return new InfoMessage(MessageType.ERROR, new SimpleStringProperty(text));
+        return error(text, -1);
     }
+
+    /**
+     * Create an error message with a count.
+     * @param text
+     * @param count
+     * @return
+     */
+    public static InfoMessage error(ObservableStringValue text, ObservableNumberValue count) {
+        return new InfoMessage(MessageType.ERROR, text, count);
+    }
+
+    /**
+     * Create an error message with static text and a count.
+     * @param text
+     * @param count
+     * @return
+     */
+    public static InfoMessage error(String text, int count) {
+        return error(new SimpleStringProperty(text), new SimpleIntegerProperty(count));
+    }
+
+    /**
+     * Create a error message to show a count of errors.
+     * @param count
+     * @return
+     */
+    public static InfoMessage error(ObservableNumberValue count) {
+        return error(Bindings.createStringBinding(() -> {
+                    int value = count.intValue();
+                    if (value == 1)
+                        return "1 error";
+                    else
+                        return value + " error";
+                }), count);
+    }
+
 
     /**
      * Read only property containing the message text.
@@ -129,6 +248,23 @@ public class InfoMessage {
      */
     public String getText() {
         return text.get();
+    }
+
+    /**
+     * Read only property containing any count associated with the text (may be null).
+     * @return
+     */
+    public ReadOnlyObjectProperty<Number> countProperty() {
+        return count;
+    }
+
+    /**
+     * Counts associated with the message, or -1 if the count is null.
+     * @return
+     */
+    public int getCount() {
+        var val = count.getValue();
+        return val == null ? -1 : val.intValue();
     }
 
     /**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -28,10 +28,12 @@ import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
+import javafx.beans.binding.ListBinding;
 import javafx.beans.binding.ObjectExpression;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
@@ -331,10 +333,7 @@ public class BrightnessContrastCommand implements Runnable {
 	private ObjectExpression<InfoMessage> infoMessage = Bindings.createObjectBinding(() -> {
 		if (warningList.isEmpty())
 			return null;
-		if (warningList.size() == 1)
-			return InfoMessage.warning("1 warning");
-		else
-			return InfoMessage.warning(warningList.size() + " warnings");
+		return InfoMessage.warning(new SimpleIntegerProperty(warningList.size()));
 	}, warningList);
 
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/LogViewerCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/LogViewerCommand.java
@@ -24,15 +24,23 @@
 package qupath.lib.gui.commands;
 
 import javafx.application.Platform;
-import javafx.scene.Parent;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.ObjectExpression;
+import javafx.beans.property.LongProperty;
+import javafx.beans.property.SimpleLongProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.scene.Scene;
+import javafx.scene.layout.Region;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.fx.utils.FXUtils;
+import qupath.lib.gui.actions.InfoMessage;
 import qupath.lib.gui.prefs.SystemMenuBar;
+import qupath.ui.logviewer.ui.main.LogMessageCounts;
 import qupath.ui.logviewer.ui.main.LogViewer;
 import qupath.ui.logviewer.ui.textarea.TextAreaLogViewer;
 
@@ -44,7 +52,7 @@ import java.io.IOException;
  * @author Pete Bankhead
  *
  */
-public class LogViewerCommand implements Runnable {
+public class LogViewerCommand {
 
 	private static final Logger logger = LoggerFactory.getLogger(LogViewerCommand.class);
 
@@ -52,7 +60,13 @@ public class LogViewerCommand implements Runnable {
 
 	private Window parent;
 
-	private Parent logviewer;
+	private Region logviewer;
+
+	private LogMessageCounts counts;
+
+	private LongProperty errorMessageCounts = new SimpleLongProperty();
+
+	private ObservableList<String> errorCounts = FXCollections.observableArrayList();
 
 	/**
 	 * Constructor.
@@ -63,6 +77,10 @@ public class LogViewerCommand implements Runnable {
 		try {
 			LogViewer logviewer = new LogViewer();
 			SystemMenuBar.manageChildMenuBar(logviewer.getMenubar());
+			// Get counts so we can display warning badges
+			this.counts = logviewer.getAllLogsMessageCounts();
+			errorMessageCounts.bind(counts.errorLevelCountsProperty());
+
 			// Fix cell size for better performance
 			var table = logviewer.getTable();
 			table.setFixedCellSize(25);
@@ -73,10 +91,9 @@ public class LogViewerCommand implements Runnable {
 		}
 	}
 
-	@Override
-	public void run() {
+	public void show() {
 		if (!Platform.isFxApplicationThread()) {
-			Platform.runLater(() -> run());
+			Platform.runLater(() -> show());
 			return;
 		}
 		if (dialog == null) {
@@ -93,7 +110,9 @@ public class LogViewerCommand implements Runnable {
 			dialog.sizeToScene();
 			// TODO: It would be nice to figure this out automatically
 			dialog.setMinWidth(600);
-			dialog.setMinHeight(440);
+			dialog.setMinHeight(400);
+//			dialog.setMinWidth(logviewer.getWidth());
+//			dialog.setMinHeight(logviewer.getHeight() + 30);
 			FXUtils.retainWindowPosition(dialog);
 		} else {
 			dialog.show();
@@ -104,5 +123,29 @@ public class LogViewerCommand implements Runnable {
 			table.scrollTo(table.getItems().size() - 1);
 		}
 	}
+
+	/**
+	 * Get the counts of all messages logged by the log viewer.
+	 * @return
+	 */
+	public LogMessageCounts getLogMessageCounts() {
+		return counts;
+	}
+
+
+	private ObjectExpression<InfoMessage> infoMessage = Bindings.createObjectBinding(() -> {
+		if (errorMessageCounts.get() <= 0L)
+			return null;
+		return InfoMessage.error(errorMessageCounts);
+	}, errorMessageCounts);
+
+	/**
+	 * Get a string expression to draw attention to error messages.
+	 * @return a string expression that evaluates to the error message, or null if there are no errors
+	 */
+	public ObjectExpression<InfoMessage> getInfoMessage() {
+		return infoMessage;
+	}
+
 
 }

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -117,3 +117,10 @@
 .error-label-text {
   -fx-text-fill: -qp-script-error-color;
 }
+
+.toolbar-badge > .badge-text {
+  -fx-fill: white;
+  -fx-font-size: 6pt;
+  -fx-font-weight: bold;
+  -fx-text-alignment: center;
+}


### PR DESCRIPTION
Show a small badge in the log toolbar button to try attention to errors. This is intended to be useful whenever the log viewer is not open, but the user may need to see an error reported there.

Also set the minimum size for the main QuPath window, because @alanocallaghan had a point.

![error-badges](https://github.com/qupath/qupath/assets/4690904/e073b3e3-0a62-41dd-87e9-4b3991284f8b)
