### PR TITLE
Bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This is a work-in-progress for the next QuPath release.
 * Several bug fixes in the view tracker (https://github.com/qupath/qupath/pull/1329)
 * Occasional misleading 'Reader is null - was the image already closed?' exceptions (https://github.com/qupath/qupath/issues/1265)
 * Using existing channel names (e.g. 'Red', 'Green', 'Blue') for color deconvolution can confuse brightness/contrast settings (https://github.com/qupath/qupath/issues/1245)
+* The centroid-to-centroid distance between an object & itself can be > 0 (https://github.com/qupath/qupath/issues/1249)
 
 ### Dependency updates
 * Bio-Formats 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This is a work-in-progress for the next QuPath release.
 * Slide label can be too big for the screen (https://github.com/qupath/qupath/issues/1263)
 * Slide label doesn't update as expected when changing the image (https://github.com/qupath/qupath/issues/1246)
 * Several bug fixes in the view tracker (https://github.com/qupath/qupath/pull/1329)
+* Occasional misleading 'Reader is null - was the image already closed?' exceptions (https://github.com/qupath/qupath/issues/1265)
 
 ### Dependency updates
 * Bio-Formats 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This is a work-in-progress for the next QuPath release.
 * Slide label doesn't update as expected when changing the image (https://github.com/qupath/qupath/issues/1246)
 * Several bug fixes in the view tracker (https://github.com/qupath/qupath/pull/1329)
 * Occasional misleading 'Reader is null - was the image already closed?' exceptions (https://github.com/qupath/qupath/issues/1265)
+* Using existing channel names (e.g. 'Red', 'Green', 'Blue') for color deconvolution can confuse brightness/contrast settings (https://github.com/qupath/qupath/issues/1245)
 
 ### Dependency updates
 * Bio-Formats 7.0.0

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -1404,7 +1404,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 						return new IOException("Bio-Formats does not support JPEG-XR on Apple Silicon: " + t.getMessage(), t);
 					}
 					if (message.contains("org.libjpegturbo.turbojpeg.TJDecompressor")) {
-						return new IOException("Bio-Formats does not currently support libjpegturbo on Apple Silicon", t);
+						return new IOException("Bio-Formats does not currently support libjpeg-turbo on Apple Silicon", t);
 					}
 				}
 			}

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -23,63 +23,6 @@
 
 package qupath.lib.images.servers.bioformats;
 
-import java.awt.image.BandedSampleModel;
-import java.awt.image.BufferedImage;
-import java.awt.image.ColorModel;
-import java.awt.image.ComponentSampleModel;
-import java.awt.image.DataBuffer;
-import java.awt.image.DataBufferByte;
-import java.awt.image.DataBufferDouble;
-import java.awt.image.DataBufferFloat;
-import java.awt.image.DataBufferInt;
-import java.awt.image.DataBufferShort;
-import java.awt.image.DataBufferUShort;
-import java.awt.image.PixelInterleavedSampleModel;
-import java.awt.image.SampleModel;
-import java.awt.image.WritableRaster;
-import java.io.File;
-import java.io.IOException;
-import java.lang.ref.Cleaner;
-import java.lang.ref.Cleaner.Cleanable;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
-import java.nio.IntBuffer;
-import java.nio.ShortBuffer;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.ForkJoinTask;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.IntStream;
-
-import javax.imageio.ImageIO;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import ome.units.UNITS;
-import ome.units.quantity.Length;
-import picocli.CommandLine;
-import picocli.CommandLine.Option;
-import picocli.CommandLine.Unmatched;
-import loci.common.DataTools;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.formats.ClassList;
@@ -98,6 +41,13 @@ import loci.formats.meta.DummyMetadata;
 import loci.formats.meta.MetadataStore;
 import loci.formats.ome.OMEPyramidStore;
 import loci.formats.ome.OMEXMLMetadata;
+import ome.units.UNITS;
+import ome.units.quantity.Length;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Unmatched;
 import qupath.lib.color.ColorModelFactory;
 import qupath.lib.common.ColorTools;
 import qupath.lib.common.GeneralTools;
@@ -109,6 +59,36 @@ import qupath.lib.images.servers.ImageServerMetadata;
 import qupath.lib.images.servers.ImageServerMetadata.ImageResolutionLevel;
 import qupath.lib.images.servers.PixelType;
 import qupath.lib.images.servers.TileRequest;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.io.File;
+import java.io.IOException;
+import java.lang.ref.Cleaner;
+import java.lang.ref.Cleaner.Cleanable;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 /**
  * QuPath ImageServer that uses the Bio-Formats library to read image data.
@@ -1039,7 +1019,9 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 	static class ReaderPool implements AutoCloseable {
 		
 		private static final Logger logger = LoggerFactory.getLogger(ReaderPool.class);
-		
+
+		private static final int DEFAULT_TIMEOUT_SECONDS = 60;
+
 		/**
 		 * Absolute maximum number of permitted readers (queue capacity)
 		 */
@@ -1061,8 +1043,10 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		
 		private ForkJoinTask<?> task;
 		private final List<ImageChannel> channels;
-		
-		
+
+		private int timeoutSeconds;
+
+		// This may be reused by OMERO extension? Not sure, but need to change cautiously...
 		ReaderPool(BioFormatsServerOptions options, String id, BioFormatsArgs args, List<ImageChannel> channels) throws FormatException, IOException {
 			this.id = id;
 			this.options = options;
@@ -1071,6 +1055,8 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			
 			queue = new ArrayBlockingQueue<>(MAX_QUEUE_CAPACITY); // Set a reasonably large capacity (don't want to block when trying to add)
 			metadata = (OMEPyramidStore)MetadataTools.createOMEXMLMetadata();
+
+			timeoutSeconds = getTimeoutSeconds();
 			
 			// Create the main reader
 			long startTime = System.currentTimeMillis();
@@ -1084,6 +1070,23 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			
 			// Store the class so we don't need to go hunting later
 			classList = unwrapClasslist(mainReader);
+		}
+
+		/**
+		 * Make the timeout adjustable.
+		 * See https://github.com/qupath/qupath/issues/1265
+		 * @return
+		 */
+		private int getTimeoutSeconds() {
+			String timeoutString = System.getProperty("bioformats.readerpool.timeout", null);
+			if (timeoutString != null) {
+				try {
+					return Integer.parseInt(timeoutString);
+				} catch (NumberFormatException e) {
+					logger.warn("Unable to parse timeout value: {}", timeoutString, e);
+				}
+			}
+			return DEFAULT_TIMEOUT_SECONDS;
 		}
 		
 		IFormatReader getMainReader() {
@@ -1266,7 +1269,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		
 				
 		
-		private IFormatReader nextQueuedReader() throws InterruptedException {
+		private IFormatReader nextQueuedReader() {
 			var nextReader = queue.poll();
 			if (nextReader != null)
 				return nextReader;
@@ -1279,7 +1282,13 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			if (isClosed)
 				return null;
 			try {
-				return queue.poll(60, TimeUnit.SECONDS);
+				var reader = queue.poll(timeoutSeconds, TimeUnit.SECONDS);
+				// See https://github.com/qupath/qupath/issues/1265
+				if (reader == null) {
+					logger.warn("Bio-Formats reader request timed out after {} seconds - returning main reader", timeoutSeconds);
+					return mainReader;
+				} else
+					return reader;
 			} catch (InterruptedException e) {
 				logger.warn("Interrupted exception when awaiting next queued reader: {}", e.getLocalizedMessage());
 				return isClosed ? null : mainReader;
@@ -1337,8 +1346,9 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 						try {
 							byte[] bytesSimple = ipReader.openBytes(ind, tileX, tileY, tileWidth, tileHeight);
 							return AWTImageTools.openImage(bytesSimple, ipReader, tileWidth, tileHeight);
-						} catch (Exception e) {
-							logger.error("Error opening image " + ind + " for " + tileRequest.getRegionRequest(), e);
+						} catch (Exception | UnsatisfiedLinkError e) {
+							logger.warn("Unable to open image " + ind + " for " + tileRequest.getRegionRequest());
+							throw convertToIOException(e);
 						}
 					}
 					// Read bytes for all the required channels
@@ -1350,13 +1360,12 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 							bytes[c] = ipReader.openBytes(ind, tileX, tileY, tileWidth, tileHeight);
 							length = bytes[c].length;
 						}
-					} catch (FormatException e) {
-						throw new IOException(e);
+					} catch (Exception | UnsatisfiedLinkError e) {
+						throw convertToIOException(e);
 					}
 				}
 			} finally {
-				if (ipReader != null)
-					queue.put(ipReader);
+				queue.put(ipReader);
 			}
 
 			OMEPixelParser omePixelParser = new OMEPixelParser.Builder()
@@ -1379,7 +1388,29 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 					.build();
 			
 			return omePixelParser.parse(bytes, tileWidth, tileHeight, nChannels, colorModel);
-			
+		}
+
+		/**
+		 * Ensure a throwable is an IOException.
+		 * This gives the opportunity to include more human-readable messages for common errors.
+		 * @param t
+		 * @return
+		 */
+		private static IOException convertToIOException(Throwable t) {
+			if (GeneralTools.isMac()) {
+				String message = t.getMessage();
+				if (message != null) {
+					if (message.contains("ome.jxrlib.JXRJNI")) {
+						return new IOException("Bio-Formats does not support JPEG-XR on Apple Silicon: " + t.getMessage(), t);
+					}
+					if (message.contains("org.libjpegturbo.turbojpeg.TJDecompressor")) {
+						return new IOException("Bio-Formats does not currently support libjpegturbo on Apple Silicon", t);
+					}
+				}
+			}
+			if (t instanceof IOException e)
+				return e;
+			return new IOException(t);
 		}
 		
 		
@@ -1403,8 +1434,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 					}
 				}
 			} finally {
-				if (reader != null)
-					queue.put(reader);
+				queue.put(reader);
 			}
 		}
 		

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/OMEPixelParser.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/OMEPixelParser.java
@@ -1,14 +1,59 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
+ * Contact: IP Management (ipmanagement@qub.ac.uk)
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
 package qupath.lib.images.servers.bioformats;
 
 import loci.common.DataTools;
 import qupath.lib.images.servers.PixelType;
 
-import java.awt.image.*;
-import java.nio.*;
+import java.awt.image.BandedSampleModel;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.ComponentSampleModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
+import java.awt.image.DataBufferDouble;
+import java.awt.image.DataBufferFloat;
+import java.awt.image.DataBufferInt;
+import java.awt.image.DataBufferShort;
+import java.awt.image.DataBufferUShort;
+import java.awt.image.PixelInterleavedSampleModel;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.ShortBuffer;
+
 
 /**
  * This class can parse raw bytes into a {@link BufferedImage}.
- * INT8 and UINT32 images are currently not supported.
+ * It is intended for use with non-RGB images; {@link loci.formats.gui.AWTImageTools} can be used for RGB images.
+ *
+ * @implNote INT8 and UINT32 images are currently not supported.
  */
 public class OMEPixelParser {
 

--- a/qupath-extension-svg/src/main/java/qupath/lib/extension/svg/SvgTools.java
+++ b/qupath-extension-svg/src/main/java/qupath/lib/extension/svg/SvgTools.java
@@ -487,7 +487,7 @@ public class SvgTools {
 				try {
 					transformInverse = transform.createInverse();
 				} catch (NoninvertibleTransformException e) {
-					logger.warn("Can't include images - unable to invert image transform: ", e.getMessage(), e);
+					logger.warn("Can't include images - unable to invert image transform: {}", e.getMessage(), e);
 				}
 			}
 
@@ -495,17 +495,23 @@ public class SvgTools {
 			boolean objectsDrawn = false;
 			if (transformInverse != null && includeImages) {
 				if (imageData != null) {
-					DefaultImageRegionStore store;
-					ImageDisplay display;
-					if (viewer == null) {
-						store = ImageRegionStoreFactory.createImageRegionStore(1024*1024L*16);
-						display = new ImageDisplay(imageData);
-					} else {
-						store = viewer.getImageRegionStore();
-						if (viewer.getImageData() == imageData)
-							display = viewer.getImageDisplay();
-						else
-							display = new ImageDisplay(imageData);							
+					DefaultImageRegionStore store = null;
+					ImageDisplay display = null;
+					try {
+						if (viewer == null) {
+							store = ImageRegionStoreFactory.createImageRegionStore(1024 * 1024L * 16);
+							display = ImageDisplay.create(imageData);
+						} else {
+							store = viewer.getImageRegionStore();
+							if (viewer.getImageData() == imageData)
+								display = viewer.getImageDisplay();
+							else
+								display = ImageDisplay.create(imageData);
+						}
+					} catch (IOException e) {
+						logger.warn("Unable to create image display, may not be able to include images", e);
+						if (store == null)
+							store = ImageRegionStoreFactory.createImageRegionStore(1024 * 1024L * 16);
 					}
 					
 					if (imageInclude == ImageIncludeType.LINK) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -1437,6 +1437,8 @@ public class QuPathGUI {
 			return true;
 		} catch (Exception e) {
 			Dialogs.showErrorMessage("Load ImageData", e);
+			// If this failed
+			viewer.resetImageData();
 			return false;
 		}
 	}
@@ -2468,7 +2470,7 @@ public class QuPathGUI {
 			if (imageData != null) {
 				if (!checkSaveChanges(imageData))
 					return;
-				viewer.setImageData(null);
+				viewer.resetImageData();
 			}
 		}
 		
@@ -2595,7 +2597,7 @@ public class QuPathGUI {
 			if (!isReadOnly() && !promptToSaveChangesOrCancel(dialogTitle, imageData))
 				return false;
 		}
-		viewer.setImageData(null);
+		viewer.resetImageData();
 		return true;
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -262,7 +262,10 @@ public class QuPathGUI {
 		logViewerCommand = new LogViewerCommand(stage);
 		initializeLoggingToFile();
 		logBuildVersion();				
-		
+
+		// Try to ensure that any dialogs are shown with a sensible owner
+		Dialogs.setPrimaryWindow(stage);
+
 		// Set this as the current instance
 		ensureQuPathInstanceSet();
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -337,8 +337,15 @@ public class Commands {
 		}
 		
 		ImageServer<BufferedImage> server = viewer.getServer();
-		if (renderedImage)
-			server = RenderedImageServer.createRenderedServer(viewer);
+		if (renderedImage) {
+			try {
+				server = RenderedImageServer.createRenderedServer(viewer);
+			} catch (IOException e) {
+				Dialogs.showErrorMessage("Export image region", "Unable to create rendered image server");
+				logger.error(e.getMessage(), e);
+				return;
+			}
+		}
 		PathObject pathObject = viewer.getSelectedObject();
 		ROI roi = pathObject == null ? null : pathObject.getROI();
 		
@@ -453,8 +460,15 @@ public class Commands {
 		exportDownsample.set(downsample.get());
 		
 		// Now that we know the output, we can create a new server to ensure it is downsampled as the necessary resolution
-		if (renderedImage && downsample.get() != server.getDownsampleForResolution(0))
-			server = new RenderedImageServer.Builder(viewer).downsamples(downsample.get()).build();
+		if (renderedImage && downsample.get() != server.getDownsampleForResolution(0)) {
+			try {
+				server = new RenderedImageServer.Builder(viewer).downsamples(downsample.get()).build();
+			} catch (IOException e) {
+				Dialogs.showErrorMessage("Export image region", "Unable to create rendered image server");
+				logger.error(e.getMessage(), e);
+				return;
+			}
+		}
 		
 //		selectedImageType.set(comboImageType.getSelectionModel().getSelectedItem());
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
@@ -749,7 +749,7 @@ class ProjectImportImagesCommand {
 			if (imageDisplay == null) {
 				// By wrapping the thumbnail, we avoid slow z-stack/time series requests & determine brightness & contrast just from one plane
 				var wrappedServer = new WrappedBufferedImageServer("Dummy", img2, server.getMetadata().getChannels());
-				imageDisplay = new ImageDisplay(new ImageData<>(wrappedServer));
+				imageDisplay = ImageDisplay.create(new ImageData<>(wrappedServer));
 //				imageDisplay = new ImageDisplay(new ImageData<>(server));
 			}
 			for (ChannelDisplayInfo info : imageDisplay.selectedChannels()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMACommands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMACommands.java
@@ -23,6 +23,7 @@ package qupath.lib.gui.commands;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -149,9 +150,13 @@ public class TMACommands {
 			if (!file.getName().endsWith(".qptma"))
 				file = new File(file.getParentFile(), file.getName() + ".qptma");
 			double downsample = PathPrefs.tmaExportDownsampleProperty().get();
-			TMADataIO.writeTMAData(file, imageData, overlayOptions, downsample);
-			WorkflowStep step = new DefaultScriptableWorkflowStep("Export TMA data", "exportTMAData(\"" + GeneralTools.escapeFilePath(file.getParentFile().getAbsolutePath()) + "\", " + downsample + ")");
-			imageData.getHistoryWorkflow().addStep(step);
+			try {
+				TMADataIO.writeTMAData(file, imageData, overlayOptions, downsample);
+				WorkflowStep step = new DefaultScriptableWorkflowStep("Export TMA data", "exportTMAData(\"" + GeneralTools.escapeFilePath(file.getParentFile().getAbsolutePath()) + "\", " + downsample + ")");
+				imageData.getHistoryWorkflow().addStep(step);
+			} catch (IOException e) {
+				Dialogs.showErrorMessage(title, e);
+			}
 //			PathAwtIO.writeTMAData(file, imageData, viewer.getOverlayOptions(), Double.NaN);
 		}
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastHistogramPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastHistogramPane.java
@@ -160,7 +160,12 @@ public class BrightnessContrastHistogramPane extends BorderPane {
      * @param channelSelected
      */
     public void updateHistogram(ImageDisplay imageDisplay, ChannelDisplayInfo channelSelected) {
-        Histogram histogram = (imageDisplay == null || channelSelected == null) ? null : imageDisplay.getHistogram(channelSelected);
+        Histogram histogram;
+        if (imageDisplay == null || channelSelected == null)
+            histogram = null;
+        else
+            histogram = imageDisplay.getHistogram(channelSelected);
+
         if (histogram == null) {
             // Try to show RGB channels together
             if (channelSelected != null && imageDisplay != null &&

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/images/servers/RenderedImageServer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/images/servers/RenderedImageServer.java
@@ -107,7 +107,7 @@ public class RenderedImageServer extends AbstractTileableImageServer implements 
 	 * @return
 	 * @see Builder
 	 */
-	public static ImageServer<BufferedImage> createRenderedServer(QuPathViewer viewer) {
+	public static ImageServer<BufferedImage> createRenderedServer(QuPathViewer viewer) throws IOException {
 		return new Builder(viewer)
 				.build();
 	}
@@ -118,7 +118,7 @@ public class RenderedImageServer extends AbstractTileableImageServer implements 
 	 * @param renderer
 	 * @return
 	 */
-	public static ImageServer<BufferedImage> createRenderedServer(ImageServer<BufferedImage> server, ImageRenderer renderer) {
+	public static ImageServer<BufferedImage> createRenderedServer(ImageServer<BufferedImage> server, ImageRenderer renderer) throws IOException {
 		return new Builder(new ImageData<>(server))
 				.renderer(renderer)
 				.backgroundColor(new Color(0, true))
@@ -255,7 +255,7 @@ public class RenderedImageServer extends AbstractTileableImageServer implements 
 		 * Create the rendered image server.
 		 * @return
 		 */
-		public ImageServer<BufferedImage> build() {
+		public ImageServer<BufferedImage> build() throws IOException {
 			// Try to use existing store/display if possible
 			if (this.store == null || this.renderer == null) {
 				QuPathViewer viewer = null;
@@ -267,7 +267,7 @@ public class RenderedImageServer extends AbstractTileableImageServer implements 
 				ImageRenderer renderer = null;
 				if (viewer == null) {
 					store = ImageRegionStoreFactory.createImageRegionStore(Runtime.getRuntime().maxMemory() / 4L);
-					renderer = new ImageDisplay(imageData);
+					renderer = ImageDisplay.create(imageData);
 				} else {
 					store = viewer.getImageRegionStore();
 					renderer = viewer.getImageDisplay();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ImageDetailsPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ImageDetailsPane.java
@@ -41,6 +41,7 @@ import java.util.Locale;
 import java.util.Locale.Category;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 import javafx.scene.control.TitledPane;
@@ -961,7 +962,7 @@ public class ImageDetailsPane implements ChangeListener<ImageData<BufferedImage>
 			if (roi != null) {
 				if ((roi instanceof RectangleROI) && 
 						!roi.isEmpty() &&
-						((RectangleROI) roi).getArea() < 500*500) {
+						roi.getArea() < 500*500) {
 					if (Dialogs.showYesNoDialog("Color deconvolution stains", message)) {
 						ImageServer<BufferedImage> server = imageData.getServer();
 						BufferedImage img = null;
@@ -1034,6 +1035,11 @@ public class ImageDetailsPane implements ChangeListener<ImageData<BufferedImage>
 			String valuesAfter = params.getStringParameterValue("values");
 			if (collectiveName.equals(collectiveNameBefore) && nameAfter.equals(nameBefore) && valuesAfter.equals(valuesBefore) && !wasChanged)
 				return;
+
+			if (Set.of("Red", "Green", "Blue").contains(nameAfter)) {
+				Dialogs.showErrorMessage("Set stain vector", "Cannot set stain name to 'Red', 'Green', or 'Blue' - please choose a different name");
+				return;
+			}
 
 			double[] valuesParsed = ColorDeconvolutionStains.parseStainValues(Locale.getDefault(Category.FORMAT), valuesAfter);
 			if (valuesParsed == null) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SimpleImageViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SimpleImageViewer.java
@@ -524,12 +524,17 @@ public class SimpleImageViewer {
         if (requiresAutoContrast(imgBuffered)) {
             // Non-RGB images probably need to have contrast settings applied before they can be visualized.
             // By wrapping the image, we avoid slow z-stack/time series requests & determine brightness & contrast just from one plane.
-            var wrappedServer = new WrappedBufferedImageServer("Dummy", imgBuffered);
-            var imageDisplay = new ImageDisplay(new ImageData<>(wrappedServer));
-            for (ChannelDisplayInfo info : imageDisplay.selectedChannels()) {
-                imageDisplay.autoSetDisplayRange(info, saturation.get()/100.0);
+            try {
+                var wrappedServer = new WrappedBufferedImageServer("Dummy", imgBuffered);
+                var imageDisplay = ImageDisplay.create(new ImageData<>(wrappedServer));
+                for (ChannelDisplayInfo info : imageDisplay.selectedChannels()) {
+                    imageDisplay.autoSetDisplayRange(info, saturation.get() / 100.0);
+                }
+                imgBuffered = imageDisplay.applyTransforms(imgBuffered, null);
+            } catch (Exception e) {
+                // Not expect to happen, since we have a cached buffered image
+                logger.error("Error applying auto contrast to image", e);
             }
-            imgBuffered = imageDisplay.applyTransforms(imgBuffered, null);
         }
         return SwingFXUtils.toFXImage(imgBuffered, null);
     }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMADataIO.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMADataIO.java
@@ -85,7 +85,7 @@ public class TMADataIO {
 	 * @param file
 	 * @param imageData
 	 */
-	public static void writeTMAData(File file, final ImageData<BufferedImage> imageData) {
+	public static void writeTMAData(File file, final ImageData<BufferedImage> imageData) throws IOException {
 		writeTMAData(file, imageData, null, -1);
 	}
 	
@@ -97,7 +97,7 @@ public class TMADataIO {
 	 * @param overlayOptions 
 	 * @param downsampleFactor The downsample factor used for the TMA cores. If NaN, an automatic downsample value will be selected (&gt;= 1).  If &lt;= 0, no cores are exported.
 	 */
-	public static void writeTMAData(File file, final ImageData<BufferedImage> imageData, OverlayOptions overlayOptions, final double downsampleFactor) {
+	public static void writeTMAData(File file, final ImageData<BufferedImage> imageData, OverlayOptions overlayOptions, final double downsampleFactor) throws IOException {
 		if (imageData == null || imageData.getHierarchy() == null || imageData.getHierarchy().getTMAGrid() == null) {
 			logger.error("No TMA data available to save!");
 			return;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -767,22 +767,20 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 
 	/**
 	 * Create a new viewer.
-	 * @param imageData image data to show within the viewer
 	 * @param regionStore store used to tile caching
 	 * @param overlayOptions overlay options to control the viewer display
 	 */
-	public QuPathViewer(final ImageData<BufferedImage> imageData, DefaultImageRegionStore regionStore, OverlayOptions overlayOptions) {
-		this(imageData, regionStore, overlayOptions, new ImageDisplay(null));
+	public QuPathViewer(DefaultImageRegionStore regionStore, OverlayOptions overlayOptions) {
+		this(regionStore, overlayOptions, new ImageDisplay());
 	}
 	
 	/**
 	 * Create a new viewer.
-	 * @param imageData image data to show within the viewer
 	 * @param regionStore store used to tile caching
 	 * @param overlayOptions overlay options to control the viewer display
 	 * @param imageDisplay image display used to control the image display (conversion to RGB)
 	 */
-	public QuPathViewer(final ImageData<BufferedImage> imageData, DefaultImageRegionStore regionStore, OverlayOptions overlayOptions, ImageDisplay imageDisplay) {
+	private QuPathViewer(DefaultImageRegionStore regionStore, OverlayOptions overlayOptions, ImageDisplay imageDisplay) {
 		super();
 
 		this.regionStore = regionStore;
@@ -836,7 +834,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 		coreOverlayLayers.addListener((Change<? extends PathOverlay> e) -> refreshAllOverlayLayers());
 		allOverlayLayers.addListener((Change<? extends PathOverlay> e) -> repaint());
 		
-		hierarchyOverlay = new HierarchyOverlay(this.regionStore, overlayOptions, imageData);
+		hierarchyOverlay = new HierarchyOverlay(this.regionStore, overlayOptions, null);
 		tmaGridOverlay = new TMAGridOverlay(overlayOptions);
 		gridOverlay = new GridOverlay(overlayOptions);
 //		pixelLayerOverlay = new PixelLayerOverlay(this);
@@ -847,8 +845,6 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 				hierarchyOverlay,
 				gridOverlay
 		);
-
-		setImageData(imageData);
 
 		this.regionStore.addTileListener(this);
 
@@ -1523,7 +1519,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 	 * Set the current image for this viewer.
 	 * @param imageDataNew
 	 */
-	public void setImageData(ImageData<BufferedImage> imageDataNew) {
+	public void setImageData(ImageData<BufferedImage> imageDataNew) throws IOException {
 		if (this.imageDataProperty.get() == imageDataNew)
 			return;
 
@@ -1574,8 +1570,17 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 					}
 				}
 			}
-			if (!displaySet)
-				imageDisplay.setImageData(imageDataNew, keepDisplay);
+			if (!displaySet) {
+				try {
+					imageDisplay.setImageData(imageDataNew, keepDisplay);
+				} catch (Exception | UnsatisfiedLinkError e2) {
+					// This can fail if the image isn't actually open-able.
+					// If we don't reset, then the viewer will be in a bad state and continually through exceptions.
+					logger.warn("Caught exception setting ImageData - will reset to null ({})", e2.getMessage());
+					setImageData(null);
+					throw e2;
+				}
+			}
 			
 			// For non-RGB images, the channel colors in our server metadata might now be out of sync with the 
 			// brightness/contrast, based upon whatever we extracted from the image properties or kept from the last image.
@@ -1635,7 +1640,19 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 		
 		logger.info("Image data set to {}", imageDataNew);
 	}
-	
+
+
+	/**
+	 * Reset the image data to null.
+	 */
+	public void resetImageData() {
+		try {
+			setImageData(null);
+		} catch (IOException e) {
+			// Should not happen - exception only 'expected' when an image cannot be read
+			logger.error("Error resetting image data", e);
+		}
+	}
 	
 	
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
@@ -78,14 +78,13 @@ public class QuPathViewerPlus extends QuPathViewer {
 	
 	/**
 	 * Create a new viewer.
-	 * @param imageData image data to show within the viewer
 	 * @param regionStore store used to tile caching
 	 * @param overlayOptions overlay options to control the viewer display
 	 * @param viewerDisplayOptions viewer options to control additional panes and labels
 	 */
-	public QuPathViewerPlus(final ImageData<BufferedImage> imageData, final DefaultImageRegionStore regionStore, final OverlayOptions overlayOptions,
+	public QuPathViewerPlus(final DefaultImageRegionStore regionStore, final OverlayOptions overlayOptions,
 			final ViewerPlusDisplayOptions viewerDisplayOptions) {
-		super(imageData, regionStore, overlayOptions);
+		super(regionStore, overlayOptions);
 		
 		
 		sliderZ.setOrientation(Orientation.VERTICAL);
@@ -106,8 +105,6 @@ public class QuPathViewerPlus extends QuPathViewer {
 		});
 		
 		// Add the overview (preview image for navigation)
-		if (imageData != null)
-			overview.imageDataChanged(this, null, imageData);
 		Node overviewNode = overview.getNode();
 		basePane.getChildren().add(overviewNode);
 		AnchorPane.setTopAnchor(overviewNode, (double)padding);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
@@ -374,7 +374,7 @@ public class ViewerManager implements QuPathViewerListener {
 	 * @return
 	 */
 	protected QuPathViewerPlus createViewer() {
-		QuPathViewerPlus viewerNew = new QuPathViewerPlus(null, qupath.getImageRegionStore(), overlayOptions, viewerDisplayOptions);
+		QuPathViewerPlus viewerNew = new QuPathViewerPlus(qupath.getImageRegionStore(), overlayOptions, viewerDisplayOptions);
 		setupViewer(viewerNew);
 		viewerNew.addViewerListener(this);
 		viewers.add(viewerNew);


### PR DESCRIPTION
Fixes for
* https://github.com/qupath/qupath/issues/1265
* https://github.com/qupath/qupath/issues/1245
* https://github.com/qupath/qupath/issues/1249

Also improve image opening behavior... or non-opening when it fails ([here](https://github.com/qupath/qupath/commit/4b4955cea256d70272e96f7714cafe6e1a8b9762)).

> Throw an `IOException` if `ImageDisplay.setImageData()` fails, and remove the constructor that takes an `ImageData` parameter in favor of adding a static `create()` method instead.
>
> The purpose is to 'fail faster and better' if pixels cannot be read from an image, to avoid putting the viewer into an invalid state.
> 
> Previously, failure to open an image (e.g. because JPEGXR decompression was unavailable on Apple Silicon) would lead to an extremely uninformative NPE, and then possibly a lot more exceptions when attempting to interact with the viewer in any way.
> 
> When making these changes, the constructors for `QuPathViewer` were changed to no longer take an `ImageData` as a parameter. This was always null anyway (viewers were always created without an image), so makes no real difference to the current code - but the change avoids the possibility of the constructor having to throw an exception if the image couldn't be set. Now the image must be set as a second step, after the viewer has been created.