### PR TITLE
Create `ObjectMerger` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This is a work-in-progress for the next QuPath release.
 
 #### Processing & analysis
 * Faster processing & reduced memory use for pixel classification measurements (https://github.com/qupath/qupath/pull/1332)
+* New `ObjectMerger` class to simplify creating new tile-based segmentation methods (https://github.com/qupath/qupath/pull/1346)
 
 #### Import & export
 * SVG export now supports overlays (https://github.com/qupath/qupath/issues/1272)

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -116,7 +116,6 @@ import qupath.lib.objects.PathCellObject;
 import qupath.lib.objects.PathDetectionObject;
 import qupath.lib.objects.TMACoreObject;
 import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassFactory;
 import qupath.lib.objects.classes.PathClassTools;
 import qupath.lib.objects.hierarchy.DefaultTMAGrid;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
@@ -275,7 +274,6 @@ public class QP {
 			// Static constructors
 			PathObjects.class,
 			ROIs.class,
-			PathClassFactory.class,
 			Projects.class,
 			
 			// Tools and static classes

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjects.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjects.java
@@ -176,7 +176,7 @@ public class PathObjects {
 	}
 
 	/**
-	 * Create a tile object.
+	 * Create a tile object, with a classification and measurements list.
 	 * <p>
 	 * Tile objects represent a special case of a detection objects, were the ROI doesn't represent any particular structure 
 	 * (e.g. it is a superpixel or square tile representing a local collection of pixels used on the path to region segmentation).
@@ -192,6 +192,23 @@ public class PathObjects {
 		if (roi == null)
 			throw new IllegalArgumentException("A ROI is required to create a detection object!");
 		return new PathTileObject(roi, pathClass, measurements);
+	}
+
+	/**
+	 * Create a tile object.
+	 * <p>
+	 * Tile objects represent a special case of a detection objects, were the ROI doesn't represent any particular structure
+	 * (e.g. it is a superpixel or square tile representing a local collection of pixels used on the path to region segmentation).
+	 *
+	 * @param roi
+	 * @param pathClass
+	 * @return
+	 *
+	 * @see #createDetectionObject
+	 * @since v0.5.0
+	 */
+	public static PathObject createTileObject(final ROI roi, final PathClass pathClass) {
+		return createTileObject(roi, pathClass, null);
 	}
 	
 	/**
@@ -212,7 +229,7 @@ public class PathObjects {
 	}
 	
 	/**
-	 * Create a cell object.
+	 * Create a cell object with an optional classification and measurements list.
 	 * <p>
 	 * Cell objects represent a special case of a detection objects, where an additional ROI can be stored representing 
 	 * the cell nucleus.
@@ -227,6 +244,41 @@ public class PathObjects {
 	 */
 	public static PathObject createCellObject(final ROI roiCell, final ROI roiNucleus, final PathClass pathClass, final MeasurementList measurements) {
 		return new PathCellObject(roiCell, roiNucleus, pathClass, measurements);
+	}
+
+	/**
+	 * Create a cell object with an optional classification.
+	 * <p>
+	 * Cell objects represent a special case of a detection objects, where an additional ROI can be stored representing
+	 * the cell nucleus.
+	 *
+	 * @param roiCell
+	 * @param roiNucleus
+	 * @param pathClass
+	 * @return
+	 *
+	 * @see #createDetectionObject
+	 * @since v0.5.0
+	 */
+	public static PathObject createCellObject(final ROI roiCell, final ROI roiNucleus, final PathClass pathClass) {
+		return createCellObject(roiCell, roiNucleus, pathClass, null);
+	}
+
+	/**
+	 * Create a cell object.
+	 * <p>
+	 * Cell objects represent a special case of a detection objects, where an additional ROI can be stored representing
+	 * the cell nucleus.
+	 *
+	 * @param roiCell
+	 * @param roiNucleus
+	 * @return
+	 *
+	 * @see #createDetectionObject
+	 * @since v0.5.0
+	 */
+	public static PathObject createCellObject(final ROI roiCell, final ROI roiNucleus) {
+		return createCellObject(roiCell, roiNucleus, null);
 	}
 	
 

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassFactory.java
@@ -44,7 +44,11 @@ import qupath.lib.common.LogTools;
 public final class PathClassFactory {
 	
 	private static final Logger logger = LoggerFactory.getLogger(PathClassFactory.class);
-	
+
+	static {
+		logger.warn("PathClassFactory is deprecated since v0.4.0 and will be removed - use PathClass methods instead");
+	}
+
 	// Suppressed default constructor for non-instantiability
 	private PathClassFactory() {
 		throw new AssertionError();

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -286,10 +286,10 @@ public class ObjectMerger {
      * @param sharedBoundaryThreshold proportion of the possibly-clipped boundary that must be shared
      *
      * @return an object merger that uses a shared boundary criterion
-     * @see #createSharedBoundaryMerger(double, double)
+     * @see #createSharedTileBoundaryMerger(double, double)
      */
-    public static ObjectMerger createSharedBoundaryMerger(double sharedBoundaryThreshold) {
-        return createSharedBoundaryMerger(sharedBoundaryThreshold, 0.125);
+    public static ObjectMerger createSharedTileBoundaryMerger(double sharedBoundaryThreshold) {
+        return createSharedTileBoundaryMerger(sharedBoundaryThreshold, 0.125);
     }
 
     /**
@@ -313,7 +313,7 @@ public class ObjectMerger {
      *                         shared exactly. A typical value is 0.125, which allows for a small, sub-pixel overlap.
      * @return an object merger that uses a shared boundary criterion and overlap tolerance
      */
-    public static ObjectMerger createSharedBoundaryMerger(double sharedBoundaryThreshold, double overlapTolerance) {
+    public static ObjectMerger createSharedTileBoundaryMerger(double sharedBoundaryThreshold, double overlapTolerance) {
         return new ObjectMerger(
                 ObjectMerger::sameClassTypePlaneTest,
                 createBoundaryOverlapTest(sharedBoundaryThreshold, overlapTolerance),
@@ -346,11 +346,11 @@ public class ObjectMerger {
      * This strictness can cause unexpected results due to floating point precision issues, unless it is certain that
      * the ROIs are perfectly aligned (e.g they are generated using integer coordinates on a pixel grid).
      * <p>
-     * If this is not the case, {@link #createSharedBoundaryMerger(double, double)} is usually preferable, since it
+     * If this is not the case, {@link #createSharedTileBoundaryMerger(double, double)} is usually preferable, since it
      * can include a small overlap tolerance.
      *
      * @return an object merger that can merge together any objects with similar ROIs and the same classification
-     * @see #createSharedBoundaryMerger(double, double)
+     * @see #createSharedTileBoundaryMerger(double, double)
      */
     public static ObjectMerger createTouchingMerger() {
         return new ObjectMerger(

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -1,0 +1,250 @@
+package qupath.lib.objects.utils;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequenceFilter;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.index.quadtree.Quadtree;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.lib.objects.PathCellObject;
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.PathObjects;
+import qupath.lib.roi.RoiTools;
+import qupath.lib.roi.interfaces.ROI;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+public class ObjectMerger {
+
+    private static final Logger logger = LoggerFactory.getLogger(ObjectMerger.class);
+
+    /**
+     * Merge objects that share a common boundary and have the same classification.
+     * <p>
+     * This is intended for post-processing a tile-based segmentation, where the tiling has been strictly enforced
+     * (i.e. any objects have been clipped to non-overlapping tile boundaries).
+     *
+     * @param pathObjects
+     * @param sharedBoundaryThreshold
+     * @return
+     */
+    public static List<PathObject> resolveTileSplits(Collection<? extends PathObject> pathObjects, double sharedBoundaryThreshold) {
+
+        // Create a priority queue to ensure the objects are sorted by ROI bounds
+        Comparator<PathObject> comparator = Comparator
+                .comparingDouble((PathObject p) -> p.getROI().getBoundsX())
+                    .thenComparingDouble(p -> p.getROI().getBoundsY())
+                    .thenComparingDouble(p -> p.getROI().getBoundsWidth())
+                    .thenComparingDouble(p -> p.getROI().getBoundsHeight());
+
+        PriorityQueue<PathObject> queue = new PriorityQueue<>(comparator);
+        queue.addAll(pathObjects);
+
+        // Build a spatial index
+        Quadtree tree = new Quadtree();
+        Map<ROI, Geometry> geometryMap = new HashMap<>();
+        for (var p : pathObjects) {
+            var geom = p.getROI().getGeometry();
+            var envelope = geom.getEnvelopeInternal();
+            tree.insert(envelope, p);
+            geometryMap.put(p.getROI(), geom);
+        }
+
+        // Retain a set of objects we have already decided to remove
+        Set<PathObject> toRemove = new HashSet<>();
+
+        // Find potential overlaps
+        List<PathObject> results = new ArrayList<>();
+        while (!queue.isEmpty()) {
+            PathObject p = queue.poll();
+            if (toRemove.contains(p))
+                continue;
+
+            // Add the current object to the results (we still might remove it later)
+            results.add(p);
+
+            // Find all objects that potentially touch the current object (using a small bounding box expansion)
+            var geom = geometryMap.computeIfAbsent(p.getROI(), ROI::getGeometry);
+            var envelope = geom.getEnvelopeInternal();
+            var envelopeQuery = new Envelope(envelope);
+            envelopeQuery.expandBy(0.5d);
+            var potentialOverlaps = (List<PathObject>)tree.query(envelopeQuery);
+
+            for (var overlap : potentialOverlaps) {
+                if (overlap == p ||
+                        toRemove.contains(overlap) ||
+                        !Objects.equals(p.getPathClass(), overlap.getPathClass()) ||
+                        !Objects.equals(p.getROI().getImagePlane(), overlap.getROI().getImagePlane()) ||
+                        !Objects.equals(p.getClass(), overlap.getClass()))
+                    continue;
+
+                // If the potential overlap is completely contained, merging is equivalent to removal
+                var geomOverlap = geometryMap.computeIfAbsent(overlap.getROI(), k -> overlap.getROI().getGeometry());
+                if (geom.covers(geomOverlap)) {
+                    toRemove.add(overlap);
+                    continue;
+                }
+
+                // Search for a shared bounding box edge
+                // If the shared intersection is large enough, merge the two objects
+                if (testMergeBySharedBoundary(geom, geomOverlap, sharedBoundaryThreshold)) {
+                    logger.debug("Merging {} and {}", p, overlap);
+                    PathObject newObject = mergeObjects(p, overlap);
+
+                    // Update our queue & spatial tree
+                    queue.add(newObject);
+                    var mergedROI = newObject.getROI();
+                    var geomNew = mergedROI.getGeometry();
+                    tree.insert(geomNew.getEnvelopeInternal(), newObject);
+                    geometryMap.put(mergedROI, geom);
+
+                    // Flag both objects for removal
+                    toRemove.add(p);
+                    toRemove.add(overlap);
+                    break;
+                }
+            }
+        }
+        logger.debug("Removing {} merged objects", toRemove.size());
+        results.removeAll(toRemove);
+        return results;
+    }
+
+//    // TODO: Consider implementing this in the future
+//    private static boolean testMergeBySharedArea(Geometry geom, Geometry geomOverlap, double sharedAreaThreshold) {
+//    }
+
+    private static boolean testMergeBySharedBoundary(Geometry geom, Geometry geomOverlap, double sharedBoundaryThreshold) {
+        double pixelOverlapTolerance = 0.125;
+        if (calculateUpperLowerSharedBoundaryIntersectionScore(geom, geomOverlap, pixelOverlapTolerance) >= sharedBoundaryThreshold)
+            return true;
+        else if (calculateLeftRightSharedBoundaryIntersectionScore(geom, geomOverlap, pixelOverlapTolerance) >= sharedBoundaryThreshold)
+            return true;
+        else
+            return false;
+    }
+
+
+
+    private static PathObject mergeObjects(PathObject pathObject, PathObject pathObject2) {
+        var mergedROI = RoiTools.union(pathObject.getROI(), pathObject2.getROI());
+        if (pathObject.isTile()) {
+            return PathObjects.createTileObject(mergedROI, pathObject.getPathClass(), null);
+        } else if (pathObject.isCell()) {
+            ROI nucleusROI = getNucleusROI(pathObject);
+            if (nucleusROI == null)
+                nucleusROI = getNucleusROI(pathObject2);
+            else if (getNucleusROI(pathObject2) != null)
+                nucleusROI = RoiTools.union(nucleusROI, getNucleusROI(pathObject2));
+            return PathObjects.createCellObject(mergedROI, nucleusROI, pathObject.getPathClass(), null);
+        } else if (pathObject.isDetection()) {
+            return PathObjects.createDetectionObject(mergedROI, pathObject.getPathClass());
+        } else if (pathObject.isAnnotation()) {
+            return PathObjects.createAnnotationObject(mergedROI, pathObject.getPathClass());
+        } else
+            throw new IllegalArgumentException("Unsupported object type for merging: " + pathObject.getClass());
+    }
+
+    private static ROI getNucleusROI(PathObject pathObject) {
+        if (pathObject instanceof PathCellObject cell)
+            return cell.getNucleusROI();
+        return null;
+    }
+
+
+
+    private static double calculateUpperLowerSharedBoundaryIntersectionScore(Geometry upper, Geometry lower, double tolerance) {
+        var envUpper = upper.getEnvelopeInternal();
+        var envLower = lower.getEnvelopeInternal();
+        // We only consider the lower and upper boundaries, which must be very close to one another - with no gaps
+        if (envUpper.getMaxY() >= envLower.getMinY() && Math.abs(envUpper.getMaxY() - envLower.getMinY()) < tolerance) {
+            var upperIntersection = createEnvelopeIntersection(upper, envUpper.getMinX(), envUpper.getMaxY(), envUpper.getMaxX(), envUpper.getMaxY());
+            var lowerIntersection = createEnvelopeIntersection(lower, envLower.getMinX(), envLower.getMinY(), envLower.getMaxX(), envLower.getMinY());
+            double smallestIntersectionLength = Math.min(upperIntersection.getLength(), lowerIntersection.getLength());
+            if (smallestIntersectionLength <= 0)
+                return 0.0;
+            // For a non-zero tolerance, we may need to shift the geometries
+            if (envUpper.getMaxY() != envLower.getMinY()) {
+                lowerIntersection.apply(new SetOrdinateFilter(CoordinateSequence.Y, envUpper.getMaxY()));
+            }
+            var sharedIntersection = upperIntersection.intersection(lowerIntersection);
+            return sharedIntersection.getLength() / smallestIntersectionLength;
+        } else {
+            return 0.0;
+        }
+    }
+
+    private static double calculateLeftRightSharedBoundaryIntersectionScore(Geometry left, Geometry right, double tolerance) {
+        var envLeft = left.getEnvelopeInternal();
+        var envRight = right.getEnvelopeInternal();
+        // We only consider the right and left boundaries, which must be very close to one another - with no gaps
+        if (envLeft.getMaxX() >= envRight.getMinX() && Math.abs(envLeft.getMaxX() - envRight.getMinX()) < tolerance) {
+            var leftIntersection = createEnvelopeIntersection(left, envLeft.getMaxX(), envLeft.getMinY(), envLeft.getMaxX(), envLeft.getMaxY());
+            var rightIntersection = createEnvelopeIntersection(right, envRight.getMinX(), envRight.getMinY(), envRight.getMinX(), envRight.getMaxY());
+            double smallestIntersectionLength = Math.min(leftIntersection.getLength(), rightIntersection.getLength());
+            if (smallestIntersectionLength <= 0)
+                return 0.0;
+            // For a non-zero tolerance, we may need to shift the geometries
+            if (envLeft.getMaxX() != envRight.getMinX()) {
+                rightIntersection.apply(new SetOrdinateFilter(CoordinateSequence.X, envLeft.getMaxX()));
+            }
+            var sharedIntersection = leftIntersection.intersection(rightIntersection);
+            return sharedIntersection.getLength() / smallestIntersectionLength;
+        } else {
+            return 0.0;
+        }
+    }
+
+
+    private static Geometry createEnvelopeIntersection(Geometry geom, double x1, double y1, double x2, double y2) {
+        var factory = geom.getFactory();
+        var line = createLine(factory, x1, y1, x2, y2);
+        return geom.intersection(line);
+    }
+
+    private static LineString createLine(GeometryFactory factory, double x1, double y1, double x2, double y2) {
+        return factory.createLineString(new Coordinate[]{new Coordinate(x1, y1), new Coordinate(x2, y2)});
+    }
+
+    private static class SetOrdinateFilter implements CoordinateSequenceFilter {
+
+        private final int ordinateIndex;
+        private final double value;
+
+        SetOrdinateFilter(int ordinateIndex, double value) {
+            this.ordinateIndex = ordinateIndex;
+            this.value = value;
+        }
+
+        @Override
+        public void filter(CoordinateSequence seq, int i) {
+            seq.setOrdinate(i, ordinateIndex, value);
+        }
+
+        @Override
+        public boolean isDone() {
+            return false;
+        }
+
+        @Override
+        public boolean isGeometryChanged() {
+            return false;
+        }
+
+    }
+
+
+}

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/package-info.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Helper classes for working with {@linkplain qupath.lib.objects.PathObject PathObjects}.
+ */
+package qupath.lib.objects.utils;

--- a/qupath-core/src/test/java/qupath/lib/objects/utils/TestObjectMerger.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/utils/TestObjectMerger.java
@@ -56,7 +56,7 @@ public class TestObjectMerger {
         assertEquals(1, mergedByClassification.stream().filter(o -> o.getPathClass().equals(PathClass.fromString("B"))).count());
         assertEquals(1, mergedByClassification.stream().filter(o -> o.getPathClass().equals(PathClass.fromString("C"))).count());
 
-        var mergedByBoundary = ObjectMerger.createSharedBoundaryMerger(0.5).merge(pathObjects);
+        var mergedByBoundary = ObjectMerger.createSharedTileBoundaryMerger(0.5).merge(pathObjects);
         assertEquals(5, mergedByBoundary.size());
         assertEquals(3, mergedByBoundary.stream().filter(o -> o.getPathClass().equals(PathClass.fromString("A"))).count());
         assertEquals(1, mergedByBoundary.stream().filter(o -> o.getPathClass().equals(PathClass.fromString("B"))).count());
@@ -87,7 +87,7 @@ public class TestObjectMerger {
         assertEquals(1, mergedByClassification.stream().filter(o -> o.getPathClass().equals(PathClass.fromString("B"))).count());
         assertEquals(1, mergedByClassification.stream().filter(o -> o.getPathClass().equals(PathClass.fromString("C"))).count());
 
-        var mergedByBoundary = ObjectMerger.createSharedBoundaryMerger(0.5).merge(pathObjects);
+        var mergedByBoundary = ObjectMerger.createSharedTileBoundaryMerger(0.5).merge(pathObjects);
         assertEquals(5, mergedByBoundary.size());
         assertEquals(3, mergedByBoundary.stream().filter(o -> o.getPathClass().equals(PathClass.fromString("A"))).count());
         assertEquals(1, mergedByBoundary.stream().filter(o -> o.getPathClass().equals(PathClass.fromString("B"))).count());
@@ -113,7 +113,7 @@ public class TestObjectMerger {
         assertEquals(1, mergedByClassification.size());
         assertEquals(objectSize * objectSize * 1.5, mergedByClassification.get(0).getROI().getArea(), 0.0001);
 
-        var mergedByBoundary = ObjectMerger.createSharedBoundaryMerger(0.5).merge(pathObjects);
+        var mergedByBoundary = ObjectMerger.createSharedTileBoundaryMerger(0.5).merge(pathObjects);
         assertEquals(2, mergedByBoundary.size());
 
         var mergedByTouching = ObjectMerger.createTouchingMerger().merge(pathObjects);
@@ -133,7 +133,7 @@ public class TestObjectMerger {
         assertEquals(1, mergedByClassification.size());
         assertEquals(objectSize * objectSize * 2, mergedByClassification.get(0).getROI().getArea(), 0.0001);
 
-        var mergedByBoundary = ObjectMerger.createSharedBoundaryMerger(0.5).merge(pathObjects);
+        var mergedByBoundary = ObjectMerger.createSharedTileBoundaryMerger(0.5).merge(pathObjects);
         assertEquals(1, mergedByBoundary.size());
         assertEquals(objectSize * objectSize * 2, mergedByBoundary.get(0).getROI().getArea(), 0.0001);
 
@@ -155,14 +155,14 @@ public class TestObjectMerger {
         assertEquals(1, mergedByClassification.size());
         assertEquals(objectSize * objectSize * 2, mergedByClassification.get(0).getROI().getArea(), 0.0001);
 
-        var mergedByBoundary = ObjectMerger.createSharedBoundaryMerger(0.5).merge(pathObjects);
+        var mergedByBoundary = ObjectMerger.createSharedTileBoundaryMerger(0.5).merge(pathObjects);
         assertEquals(1, mergedByBoundary.size());
         assertEquals(objectSize * objectSize * 2, mergedByBoundary.get(0).getROI().getArea(), 0.0001);
 
-        var mergedByBoundaryTooHigh = ObjectMerger.createSharedBoundaryMerger(0.75).merge(pathObjects);
+        var mergedByBoundaryTooHigh = ObjectMerger.createSharedTileBoundaryMerger(0.75).merge(pathObjects);
         assertEquals(2, mergedByBoundaryTooHigh.size());
 
-        var mergedByBoundaryLower = ObjectMerger.createSharedBoundaryMerger(0.25).merge(pathObjects);
+        var mergedByBoundaryLower = ObjectMerger.createSharedTileBoundaryMerger(0.25).merge(pathObjects);
         assertEquals(1, mergedByBoundary.size());
         assertEquals(objectSize * objectSize * 2, mergedByBoundaryLower.get(0).getROI().getArea(), 0.0001);
 
@@ -185,7 +185,7 @@ public class TestObjectMerger {
         var mergedByClassification = ObjectMerger.createSharedClassificationMerger().merge(pathObjects);
         assertEquals(3, mergedByClassification.size());
 
-        var mergedByBoundary = ObjectMerger.createSharedBoundaryMerger(0.5).merge(pathObjects);
+        var mergedByBoundary = ObjectMerger.createSharedTileBoundaryMerger(0.5).merge(pathObjects);
         assertEquals(3, mergedByBoundary.size());
 
         var mergedByTouching = ObjectMerger.createTouchingMerger().merge(pathObjects);

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/RBGColorTransformInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/RBGColorTransformInfo.java
@@ -31,7 +31,6 @@ import qupath.lib.images.ImageData;
 
 class RBGColorTransformInfo extends AbstractSingleChannelInfo {
 
-	private transient int[] buffer = null;
 	private ColorTransformer.ColorTransformMethod method;
 	private transient ColorModel colorModel;
 	private transient ColorModel colorModelInverted = null;
@@ -92,7 +91,7 @@ class RBGColorTransformInfo extends AbstractSingleChannelInfo {
 	@Override
 	public synchronized float[] getValues(BufferedImage img, int x, int y, int w, int h, float[] array) {
 		// Try to get the RGB buffer directly
-		buffer = RGBDirectChannelInfo.getRGBIntBuffer(img);
+		int[] buffer = RGBDirectChannelInfo.getRGBIntBuffer(img);
 		// If we didn't get a buffer the fast way, we need to get one the slow way...
 		if (buffer == null)
 			buffer = img.getRGB(x, y, w, h, buffer, 0, w);


### PR DESCRIPTION
Introduce `qupath.lib.objects.utils.ObjectMerger` as an attempt to provide a general, reusable and performant way to handle tile boundary issues with segmentation algorithms.

It is designed to support different merging criteria, with three baseline implementations for now. This might be extended in the future.

The following Groovy script shows it in action:

```groovy
import qupath.lib.objects.utils.ObjectMerger

def pathObjects = getSelectedObjects()

println "Before merging: ${pathObjects.size()}"

// Create a merger that requires one horizontal/vertical boundary to match
// (with a minimum shared length threshold, and a small overlap tolerance)
double threshold = 0.75
def merger = ObjectMerger.createSharedTileBoundaryMerger(threshold)

// Alternatives
// merger = ObjectMerger.createSharedClassificationMerger() // ROIs can be discontinuous
// merger = ObjectMerger.createTouchingMerger() // ROIs must touch, but not intersect

// Do the merging
def mergedObjects = merger.merge(pathObjects)
println "After merging: ${mergedObjects.size()}"

// Replace the objects
removeObjects(pathObjects, true)
addObjects(mergedObjects)
```

On my M1 Max Mac Studio it is capable of reducing 88350 detections to 76394 in 2-4 seconds.