### PR TITLE
Extend tiler to support different alignments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ This is a work-in-progress for the next QuPath release.
 
 #### Processing & analysis
 * Faster processing & reduced memory use for pixel classification measurements (https://github.com/qupath/qupath/pull/1332)
+* New *Objects → Annotations... → Split annotations by lines* command (https://github.com/qupath/qupath/pull/1349)
 * New `ObjectMerger` class to simplify creating new tile-based segmentation methods (https://github.com/qupath/qupath/pull/1346)
-* New `Tiler` class to generate tiles within other objects (https://github.com/qupath/qupath/pull/1347)
+* New `Tiler` class to generate tiles within other objects (https://github.com/qupath/qupath/pull/1347) (https://github.com/qupath/qupath/pull/1349) (https://github.com/qupath/qupath/issues/1277)
 
 #### Import & export
 * SVG export now supports overlays (https://github.com/qupath/qupath/issues/1272)

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/Tiler.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/Tiler.java
@@ -437,11 +437,43 @@ public class Tiler {
         }
 
         /**
+         * Start tiles at the top center of the ROI bounding box.
+         * @return this builder
+         */
+        public Builder alignTopCenter() {
+            return alignment(TileAlignment.TOP_CENTER);
+        }
+
+        /**
          * Match tiles to the top right of the ROI bounding box.
          * @return this builder
          */
         public Builder alignTopRight() {
             return alignment(TileAlignment.TOP_RIGHT);
+        }
+
+        /**
+         * Match tiles to the center left of the ROI bounding box.
+         * @return this builder
+         */
+        public Builder alignCenterLeft() {
+            return alignment(TileAlignment.CENTER_LEFT);
+        }
+
+        /**
+         * Center tiles within the ROI bounding box.
+         * @return this builder
+         */
+        public Builder alignCenter() {
+            return alignment(TileAlignment.CENTER);
+        }
+
+        /**
+         * Match tiles to the center left of the ROI bounding box.
+         * @return this builder
+         */
+        public Builder alignCenterRight() {
+            return alignment(TileAlignment.CENTER_RIGHT);
         }
 
         /**
@@ -453,19 +485,19 @@ public class Tiler {
         }
 
         /**
+         * Start tiles at the bottom center of the ROI bounding box.
+         * @return this builder
+         */
+        public Builder alignBottomCenter() {
+            return alignment(TileAlignment.BOTTOM_CENTER);
+        }
+
+        /**
          * Match tiles to the bottom right of the ROI bounding box.
          * @return this builder
          */
         public Builder alignBottomRight() {
             return alignment(TileAlignment.BOTTOM_RIGHT);
-        }
-
-        /**
-         * Center tiles within the ROI bounding box.
-         * @return this builder
-         */
-        public Builder alignCenter() {
-            return alignment(TileAlignment.CENTER);
         }
 
         /**


### PR DESCRIPTION
Support different methods of aligning tiles with the new `Tiler` class.

This addresses @ofrag's feature request in 
* https://github.com/qupath/qupath/issues/1277

```groovy
def selected = getSelectedObject()

def tiles = qupath.lib.objects.utils.Tiler.builder(256, 512)
     // Just use one of the alignment options!
    .alignCenter()
    .alignTopLeft()
    .alignTopRight()
    .alignBottomLeft()
    .alignBottomRight()
    // Select whatever other options are needed
    .filterByCentroid(false)
    .trimToParent(false)
    .build()
    .createAnnotations(selected.getROI())
    
    
selected.clearChildObjects()
selected.addChildObjects(tiles)
```

The screenshot shows an example using `alignTopRight()`

![image](https://github.com/qupath/qupath/assets/4690904/2516725c-3513-4f0c-9e2c-fdb9421c62f2)
