### PR TITLE
Set min dims for some stages

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ParameterDialogWrapper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ParameterDialogWrapper.java
@@ -124,6 +124,9 @@ class ParameterDialogWrapper<T> {
 		}, btnRun.disabledProperty()));
 
 		final Stage dialog = new Stage();
+		dialog.setMinWidth(300);
+		dialog.setMinHeight(200);
+
 		QuPathGUI qupath = QuPathGUI.getInstance();
 		if (qupath != null)
 			dialog.initOwner(qupath.getStage());

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -770,6 +770,8 @@ public class Commands {
 		var scene = new Scene(pane.getPane());
 		stage.setScene(scene);
 		stage.setWidth(300);
+		stage.setMinHeight(200);
+		stage.setMinWidth(200);
 		stage.setTitle("Specify annotation");
 		stage.initOwner(qupath.getStage());
 		return stage;
@@ -1365,6 +1367,8 @@ public class Commands {
 	 */
 	public static void launchTMADataViewer(QuPathGUI qupath) {
 		Stage stage = new Stage();
+		stage.setMinHeight(200);
+		stage.setMinWidth(200);
 		if (qupath != null)
 			stage.initOwner(qupath.getStage());
 		TMASummaryViewer tmaViewer = new TMASummaryViewer(stage);
@@ -1910,6 +1914,8 @@ public class Commands {
 	public static Stage createWorkflowDisplayDialog(QuPathGUI qupath) {
 		var view = new WorkflowCommandLogView(qupath);
 		Stage dialog = new Stage();
+		dialog.setMinHeight(200);
+		dialog.setMinWidth(200);
 		dialog.initOwner(qupath.getStage());
 		dialog.setTitle("Workflow viewer");
 		Pane pane = view.getPane();


### PR DESCRIPTION
Open for discussion on whether we should continue hunting for stages without min sizes set, or should just replace Stage with some thin wrapper that has some basic settings.

For example I'd love a keymapping to close the currently focused window (unless it's the main QuPath window). Usually shortcut+w closes the current tab in script editors, web browsers, etc.