### PR TITLE
Script editor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ This is a work-in-progress for the next QuPath release.
 * File &rarr; Export snapshots* supports PNG, JPEG and TIFF (not just PNG)
 * Support sorting project entries by name, ID, and URI
   * Right-click on the project list to access the *Sort by...* menu
+* Improved script editor auto-complete
+  * Activate with *Ctrl + space*, cancel with *Esc*
+  * Completions update while typing
 
 #### Processing & analysis
 * Faster processing & reduced memory use for pixel classification measurements (https://github.com/qupath/qupath/pull/1332)

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/CodeAreaControl.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/CodeAreaControl.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -219,6 +219,11 @@ public class CodeAreaControl implements ScriptEditorControl<VirtualizedScrollPan
 		if (popup != null)
 			return popup;
 		return contextMenu;
+	}
+
+	@Override
+	public void requestFocus() {
+		textArea.requestFocus();
 	}
 
 	private ReadOnlyIntegerProperty caretReadOnly;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -2105,8 +2105,14 @@ public class DefaultScriptEditor implements ScriptEditor {
 		if (dialog == null)
 			createDialog();
 		addNewScript(script, getDefaultLanguage(name), true);
-		if (!dialog.isShowing())
+		if (!dialog.isShowing()) {
 			dialog.show();
+			// Attempt to focus the editor
+			// (This appears not to work, at least not for the rich script editor)
+			var current = getCurrentEditorControl();
+			if (current != null)
+				current.requestFocus();
+		}
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptEditorControl.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptEditorControl.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -151,5 +151,12 @@ public interface ScriptEditorControl<T extends Region>  extends TextAppendable, 
 	 * @return
 	 */
 	public ContextMenu getContextMenu();
-	
+
+	/**
+	 * Request that the control is focused.
+	 */
+	default void requestFocus() {
+		getRegion().requestFocus();
+	}
+
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/TextAreaControl.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/TextAreaControl.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -190,7 +190,12 @@ public class TextAreaControl implements ScriptEditorControl<TextArea> {
 	public ContextMenu getContextMenu() {
 		return textArea.getContextMenu();
 	}
-	
+
+	@Override
+	public void requestFocus() {
+		textArea.requestFocus();
+	}
+
 	@Override
 	public ReadOnlyIntegerProperty caretPositionProperty() {
 		return textArea.caretPositionProperty();


### PR DESCRIPTION
* Autocomplete options update while typing
* Pressing 'tab' or 'enter' applies the focused completion (probably the first) if none are selected
* Pressing 'Escape' removes the completion popup
* A newly-created script editor now opens with the editor in focus