### PR TITLE
Support reloading display settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,8 @@ task mergedJavadocs(type: Javadoc,
 	options.encoding = 'UTF-8'
 
 	options.links "https://docs.oracle.com/en/java/javase/${libs.versions.jdk.get()}/docs/api/"
-	options.links "https://openjfx.io/javadoc/${libs.versions.javafxJavadoc.get()}/"
+    // Need to use the major version only with javafx
+	options.links "https://openjfx.io/javadoc/${libs.versions.javafx.get().split('\\.')[0]}/"
 	options.links "https://javadoc.io/doc/org.bytedeco/javacpp/${libs.versions.javacpp.get()}/"
 	options.links "https://javadoc.io/doc/org.bytedeco/opencv/${libs.versions.opencv.get()}/"
 	options.links "https://javadoc.io/doc/com.google.code.gson/gson/${libs.versions.gson.get()}/"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,6 @@ javacpp         = "1.5.9"
   cuda          = "12.1-8.9-1.5.9"
   
 javafx          = "20.0.2"
-javafxJavadoc   = "19"
 jfreeSvg        = "5.0.5"
 jfxtras         = "17-r1"
 jts             = "1.19.0"


### PR DESCRIPTION
Support reloading display settings
1. via drag & drop onto a viewer
2. in a script

Here's an example that uses the display settings to export rendered RGB images with different settings (saved in the project):

```groovy
import qupath.lib.gui.images.servers.RenderedImageServer
import qupath.lib.gui.viewer.overlays.HierarchyOverlay

import static qupath.lib.gui.scripting.QPEx.*

// Choose a sensible downsample
def imageData = getCurrentImageData()
double downsample = Math.max(1.0, Math.max(imageData.server.width, imageData.server.height) / 512)

// Get the viewer for some options
def viewer = getCurrentViewer()

// Create an output directory
def dirOutput = buildFilePath(PROJECT_BASE_DIR, 'rendered_export')
mkdirs(dirOutput)

// Get the image name
def name = getCurrentImageNameWithoutExtension()

// Create a rendered server that includes a hierarchy overlay using the display settings saved in the project
for (def settingsName in ['my first settings', 'my second settings']) {
    def settings = loadDisplaySettings(settingsName)
    def server = new RenderedImageServer.Builder(imageData)
        .downsamples(downsample)
        .settings(settings)
        .layers(new HierarchyOverlay(viewer.getImageRegionStore(), viewer.getOverlayOptions(), imageData))
        .build()
        
    // Write the image
    String path = buildFilePath(dirOutput, "$name [$settingsName].png")
    writeImage(server, path)        
}
```