### PR TITLE
Use 'crop' rather than 'trim' with Tiler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ task mergedJavadocs(type: Javadoc,
 }
 
 /*
- * Get version cataglog
+ * Get version catalog
  */
 catalog {
     versionCatalog {

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
@@ -73,7 +73,7 @@ import qupath.lib.objects.TMACoreObject;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.classes.PathClassTools;
 import qupath.lib.plugins.AbstractInteractivePlugin;
-import qupath.lib.plugins.PluginRunner;
+import qupath.lib.plugins.TaskRunner;
 import qupath.lib.plugins.parameters.ParameterList;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.regions.RegionRequest;
@@ -92,8 +92,8 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 	
 	
 	@Override
-	public boolean runPlugin(final PluginRunner pluginRunner, final ImageData<BufferedImage> imageData, final String arg) {
-		boolean success = super.runPlugin(pluginRunner, imageData, arg);
+	public boolean runPlugin(final TaskRunner taskRunner, final ImageData<BufferedImage> imageData, final String arg) {
+		boolean success = super.runPlugin(taskRunner, imageData, arg);
 		imageData.getHierarchy().fireHierarchyChangedEvent(this);
 		return success;
 	}

--- a/qupath-core-processing/src/main/java/qupath/lib/algorithms/CoherenceFeaturePlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/algorithms/CoherenceFeaturePlugin.java
@@ -48,7 +48,6 @@ import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.PathDetectionObject;
 import qupath.lib.objects.PathObject;
 import qupath.lib.plugins.AbstractInteractivePlugin;
-import qupath.lib.plugins.PluginRunner;
 import qupath.lib.plugins.parameters.ParameterList;
 import qupath.lib.regions.RegionRequest;
 import qupath.lib.roi.interfaces.ROI;

--- a/qupath-core-processing/src/main/java/qupath/lib/algorithms/IntensityFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/algorithms/IntensityFeaturesPlugin.java
@@ -64,7 +64,7 @@ import qupath.lib.objects.PathDetectionObject;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.TMACoreObject;
 import qupath.lib.plugins.AbstractInteractivePlugin;
-import qupath.lib.plugins.PluginRunner;
+import qupath.lib.plugins.TaskRunner;
 import qupath.lib.plugins.parameters.ParameterList;
 import qupath.lib.regions.RegionRequest;
 import qupath.lib.roi.RoiTools;
@@ -351,8 +351,8 @@ public class IntensityFeaturesPlugin extends AbstractInteractivePlugin<BufferedI
 	
 	
 	@Override
-	public boolean runPlugin(final PluginRunner pluginRunner, final ImageData<BufferedImage> imageData, final String arg) {
-		boolean success = super.runPlugin(pluginRunner, imageData, arg);
+	public boolean runPlugin(final TaskRunner taskRunner, final ImageData<BufferedImage> imageData, final String arg) {
+		boolean success = super.runPlugin(taskRunner, imageData, arg);
 		imageData.getHierarchy().fireHierarchyChangedEvent(this);
 		return success;
 	}

--- a/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
@@ -245,8 +245,17 @@ public class PixelProcessor<S, T, U> {
         @Override
         public void run() {
             try {
+                if (Thread.currentThread().isInterrupted()) {
+                    logger.trace("Thread interrupted - skipping task for {}", pathObject);
+                    return;
+                }
                 // Use the proxy object, if available, otherwise use the path object
-                var request = createRequest(imageData.getServer(), parentProxy == null ? pathObject : parentProxy);
+                RegionRequest request;
+                if (parentProxy != null) {
+                    request = createRequest(imageData.getServer(), parentProxy);
+                } else {
+                    request = createRequest(imageData.getServer(), pathObject);
+                }
                 Parameters.Builder<S, T> builder = Parameters.builder();
                 Parameters<S, T> params = builder.imageData(imageData)
                         .imageFunction(imageSupplier)
@@ -418,6 +427,7 @@ public class PixelProcessor<S, T, U> {
             return tiler(Tiler.builder(tileWidth, tileHeight)
                     .alignCenter()
                     .filterByCentroid(false)
+                    .cropTiles(false)
                     .build());
         }
 

--- a/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
@@ -29,9 +29,10 @@ import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.utils.ObjectMerger;
 import qupath.lib.objects.utils.Tiler;
-import qupath.lib.plugins.CommandLinePluginRunner;
+import qupath.lib.plugins.CommandLineTaskRunner;
 import qupath.lib.plugins.PathTask;
-import qupath.lib.plugins.PluginRunner;
+import qupath.lib.plugins.TaskRunner;
+import qupath.lib.plugins.TaskRunnerUtils;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.regions.Padding;
 import qupath.lib.regions.RegionRequest;
@@ -111,21 +112,21 @@ public class PixelProcessor<S, T, U> {
     }
 
     /**
-     * Process objects using the default {@link PluginRunner}.
+     * Process objects using the default {@link TaskRunner}.
      * @param imageData
      * @param pathObjects
      */
     public void processObjects(ImageData<BufferedImage> imageData, Collection<? extends PathObject> pathObjects) {
-        processObjects(new CommandLinePluginRunner(), imageData, pathObjects);
+        processObjects(TaskRunnerUtils.getDefaultInstance().createTaskRunner(), imageData, pathObjects);
     }
 
     /**
-     * Process objects using the specified {@link PluginRunner}.
+     * Process objects using the specified {@link TaskRunner}.
      * @param runner
      * @param imageData
      * @param pathObjects
      */
-    public void processObjects(PluginRunner runner, ImageData<BufferedImage> imageData, Collection<? extends PathObject> pathObjects) {
+    public void processObjects(TaskRunner runner, ImageData<BufferedImage> imageData, Collection<? extends PathObject> pathObjects) {
         if (tiler != null) {
             processTiled(runner, tiler, imageData, pathObjects);
         } else {
@@ -140,7 +141,7 @@ public class PixelProcessor<S, T, U> {
      * @param imageData
      * @param pathObjects
      */
-    private void processUntiled(PluginRunner runner, ImageData<BufferedImage> imageData, Collection<? extends PathObject> pathObjects) {
+    private void processUntiled(TaskRunner runner, ImageData<BufferedImage> imageData, Collection<? extends PathObject> pathObjects) {
         List<? extends Runnable> tasks = pathObjects.stream()
                 .distinct()
                 .map(pathObject -> new ProcessorTask(imageData, pathObject, processor, null))
@@ -156,7 +157,7 @@ public class PixelProcessor<S, T, U> {
      * @param imageData
      * @param pathObjects
      */
-    private void processTiled(PluginRunner runner, Tiler tiler, ImageData<BufferedImage> imageData, Collection<? extends PathObject> pathObjects) {
+    private void processTiled(TaskRunner runner, Tiler tiler, ImageData<BufferedImage> imageData, Collection<? extends PathObject> pathObjects) {
         if (tiler == null)
             throw new IllegalStateException("Tiler must be specified for tiled processing");
         List<ProcessorTask> tasks = new ArrayList<>();

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/FindConvexHullDetectionsPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/FindConvexHullDetectionsPlugin.java
@@ -40,7 +40,7 @@ import qupath.lib.objects.TMACoreObject;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.plugins.AbstractInteractivePlugin;
 import qupath.lib.plugins.PathTask;
-import qupath.lib.plugins.PluginRunner;
+import qupath.lib.plugins.TaskRunner;
 import qupath.lib.plugins.parameters.ParameterList;
 import qupath.lib.roi.ConvexHull;
 
@@ -138,9 +138,9 @@ public class FindConvexHullDetectionsPlugin<T> extends AbstractInteractivePlugin
 	
 	
 	@Override
-	public boolean runPlugin(final PluginRunner pluginRunner, final ImageData<T> imageData, final String arg) {
+	public boolean runPlugin(final TaskRunner taskRunner, final ImageData<T> imageData, final String arg) {
 		nObjectsRemoved.set(0);
-		return super.runPlugin(pluginRunner, imageData, arg);
+		return super.runPlugin(taskRunner, imageData, arg);
 	}
 	
 

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -122,7 +122,7 @@ import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.objects.hierarchy.TMAGrid;
 import qupath.lib.objects.utils.ObjectMerger;
 import qupath.lib.objects.utils.Tiler;
-import qupath.lib.plugins.CommandLinePluginRunner;
+import qupath.lib.plugins.CommandLineTaskRunner;
 import qupath.lib.plugins.PathPlugin;
 import qupath.lib.projects.Project;
 import qupath.lib.projects.ProjectIO;
@@ -1464,7 +1464,7 @@ public class QP {
 			Class<?> cPlugin = QP.class.getClassLoader().loadClass(className);
 			Constructor<?> cons = cPlugin.getConstructor();
 			final PathPlugin plugin = (PathPlugin)cons.newInstance();
-			return plugin.runPlugin(new CommandLinePluginRunner(), imageData, args);
+			return plugin.runPlugin(new CommandLineTaskRunner(), imageData, args);
 		} catch (Exception e) {
 			logger.error("Unable to run plugin " + className, e);
 			return false;

--- a/qupath-core-processing/src/main/java/qupath/opencv/features/DelaunayClusteringPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/features/DelaunayClusteringPlugin.java
@@ -46,7 +46,7 @@ import qupath.lib.objects.TMACoreObject;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.plugins.AbstractInteractivePlugin;
 import qupath.lib.plugins.PathTask;
-import qupath.lib.plugins.PluginRunner;
+import qupath.lib.plugins.TaskRunner;
 import qupath.lib.plugins.parameters.ParameterList;
 
 /**
@@ -70,15 +70,15 @@ public class DelaunayClusteringPlugin<T> extends AbstractInteractivePlugin<T> {
 	}	
 	
 	@Override
-	protected void preprocess(PluginRunner pluginRunner, ImageData<T> imageData) {
-		super.preprocess(pluginRunner, imageData);
+	protected void preprocess(TaskRunner taskRunner, ImageData<T> imageData) {
+		super.preprocess(taskRunner, imageData);
 		// Reset any previous connections
 		imageData.removeProperty(DefaultPathObjectConnectionGroup.KEY_OBJECT_CONNECTIONS);
 	}
 	
 	@Override
-	protected void postprocess(PluginRunner pluginRunner, ImageData<T> imageData) {
-		super.postprocess(pluginRunner, imageData);
+	protected void postprocess(TaskRunner taskRunner, ImageData<T> imageData) {
+		super.postprocess(taskRunner, imageData);
 		imageData.getHierarchy().fireHierarchyChangedEvent(this);
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/plugins/AbstractPlugin.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/AbstractPlugin.java
@@ -52,7 +52,7 @@ public abstract class AbstractPlugin<T> implements PathPlugin<T> {
 	/**
 	 * Get a collection of tasks to perform.
 	 * 
-	 * This will be called from {@link #runPlugin(PluginRunner, ImageData, String)} <b>after</b> a call to {@link #parseArgument(ImageData, String)}.
+	 * This will be called from {@link #runPlugin(TaskRunner, ImageData, String)} <b>after</b> a call to {@link #parseArgument(ImageData, String)}.
 	 *
 	 * The default implementation simply calls {@link #getParentObjects(ImageData)}, then {@link #addRunnableTasks(ImageData, PathObject, List)}
 	 * for every parent object that was returned.
@@ -133,25 +133,25 @@ public abstract class AbstractPlugin<T> implements PathPlugin<T> {
 	
 	
 	@Override
-	public boolean runPlugin(final PluginRunner pluginRunner, ImageData<T> imageData, final String arg) {
+	public boolean runPlugin(final TaskRunner taskRunner, ImageData<T> imageData, final String arg) {
 
 		if (!parseArgument(imageData, arg))
 			return false;
 
-		preprocess(pluginRunner, imageData);
+		preprocess(taskRunner, imageData);
 
 		Collection<Runnable> tasks = getTasks(imageData);
 		if (tasks.isEmpty())
 			return false;
 
-		pluginRunner.runTasks(tasks);
+		taskRunner.runTasks(tasks);
 
 		if (requestHierarchyUpdate())
 			imageData.getHierarchy().fireHierarchyChangedEvent(this);
 
-		postprocess(pluginRunner, imageData);
+		postprocess(taskRunner, imageData);
 		
-		if (pluginRunner.isCancelled())
+		if (taskRunner.isCancelled())
 			return false;
 
 		// Only add a workflow step if plugin was not cancelled
@@ -165,19 +165,19 @@ public abstract class AbstractPlugin<T> implements PathPlugin<T> {
 	 * Called after parsing the argument String, and immediately before creating &amp; running any generated tasks.
 	 * 
 	 * Does nothing by default.
-	 * @param pluginRunner
+	 * @param taskRunner
 	 * @param imageData
 	 */
-	protected void preprocess(final PluginRunner pluginRunner, final ImageData<T> imageData) {};
+	protected void preprocess(final TaskRunner taskRunner, final ImageData<T> imageData) {};
 
 	/**
 	 * Called immediately after running any generated tasks.
 	 * 
 	 * Does nothing by default.
-	 * @param pluginRunner
+	 * @param taskRunner
 	 * @param imageData
 	 */
-	protected void postprocess(final PluginRunner pluginRunner, final ImageData<T> imageData) {};
+	protected void postprocess(final TaskRunner taskRunner, final ImageData<T> imageData) {};
 
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/plugins/AbstractTaskRunner.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/AbstractTaskRunner.java
@@ -103,6 +103,11 @@ public abstract class AbstractTaskRunner implements TaskRunner {
 		monitor = makeProgressMonitor();
 		monitor.startMonitoring(null, tasks.size(), true);
 		for (Runnable task : tasks) {
+			// If a task if null, then skip it - otherwise the monitor can get stuck
+			if (task == null) {
+				logger.warn("Skipping null task");
+				continue;
+			}
 			Future<Runnable> future = service.submit(task, task);
 			pendingTasks.put(future, task);
 		}

--- a/qupath-core/src/main/java/qupath/lib/plugins/AbstractTaskRunner.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/AbstractTaskRunner.java
@@ -41,9 +41,9 @@ import qupath.lib.common.ThreadTools;
  * Abstract PluginRunner to help with the creation of plugin runners for specific circumstances,
  * e.g. running through a GUI, or from a command line only.
  */
-public abstract class AbstractPluginRunner implements PluginRunner {
+public abstract class AbstractTaskRunner implements TaskRunner {
 	
-	private static final Logger logger = LoggerFactory.getLogger(AbstractPluginRunner.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractTaskRunner.class);
 
 	private static int counter = 0;
 
@@ -62,7 +62,7 @@ public abstract class AbstractPluginRunner implements PluginRunner {
 	 * Constructor for a PluginRunner that uses the default number of threads, read from
 	 * {@link ThreadTools#getParallelism()}.
 	 */
-	protected AbstractPluginRunner() {
+	protected AbstractTaskRunner() {
 		this(-1);
 	}
 
@@ -71,7 +71,7 @@ public abstract class AbstractPluginRunner implements PluginRunner {
 	 * @param numThreads the number of threads to use, or -1 to use the default number of threads defined by
 	 *                   {@link ThreadTools#getParallelism()}.
 	 */
-	protected AbstractPluginRunner(int numThreads) {
+	protected AbstractTaskRunner(int numThreads) {
 		super();
 		this.numThreads = numThreads;
 	}

--- a/qupath-core/src/main/java/qupath/lib/plugins/CommandLineTaskRunner.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/CommandLineTaskRunner.java
@@ -37,13 +37,21 @@ import qupath.lib.regions.ImageRegion;
  * 
  * @author Pete Bankhead
  */
-public class CommandLinePluginRunner extends AbstractPluginRunner {
+public class CommandLineTaskRunner extends AbstractTaskRunner {
 	
 	/**
-	 * Constructor for a PluginRunner that send progress to a log.
+	 * Constructor for a PluginRunner that send progress to a log, and runs tasks using the default number of threads
 	 */
-	public CommandLinePluginRunner() {
+	public CommandLineTaskRunner() {
 		super();
+	}
+
+	/**
+	 * Constructor for a PluginRunner that send progress to a log.
+	 * @param nThreads the number of threads to use when running tasks
+	 */
+	public CommandLineTaskRunner(int nThreads) {
+		super(nThreads);
 	}
 
 	@Override

--- a/qupath-core/src/main/java/qupath/lib/plugins/PathPlugin.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/PathPlugin.java
@@ -66,11 +66,11 @@ public interface PathPlugin<T> {
 	 * <p>
 	 * Note: This command should block until it has completed processing.
 	 * 
-	 * @param pluginRunner
+	 * @param taskRunner
 	 * @param arg
 	 * @return
 	 */
-	public boolean runPlugin(PluginRunner pluginRunner, ImageData<T> imageData, String arg);
+	public boolean runPlugin(TaskRunner taskRunner, ImageData<T> imageData, String arg);
 	
 	/**
 	 * (Optional) short one-line description of the results, e.g. to say how many objects detected.

--- a/qupath-core/src/main/java/qupath/lib/plugins/PathTask.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/PathTask.java
@@ -35,7 +35,7 @@ public interface PathTask extends Runnable {
 	/**
 	 * Perform optional post-processing after a task has completed.
 	 * <p>
-	 * When processing a collection of tasks with a {@link PluginRunner}, this method 
+	 * When processing a collection of tasks with a {@link TaskRunner}, this method
 	 * should be called on the same thread. The choice of thread depends on the runner, but 
 	 * may be the Event Dispatch Thread when using Swing or Application thread for JavaFX.
 	 * @param wasCancelled 

--- a/qupath-core/src/main/java/qupath/lib/plugins/TaskRunner.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/TaskRunner.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 /**
  * A minimal interface for a class capable of running tasks in parallel, giving feedback to the user.
  */
-public interface PluginRunner {
+public interface TaskRunner {
 
 	/**
 	 * Query if the plugin can be cancelled while running.

--- a/qupath-core/src/main/java/qupath/lib/plugins/TaskRunnerUtils.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/TaskRunnerUtils.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2023 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.lib.plugins;
+
+import qupath.lib.common.ThreadTools;
+
+import java.util.function.IntFunction;
+
+/**
+ * A utility class to help with the creation of {@link TaskRunner} instances.
+ * <p>
+ * An application can use {@link #setCreateFunction(IntFunction)} and #setCreateHeadlessFunction(IntFunction)} to
+ * control the creation of {@link TaskRunner} instances.
+ * @since v0.5.0
+ */
+public class TaskRunnerUtils {
+
+    private static IntFunction<TaskRunner> DEFAULT_HEADLESS_FUNCTION = (int nThreads) -> new CommandLineTaskRunner(nThreads);
+
+    private IntFunction<TaskRunner> headlessFunction = DEFAULT_HEADLESS_FUNCTION;
+
+    private IntFunction<TaskRunner> function = DEFAULT_HEADLESS_FUNCTION;
+
+    private static TaskRunnerUtils INSTANCE = new TaskRunnerUtils();
+
+    private TaskRunnerUtils() {}
+
+    /**
+     * Get the default instance. This is a singleton, shared across an application.
+     * @return
+     */
+    public static TaskRunnerUtils getDefaultInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Create a new instance. This may be used if part of an application requires its {@link TaskRunner} instances
+     * to differ from those used elsewhere.
+     * @return
+     */
+    public static TaskRunnerUtils newInstance() {
+        return new TaskRunnerUtils();
+    }
+
+    /**
+     * Get the default function used to create {@link TaskRunner} instances.
+     * This is suitable for use in a headless environment.
+     * @return
+     */
+    public static IntFunction<TaskRunner> getDefaultCreateFunction() {
+        return DEFAULT_HEADLESS_FUNCTION;
+    }
+
+    /**
+     * Set the function used to generate new {@link TaskRunner} instances.
+     * @param function a creator function that takes a requested number of threads as input
+     * @return this instance
+     */
+    public TaskRunnerUtils setCreateHeadlessFunction(IntFunction<TaskRunner> function) {
+        this.headlessFunction = function;
+        return this;
+    }
+
+    /**
+     * Set the function used to generate new headless {@link TaskRunner} instances.
+     * @param function a creator function that takes a requested number of threads as input
+     * @return this instance
+     */
+    public TaskRunnerUtils setCreateFunction(IntFunction<TaskRunner> function) {
+        this.function = function;
+        return this;
+    }
+
+    /**
+     * Create a new {@link TaskRunner} instance, using the default number of threads from
+     * {@link ThreadTools#getParallelism()}.
+     * The task runner may support headless use, but does not have to.
+     * @return
+     */
+    public TaskRunner createTaskRunner() {
+        return createTaskRunner(ThreadTools.getParallelism());
+    }
+
+    /**
+     * Create a new {@link TaskRunner} instance with the specified number of threads.
+     * The task runner may support headless use, but does not have to.
+     * @param nThreads
+     * @return
+     */
+    public TaskRunner createTaskRunner(int nThreads) {
+        return function.apply(nThreads);
+    }
+
+    /**
+     * Create a new headless {@link TaskRunner} instance, using the default number of threads from
+     * {@link ThreadTools#getParallelism()}.
+     * @return
+     */
+    public TaskRunner createHeadlessTaskRunner() {
+        return createHeadlessTaskRunner(ThreadTools.getParallelism());
+    }
+
+    /**
+     * Create a new headless {@link TaskRunner} instance with the specified number of threads.
+     * @param nThreads
+     * @return
+     */
+    public TaskRunner createHeadlessTaskRunner(int nThreads) {
+        return headlessFunction.apply(nThreads);
+    }
+
+}

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
@@ -67,7 +67,7 @@ import qupath.lib.objects.PathObject;
 import qupath.lib.objects.TMACoreObject;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.plugins.AbstractPlugin;
-import qupath.lib.plugins.PluginRunner;
+import qupath.lib.plugins.TaskRunner;
 import qupath.lib.plugins.parameters.ParameterList;
 import qupath.lib.regions.RegionRequest;
 import qupath.lib.roi.LineROI;
@@ -116,7 +116,7 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 	}
 
 	@Override
-	public boolean runPlugin(final PluginRunner runner, final ImageData<BufferedImage> imageData, final String arg) {
+	public boolean runPlugin(final TaskRunner runner, final ImageData<BufferedImage> imageData, final String arg) {
 		if (!parseArgument(imageData, arg))
 			return false;
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ParameterDialogWrapper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ParameterDialogWrapper.java
@@ -46,7 +46,7 @@ import qupath.lib.images.ImageData;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.plugins.PathInteractivePlugin;
-import qupath.lib.plugins.PluginRunner;
+import qupath.lib.plugins.TaskRunner;
 import qupath.lib.plugins.parameters.ParameterList;
 import qupath.lib.plugins.workflow.WorkflowStep;
 
@@ -68,10 +68,10 @@ class ParameterDialogWrapper<T> {
 	 * Constructor.
 	 * @param plugin plugin for which this dialog should be shown
 	 * @param params parameters to display
-	 * @param pluginRunner the {@link PluginRunner} that may be used to run this plugin if necessary
+	 * @param taskRunner the {@link TaskRunner} that may be used to run this plugin if necessary
 	 */
-	public ParameterDialogWrapper(final PathInteractivePlugin<T> plugin, final ParameterList params, final PluginRunner pluginRunner) {
-		dialog = createDialog(plugin, params, pluginRunner);
+	public ParameterDialogWrapper(final PathInteractivePlugin<T> plugin, final ParameterList params, final TaskRunner taskRunner) {
+		dialog = createDialog(plugin, params, taskRunner);
 	}
 
 	/**
@@ -111,7 +111,7 @@ class ParameterDialogWrapper<T> {
 		return panel.getParameters();
 	}
 
-	private Stage createDialog(final PathInteractivePlugin<T> plugin, final ParameterList params, final PluginRunner pluginRunner) {
+	private Stage createDialog(final PathInteractivePlugin<T> plugin, final ParameterList params, final TaskRunner taskRunner) {
 		panel = new ParameterPanelFX(params);
 		panel.getPane().setPadding(new Insets(5, 5, 5, 5));
 
@@ -169,7 +169,7 @@ class ParameterDialogWrapper<T> {
 					try {
 						var historyWorkflow = imageData.getHistoryWorkflow();
 						WorkflowStep lastStep = historyWorkflow.getLastStep();
-						boolean success = plugin.runPlugin(pluginRunner, (ImageData<T>)imageData, ParameterList.convertToJson(params));
+						boolean success = plugin.runPlugin(taskRunner, (ImageData<T>)imageData, ParameterList.convertToJson(params));
 						WorkflowStep lastStepNew = historyWorkflow.getLastStep();
 						if (success && lastStep != lastStepNew)
 							lastWorkflowStep = lastStepNew;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/PluginRunnerFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/PluginRunnerFX.java
@@ -82,6 +82,16 @@ class PluginRunnerFX extends AbstractPluginRunner {
 		this.qupath = qupath;
 	}
 
+	/**
+	 * Constructor specifying the number of threads.
+	 * @param qupath the QuPath instance
+	 * @param nThreads the number of threads to use
+	 */
+	public PluginRunnerFX(final QuPathGUI qupath, final int nThreads) {
+		super(nThreads);
+		this.qupath = qupath;
+	}
+
 	@Override
 	public SimpleProgressMonitor makeProgressMonitor() {
 		if (Platform.isFxApplicationThread()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -161,8 +161,6 @@ import qupath.lib.scripting.languages.ExecutableLanguage;
 import qupath.lib.scripting.languages.ScriptLanguage;
 import qupath.lib.gui.scripting.DefaultScriptEditor;
 import qupath.lib.gui.scripting.QPEx;
-import qupath.ui.logviewer.ui.main.LogMessageCounts;
-import qupath.ui.logviewer.ui.main.LogViewer;
 
 
 /**
@@ -2182,7 +2180,7 @@ public class QuPathGUI {
 				// We use the US locale because we need to ensure decimal points (not commas)
 				ParameterList.updateParameterList(params, map, Locale.US);
 			}
-			var runner = new PluginRunnerFX(this);
+			var runner = new TaskRunnerFX(this);
 			ParameterDialogWrapper<BufferedImage> dialog = new ParameterDialogWrapper<>(pluginInteractive, params, runner);
 			dialog.showDialog();
 			return !runner.isCancelled();
@@ -2190,7 +2188,7 @@ public class QuPathGUI {
 		else {
 			try {
 				pluginRunning.set(true);
-				var runner = new PluginRunnerFX(this);
+				var runner = new TaskRunnerFX(this);
 				@SuppressWarnings("unused")
 				var completed = plugin.runPlugin(runner, imageData, arg);
 				return !runner.isCancelled();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/TaskRunnerFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/TaskRunnerFX.java
@@ -48,9 +48,9 @@ import javafx.stage.Stage;
 import javafx.util.Duration;
 import qupath.fx.utils.GridPaneUtils;
 import qupath.lib.images.ImageData;
-import qupath.lib.plugins.CommandLinePluginRunner;
+import qupath.lib.plugins.CommandLineTaskRunner;
 import qupath.lib.plugins.PathTask;
-import qupath.lib.plugins.AbstractPluginRunner;
+import qupath.lib.plugins.AbstractTaskRunner;
 import qupath.lib.plugins.SimpleProgressMonitor;
 import qupath.lib.regions.ImageRegion;
 
@@ -60,24 +60,20 @@ import qupath.lib.regions.ImageRegion;
  * @author Pete Bankhead
  *
  */
-class PluginRunnerFX extends AbstractPluginRunner {
+public class TaskRunnerFX extends AbstractTaskRunner {
 
-	private static final Logger logger = LoggerFactory.getLogger(PluginRunnerFX.class);
+	private static final Logger logger = LoggerFactory.getLogger(TaskRunnerFX.class);
 	
 	// Time to delay QuPath viewer repaints when running plugin tasks
 	private static long repaintDelayMillis = 1000;
 
 	private QuPathGUI qupath;
 
-	// Snapshot of the current image data, used only within runTasks()
-	// Because the method is synchronized, it is not expected to cause trouble
-	private ImageData<BufferedImage> currentImageData; // Consider reinstating - at least as an option
-
 	/**
 	 * Constructor.
 	 * @param qupath the QuPath instance
 	 */
-	public PluginRunnerFX(final QuPathGUI qupath) {
+	public TaskRunnerFX(final QuPathGUI qupath) {
 		super();
 		this.qupath = qupath;
 	}
@@ -87,7 +83,7 @@ class PluginRunnerFX extends AbstractPluginRunner {
 	 * @param qupath the QuPath instance
 	 * @param nThreads the number of threads to use
 	 */
-	public PluginRunnerFX(final QuPathGUI qupath, final int nThreads) {
+	public TaskRunnerFX(final QuPathGUI qupath, final int nThreads) {
 		super(nThreads);
 		this.qupath = qupath;
 	}
@@ -96,7 +92,7 @@ class PluginRunnerFX extends AbstractPluginRunner {
 	public SimpleProgressMonitor makeProgressMonitor() {
 		if (Platform.isFxApplicationThread()) {
 			logger.warn("Progress monitor cannot be created from JavaFX application thread - will default to command line monitor");
-			return new CommandLinePluginRunner.CommandLineProgressMonitor();
+			return new CommandLineTaskRunner.CommandLineProgressMonitor();
 		} else
 			return new PluginProgressMonitorFX(qupath.getStage());
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMADataIO.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMADataIO.java
@@ -58,7 +58,7 @@ import qupath.lib.objects.TMACoreObject;
 import qupath.lib.objects.hierarchy.DefaultTMAGrid;
 import qupath.lib.objects.hierarchy.TMAGrid;
 import qupath.lib.plugins.AbstractPlugin;
-import qupath.lib.plugins.CommandLinePluginRunner;
+import qupath.lib.plugins.CommandLineTaskRunner;
 import qupath.lib.regions.RegionRequest;
 import qupath.lib.roi.interfaces.ROI;
 
@@ -200,7 +200,7 @@ public class TMADataIO {
 			ExportCoresPlugin plugin = new ExportCoresPlugin(dirData, renderedImageServer, downsample, coreExt);
 			var qupath = QuPathGUI.getInstance();
 			if (qupath == null || qupath.getImageData() != imageData) {
-				plugin.runPlugin(new CommandLinePluginRunner(), imageData,null);
+				plugin.runPlugin(new CommandLineTaskRunner(), imageData,null);
 			} else {
 				try {
 					qupath.runPlugin(plugin, null, false);


### PR DESCRIPTION
Minor changes:
* Use 'crop' rather than 'trim' with Tiler
   * Turn this setting off by default with `PixelProcessor`

Major change:
* Convert `PluginRunner` to `TaskRunner`
* Provide `QPEx.createTaskRunner()` and `QPEx.createTaskRunner(int nThreads)` methods

The reasoning is that `PluginRunner` no longer really makes sense as a name: the class rather represents a simple and generic way to run tasks in parallel. It's also more general than in previous QuPath releases.

The following script shows it in action:

```groovy
def tasks = []
for (int i in 1..50) {
    int n = i
    tasks << () -> sleepyTask(n)
}

def runner = createTaskRunner()
runner.runTasks(tasks)

def sleepyTask(int n) {
    Thread.sleep(250L)
    println "I'm awake! And I'm task $n"
}
```

When run interactively, this should show a progress dialog (after a short delay). But when using *Run for project* it will switch to using a command line task runner, and not generate a new dialog of its own.

The number of threads can also be specified. For example, for single-threaded tasks we can use
```groovy
def runner = createTaskRunner(1)
```

This is an easy way to provide a progress monitor for multiple tasks.