### PR TITLE
Show only error count since log visible

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/ActionTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/ActionTools.java
@@ -882,7 +882,7 @@ public class ActionTools {
 		updateInfoMessageStyleClasses(circle, message.get());
 		var tooltip = new Tooltip();
 		tooltip.textProperty().bind(message.flatMap(InfoMessage::textProperty));
-		Tooltip.install(circle, tooltip);
+		Tooltip.install(stack, tooltip);
 		tooltip.setShowDelay(Duration.ZERO);
 		message.addListener((v, o, n) -> updateInfoMessageStyleClasses(circle, n));
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
@@ -152,7 +152,10 @@ public class CommonActions {
 		MEASURE_DETECTIONS = qupath.createImageDataAction(imageData -> Commands.showDetectionMeasurementTable(qupath, imageData));
 		MEASURE_GRID_ANNOTATIONS = qupath.createImageDataAction(imageData -> Commands.showAnnotationGridView(qupath));
 		MEASURE_GRID_TMA_CORES = qupath.createImageDataAction(imageData -> Commands.showTMACoreGridView(qupath));
-		HELP_VIEWER = Commands.createSingleStageAction(() -> ContextHelpViewer.getInstance(qupath).getStage());
+
+		var contextHelp = ContextHelpViewer.getInstance(qupath);
+		HELP_VIEWER = Commands.createSingleStageAction(() -> contextHelp.getStage());
+		ActionTools.installInfoMessage(HELP_VIEWER, contextHelp.getInfoMessage());
 		
 		// This has the effect of applying the annotations
 		ActionTools.getAnnotatedActions(this);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
@@ -154,6 +154,8 @@ public class ContextHelpViewer {
 	
 	private List<HelpListEntry> createHelpEntries() {
 		return Arrays.asList(
+				createUnseenErrors(),
+				createZoomToFitEntry(),
 				createSelectionModelEntry(),
 				createAnnotationsHiddenEntry(),
 				createDetectionsHiddenEntry(),
@@ -391,6 +393,9 @@ public class ContextHelpViewer {
 	
 	Label createHelpLabel(HelpListEntry entry) {
 		var label = new Label();
+		label.setGraphicTextGap(8.0);
+		label.setAlignment(Pos.CENTER);
+		label.setTextAlignment(TextAlignment.CENTER);
 		label.textProperty().bind(entry.textProperty());
 		label.graphicProperty().bind(entry.graphicProperty());
 		label.setPadding(new Insets(5.0, 10.0, 5.0, 10.0));
@@ -413,6 +418,15 @@ public class ContextHelpViewer {
 				createIcon(PathIcons.SELECTION_MODE));
 		entry.visibleProperty().bind(
 				PathPrefs.selectionModeProperty());
+		return entry;
+	}
+
+	private HelpListEntry createUnseenErrors() {
+		var entry = HelpListEntry.createWarning(
+				"ContextHelp.warning.unseenErrors",
+				createIcon(PathIcons.LOG_VIEWER));
+		entry.visibleProperty().bind(
+				qupath.getLogViewerCommand().hasUnseenErrors());
 		return entry;
 	}
 	
@@ -458,6 +472,14 @@ public class ContextHelpViewer {
 				"ContextHelp.warning.opacityZero");
 		entry.visibleProperty().bind(
 				qupath.getOverlayOptions().opacityProperty().lessThanOrEqualTo(0.0));
+		return entry;
+	}
+
+	private HelpListEntry createZoomToFitEntry() {
+		var entry = HelpListEntry.createWarning(
+				"ContextHelp.warning.zoomToFit", createIcon(PathIcons.ZOOM_TO_FIT));
+		entry.visibleProperty().bind(
+				qupath.viewerProperty().flatMap(QuPathViewer::zoomToFitProperty));
 		return entry;
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/LogViewerCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/LogViewerCommand.java
@@ -29,8 +29,10 @@ import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.NumberBinding;
 import javafx.beans.binding.ObjectExpression;
 import javafx.beans.binding.StringBinding;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.LongProperty;
 import javafx.beans.property.SimpleLongProperty;
+import javafx.beans.value.ObservableBooleanValue;
 import javafx.scene.Scene;
 import javafx.scene.layout.Region;
 import javafx.stage.Modality;
@@ -71,7 +73,7 @@ public class LogViewerCommand {
 
 	private NumberBinding unseenMessageCounts = errorMessageCounts.subtract(lastSeenErrorMessageCount);
 
-	private BooleanBinding hasErrors = unseenMessageCounts.greaterThan(0);
+	private BooleanBinding hasUnseenErrors = unseenMessageCounts.greaterThan(0);
 
 	private StringBinding errorMessageBinding = createErrorMessageBinding();
 
@@ -160,12 +162,21 @@ public class LogViewerCommand {
 		return counts;
 	}
 
+	/**
+	 * Boolean binding indicating whether there are any unseen errors.
+	 * 'Unseen' here means errors that occur since the log viewer was visible.
+	 * @return
+	 */
+	public ObservableBooleanValue hasUnseenErrors() {
+		return hasUnseenErrors;
+	}
+
 
 	private ObjectExpression<InfoMessage> infoMessage = Bindings.createObjectBinding(() -> {
-		if (!hasErrors.get())
+		if (!hasUnseenErrors.get())
 			return null;
 		return errorMessage;
-	}, hasErrors);
+	}, hasUnseenErrors);
 
 	/**
 	 * Get a string expression to draw attention to error messages.

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -10,6 +10,10 @@ ContextHelp.warning.pixelOverlayHidden = Pixel classification overlay is hidden
 ContextHelp.warning.opacityZero = Opacity slider is zero (unselected objects won't be visible)
 ContextHelp.warning.noImage = No image is open in the current viewer
 ContextHelp.warning.noProject = No project is open (QuPath works best using projects)
+ContextHelp.warning.gamma = Gamma value is not 1.0. This affects how the image is displayed.\n\
+                            Change the gamma with the brightness/contrast dialog.
+ContextHelp.warning.invertedBackground = Image is being shown with inverted background.\n\
+                            Change this option in the brightness/contrast dialog.
 
 # Startup/Welcome message
 

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -14,6 +14,10 @@ ContextHelp.warning.gamma = Gamma value is not 1.0. This affects how the image i
                             Change the gamma with the brightness/contrast dialog.
 ContextHelp.warning.invertedBackground = Image is being shown with inverted background.\n\
                             Change this option in the brightness/contrast dialog.
+ContextHelp.warning.zoomToFit = Zoom-to-fit is active.\n\
+                            This will block normal panning & zooming in the viewer.
+ContextHelp.warning.unseenErrors = There are errors reported in the log that have not yet been seen.\n\
+                            Please check the log for details.
 
 # Startup/Welcome message
 

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -18,6 +18,10 @@ ContextHelp.warning.zoomToFit = Zoom-to-fit is active.\n\
                             This will block normal panning & zooming in the viewer.
 ContextHelp.warning.unseenErrors = There are errors reported in the log that have not yet been seen.\n\
                             Please check the log for details.
+ContextHelp.warning.pixelSizeMissing = Pixel size information is not set.\n\
+                            This is required for some commands, and can be set under the 'Image' tab.
+ContextHelp.warning.imageTypeMissing = The image type is not set.\n\
+                            This is required for some commands, and can be set under the 'Image' tab.
 
 # Startup/Welcome message
 


### PR DESCRIPTION
In the log badge/info message, show only the count of *unseen* errors (i.e. those that have occurred since the log viewer was last visible).