### PR TITLE
Use javafx-gradle-plugin v0.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'qupath.java-conventions'
     id 'version-catalog'
+    id 'maven-publish'
 }
 
 // We don't want to generate javadocs for the root project

--- a/buildSrc/src/main/groovy/qupath.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.java-conventions.gradle
@@ -5,7 +5,6 @@
 
 plugins {
     id 'java'
-    id 'maven-publish'
 }
 
 java {

--- a/buildSrc/src/main/groovy/qupath.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.publishing-conventions.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id 'java'
+    id 'maven-publish'
+}
+
 publishing {
     repositories {
         maven {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,7 +106,9 @@ yaml          = ["snakeyaml"]
 [plugins]
 # Use the javafx plugin to add modules
 javacpp        = { id = "org.bytedeco.gradle-javacpp-platform",     version.ref = "javacpp" }
-javafx         = { id = "org.openjfx.javafxplugin",                 version = "0.0.13" }
+# If javafx plugin causes trouble, see https://github.com/openjfx/javafx-gradle-plugin#migrating-from-0014-to-010
+javafx         = { id = "org.openjfx.javafxplugin",                 version = "0.1.0" }
+#javafx         = { id = "org.openjfx.javafxplugin",                 version = "0.0.14" }
 jpackage       = { id = "org.beryx.runtime",                        version = "1.13.0" } # Non-modular
 # jpackage       = { id = "org.beryx.jlink",                          version = "2.26.0" } # Modular
-license-report = { id = "com.github.jk1.dependency-license-report", version = "2.0" }
+license-report = { id = "com.github.jk1.dependency-license-report", version = "2.5" }

--- a/qupath-app/build.gradle
+++ b/qupath-app/build.gradle
@@ -24,6 +24,7 @@ plugins {
     id 'application'
     alias(libs.plugins.license.report)
     alias(libs.plugins.jpackage)
+    alias(libs.plugins.javafx)
 }
 
 
@@ -47,6 +48,18 @@ ext {
     qupathAppName = "QuPath-${qupathVersion}"
 }
 
+// Required since moving to JavaFX Gradle Plugin v0.1.0
+javafx {
+    version = libs.versions.javafx.get()
+    modules = ["javafx.base",
+               "javafx.controls",
+               "javafx.graphics",
+               "javafx.media",
+               "javafx.fxml",
+               "javafx.web",
+               "javafx.swing"]
+}
+
 // Determine java version associated with toolchain
 def toolchainJavaVersion = getToolchainJavaVersion()
 
@@ -57,6 +70,11 @@ application {
     mainClass = "qupath.QuPath"
     applicationName = qupathAppName
     applicationDefaultJvmArgs = buildDefaultJvmArgs("${rootProject.buildDir}/natives", toolchainJavaVersion)
+
+    // Necessary when using ./gradlew run to support style manager to change themes
+    applicationDefaultJvmArgs << '--add-opens'
+    applicationDefaultJvmArgs << 'javafx.graphics/com.sun.javafx.css=ALL-UNNAMED'
+
 }
 
 /**
@@ -182,6 +200,13 @@ licenseReport {
 //               new CsvReportRenderer(),
                  new InventoryHtmlReportRenderer('index.html', 'Third party licenses', fileUnknown)]
     outputDir = "${rootProject.buildDir}/reports/dependency-license"
+
+    // TODO: Try to remove this. It's needed (I think) due to the license plugin not supporting
+    //       Gradle variants, as required by the JavaFX Gradle Plugin v0.1.0. Possibly-relevant links:
+    //       - https://github.com/openjfx/javafx-gradle-plugin#variants
+    //       - https://github.com/jk1/Gradle-License-Report/issues/199
+    //       The JavaFX license is still included in QuPath, but unfortunately not in this report.
+    excludeGroups = ['org.openjfx']
 }
 tasks.startScripts.dependsOn("generateLicenseReport")
 

--- a/qupath-extension-bioformats/build.gradle
+++ b/qupath-extension-bioformats/build.gradle
@@ -2,6 +2,8 @@ plugins {
   id 'qupath.extension-conventions'
   id 'qupath.publishing-conventions'
   id 'java-library'
+
+  alias(libs.plugins.javafx)
 }
 
 ext.moduleName = 'qupath.extension.bioformats'

--- a/qupath-extension-processing/build.gradle
+++ b/qupath-extension-processing/build.gradle
@@ -2,6 +2,8 @@ plugins {
   id 'qupath.extension-conventions'
   id 'qupath.publishing-conventions'
   id 'java-library'
+
+  alias(libs.plugins.javafx)
 }
 
 ext.moduleName = 'qupath.extension.processing'

--- a/qupath-extension-script-editor/build.gradle
+++ b/qupath-extension-script-editor/build.gradle
@@ -1,6 +1,8 @@
 plugins {
   id 'qupath.extension-conventions'
   id 'java-library'
+
+  alias(libs.plugins.javafx)
 }
 
 ext.moduleName = 'qupath.extension.scripteditor'

--- a/qupath-extension-svg/build.gradle
+++ b/qupath-extension-svg/build.gradle
@@ -1,6 +1,8 @@
 plugins {
   id 'qupath.extension-conventions'
   id 'java-library'
+
+  alias(libs.plugins.javafx)
 }
 
 ext.moduleName = 'qupath.extension.svg'


### PR DESCRIPTION
This was a more painful change than it sounds, but should resolve issue with JavaFX classifiers being included in published poms.

---

See the [migration guide here](https://github.com/openjfx/javafx-gradle-plugin#migrating-from-0014-to-010).

The main QuPath-related issue seems to have been [sets the `--module-path` here](https://github.com/openjfx/javafx-gradle-plugin/blob/bdf717a65ab0caac9cfa677efc9d3943e6f8483e/src/main/java/org/openjfx/gradle/JavaFXPlugin.java#L105).

The module path wasn't otherwise being set, as can be seen by running the one-line script in QuPath:
```groovy
println System.properties['jdk.module.path']
```
which prints `null`.

To get things working with the v0.1.0 plugin, I had to specify JavaFX modules inside `qupath-app`:

```groovy
javafx {
    version = libs.versions.javafx.get()
    modules = ["javafx.base",
               "javafx.controls",
               "javafx.graphics",
               "javafx.media",
               "javafx.fxml",
               "javafx.web",
               "javafx.swing"]
}
```

But doing that led to exceptions when using `./gradlew run` 

```
q.lib.gui.prefs.QuPathStyleManager - Unable to call addUserAgentStylesheet
java.lang.IllegalAccessException: class qupath.lib.gui.prefs.QuPathStyleManager cannot access class com.sun.javafx.css.StyleManager (in module javafx.graphics) because module javafx.graphics does not export com.sun.javafx.css to unnamed module @6150c3ec
        at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:392)
        at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:674)
        at java.base/java.lang.reflect.Method.invoke(Method.java:560)
        at qupath.lib.gui.prefs.QuPathStyleManager.addStyleSheets(QuPathStyleManager.java:576)
```

These could be addressed by adding
```gradle
application {
   // ... other stuff

  // Necessary when using ./gradlew run to support style manager to change themes
    applicationDefaultJvmArgs << '--add-opens'
    applicationDefaultJvmArgs << 'javafx.graphics/com.sun.javafx.css=ALL-UNNAMED'
}
```
However this doesn't seem to be needed when using the `jpackage` output, since there the module path still is not actually used (verified using the above script again).

Problems still persisted with variant-related issues when building `qupath-app` specifically, which I eventually tracked down to the use of https://github.com/jk1/Gradle-License-Report

The workaround is to incorporate `excludeGroups = ['org.openjfx']` into `licenseReport` - which is unfortunate, but the JavaFX licenses should still be bundled in QuPath via other means.

----

The requirement for `--add-opens` made this a slightly scary change to make shortly before release, in case it is also needed in other places - but as far as I can tell its importance is limited to when `./gradlew run` is used and not the final packages.

The reason for doing this anyway is that it should resolve a longstanding problem whereby JavaFX dependencies with classifiers relating to the build platform are included in the pom. This can be seen [here](https://maven.scijava.org/content/repositories/releases/io/github/qupath/qupath-gui-fx/0.4.4/qupath-gui-fx-0.4.4.pom).