### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This is a work-in-progress for the next QuPath release.
 
+> To run on Mac, QuPath v0.5.0 requires macOS 11 or later.
+> This is because of recent changes in JavaFX - for more details, see [here](https://github.com/openjdk/jfx/blob/master/doc-files/release-notes-21.md#javafx-requires-macos-11-or-later)
+> and [here](https://bugs.openjdk.org/browse/JDK-8308114).
+
 ### Enhancements
 
 #### User interface
@@ -60,15 +64,17 @@ This is a work-in-progress for the next QuPath release.
 ### Dependency updates
 * Bio-Formats 7.0.0
 * DeepJavaLibrary 0.23.0
-* Groovy 4.0.14
+* Groovy 4.0.15
+* Guava 32.1.2-jre
 * ImageJ 1.54f
 * JavaCPP 1.5.9
-* JavaFX 20.0.2
+* JavaFX 21
 * Logback 1.3.11
 * OpenCV 4.7.0
-* Picocli 4.7.4
+* Picocli 4.7.5
 * RichTextFX 0.11.1
-* SLF4J 2.0.7
+* SLF4J 2.0.9
+* snakeyaml 2.2
 
 
 ## Version 0.4.4

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name='qupath-conventions'
+

--- a/buildSrc/src/main/groovy/qupath.common-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.common-conventions.gradle
@@ -94,13 +94,7 @@ dependencies {
         opencv libs.bundles.opencv
 
 
-    guava libs.guava, {
-        exclude group: 'com.google.code.findbugs'
-        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
-        exclude group: 'org.checkerframework', module: 'checker-qual'
-    }
+    guava libs.guava
 
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,9 +10,9 @@ controlsFX      = "11.1.2"
 
 deepJavaLibrary = "0.23.0"
 
-groovy          = "4.0.14"
+groovy          = "4.0.15"
 gson            = "2.10.1"
-guava           = "31.1-jre"
+guava           = "32.1.2-jre"
 
 ikonli          = "12.3.1"
 imagej          = "1.54f"
@@ -23,7 +23,7 @@ javacpp         = "1.5.9"
   opencv        = "4.7.0-1.5.9"
   cuda          = "12.1-8.9-1.5.9"
   
-javafx          = "20.0.2"
+javafx          = "21"
 jfreeSvg        = "5.0.5"
 jfxtras         = "17-r1"
 jts             = "1.19.0"
@@ -32,13 +32,13 @@ junit           = "5.9.2"
 logback         = "1.3.11"
 logviewer       = "0.1.0-SNAPSHOT"
 
-picocli         = "4.7.4"
+picocli         = "4.7.5"
 qupath-fxtras   = "0.1.0-SNAPSHOT"
 
 richtextfx      = "0.11.1"
 
-slf4j           = "2.0.7"
-snakeyaml       = "1.33"
+slf4j           = "2.0.9"
+snakeyaml       = "2.2"
 
 
 [libraries]

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowSystemInfoCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowSystemInfoCommand.java
@@ -128,13 +128,25 @@ class ShowSystemInfoCommand {
 	    // Show paths (at the end, since they may be rather long)
 		sb.append("\n");
 		sb.append("Library path:");
-		for (String p : System.getProperty("java.library.path").split(File.pathSeparator))
+		for (String p : System.getProperty("java.library.path", "").split(File.pathSeparator))
 			sb.append("\n      ").append(p);
 		sb.append("\n\n");
+
+		// Module path often empty, but may not be depending upon how QuPath is launched
+		// (and will be useful for debugging as we attempt to become more modular)
+		var modulePath = System.getProperty("jdk.module.path", null);
+		if (modulePath != null) {
+			sb.append("Module path:");
+			for (String p : modulePath.split(File.pathSeparator))
+				sb.append("\n      ").append(p);
+			sb.append("\n\n");
+		}
+
+		// Class path currently always important
 		sb.append("Class path:");
-		for (String p : System.getProperty("java.class.path").split(File.pathSeparator))
+		for (String p : System.getProperty("java.class.path", "").split(File.pathSeparator))
 			sb.append("\n      ").append(p);
-		
+
 		logger.trace("Creating system info string:\n{}", sb);
 		
 		return sb.toString();

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,3 +18,17 @@ include 'qupath-extension-svg'
 include 'qupath-extension-script-editor'
 include 'qupath-extension-openslide'
 include 'qupath-extension-bioformats'
+
+// Support JavaFX dependency override
+// This can be used to create a build for older versions of macOS
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            def javafxOverride = System.properties.getOrDefault('javafx-version', null)
+            if (javafxOverride) {
+                println "Overriding JavaFX version to request $javafxOverride"
+                version('javafx', javafxOverride)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Document that QuPath needs macOS 11 or later - although also add a flag so that it's possible to request a different JavaFX version when building (via a system property)
```
./gradlew clean jpackage -Djavafx-version=20.0.2
```
Also include the module path in the system info, if available (since this is set when using `gradlew run` and is handy to see for debugging).