### PR TITLE
Make both rpm and deb installers for linux builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,21 +8,20 @@
  jobs:
    build:
 
-     strategy:
-       matrix:
-         platform: [ubuntu-latest, macos-latest, windows-latest]
-     runs-on: ${{ matrix.platform }}
-
-     steps:
-     - uses: actions/checkout@v3
-     - name: Set up JDK 17
-       uses: actions/setup-java@v3
-       with:
-         java-version: '17'
-         distribution: 'temurin'
-     - name: Validate Gradle wrapper
-       uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-     - name: Build with Gradle
-       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
-       with:
-         arguments: build -P toolchain=17
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Validate Gradle wrapper
+      uses: gradle/wrapper-validation-action@v1
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build -P toolchain=17

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -8,31 +8,51 @@
  jobs:
    build:
 
-     strategy:
-       matrix:
-         platform: [ubuntu-latest, macos-latest, windows-latest]
-     runs-on: ${{ matrix.platform }}
-
-     steps:
-     - uses: actions/checkout@v3
-     - name: Set up JDK 17
-       uses: actions/setup-java@v3
-       with:
-         java-version: '17'
-         distribution: 'temurin'
-     - name: Validate Gradle wrapper
-       uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-     - name: Build with Gradle
-       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
-       with:
-         arguments: jpackage -P git-commit=true -P package=installer mergedJavadoc
-     - uses: actions/upload-artifact@v3
-       with:
-         name: jpackage ${{ matrix.platform }}
-         path: build/dist
-         retention-days: 1
-     - uses: actions/upload-artifact@v3
-       with:
-         name: javadoc ${{ matrix.platform }}
-         path: build/docs/javadoc
-         retention-days: 1
+    strategy:
+      matrix:
+        include: 
+          - platform: ubuntu-latest
+            type: deb
+          - platform: ubuntu-latest
+            container: fedora:latest
+            type: rpm
+          - platform: macos-latest
+            type: pkg
+          - platform: windows-latest
+            type: msi
+    container: ${{ matrix.container }}
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies (fedora)
+      if: matrix.container == 'fedora:latest'
+      run: |
+        dnf install -y binutils git rpm-build
+        git config --global --add safe.directory /__w/qupath/qupath
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Validate Gradle wrapper
+      uses: gradle/wrapper-validation-action@v1
+    - name: Build with Gradle (Win/Mac/Linux deb)
+      if: matrix.container == ''
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: jpackage -P git-commit=true -P package=installer mergedJavadoc
+    - name: Build with Gradle (Linux rpm)
+      if: matrix.container == 'fedora:latest'
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: jpackage -P git-commit=true -P package=rpm mergedJavadoc
+    - uses: actions/upload-artifact@v3
+      with:
+        name: jpackage-${{ matrix.type }}
+        path: build/dist
+        retention-days: 1
+    - uses: actions/upload-artifact@v3
+      with:
+        name: javadoc-${{ matrix.type }}
+        path: build/docs/javadoc
+        retention-days: 1


### PR DESCRIPTION
Could add something to the PlatformPlugin code, but I think it's simpler just to explicitly build RPMs on Fedora.

If we remove the tar.gz, we should probably provide instructions to make them from source, just in case somebody's workflow relies on it.