### PR TITLE
Temporarily reinstate old methods/classes

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -49,6 +49,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 import javax.imageio.ImageIO;
@@ -103,6 +105,7 @@ import javafx.stage.WindowEvent;
 import qupath.fx.utils.FXUtils;
 import qupath.fx.dialogs.FileChoosers;
 import qupath.lib.common.GeneralTools;
+import qupath.lib.common.LogTools;
 import qupath.lib.common.Timeit;
 import qupath.lib.common.Version;
 import qupath.lib.gui.actions.ActionTools;
@@ -2892,5 +2895,62 @@ public class QuPathGUI {
 			viewerActions = new ViewerActions(getViewerManager());
 		return viewerActions;
 	}
-	
+
+
+	/**
+	 * Legacy methods, to be removed in future versions.
+	 */
+
+
+	/**
+	 * Create an executor using a single thread.
+	 * <p>
+	 * Optionally specify an owner, in which case the same Executor will be returned for the owner
+	 * for so long as the Executor has not been shut down; if it has been shut down, a new Executor will be returned.
+	 * <p>
+	 * Specifying an owner is a good idea if there is a chance that any submitted tasks could block,
+	 * since the same Executor will be returned for all requests that give a null owner.
+	 * <p>
+	 * The advantage of using this over creating an ExecutorService some other way is that
+	 * shutdown will be called on any pools created this way whenever QuPath is quit.
+	 *
+	 * @param owner
+	 * @return
+	 * @deprecated since v0.5.0; use {@link #getThreadPoolManager()}
+	 */
+	@Deprecated
+	public ExecutorService createSingleThreadExecutor(final Object owner) {
+		LogTools.logOnce(logger, "QuPathGUI.createSingleThreadExecutor(Object) is deprecated and will be removed; " +
+				"use QuPathGUI.getThreadPoolManager().getSingleThreadExecutor(owner) instead");
+		return getThreadPoolManager().getSingleThreadExecutor(owner);
+	}
+
+	/**
+	 * Create a completion service that uses a shared threadpool for the application.
+	 * @param <V>
+	 *
+	 * @param cls
+	 * @return
+	 * @deprecated since v0.5.0; use {@link #getThreadPoolManager()}
+	 */
+	@Deprecated
+	public <V> ExecutorCompletionService<V> createSharedPoolCompletionService(Class<V> cls) {
+		LogTools.logOnce(logger, "QuPathGUI.createSharedPoolCompletionService(Class) is deprecated and will be removed; " +
+				"use QuPathGUI.getThreadPoolManager().createSharedPoolCompletionService(Class) instead");
+		return getThreadPoolManager().createSharedPoolCompletionService(cls);
+	}
+
+	/**
+	 * Submit a short task to a shared thread pool
+	 *
+	 * @param runnable
+	 * @deprecated since v0.5.0; use {@link #getThreadPoolManager()}
+	 */
+	@Deprecated
+	public void submitShortTask(final Runnable runnable) {
+		LogTools.logOnce(logger, "QuPathGUI.submitShortTask() is deprecated and will be removed; " +
+						"use QuPathGUI.getThreadPoolManager().submitShortTask() instead");
+		getThreadPoolManager().submitShortTask(runnable);
+	}
+
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/Urls.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/Urls.java
@@ -38,7 +38,7 @@ public final class Urls {
 	
 	private static final Logger logger = LoggerFactory.getLogger(Urls.class);
 	
-	private static final String DOCS_VERSION = "0.4";
+	private static final String DOCS_VERSION = "latest";
 	
 	static {
 		var version = QuPathGUI.getVersion();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/Dialogs.java
@@ -1,0 +1,1046 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
+ * Contact: IP Management (ipmanagement@qub.ac.uk)
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.dialogs;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.WeakHashMap;
+import java.util.stream.Collectors;
+
+import org.controlsfx.control.Notifications;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javafx.application.Platform;
+import javafx.geometry.Insets;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ChoiceDialog;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.DialogPane;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextInputDialog;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+import qupath.fx.utils.FXUtils;
+import qupath.lib.common.LogTools;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.gui.prefs.QuPathStyleManager;
+import qupath.lib.plugins.parameters.ParameterList;
+
+/**
+ * Legacy class, deprecated since v0.5.0.
+ * Replaced by {@link qupath.fx.dialogs.Dialogs} and {@link qupath.fx.dialogs.FileChoosers}.
+ * @deprecated since v0.5.0.
+ */
+@Deprecated
+public class Dialogs {
+	
+	private static final Logger logger = LoggerFactory.getLogger(Dialogs.class);
+	
+	/**
+	 * Possible buttons pressed in a yes/no/cancel dialog.
+	 */
+	public enum DialogButton {
+		/**
+		 * "Yes" option
+		 */
+		YES,
+		/**
+		 * "No" option
+		 */
+		NO,
+		/**
+		 * "Cancel" option
+		 */
+		CANCEL
+		}
+
+
+	/**
+	 * Show a confirm dialog (OK/Cancel).
+	 * @param title
+	 * @param text
+	 * @return
+	 */
+	public static boolean showConfirmDialog(String title, String text) {
+		return showConfirmDialog(title, createContentLabel(text));
+	}
+
+	private static void logDeprecated() {
+		LogTools.warnOnce(logger, "qupath.lib.gui.dialogs.Dialogs is deprecated and will be removed in the next QuPath release" +
+				" - please use qupath.fx.dialogs.Dialogs for dialogs instead");
+	}
+
+	private static void logDeprecatedChoosers() {
+		LogTools.warnOnce(logger, "qupath.lib.gui.dialogs.Dialogs is deprecated and will be removed in the next QuPath release" +
+				" - please use qupath.fx.dialogs.FileChoosers for file/directory choosers instead");
+	}
+	
+	/**
+	 * Show a message dialog (OK button only), with the content contained within a Node.
+	 * @param title
+	 * @param node
+	 * @return
+	 */
+	public static boolean showMessageDialog(final String title, final Node node) {
+		return new Builder()
+//				.alertType(AlertType.NONE)
+				.buttons(ButtonType.OK)
+				.title(title)
+				.content(node)
+				.resizable()
+				.showAndWait()
+				.orElse(ButtonType.CANCEL) == ButtonType.OK;
+	}
+	
+	/**
+	 * Show a standard message dialog.
+	 * @param title
+	 * @param message
+	 * @return 
+	 */
+	public static boolean showMessageDialog(String title, String message) {
+		return showMessageDialog(title, createContentLabel(message));
+	}
+	
+	/**
+	 * Show a confirm dialog (OK/Cancel).
+	 * @param title
+	 * @param node
+	 * @return
+	 */
+	public static boolean showConfirmDialog(String title, Node node) {
+		logDeprecated();
+		return qupath.fx.dialogs.Dialogs.showConfirmDialog(title, node);
+	}
+	
+	/**
+	 * Show a Yes/No dialog.
+	 * @param title
+	 * @param text
+	 * @return
+	 */
+	public static boolean showYesNoDialog(String title, String text) {
+		logDeprecated();
+		return new Builder()
+			.alertType(AlertType.NONE)
+			.buttons(ButtonType.YES, ButtonType.NO)
+			.title(title)
+			.content(createContentLabel(text))
+			.showAndWait()
+			.orElse(ButtonType.NO) == ButtonType.YES;
+	}
+	
+	/**
+	 * Create a content label. This is patterned on the default behavior for {@link DialogPane} but 
+	 * sets the min size to be the preferred size, which is necessary to avoid ellipsis when using long 
+	 * Strings on Windows with scaling other than 100%.
+	 * @param text
+	 * @return
+	 */
+	private static Label createContentLabel(String text) {
+		var label = new Label(text);
+		label.setMaxWidth(Double.MAX_VALUE);
+        label.setMaxHeight(Double.MAX_VALUE);
+        label.setMinSize(Label.USE_PREF_SIZE, Label.USE_PREF_SIZE);
+        label.setWrapText(true);
+        label.setPrefWidth(360);
+        return label;
+	}
+	
+	/**
+	 * Show a Yes/No/Cancel dialog.
+	 * @param title dialog box title
+	 * @param text prompt message
+	 * @return a {@link DialogButton} indicating the response (YES, NO, CANCEL)
+	 */
+	public static DialogButton showYesNoCancelDialog(String title, String text) {
+		logDeprecated();
+		var result = new Builder()
+				.alertType(AlertType.NONE)
+				.buttons(ButtonType.YES, ButtonType.NO, ButtonType.CANCEL)
+				.title(title)
+				.content(createContentLabel(text))
+				.resizable()
+				.showAndWait()
+				.orElse(ButtonType.CANCEL);
+		return getJavaFXPaneYesNoCancel(result);
+	}
+	
+	
+	private static DialogButton getJavaFXPaneYesNoCancel(final ButtonType buttonType) {
+		if (buttonType == ButtonType.YES)
+			return DialogButton.YES;
+		if (buttonType == ButtonType.NO)
+			return DialogButton.NO;
+		if (buttonType == ButtonType.CANCEL)
+			return DialogButton.CANCEL;
+		return null;
+	}
+		
+
+	/**
+	 * Show a (modal) dialog for a specified ParameterList.
+	 * 
+	 * @param title
+	 * @param params
+	 * @return False if the user pressed 'cancel', true otherwise
+	 */
+	public static boolean showParameterDialog(String title, ParameterList params) {
+		return showConfirmDialog(title, new ParameterPanelFX(params).getPane());
+	}
+	
+	
+	/**
+	 * Show an input dialog requesting a numeric value. Only scientific notation and digits 
+	 * with/without a decimal separator (e.g. ".") are permitted.
+	 *
+	 * @param title
+	 * @param message
+	 * @param initialInput
+	 * @return Number input by the user, or NaN if no valid number was entered, or null if cancel was pressed.
+	 */
+	public static Double showInputDialog(final String title, final String message, final Double initialInput) {
+		if (Platform.isFxApplicationThread()) {
+			logDeprecated();
+			TextInputDialog dialog = new TextInputDialog(initialInput.toString());
+			FXUtils.restrictTextFieldInputToNumber(dialog.getEditor(), true);
+			dialog.setTitle(title);
+			if (QuPathGUI.getInstance() != null)
+				dialog.initOwner(getDefaultOwner());
+			dialog.setHeaderText(null);
+			dialog.setContentText(message);
+			dialog.setResizable(true);
+			// Traditional way to get the response value.
+			Optional<String> result = dialog.showAndWait();
+			if (result.isPresent()) {
+				try {
+					return Double.parseDouble(result.get());
+				} catch (Exception e) {
+					// Can still happen since the TextField restrictions allow intermediate (invalid) formats
+					logger.error("Unable to parse numeric value from {}", result);
+					return Double.NaN;
+				}
+			}
+		} else
+			return FXUtils.callOnApplicationThread(() -> showInputDialog(title, message, initialInput));
+		return null;
+	}
+	
+	/**
+	 * Show an input dialog requesting a String input.
+	 * 
+	 * @param title
+	 * @param message
+	 * @param initialInput
+	 * @return
+	 */
+	public static String showInputDialog(final String title, final String message, final String initialInput) {
+		logDeprecated();
+		if (Platform.isFxApplicationThread()) {
+			logDeprecated();
+			TextInputDialog dialog = new TextInputDialog(initialInput);
+			dialog.setTitle(title);
+			if (QuPathGUI.getInstance() != null)
+				dialog.initOwner(getDefaultOwner());
+			dialog.setHeaderText(null);
+			dialog.setContentText(message);
+			dialog.setResizable(true);
+			// Traditional way to get the response value.
+			Optional<String> result = dialog.showAndWait();
+			if (result.isPresent())
+			    return result.get();
+		} else {
+			return FXUtils.callOnApplicationThread(() -> showInputDialog(title, message, initialInput));
+		}
+		return null;
+	}
+	
+	/**
+	 * Show a choice dialog with an array of choices (selection from ComboBox or similar).
+	 * @param <T>
+	 * @param title dialog title
+	 * @param message dialog prompt
+	 * @param choices array of available options
+	 * @param defaultChoice initial selected option
+	 * @return chosen option, or {@code null} if the user cancels the dialog
+	 */
+	public static <T> T showChoiceDialog(final String title, final String message, final T[] choices, final T defaultChoice) {
+		return showChoiceDialog(title, message, Arrays.asList(choices), defaultChoice);
+	}
+	
+	/**
+	 * Show a choice dialog with a collection of choices (selection from ComboBox or similar).
+	 * @param <T>
+	 * @param title dialog title
+	 * @param message dialog prompt
+	 * @param choices list of available options
+	 * @param defaultChoice initial selected option
+	 * @return chosen option, or {@code null} if the user cancels the dialog
+	 */
+	public static <T> T showChoiceDialog(final String title, final String message, final Collection<T> choices, final T defaultChoice) {
+		if (Platform.isFxApplicationThread()) {
+			logDeprecated();
+			ChoiceDialog<T> dialog = new ChoiceDialog<>(defaultChoice, choices);
+			dialog.setTitle(title);
+			if (QuPathGUI.getInstance() != null)
+				dialog.initOwner(getDefaultOwner());
+			dialog.getDialogPane().setHeaderText(null);
+			if (message != null)
+				dialog.getDialogPane().setContentText(message);
+			Optional<T> result = dialog.showAndWait();
+			if (result.isPresent())
+				return result.get();
+			return null;
+		} else
+			return FXUtils.callOnApplicationThread(() -> showChoiceDialog(title, message, choices, defaultChoice));
+	}
+	
+	/**
+	 * Show an error message, displaying the localized message of a {@link Throwable}.
+	 * @param title
+	 * @param e
+	 */
+	public static void showErrorMessage(final String title, final Throwable e) {
+		String message = e.getLocalizedMessage();
+		if (message == null)
+			message = "QuPath has encountered a problem, sorry.\nIf you can replicate it, please report it with 'Help -> Report bug (web)'.\n\n" + e;
+		showErrorMessage(title, message);
+		logger.error(title, e);
+	}
+	
+	/**
+	 * Show an error notification, displaying the localized message of a {@link Throwable}.
+	 * @param title
+	 * @param e
+	 */
+	public static void showErrorNotification(final String title, final Throwable e) {
+		String message = e.getLocalizedMessage();
+		if (message != null && !message.isBlank() && !message.equals(title))
+			logger.error(title + ": " + e.getLocalizedMessage(), e);
+		else
+			logger.error(title , e);
+		if (message == null)
+			message = "QuPath has encountered a problem, sorry.\nIf you can replicate it, please report it with 'Help > Report bug'.\n\n" + e;
+		if (!isHeadless())
+			showNotifications(createNotifications().title(title).text(message), AlertType.ERROR);
+	}
+
+	/**
+	 * Show an error notification.
+	 * @param title
+	 * @param message
+	 */
+	public static void showErrorNotification(final String title, final String message) {
+		logger.error(title + ": " + message);
+		if (!isHeadless())
+			showNotifications(createNotifications().title(title).text(message), AlertType.ERROR);
+	}
+
+	/**
+	 * Show a warning notification.
+	 * @param title
+	 * @param message
+	 */
+	public static void showWarningNotification(final String title, final String message) {
+		logger.warn(title + ": " + message);
+		if (!isHeadless())
+			showNotifications(createNotifications().title(title).text(message), AlertType.WARNING);
+	}
+
+	/**
+	 * Show an info notification.
+	 * @param title
+	 * @param message
+	 */
+	public static void showInfoNotification(final String title, final String message) {
+		logger.info(title + ": " + message);
+		if (!isHeadless())
+			showNotifications(createNotifications().title(title).text(message), AlertType.INFORMATION);
+	}
+
+	/**
+	 * Show a plain notification.
+	 * @param title
+	 * @param message
+	 */
+	public static void showPlainNotification(final String title, final String message) {
+		logger.info(title + ": " + message);
+		if (!isHeadless())
+			showNotifications(createNotifications().title(title).text(message), AlertType.NONE);
+	}
+	
+	/**
+	 * Show notification, making sure it is on the application thread
+	 * @param notification
+	 */
+	private static void showNotifications(Notifications notification, AlertType type) {
+		logDeprecated();
+		if (isHeadless()) {
+			logger.warn("Cannot show notifications in headless mode!");
+			return;
+		}
+		if (Platform.isFxApplicationThread()) {
+			switch (type) {
+			case CONFIRMATION:
+				notification.showConfirm();
+				break;
+			case ERROR:
+				notification.showError();
+				break;
+			case INFORMATION:
+				notification.showInformation();
+				break;
+			case WARNING:
+				notification.showWarning();
+				break;
+			case NONE:
+			default:
+				notification.show();
+				break;			
+			}
+		} else
+			Platform.runLater(() -> showNotifications(notification, type));
+	}
+	
+	
+	/**
+	 * Necessary to have owner when calling notifications (bug in controlsfx?).
+	 */
+	private static Notifications createNotifications() {
+		var stage = QuPathGUI.getInstance() == null ? null : QuPathGUI.getInstance().getStage();
+		var notifications = Notifications.create();
+		if (stage == null)
+			return notifications;
+		
+		if (!QuPathStyleManager.isDefaultStyle())
+			notifications = notifications.darkStyle();
+		
+		return notifications.owner(stage);
+	}
+	
+	/**
+	 * Show an error message that no image is available. This is included to help 
+	 * standardize the message throughout the software.
+	 * @param title
+	 */
+	public static void showNoImageError(String title) {
+		showErrorMessage(title, "No image is available!");
+	}
+	
+	/**
+	 * Show an error message that no project is available. This is included to help 
+	 * standardize the message throughout the software.
+	 * @param title
+	 */
+	public static void showNoProjectError(String title) {
+		showErrorMessage(title, "No project is available!");
+	}
+	
+	
+	/**
+	 * Show an error message.
+	 * @param title
+	 * @param message
+	 */
+	public static void showErrorMessage(final String title, final String message) {
+		logger.error(title + ": " + message);
+		if (!isHeadless())
+			showErrorMessage(title, createContentLabel(message));
+	}
+	
+	/**
+	 * Show an error message, with the content defined within a {@link Node}.
+	 * @param title
+	 * @param node
+	 */
+	public static void showErrorMessage(final String title, final Node node) {
+		logDeprecated();
+		new Builder()
+			.alertType(AlertType.ERROR)
+			.title(title)
+			.content(node)
+			.show();
+	}
+
+	/**
+	 * Show a plain message.
+	 * @param title
+	 * @param message
+	 */
+	public static void showPlainMessage(final String title, final String message) {
+		logDeprecated();
+		logger.info(title + ": " + message);
+		if (!isHeadless()) {
+			new Builder()
+				.alertType(AlertType.INFORMATION)
+				.title(title)
+				.content(createContentLabel(message))
+				.show();
+		}
+	}
+	
+	/**
+	 * Show a window containing plain text, with the specified properties.
+	 * 
+	 * @param owner
+	 * @param title
+	 * @param contents
+	 * @param modality
+	 * @param isEditable
+	 */
+	public static void showTextWindow(final Window owner, final String title, final String contents, final Modality modality, final boolean isEditable) {
+		if (!Platform.isFxApplicationThread()) {
+			Platform.runLater(() -> showTextWindow(owner, title, contents, modality, isEditable));
+			return;
+		}
+		logDeprecated();
+		logger.info("{}\n{}", title, contents);
+		Stage dialog = new Stage();
+		if (owner == null)
+			dialog.initOwner(getDefaultOwner());
+		else
+			dialog.initOwner(owner);
+		dialog.initModality(modality);
+		dialog.setTitle(title);
+		
+		TextArea textArea = new TextArea();
+		textArea.setPrefColumnCount(60);
+		textArea.setPrefRowCount(25);
+
+		textArea.setText(contents);
+		textArea.setWrapText(true);
+		textArea.positionCaret(0);
+		textArea.setEditable(isEditable);
+		
+		dialog.setScene(new Scene(textArea));
+		dialog.show();
+	}
+	
+	/**
+	 * Prompt to open a list of files.
+	 * 
+	 * @param title
+	 * @param dirBase
+	 * @param filterDescription
+	 * @param exts
+	 * @return
+	 */
+	public static List<File> promptForMultipleFiles(String title, File dirBase, String filterDescription, String... exts) {
+		return getSharedChooser().promptForMultipleFiles(title, dirBase, filterDescription, exts);
+	}
+
+	/**
+	 * Prompt user to select a directory.
+	 * 
+	 * @param dirBase base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @return selected directory, or null if no directory was selected
+	 */
+	public static File promptForDirectory(File dirBase) {
+		return getSharedChooser().promptForDirectory(dirBase);
+	}
+	
+	/**
+	 * Prompt user to select a directory.
+	 * 
+	 * @param title the title to display for the dialog (may be null to use default)
+	 * @param dirBase base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @return selected directory, or null if no directory was selected
+	 */
+	public static File promptForDirectory(String title, File dirBase) {
+		return getSharedChooser().promptForDirectory(title, dirBase);
+	}
+
+	/**
+	 * Prompt the user for a file with some kind of file dialog.
+	 * @param title the title to display for the dialog (may be null to use default)
+	 * @param dirBase base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @param filterDescription description to (possibly) show for the file name filter (may be null if no filter should be used)
+	 * @param exts optional array of file extensions if filterDescription is not null
+	 * 
+	 * @return the File selected by the user, or null if the dialog was cancelled
+	 */
+	public static File promptForFile(String title, File dirBase, String filterDescription, String... exts) {
+		return getSharedChooser().promptForFile(title, dirBase, filterDescription, exts);
+	}
+
+	/**
+	 * Prompt user to select a file.
+	 * 
+	 * @param dirBase base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @return the File selected by the user, or null if the dialog was cancelled
+	 */
+	public static File promptForFile(File dirBase) {
+		return getSharedChooser().promptForFile(dirBase);
+	}
+
+	/**
+	 * Prompt user to select a file path to save.
+	 * 
+	 * @param title the title to display for the dialog (may be null)
+	 * @param dirBase the base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @param defaultName default file name
+	 * @param filterName description to show for the file name filter (may be null if no filter should be used)
+	 * @param ext extension that should be used for the saved file (may be empty or null if not specified)
+	 * @return the File selected by the user, or null if the dialog was cancelled
+	 */
+	public static File promptToSaveFile(String title, File dirBase, String defaultName, String filterName, String ext) {
+		return getSharedChooser().promptToSaveFile(title, dirBase, defaultName, filterName, ext);
+	}
+	
+	/**
+	 * Prompt user to select a file path to save, providing zero or more file extensions as an option.
+	 * 
+	 * @param title the title to display for the dialog (may be null)
+	 * @param dirBase the base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @param defaultName default file name
+	 * @param filters map of file type descriptions (keys) and file extensions (values); may be empty if an 'all files' filter should be used
+	 * @return the File selected by the user, or null if the dialog was cancelled
+	 * @since v0.4.0
+	 */
+	public static File promptToSaveFile(String title, File dirBase, String defaultName, Map<String, String> filters) {
+		return getSharedChooser().promptToSaveFile(title, dirBase, defaultName, filters);
+	}
+
+	/**
+	 * Prompt user to select a file or input a URL.
+	 * 
+	 * @param title dialog title
+	 * @param defaultPath default path to display - may be null
+	 * @param dirBase base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @param filterDescription description to (possibly) show for the file name filter (may be null if no filter should be used)
+	 * @param exts optional array of file extensions if filterDescription is not null
+	 * @return the path to the file or URL, or null if no path was provided.
+	 */
+	public static String promptForFilePathOrURL(String title, String defaultPath, File dirBase, String filterDescription,
+			String... exts) {
+		return getSharedChooser().promptForFilePathOrURL(title, defaultPath, dirBase, filterDescription, exts);
+	}
+	
+	private static QuPathChooser defaultFileChooser = new QuPathChooserFX(null);
+	private static Map<Window, QuPathChooser> fileChooserMap = new WeakHashMap<>();
+
+	
+	/**
+	 * Get a default owner window.
+	 * This is the main QuPath window, if available, unless we have any modal stages.
+	 * If we do have modal stages, and one is in focus, use that.
+	 * Otherwise, return null and let JavaFX figure out the owner.
+	 * @return
+	 */
+	private static Window getDefaultOwner() {
+		List<Stage> modalStages = Window.getWindows().stream()
+				.filter(w -> w.isShowing() && w instanceof Stage)
+				.map(w -> (Stage)w)
+				.filter(s -> s.getModality() != Modality.NONE)
+				.collect(Collectors.toList());
+		if (modalStages.isEmpty()) {
+			var qupath = QuPathGUI.getInstance();
+			if (qupath != null)
+				return qupath.getStage();
+			return null;
+		}
+		var focussedStages = modalStages.stream()
+				.filter(s -> s.isFocused())
+				.collect(Collectors.toList());
+		if (focussedStages.size() == 1)
+			return focussedStages.get(0);
+		return null;
+	}
+	
+	/**
+	 * Get a {@link QuPathChooser} instance linked to a specific window.
+	 * This may both influence the display of the chooser (by setting the parent window) and the starting directory 
+	 * (by remembering the last known directory for the chooser).
+	 * @param window
+	 * @return a {@link QuPathChooser} associated with the specified window.
+	 */
+	public static QuPathChooser getChooser(Window window) {
+		logDeprecatedChoosers();
+		if (window == null)
+			return defaultFileChooser;
+		return fileChooserMap.computeIfAbsent(window, w -> new QuPathChooserFX(w));
+	}
+
+	private static QuPathChooser getSharedChooser() {
+		return getChooser(getDefaultOwner());
+	}
+	
+	/**
+	 * Create a new builder to generate a custom dialog.
+	 * @return
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+	
+	
+	private static boolean isHeadless() {
+		return QuPathGUI.getInstance() == null;
+	}
+
+	/**
+	 * Builder class to create a custom {@link Dialog}.
+	 */
+	@Deprecated
+	public static class Builder {
+		
+		private AlertType alertType;
+		private Window owner = null;
+		private String title = "";
+		private String header = null;
+		private String contentText = null;
+		private Node expandableContent = null;
+		private Node content = null;
+		private boolean resizable = false;
+		private double width = -1;
+		private double height = -1;
+		private double prefWidth = -1;
+		private double prefHeight = -1;
+		private List<ButtonType> buttons = null;
+		private Modality modality = Modality.APPLICATION_MODAL;
+		
+		/**
+		 * Specify the dialog title.
+		 * @param title dialog title
+		 * @return this builder
+		 */
+		public Builder title(String title) {
+			this.title = title;
+			return this;
+		}
+		
+		/**
+		 * Specify the dialog header text.
+		 * This is text that is displayed prominently within the dialog.
+		 * @param header dialog header
+		 * @return this builder
+		 * @see #contentText(String)
+		 */
+		public Builder headerText(String header) {
+			this.header = header;
+			return this;
+		}
+		
+		/**
+		 * Specify the dialog content text.
+		 * This is text that is displayed within the dialog.
+		 * @param content dialog content text
+		 * @return this builder
+		 * @see #headerText(String)
+		 */
+		public Builder contentText(String content) {
+			this.contentText = content;
+			return this;
+		}
+		
+		/**
+		 * Specify a {@link Node} to display within the dialog.
+		 * @param content dialog content
+		 * @return this builder
+		 * @see #contentText(String)
+		 */
+		public Builder content(Node content) {
+			this.content = content;
+			return this;
+		}
+		
+		/**
+		 * Specify a {@link Node} to display within the dialog as expandable content, not initially visible.
+		 * @param content dialog expandable content
+		 * @return this builder
+		 * @see #content(Node)
+		 */
+		public Builder expandableContent(Node content) {
+			this.expandableContent = content;
+			return this;
+		}
+		
+		/**
+		 * Specify the dialog owner.
+		 * @param owner dialog title
+		 * @return this builder
+		 */
+		public Builder owner(Window owner) {
+			this.owner = owner;
+			return this;
+		}
+		
+		/**
+		 * Make the dialog resizable (but default it is not).
+		 * @return this builder
+		 */
+		public Builder resizable() {
+			resizable = true;
+			return this;
+		}
+
+		/**
+		 * Specify that the dialog should be non-modal.
+		 * By default, most dialogs are modal (and therefore block clicks to other windows).
+		 * @return this builder
+		 */
+		public Builder nonModal() {
+			this.modality = Modality.NONE;
+			return this;
+		}
+		
+		/**
+		 * Specify the modality of the dialog.
+		 * @param modality requested modality
+		 * @return this builder
+		 */
+		public Builder modality(Modality modality) {
+			this.modality = modality;
+			return this;
+		}
+		
+		/**
+		 * Create a dialog styled as a specified alert type.
+		 * @param type 
+		 * @return this builder
+		 */
+		public Builder alertType(AlertType type) {
+			alertType = type;
+			return this;
+		}
+		
+		/**
+		 * Create a warning alert dialog.
+		 * @return this builder
+		 */
+		public Builder warning() {
+			return alertType(AlertType.WARNING);
+		}
+		
+		/**
+		 * Create an error alert dialog.
+		 * @return this builder
+		 */
+		public Builder error() {
+			return alertType(AlertType.ERROR);
+		}
+		
+		/**
+		 * Create an information alert dialog.
+		 * @return this builder
+		 */
+		public Builder information() {
+			return alertType(AlertType.INFORMATION);
+		}
+		
+		/**
+		 * Create an confirmation alert dialog.
+		 * @return this builder
+		 */
+		public Builder confirmation() {
+			return alertType(AlertType.CONFIRMATION);
+		}
+		
+		/**
+		 * Specify the buttons to display in the dialog.
+		 * @param buttonTypes buttons to use
+		 * @return this builder
+		 */
+		public Builder buttons(ButtonType... buttonTypes) {
+			this.buttons = Arrays.asList(buttonTypes);
+			return this;
+		}
+		
+		/**
+		 * Specify the buttons to display in the dialog.
+		 * @param buttonNames names of buttons to use
+		 * @return this builder
+		 */
+		public Builder buttons(String... buttonNames) {
+			var list = new ArrayList<ButtonType>();
+			for (String name : buttonNames) {
+				ButtonType type;
+				switch (name.toLowerCase()) {
+				case "ok": type = ButtonType.OK; break;
+				case "yes": type = ButtonType.YES; break;
+				case "no": type = ButtonType.NO; break;
+				case "cancel": type = ButtonType.CANCEL; break;
+				case "apply": type = ButtonType.APPLY; break;
+				case "close": type = ButtonType.CLOSE; break;
+				case "finish": type = ButtonType.FINISH; break;
+				case "next": type = ButtonType.NEXT; break;
+				case "previous": type = ButtonType.PREVIOUS; break;
+				default: type = new ButtonType(name); break;
+				}
+				list.add(type);
+			}
+			this.buttons = list;
+			return this;
+		}
+		
+		/**
+		 * Specify the dialog width.
+		 * @param width requested width
+		 * @return this builder
+		 */
+		public Builder width(double width) {
+			this.width = width;
+			return this;
+		}
+		
+		/**
+		 * Specify the dialog height.
+		 * @param height requested height
+		 * @return this builder
+		 */
+		public Builder height(double height) {
+			this.height = height;
+			return this;
+		}
+		
+		/**
+		 * Specify the preferred width of the dialog pane.
+		 * @param prefWidth preferred width
+		 * @return this builder
+		 * @since v0.4.0
+		 */
+		public Builder prefWidth(double prefWidth) {
+			this.prefWidth = prefWidth;
+			return this;
+		}
+		
+		/**
+		 * Specify the preferred height of the dialog pane.
+		 * @param prefHeight preferred height
+		 * @return this builder
+		 * @since v0.4.0
+		 */
+		public Builder prefHeight(double prefHeight) {
+			this.prefHeight = prefHeight;
+			return this;
+		}
+		
+		/**
+		 * Specify the dialog height.
+		 * @param width requested width
+		 * @param height requested height
+		 * @return this builder
+		 */
+		public Builder size(double width, double height) {
+			this.width = width;
+			this.height = height;
+			return this;
+		}
+		
+		/**
+		 * Build the dialog.
+		 * @return a {@link Dialog} created with the specified features.
+		 */
+		public Dialog<ButtonType> build() {
+			Dialog<ButtonType> dialog;
+			if (alertType == null)
+				dialog = new Dialog<>();
+			else
+				dialog = new Alert(alertType);
+			
+			if (owner == null) {
+				dialog.initOwner(getDefaultOwner());
+			} else
+				dialog.initOwner(owner);
+			
+			dialog.setTitle(title);
+			if (header != null)
+				dialog.setHeaderText(header);
+			else
+				// The alert type can make some rather ugly header text appear
+				dialog.setHeaderText(null);
+			if (contentText != null)
+				dialog.setContentText(contentText);
+			if (content != null)
+				dialog.getDialogPane().setContent(content);
+			if (expandableContent != null)
+				dialog.getDialogPane().setExpandableContent(expandableContent);
+			if (width > 0)
+				dialog.setWidth(width);
+			if (height > 0)
+				dialog.setHeight(height);
+			if (prefWidth > 0)
+				dialog.getDialogPane().setPrefWidth(prefWidth);
+			if (prefHeight > 0)
+				dialog.getDialogPane().setPrefHeight(prefHeight);
+			if (buttons != null)
+				dialog.getDialogPane().getButtonTypes().setAll(buttons);
+			
+			// We do need to be able to close the dialog somehow
+			if (dialog.getDialogPane().getButtonTypes().isEmpty()) {
+				dialog.getDialogPane().getScene().getWindow().setOnCloseRequest(e -> dialog.hide());
+			}
+			
+			dialog.setResizable(resizable);
+			dialog.initModality(modality);
+			
+			// There's sometimes annoying visual bug in dark mode that results in a white/light 
+			// thin line at the bottom of the dialog - padding seems to fix it
+			if (Insets.EMPTY.equals(dialog.getDialogPane().getPadding()))
+				dialog.getDialogPane().setStyle("-fx-background-insets: -1; -fx-padding: 1px;");
+			
+			return dialog;
+		}
+		
+		
+		/**
+		 * Show the dialog.
+		 * This is similar to {@code build().show()} except that it will automatically 
+		 * be called on the JavaFX application thread even if called from another thread.
+		 */
+		public void show() {
+			if (isHeadless()) {
+				logger.warn("Cannot show dialog in headless mode!");
+				return;
+			}
+			FXUtils.runOnApplicationThread(() -> build().show());
+		}
+		
+		/**
+		 * Show the dialog.
+		 * This is similar to {@code build().showAndWait()} except that it will automatically 
+		 * be called on the JavaFX application thread even if called from another thread.
+		 * Callers should be cautious that this does not result in deadlock (e.g. if called from 
+		 * the Swing Event Dispatch Thread on some platforms).
+		 * @return 
+		 */
+		public Optional<ButtonType> showAndWait() {
+			return FXUtils.callOnApplicationThread(() -> build().showAndWait());
+		}
+		
+	}
+	
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/QuPathChooser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/QuPathChooser.java
@@ -1,0 +1,150 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
+ * Contact: IP Management (ipmanagement@qub.ac.uk)
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.dialogs;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Interface to help with prompting users to select files or directories.
+ * The intention is that sub-classes might use different kinds of (possibly platform-specific) file choosers.
+ * <p>
+ * In truth, having this as an interface made most sense back in the Swing days - whenever it was often the
+ * case that the Swing and AWT dialogs were quite different in appearance (and pleasantness).
+ * <p>
+ * With JavaFX that's not so important - however it is maintained as an interface in case alternative dialogs
+ * might be introduced in the future.
+ * 
+ * @author Pete Bankhead
+ * @deprecated since v0.5.0, use {@link qupath.fx.dialogs.FileChoosers} instead
+ */
+@Deprecated
+interface QuPathChooser {
+
+	/**
+	 * Set the last directory, which will be used as the base directory in future file choosers.
+	 * <p>
+	 * If a file (not directory) is given, the parent directory will be used.
+	 * If the file does not exist, the last directory will be set to null.
+	 * 
+	 * @param dir
+	 */
+	public void setLastDirectory(File dir);
+
+	/**
+	 * Get the last directory, which may be used as the starting directory the next time the chooser is shown 
+	 * if no other directory is specified.
+	 * 
+	 * @return
+	 */
+	public File getLastDirectory();
+	
+	/**
+	 * Prompt to open a list of files.
+	 * 
+	 * @param title
+	 * @param dirBase
+	 * @param filterDescription
+	 * @param exts
+	 * @return
+	 */
+	public List<File> promptForMultipleFiles(String title, File dirBase, String filterDescription, String... exts);
+	
+	/**
+	 * Prompt user to select a directory.
+	 * 
+	 * @param dirBase base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @return selected directory, or null if no directory was selected
+	 */
+	public default File promptForDirectory(File dirBase) {
+		return promptForDirectory(null, dirBase);
+	}
+	
+	/**
+	 * Prompt user to select a directory.
+	 * 
+	 * @param title the title to display for the dialog (may be null to use default)
+	 * @param dirBase base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @return selected directory, or null if no directory was selected
+	 */
+	public abstract File promptForDirectory(String title, File dirBase);
+
+	/**
+	 * Prompt the user for a file with some kind of file dialog.
+	 * @param title the title to display for the dialog (may be null to use default)
+	 * @param dirBase base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @param filterDescription description to (possibly) show for the file name filter (may be null if no filter should be used)
+	 * @param exts optional array of file extensions if filterDescription is not null
+	 * 
+	 * @return the File selected by the user, or null if the dialog was cancelled
+	 */
+	public abstract File promptForFile(String title, File dirBase, String filterDescription, String... exts);
+
+	/**
+	 * Prompt user to select a file.
+	 * 
+	 * @param dirBase base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @return the File selected by the user, or null if the dialog was cancelled
+	 */
+	public File promptForFile(File dirBase);
+	
+	/**
+	 * Prompt user to select a file path to save, using a single file extension as an option.
+	 * 
+	 * @param title the title to display for the dialog (may be null)
+	 * @param dirBase the base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @param defaultName default file name
+	 * @param filterDescription description to show for the file name filter (may be null if no filter should be used)
+	 * @param ext extension that should be used for the saved file (may be empty or null if not specified)
+	 * @return the File selected by the user, or null if the dialog was cancelled
+	 */
+	public File promptToSaveFile(String title, File dirBase, String defaultName, String filterDescription, String ext);
+	
+	/**
+	 * Prompt user to select a file path to save, providing zero or more file extensions as an option.
+	 * 
+	 * @param title the title to display for the dialog (may be null)
+	 * @param dirBase the base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @param defaultName default file name
+	 * @param filters map of file type descriptions (keys) and file extensions (values); may be empty if an 'all files' filter should be used
+	 * @return the File selected by the user, or null if the dialog was cancelled
+	 * @since v0.4.0
+	 */
+	public File promptToSaveFile(String title, File dirBase, String defaultName, Map<String, String> filters);
+	
+	/**
+	 * Prompt user to select a file or input a URL.
+	 * 
+	 * @param title dialog title
+	 * @param defaultPath default path to display - may be null
+	 * @param dirBase base directory to display; if null or not an existing directory, the value under getLastDirectory() should be used
+	 * @param filterDescription description to (possibly) show for the file name filter (may be null if no filter should be used)
+	 * @param exts optional array of file extensions if filterDescription is not null
+	 * @return the path to the file or URL, or null if no path was provided.
+	 */
+	public String promptForFilePathOrURL(String title, String defaultPath, File dirBase, String filterDescription, String... exts);
+	
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/QuPathChooserFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/QuPathChooserFX.java
@@ -1,0 +1,416 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
+ * Contact: IP Management (ipmanagement@qub.ac.uk)
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.dialogs;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javafx.application.Platform;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+import javafx.stage.FileChooser.ExtensionFilter;
+import qupath.fx.utils.FXUtils;
+import qupath.fx.utils.GridPaneUtils;
+import qupath.lib.common.GeneralTools;
+import javafx.stage.Window;
+
+/**
+ * Implementation of {@link QuPathChooser} using JavaFX.
+ * 
+ * @author Pete Bankhead
+ * @deprecated since v0.5.0
+ */
+@Deprecated
+class QuPathChooserFX implements QuPathChooser {
+	
+	private static final Logger logger = LoggerFactory.getLogger(QuPathChooserFX.class);
+	
+	private Window ownerWindow = null;
+	private FileChooser fileChooser = new FileChooser();
+	private DirectoryChooser directoryChooser = new DirectoryChooser();
+	
+	private ExtensionFilter allFiles = new ExtensionFilter("All Files", "*.*");
+	
+	private File lastDir;
+	
+	/**
+	 * Create a {@link QuPathChooser} using JavaFX.
+	 * @param ownerWindow
+	 */
+	public QuPathChooserFX(final Window ownerWindow) {
+		this.ownerWindow = ownerWindow;
+	}
+	
+
+	@Override
+	public void setLastDirectory(File dir) {
+		if (dir == null)
+			lastDir = null;
+		else if (dir.isDirectory()) {
+			if (dir.exists())
+				lastDir = dir;
+			return;
+		} else
+			setLastDirectory(dir.getParentFile());
+	}
+
+	@Override
+	public File getLastDirectory() {
+		if (lastDir != null && lastDir.isDirectory())
+			return lastDir;
+		return null;
+	}
+	
+	private File getUsefulBaseDirectory(File dirBase) {
+		if (dirBase == null || !dirBase.isDirectory())
+			return getLastDirectory();
+		else
+			return dirBase;
+	}
+
+	@Override
+	public File promptForDirectory(String title, File dirBase) {
+		
+		if (!Platform.isFxApplicationThread()) {
+			return FXUtils.callOnApplicationThread(() -> promptForDirectory(title, dirBase));
+		}
+		
+		File lastDir = getLastDirectory();
+		directoryChooser.setTitle(title);
+		directoryChooser.setInitialDirectory(getUsefulBaseDirectory(dirBase));
+		File dirSelected = directoryChooser.showDialog(ownerWindow);
+		if (dirSelected != null) {
+			if (dirBase == null)
+				setLastDirectory(dirSelected);
+			else
+				fileChooser.setInitialDirectory(lastDir);
+		}
+		
+		logger.trace("Returning directory: {}", dirSelected);
+		
+		return dirSelected;
+	}
+	
+	
+	@Override
+	public List<File> promptForMultipleFiles(String title, File dirBase, String filterDescription, String... exts) {
+		
+		if (!Platform.isFxApplicationThread()) {
+			return FXUtils.callOnApplicationThread(() -> promptForMultipleFiles(title, dirBase, filterDescription, exts));
+		}
+		
+		File lastDir = getLastDirectory();
+		fileChooser.setInitialDirectory(getUsefulBaseDirectory(dirBase));
+		if (title != null)
+			fileChooser.setTitle(title);
+		else
+			fileChooser.setTitle("Choose file");
+		if (filterDescription != null && exts != null && exts.length > 0) {
+			ExtensionFilter filter = getExtensionFilter(filterDescription, exts);
+			fileChooser.getExtensionFilters().setAll(filter, allFiles);
+			fileChooser.setSelectedExtensionFilter(filter);
+		} else {
+			fileChooser.getExtensionFilters().clear();
+			fileChooser.setSelectedExtensionFilter(null);
+		}
+		
+		
+		// Ensure we make our request on the correct thread
+		List<File> filesSelected = fileChooser.showOpenMultipleDialog(ownerWindow);
+		
+		// Set the last directory if we aren't dealing with a directory that has been specifically requested this time
+		if (filesSelected != null && !filesSelected.isEmpty()) {
+			if (dirBase == null)
+				setLastDirectory(filesSelected.get(0));
+			else
+				fileChooser.setInitialDirectory(lastDir);
+		}
+		
+		logger.trace("Returning files: {}", filesSelected);
+		
+		return filesSelected;
+
+	}
+	
+	
+	/**
+	 * Create extension filter, ensuring that the format is *.extension.
+	 * 
+	 * @param description
+	 * @param extensions
+	 * @return
+	 */
+	static ExtensionFilter getExtensionFilter(String description, String... extensions) {
+		List<String> ext = new ArrayList<>();
+		for (String e : extensions) {
+			if (e.startsWith(".")) {
+				e = "*" + e;
+			} else if (!e.startsWith("*"))
+				e = "*." + e;
+			ext.add(e);
+		}
+		return new ExtensionFilter(description, ext);
+	}
+	
+
+	@Override
+	public File promptForFile(String title, File dirBase, String filterDescription, String... exts) {
+		return promptForFile(ownerWindow, title, dirBase, filterDescription, exts);
+	}
+	
+	
+	private File promptForFile(Window owner, String title, File dirBase, String filterDescription, String... exts) {
+		
+		if (!Platform.isFxApplicationThread()) {
+			return FXUtils.callOnApplicationThread(() -> promptForFile(title, dirBase, filterDescription, exts));
+		}
+		
+		File lastDir = getLastDirectory();
+		fileChooser.setInitialDirectory(getUsefulBaseDirectory(dirBase));
+		if (title != null)
+			fileChooser.setTitle(title);
+		else
+			fileChooser.setTitle("Choose file");
+		if (filterDescription != null && exts != null && exts.length > 0) {
+			ExtensionFilter filter = getExtensionFilter(filterDescription, exts);
+			fileChooser.getExtensionFilters().setAll(filter, allFiles);
+			fileChooser.setSelectedExtensionFilter(filter);
+		} else {
+			fileChooser.getExtensionFilters().clear();
+			fileChooser.setSelectedExtensionFilter(null);
+		}
+		
+		
+		// Ensure we make our request on the correct thread
+		File fileSelected = fileChooser.showOpenDialog(owner);
+		
+		// Set the last directory if we aren't dealing with a directory that has been specifically requested this time
+		if (fileSelected != null) {
+			if (dirBase == null)
+				setLastDirectory(fileSelected);
+			else
+				fileChooser.setInitialDirectory(lastDir);
+		}
+		
+		logger.trace("Returning file: {}", fileSelected);
+		
+		return fileSelected;
+
+	}
+
+	@Override
+	public File promptForFile(File dirBase) {
+		return promptForFile(null, dirBase, null);
+	}
+
+	@Override
+	public File promptToSaveFile(String title, File dirBase, String defaultName, Map<String, String> filters) {
+		
+		if (!Platform.isFxApplicationThread()) {
+			return FXUtils.callOnApplicationThread(() -> promptToSaveFile(title, dirBase, defaultName, filters));
+		}
+
+		File lastDir = getLastDirectory();
+		fileChooser.setInitialDirectory(getUsefulBaseDirectory(dirBase));
+		if (title != null)
+			fileChooser.setTitle(title);
+		else
+			fileChooser.setTitle("Save");
+		
+		// Extract file extension from default name, if possible.
+		// We want to use this 'provided extension' if it's valid, i.e. it's found within the list of extensions.
+		// But we need to separately retain a default extension until we know if it's valid.
+		// We don't want to strip away anything after a final dot that isn't an intended file extension.
+		String providedExt = defaultName == null ? null : GeneralTools.getExtension(defaultName).orElse(null);
+		String defaultExt = null;
+		
+		// Keep track of which extension filters we are using
+		boolean useExtFilter = filters != null && !filters.isEmpty();
+		var extFilterMap = new HashMap<ExtensionFilter, String>();
+		fileChooser.getExtensionFilters().clear();
+		fileChooser.setSelectedExtensionFilter(null);
+		if (useExtFilter) {
+			for (var entry : filters.entrySet()) {
+				// Major annoyance: multipart extensions such as .ome.tif can be be automatically trimmed to the final component
+				// Windows seems to handle it properly, macOS doesn't (I think Linux doesn't either, but not sure)
+				var filterName = entry.getKey();
+				var ext = entry.getValue();
+				if (filterName != null && ext != null) {
+//				if (filterName != null && ext != null && (GeneralTools.isWindows() || !GeneralTools.isMultipartExtension(ext))) {
+					var filter = getExtensionFilter(filterName, ext);
+					if (!filter.getExtensions().isEmpty()) {
+						String currentExt = filter.getExtensions().get(0).substring(1);
+						// Test if the provided extension is something we can use by default
+						if (Objects.equals(currentExt, providedExt))
+							defaultExt = providedExt;
+						// If we don't have a default, use the current extension (unless we see later the provided extension is available)
+						else if (defaultExt == null && !filter.getExtensions().isEmpty())
+							defaultExt = currentExt;
+					}
+					extFilterMap.put(filter, ext);
+					fileChooser.getExtensionFilters().add(filter);
+					if (Objects.equals(ext, defaultExt))
+						fileChooser.setSelectedExtensionFilter(filter);
+				}
+			}
+		} else 
+			defaultExt = providedExt;
+		
+		// Try to avoid doubling up on the extension
+		if (defaultName != null) {
+			if (defaultExt != null && GeneralTools.isMultipartExtension(defaultExt) && !defaultName.toLowerCase().endsWith(defaultExt.toLowerCase()))
+				fileChooser.setInitialFileName(defaultName + defaultExt);
+			else
+				fileChooser.setInitialFileName(defaultName);
+//			if (fileChooser.getSelectedExtensionFilter() != null)
+//				fileChooser.setInitialFileName(GeneralTools.getNameWithoutExtension(new File(defaultName)));
+//			else
+//				fileChooser.setInitialFileName(defaultName);
+		} else
+			fileChooser.setInitialFileName(null);
+		
+		File fileSelected = fileChooser.showSaveDialog(ownerWindow);
+		if (fileSelected != null) {
+			// Only change the last directory if we didn't specify one
+			if (dirBase == null)
+				setLastDirectory(fileSelected);
+			else
+				fileChooser.setInitialDirectory(lastDir);
+			
+			// Ensure the extension is present
+			String name = fileSelected.getName();
+			String selectedExt = null;
+			if (useExtFilter) {
+				selectedExt = extFilterMap.getOrDefault(fileChooser.getSelectedExtensionFilter(), filters.values().iterator().next());
+			}
+			// Fix the extension if necessary
+			if (selectedExt != null && !name.toLowerCase().endsWith(selectedExt.toLowerCase())) {
+				// Handle multipart extensions; if we have the last part of the extension set, then remove it before adding the full thing
+				var previousName = name;
+				if (GeneralTools.isMultipartExtension(selectedExt)) {
+					var lastExtPart = selectedExt.substring(selectedExt.lastIndexOf("."));
+					if (name.toLowerCase().endsWith(lastExtPart.toLowerCase()))
+						name = name.substring(0, name.length()-lastExtPart.length());
+				}
+				// Add the required extension
+				if (name.endsWith("."))
+					name = name.substring(0, name.length()-1);
+				if (selectedExt.startsWith("."))
+					name = name + selectedExt;
+				else
+					name = name + "." + selectedExt;
+				fileSelected = new File(fileSelected.getParentFile(), name);
+				logger.warn("Updating name from {} to {}", previousName, name);
+			}
+		}
+		
+		logger.trace("Returning file to save: {}", fileSelected);
+		
+		return fileSelected;
+	}
+
+	@Override
+	public String promptForFilePathOrURL(String title, String defaultPath, File dirBase, String filterDescription, String... exts) {
+		if (!Platform.isFxApplicationThread()) {
+			return FXUtils.callOnApplicationThread(() -> promptForFilePathOrURL(title, defaultPath, dirBase, filterDescription, exts));
+		}
+		
+		// Create dialog
+        GridPane pane = new GridPane();
+        
+        Label label = new Label("Enter URL");
+        TextField tf = new TextField();
+        tf.setPrefWidth(400);
+        
+        Button button = new Button("Choose file");
+        button.setOnAction(new EventHandler<ActionEvent>() {
+            @Override public void handle(ActionEvent e) {
+            	// Prefer to use this window as the parent
+    			var owner = FXUtils.getWindow(button);
+    			File file = promptForFile(owner, null, dirBase, filterDescription, exts);
+            	if (file != null)
+            		tf.setText(file.getAbsolutePath());
+            }
+        });
+        
+//        label.setPadding(new Insets(0, 0, 5, 0));
+        GridPaneUtils.addGridRow(pane, 0, 0, "Input URL or choose file", label, tf, button);
+        pane.setHgap(5);
+//        pane.setTop(label);
+//        pane.setCenter(tf);
+//        pane.setRight(button);
+        
+		
+        // Show dialog
+		if (defaultPath == null)
+			tf.setText("");
+		else
+			tf.setText(defaultPath);
+		
+		Alert alert = new Alert(Alert.AlertType.NONE, "Enter image path (file or URL)", ButtonType.OK, ButtonType.CANCEL);
+		if (title == null)
+			alert.setTitle("Enter file path or URL");
+		else
+			alert.setTitle(title);
+//	    alert.initModality(Modality.APPLICATION_MODAL);
+//	    alert.initOwner(scene.getWindow());
+	    
+	    alert.getDialogPane().setContent(pane);
+	    
+	    String path = null;
+	    Optional<ButtonType> result = alert.showAndWait();
+	    if (result.isPresent() && result.get() == ButtonType.OK)
+	    	path = tf.getText().trim();
+	    
+		logger.trace("Returning path: {}", path);
+	    
+		return path;
+	}
+
+
+	@Override
+	public File promptToSaveFile(String title, File dirBase, String defaultName, String filterName, String ext) {
+		if (filterName != null && !filterName.isEmpty() && ext != null && !ext.isEmpty())
+			return promptToSaveFile(title, dirBase, defaultName, Map.of(filterName, ext));
+		return promptToSaveFile(title, dirBase, defaultName, Collections.emptyMap());
+	}
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/PaneTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/PaneTools.java
@@ -1,0 +1,431 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.tools;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Control;
+import javafx.scene.control.SplitPane;
+import javafx.scene.control.TitledPane;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.RowConstraints;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.fx.utils.FXUtils;
+import qupath.fx.utils.GridPaneUtils;
+import qupath.lib.common.LogTools;
+import qupath.lib.gui.dialogs.Dialogs;
+
+/**
+ * Assorted static functions to help when working with a JavaFX panes.
+ * 
+ * @author Pete Bankhead
+ * @deprecated since v0.5.0; {@link qupath.fx.utils.GridPaneUtils} contains many of the features.
+ */
+@Deprecated
+public class PaneTools {
+
+	private static final Logger logger = LoggerFactory.getLogger(PaneTools.class);
+
+	private static void logDeprecatedForGridPaneUtils() {
+		logDeprecatedForOther(GridPaneUtils.class);
+	}
+
+	private static void logDeprecatedForOther(Class<?> cls) {
+		LogTools.warnOnce(logger, PaneTools.class.getName() +
+				" is deprecated and will be removed in the next QuPath release" +
+				" - please use " + cls.getName() + " instead");
+	}
+
+	/**
+	 * Add a row of nodes.  The rowspan is always 1.  The colspan is 1 by default, 
+	 * unless a Node is added multiple times consecutively in which case it is the sum 
+	 * of the number of times the node is added.
+	 * 
+	 * @param pane
+	 * @param row
+	 * @param col
+	 * @param tooltipText 
+	 * @param nodes
+	 */
+	public static void addGridRow(GridPane pane, int row, int col, String tooltipText, Node... nodes) {
+		logDeprecatedForGridPaneUtils();
+		Node lastNode = null;
+		var tooltip = tooltipText == null ? null : new Tooltip(tooltipText);
+		
+		for (var n : nodes) {
+			if (n == null) {
+				col++;
+				continue;
+			}
+			if (lastNode == n) {
+				Integer span = GridPane.getColumnSpan(n);
+				if (span == null)
+					GridPane.setColumnSpan(n, 2);
+				else
+					GridPane.setColumnSpan(n, span + 1);
+			} else {
+				pane.add(n, col, row);
+				GridPane.setColumnSpan(n, 1);
+				if (tooltip != null) {
+					installTooltipRecursive(tooltip, n, false);
+				}
+			}
+			lastNode = n;
+			col++;
+		}
+	}
+	
+	static void installTooltipRecursive(Tooltip tooltip, Node node, boolean overrideExisting) {
+		if (node instanceof Control) {
+			var control = (Control)node;
+			if (overrideExisting || control.getTooltip() == null)
+				control.setTooltip(tooltip);
+		} else {
+			Tooltip.install(node, tooltip);
+			if (node instanceof Region) {
+				for (var child : ((Region)node).getChildrenUnmodifiable())
+					installTooltipRecursive(tooltip, child, overrideExisting);
+			}
+		}
+	}
+	
+	/**
+	 * Set the {@link GridPane#setHgrow(Node, Priority)} property for specified nodes.
+	 * @param priority
+	 * @param nodes
+	 */
+	public static void setHGrowPriority(Priority priority, Node... nodes) {
+		logDeprecatedForGridPaneUtils();
+		for (var n : nodes) {
+			GridPane.setHgrow(n, priority);
+		}
+	}
+
+	/**
+	 * Set the {@link GridPane#setVgrow(Node, Priority)} property for specified nodes.
+	 * @param priority
+	 * @param nodes
+	 */
+	public static void setVGrowPriority(Priority priority, Node... nodes) {
+		logDeprecatedForGridPaneUtils();
+		for (var n : nodes) {
+			GridPane.setVgrow(n, priority);
+		}
+	}
+
+	/**
+	 * Set the max width property for the specified regions.
+	 * This can be especially useful when setting the width to {@link Double#MAX_VALUE}, indicating 
+	 * that the region may be enlarged as required.
+	 * @param width
+	 * @param regions
+	 */
+	public static void setMaxWidth(double width, Region...regions) {
+		logDeprecatedForGridPaneUtils();
+		for (var r : regions)
+			r.setMaxWidth(width);
+	}
+
+	/**
+	 * Set the max height property for the specified regions.
+	 * This can be especially useful when setting the height to {@link Double#MAX_VALUE}, indicating 
+	 * that the region may be enlarged as required.
+	 * @param height
+	 * @param regions
+	 */
+	public static void setMaxHeight(double height, Region...regions) {
+		logDeprecatedForGridPaneUtils();
+		for (var r : regions)
+			r.setMaxHeight(height);
+	}
+	
+	/**
+	 * Set the min width property for the specified regions.
+	 * This can be especially useful when setting the width to {@link Region#USE_PREF_SIZE}, indicating 
+	 * that the region should not be shrunk beyond its preferred size.
+	 * @param width
+	 * @param regions
+	 */
+	public static void setMinWidth(double width, Region...regions) {
+		logDeprecatedForGridPaneUtils();
+		for (var r : regions)
+			r.setMinWidth(width);
+	}
+
+	/**
+	 * Set the min height property for the specified regions.
+	 * This can be especially useful when setting the height to {@link Region#USE_PREF_SIZE}, indicating 
+	 * that the region should not be shrunk beyond its preferred size.
+	 * @param height
+	 * @param regions
+	 */
+	public static void setMinHeight(double height, Region...regions) {
+		logDeprecatedForGridPaneUtils();
+		for (var r : regions)
+			r.setMinHeight(height);
+	}
+	
+	/**
+	 * Set the {@link GridPane#setFillWidth(Node, Boolean)} property for specified nodes.
+	 * @param doFill
+	 * @param nodes
+	 */
+	public static void setFillWidth(Boolean doFill, Node...nodes) {
+		logDeprecatedForGridPaneUtils();
+		for (var n : nodes)
+			GridPane.setFillWidth(n, doFill);
+	}
+	
+	/**
+	 * Set constraints and max width values (where possible) so that the specified nodes 
+	 * fill all available horizontal space in a {@link GridPane}.
+	 * @param nodes
+	 */
+	public static void setToExpandGridPaneWidth(Node...nodes) {
+		setFillWidth(Boolean.TRUE, nodes);
+		setHGrowPriority(Priority.ALWAYS, nodes);
+		setMaxWidth(Double.MAX_VALUE, Arrays.stream(nodes).filter(n -> n instanceof Region).map(n -> (Region)n).toArray(Region[]::new));
+	}
+	
+	/**
+	 * Set constraints and max width values (where possible) so that the specified nodes 
+	 * fill all available vertical space in a {@link GridPane}.
+	 * @param nodes
+	 */
+	public static void setToExpandGridPaneHeight(Node...nodes) {
+		setFillHeight(Boolean.TRUE, nodes);
+		setVGrowPriority(Priority.ALWAYS, nodes);
+		setMaxHeight(Double.MAX_VALUE, Arrays.stream(nodes).filter(n -> n instanceof Region).map(n -> (Region)n).toArray(Region[]::new));
+	}
+
+	
+	/**
+	 * Set the {@link GridPane#setFillHeight(Node, Boolean)} property for specified nodes.
+	 * @param doFill
+	 * @param nodes
+	 */
+	public static void setFillHeight(Boolean doFill, Node...nodes) {
+		logDeprecatedForGridPaneUtils();
+		for (var n : nodes)
+			GridPane.setFillHeight(n, doFill);
+	}
+
+	/**
+	 * Create a GridPane containing rows that resize similarly to Swing's GridLayout().
+	 * 
+	 * @param nodes
+	 * @return
+	 */
+	public static GridPane createRowGrid(final Node... nodes) {
+		logDeprecatedForGridPaneUtils();
+		GridPane pane = new GridPane();
+		int n = nodes.length;
+		for (int i = 0; i < n; i++) {
+			RowConstraints row = new RowConstraints();
+			row.setPercentHeight(100.0/n);			
+			pane.getRowConstraints().add(row);
+			pane.add(nodes[i], 0, i);
+		}
+		ColumnConstraints col = new ColumnConstraints();
+		col.setPercentWidth(100);
+		pane.getColumnConstraints().add(col);
+		return pane;
+	}
+
+	/**
+	 * Create a GridPane containing columns that resize similarly to Swing's GridLayout(),
+	 * while also resizing contained objects to have the corresponding widths.
+	 * 
+	 * @param nodes
+	 * @return
+	 */
+	public static GridPane createRowGridControls(final Node... nodes) {
+		logDeprecatedForGridPaneUtils();
+		GridPane pane = new GridPane();
+		int n = nodes.length;
+		for (int i = 0; i < n; i++) {
+			RowConstraints row = new RowConstraints();
+			row.setPercentHeight(100.0/n);			
+			pane.getRowConstraints().add(row);
+			Node node = nodes[i];
+			pane.add(node, 0, i);
+			if (node instanceof Control) {
+//				((Control)node).setMinSize(((Control) node).getPrefWidth(), ((Control) node).getPrefHeight());
+				((Control)node).prefWidthProperty().bind(pane.widthProperty());
+			}
+		}
+		ColumnConstraints col = new ColumnConstraints();
+		col.setPercentWidth(100);
+		pane.getColumnConstraints().add(col);
+		return pane;
+	}
+
+	/**
+	 * Create a GridPane containing columns that resize similarly to Swing's GridLayout(),
+	 * where controls have their widths bound to their parent.
+	 * 
+	 * @param nodes
+	 * @return
+	 */
+	public static GridPane createColumnGridControls(final Node... nodes) {
+		logDeprecatedForGridPaneUtils();
+		GridPane pane = new GridPane();
+		int n = nodes.length;
+		double maxMinWidth = 0;
+		for (int i = 0; i < n; i++) {
+			ColumnConstraints col = new ColumnConstraints();
+			col.setPercentWidth(100.0/n);			
+			pane.getColumnConstraints().add(col);
+			Node node = nodes[i];
+			pane.add(node, i, 0);
+			if (node instanceof Control) {
+				maxMinWidth = Math.max(maxMinWidth, ((Control)node).getPrefWidth());
+				((Control)node).prefWidthProperty().bind(pane.widthProperty().divide(n));
+			}
+		}
+		RowConstraints row = new RowConstraints();
+		row.setPercentHeight(100);
+		pane.getRowConstraints().add(row);
+		pane.setMinWidth(maxMinWidth * n);
+		pane.setPrefWidth(maxMinWidth * n);
+		return pane;
+	}
+
+	/**
+	 * Create a GridPane containing columns that resize similarly to Swing's GridLayout().
+	 * 
+	 * @param nodes
+	 * @return
+	 */
+	public static GridPane createColumnGrid(final Node... nodes) {
+		logDeprecatedForGridPaneUtils();
+		GridPane pane = new GridPane();
+		int n = nodes.length;
+		for (int i = 0; i < n; i++) {
+			ColumnConstraints col = new ColumnConstraints();
+			col.setPercentWidth(100.0/n);			
+			pane.getColumnConstraints().add(col);
+			pane.add(nodes[i], i, 0);
+		}
+		RowConstraints row = new RowConstraints();
+		row.setPercentHeight(100);
+		pane.getRowConstraints().add(row);
+		return pane;
+	}
+
+	/**
+	 * Create a GridPane containing columns that resize similarly to Swing's GridLayout().
+	 * 
+	 * @param nCols
+	 * @return
+	 */
+	public static GridPane createColumnGrid(final int nCols) {
+		logDeprecatedForGridPaneUtils();
+		GridPane pane = new GridPane();
+		for (int i = 0; i < nCols; i++) {
+			ColumnConstraints col = new ColumnConstraints();
+			col.setPercentWidth(100.0/nCols);			
+			pane.getColumnConstraints().add(col);
+		}
+		RowConstraints row = new RowConstraints();
+		row.setPercentHeight(100);
+		pane.getRowConstraints().add(row);
+		return pane;
+	}
+	
+	/**
+	 * Get the nodes that are included within a {@link Parent}, optionally adding other nodes recursively.
+	 * Without the recursive search, this is similar to {@link Parent#getChildrenUnmodifiable()} in most cases, 
+	 * except that a separate collection is used. However in some cases {@code getItems()} must be used instead. 
+	 * Currently this applies only to {@link SplitPane} but this may be used elsewhere if appropriate.
+	 * @param parent
+	 * @param collection
+	 * @param doRecursive
+	 * @return
+	 */
+	public static Collection<Node> getContents(Parent parent, Collection<Node> collection, boolean doRecursive) {
+		logDeprecatedForOther(FXUtils.class);
+		if (collection == null) {
+			collection = new ArrayList<>();
+		}
+		var children = parent.getChildrenUnmodifiable();
+		if (children.isEmpty() && parent instanceof SplitPane) {
+			children = ((SplitPane)parent).getItems();
+		}
+		for (var child : children) {
+			collection.add(child);
+			if (doRecursive && child instanceof Parent)
+				getContents((Parent)child, collection, doRecursive);
+		}
+		return collection;
+	}
+	
+	/**
+	 * Get the nodes of type T that are contained within a {@link Parent}, optionally adding other nodes 
+	 * recursively. This can be helpful, for example, to extract all the Buttons or Regions within a pane 
+	 * in order to set some property of all of them.
+	 * @param <T>
+	 * @param parent
+	 * @param cls
+	 * @param doRecursive
+	 * @return
+	 * 
+	 * @see #getContents(Parent, Collection, boolean)
+	 */
+	public static <T extends Node> Collection<T> getContentsOfType(Parent parent, Class<T> cls, boolean doRecursive) {
+		logDeprecatedForOther(FXUtils.class);
+		return getContents(parent, new ArrayList<>(), doRecursive).stream()
+				.filter(p -> cls.isInstance(p))
+				.map(p -> cls.cast(p))
+				.collect(Collectors.toList());
+	}
+	
+	
+	/**
+	 * Simplify the appearance of a {@link TitledPane} using CSS.
+	 * This is useful if using a {@link TitledPane} to define expanded options, which should be displayed unobtrusively.
+	 * 
+	 * @param pane the pane to simplify
+	 * @param boldTitle if true, the title should be displayed in bold
+	 */
+	public static void simplifyTitledPane(TitledPane pane, boolean boldTitle) {
+		logDeprecatedForOther(FXUtils.class);
+		var css = PaneTools.class.getClassLoader().getResource("css/titled_plain.css").toExternalForm();
+		pane.getStylesheets().add(css);
+		if (boldTitle) {
+			var css2 = PaneTools.class.getClassLoader().getResource("css/titled_bold.css").toExternalForm();
+			pane.getStylesheets().add(css2);
+		}
+	}
+	
+
+}


### PR DESCRIPTION
Bring back several key methods and classes that are used in extensions, and mark them as deprecated while logging a warning the first time they are used. The purpose is to not break more extensions than necessary, and give a clue as to how to update the code for future compatibility.