### PR TITLE
Build script improvements

### DIFF
--- a/qupath-app/build.gradle
+++ b/qupath-app/build.gradle
@@ -336,6 +336,11 @@ def fixMacOSVersion(File appFile) {
         exec {
             commandLine '/usr/libexec/PlistBuddy', '-c', "Set :CFBundleShortVersionString ${qupathVersion}", path
         }
+        String bundleId = "qupath-${versionToInclude}"
+        println "Setting CFBundleIdentifier to ${bundleId}"
+        exec {
+            commandLine '/usr/libexec/PlistBuddy', '-c', "Set :CFBundleIdentifier ${bundleId}", path
+        }
     }
 }
 
@@ -352,7 +357,7 @@ def makeMacOSPkg(File appFile) {
                 '-n', 'QuPath',
                 '--app-image', appFile.getCanonicalPath(),
                 '--type', 'pkg',
-                '--mac-package-identifier', 'qupath',
+//                '--mac-package-identifier', 'qupath',
                 '--app-version', qupathVersion
     }
 }
@@ -364,6 +369,7 @@ def makeMacOSPkg(File appFile) {
 tasks.register('jpackageFinalize') {
     doLast {
         def outputDir = new File("${rootProject.layout.buildDirectory.get()}")
+        // Loop for Mac things to do
         def appFile = new File(outputDir, "/dist/${getCorrectAppName('.app')}")
         if (appFile.exists()) {
             fixMacOSVersion(appFile)
@@ -377,7 +383,9 @@ tasks.register('jpackageFinalize') {
                 if (file.exists() && !file.name.equals(correctName)) {
                     file.renameTo(new File(file.getParent(), correctName))
                 }
-
+                // Remove the .app as it's no longer needed (and just takes up space)
+                println "Deleting " + appFile
+                delete appFile
             }
         }
     }
@@ -610,7 +618,8 @@ def configureJPackageMac(JPackageParams params) {
     updatePackageType(params, properties['platform.installerExt'])
 
     params.installerOptions += ['--mac-package-name', 'QuPath']
-    params.installerOptions += ['--mac-package-identifier', 'QuPath']
+    // Need to include the version so that we can have multiple versions installed
+    params.installerOptions += ['--mac-package-identifier', "QuPath-${qupathVersion}"]
 
     // File associations supported on Mac
     setFileAssociations(params)

--- a/qupath-app/build.gradle
+++ b/qupath-app/build.gradle
@@ -388,12 +388,31 @@ tasks.register('jpackageFinalize') {
                 delete appFile
             }
         }
+        // On windows, for the installer we should also zip up the image
+        if (project.properties['platform.name'] == 'windows') {
+            def imageDir = new File(outputDir, "/dist/${qupathAppName}")
+            if (imageDir.isDirectory() && findProperty('package')?.toLowerCase() in ['installer']) {
+                println "Zipping $imageDir"
+                ant.zip(destfile: new File(imageDir.getCanonicalPath() + ".zip")) {
+                    fileset(dir: imageDir.getCanonicalPath()) {
+                    }
+                }
+                // Ideally we'd delete here, but it often fails
+//                try {
+//                    delete imageDir
+//                } catch (IOException e) {
+//                    println "Exception trying to delete image: ${e.message}"
+//                }
+            }
+        }
     }
     // Identify outputs, which are used to create checksums
     inputs.files jpackage.outputs.files
     outputs.files(jpackage.outputs.files.asFileTree.matching {
+        // I think you can tell I'm not great with Gradle
         include {
-            return it.name.startsWith('QuPath') &&
+            return it.file.parentFile.name == 'dist' &&
+                    it.name.startsWith('QuPath') &&
                     !it.name.endsWith('.sha512') &&
                     !it.name.endsWith('.sha256') &&
                     !it.name.endsWith('.sha384')


### PR DESCRIPTION
- Delete .app when creating the installer on macOS
- Create the Windows .zip directly, so that the sha512 is also computed