### PR TITLE
Turn off fail-fast for jpackage

### DIFF
--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -9,8 +9,9 @@
    build:
 
     strategy:
+      fail-fast: false
       matrix:
-        include: 
+        include:
           - platform: ubuntu-latest
             type: deb
           - platform: ubuntu-latest


### PR DESCRIPTION
If one build fails, we still want the others