### PR TITLE
Use Number not Double with map of measurement list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ This is a work-in-progress for the next QuPath release.
   * Activate with *Ctrl + space*, cancel with *Esc*
   * Completions update while typing
 * Support for regular expressions in several 'filter' fields, e.g. for projects, channels, log messages & measurements
+* `MeasurementList.asMap()` returns `Map<String, Number` rather than `Map<String, Double>`
+  * This enables scripts to use `pathObject.measurements['Name'] = 2` rather than `pathObject.measurements['Name'] = 2d`
 
 #### Processing & analysis
 * Includes *pre-release* of OpenSlide 4.0.0

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassificationMeasurementManager.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassificationMeasurementManager.java
@@ -346,7 +346,7 @@ public class PixelClassificationMeasurementManager {
 		return ForkJoinPool.commonPool();
 	}
 
-	private Map<String, Double> getMeasurementListAsMap(ROI roi, ExecutorService pool) {
+	private Map<String, Number> getMeasurementListAsMap(ROI roi, ExecutorService pool) {
 		var ml = getMeasurementList(roi, pool);
 		return ml == null ? Collections.emptyMap() : Collections.unmodifiableMap(ml.asMap());
 	}

--- a/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
@@ -650,12 +650,12 @@ class QuPathTypeAdapters {
 			if (value != null) {
 				for (var entry : value.asMap().entrySet()) {
 					out.name(entry.getKey());
-					Double measurementValue = entry.getValue();
-					if (measurementValue == null || Double.isNaN(measurementValue))
+					Number measurementValue = entry.getValue();
+					if (measurementValue == null || Double.isNaN(measurementValue.doubleValue()))
 						out.value("NaN");
-					else if (Double.POSITIVE_INFINITY == measurementValue)
+					else if (Double.POSITIVE_INFINITY == measurementValue.doubleValue())
 						out.value("Infinity");
-					else if (Double.NEGATIVE_INFINITY == measurementValue)
+					else if (Double.NEGATIVE_INFINITY == measurementValue.doubleValue())
 						out.value("-Infinity");
 					else
 						out.value(measurementValue);

--- a/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
@@ -45,7 +45,7 @@ class DefaultMeasurementList implements MeasurementList {
 	
 	private ArrayList<Measurement> list;
 	
-	private transient Map<String, Double> mapView;
+	private transient Map<String, Number> mapView;
 	
 	DefaultMeasurementList() {
 		list = new ArrayList<>();
@@ -175,7 +175,7 @@ class DefaultMeasurementList implements MeasurementList {
 	}
 
 	@Override
-	public Map<String, Double> asMap() {
+	public Map<String, Number> asMap() {
 		if (mapView == null) {
 			synchronized(this) {
 				if (mapView == null)

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
@@ -362,7 +362,7 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * @return a map view of this measurement list
 	 * @implSpec The returned map should already be synchronized.
 	 */
-	public default Map<String, Double> asMap() {
+	public default Map<String, Number> asMap() {
 		return Collections.synchronizedMap(new MeasurementsMap(this));
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
@@ -35,7 +35,7 @@ import java.util.Set;
  * @author Pete Bankhead
  * @since v0.4.0
  */
-class MeasurementsMap extends AbstractMap<String, Double> implements Map<String, Double> {
+class MeasurementsMap extends AbstractMap<String, Number> implements Map<String, Number> {
 	
 	private MeasurementList list;
 	
@@ -44,7 +44,7 @@ class MeasurementsMap extends AbstractMap<String, Double> implements Map<String,
 	}
 
 	@Override
-	public Set<Entry<String, Double>> entrySet() {
+	public Set<Entry<String, Number>> entrySet() {
 		return new MeasurementEntrySet();
 	}
 	
@@ -105,9 +105,9 @@ class MeasurementsMap extends AbstractMap<String, Double> implements Map<String,
 	 * is possible.
 	 */
 	@Override
-	public Double put(String name, Double value) {
+	public Number put(String name, Number value) {
 		Objects.requireNonNull(value);
-		Double current = null;
+		Number current = null;
 		synchronized(list) {
 			if (list.containsKey(name))
 				current = list.get(name);
@@ -118,7 +118,7 @@ class MeasurementsMap extends AbstractMap<String, Double> implements Map<String,
 	}
 	
 	@Override
-	public void putAll(Map<? extends String, ? extends Double> map) {
+	public void putAll(Map<? extends String, ? extends Number> map) {
 		synchronized (list) {
 			// Don't repeatedly call put because we only want to close the list once 
 			// and don't need to extract previous values
@@ -144,18 +144,7 @@ class MeasurementsMap extends AbstractMap<String, Double> implements Map<String,
 	}
 	
 	
-//	public Double put(String name, double value) {
-//		Double current = null;
-//		synchronized (list) {
-//			if (list.containsNamedMeasurement(name))
-//				current = list.getMeasurementValue(name);
-//			list.putMeasurement(name, value);
-//		}
-//		return current;
-//	}
-	
-	
-	class MeasurementEntrySet extends AbstractSet<Entry<String, Double>> {
+	class MeasurementEntrySet extends AbstractSet<Entry<String, Number>> {
 
 		@Override
 		public int size() {
@@ -163,7 +152,7 @@ class MeasurementsMap extends AbstractMap<String, Double> implements Map<String,
 		}
 
 		@Override
-		public Iterator<Entry<String, Double>> iterator() {
+		public Iterator<Entry<String, Number>> iterator() {
 			return new Iterator<>() {
 				
 				private int i = 0;
@@ -174,8 +163,8 @@ class MeasurementsMap extends AbstractMap<String, Double> implements Map<String,
 				}
 
 				@Override
-				public Entry<String, Double> next() {
-					SimpleEntry<String, Double> entry = new SimpleEntry<>(list.getMeasurementName(i), list.getMeasurementValue(i));
+				public Entry<String, Number> next() {
+					SimpleEntry<String, Number> entry = new SimpleEntry<>(list.getMeasurementName(i), list.getMeasurementValue(i));
 					i++;
 					return entry;
 				}

--- a/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
@@ -105,7 +105,7 @@ class NumericMeasurementList {
 
 		private Map<String, Integer> map; // Optional map for fast measurement lookup
 		
-		private transient Map<String, Double> mapView;
+		private transient Map<String, Number> mapView;
 
 		AbstractNumericMeasurementList(int capacity) {
 			names = new ArrayList<>(capacity);
@@ -266,7 +266,7 @@ class NumericMeasurementList {
 		}
 		
 		@Override
-		public Map<String, Double> asMap() {
+		public Map<String, Number> asMap() {
 			if (mapView == null) {
 				synchronized(this) {
 					if (mapView == null)

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -177,7 +177,7 @@ public abstract class PathObject implements Externalizable {
 		return measurements;
 	}
 	
-	private transient Map<String, Double> measurementsMap;
+	private transient Map<String, Number> measurementsMap;
 	
 	/**
 	 * Get a map-based view on {@link #getMeasurementList()}.
@@ -199,7 +199,7 @@ public abstract class PathObject implements Externalizable {
 	 * @return
 	 * @since v0.4.0
 	 */
-	public Map<String, Double> getMeasurements() {
+	public Map<String, Number> getMeasurements() {
 		if (measurementsMap == null) {
 			synchronized(this) {
 				if (measurementsMap == null)

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -203,7 +203,7 @@ public class TestPathObject {
 		double[] mapValuesByIterator = new double[p.getMeasurements().size()];
 		int count = 0;
 		for (var entry : p.getMeasurements().entrySet()) {
-			mapValuesByIterator[count++] = entry.getValue();
+			mapValuesByIterator[count++] = entry.getValue().doubleValue();
 		}
 		
 		assertArrayEquals(listValues, listValuesAsArray);


### PR DESCRIPTION
* `MeasurementList.asMap()` returns `Map<String, Number` rather than `Map<String, Double>`
  * This enables scripts to use `pathObject.measurements['Name'] = 2` rather than `pathObject.measurements['Name'] = 2d`