### PR TITLE
Minor fixes, used IoU with shared boundary merging

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
@@ -29,7 +29,6 @@ import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.utils.ObjectMerger;
 import qupath.lib.objects.utils.Tiler;
-import qupath.lib.plugins.CommandLineTaskRunner;
 import qupath.lib.plugins.PathTask;
 import qupath.lib.plugins.TaskRunner;
 import qupath.lib.plugins.TaskRunnerUtils;

--- a/qupath-core/src/test/java/qupath/lib/objects/utils/TestObjectMerger.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/utils/TestObjectMerger.java
@@ -155,9 +155,14 @@ public class TestObjectMerger {
         assertEquals(1, mergedByClassification.size());
         assertEquals(objectSize * objectSize * 2, mergedByClassification.get(0).getROI().getArea(), 0.0001);
 
-        var mergedByBoundary = ObjectMerger.createSharedTileBoundaryMerger(0.5).merge(pathObjects);
+        var mergedByBoundary = ObjectMerger.createSharedTileBoundaryMerger(0.33).merge(pathObjects);
         assertEquals(1, mergedByBoundary.size());
         assertEquals(objectSize * objectSize * 2, mergedByBoundary.get(0).getROI().getArea(), 0.0001);
+
+        // This changed when using IoU (using original criterion we'd merge)
+        var mergedByBoundary2 = ObjectMerger.createSharedTileBoundaryMerger(0.5).merge(pathObjects);
+        assertEquals(2, mergedByBoundary2.size());
+        assertEquals(objectSize * objectSize, mergedByBoundary2.get(0).getROI().getArea(), 0.0001);
 
         var mergedByBoundaryTooHigh = ObjectMerger.createSharedTileBoundaryMerger(0.75).merge(pathObjects);
         assertEquals(2, mergedByBoundaryTooHigh.size());

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
@@ -101,6 +101,7 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
 import javafx.stage.Stage;
+import qupath.fx.controls.PredicateTextField;
 import qupath.fx.dialogs.FileChoosers;
 import qupath.lib.classifiers.Normalization;
 import qupath.lib.classifiers.object.ObjectClassifier;
@@ -1526,13 +1527,6 @@ public class ObjectClassifierCommand implements Runnable {
 			pane = makePane(includeFilter);
 		}
 
-		void updatePredicate(String text) {
-			if (text == null || text.isBlank())
-				list.setPredicate(p -> true);
-			else
-				list.setPredicate(p -> p.getItem().toString().toLowerCase().contains(text.toLowerCase()));
-		}
-
 		public Pane getPane() {
 			return pane;
 		}
@@ -1598,14 +1592,15 @@ public class ObjectClassifierCommand implements Runnable {
 			Pane panelButtons;
 
 			if (includeFilter) {
-				var tfFilter = new TextField("");
-				tfFilter.setTooltip(new Tooltip("Type to filter table entries (case-insensitive)"));
+				var tfFilter = new PredicateTextField<SelectableItem>(s -> s.getItem().toString());
+				var tooltip = new Tooltip("Type to filter table entries (case-insensitive)");
+				Tooltip.install(tfFilter, tooltip);
 				tfFilter.setPromptText("Type to filter table entries");
 				var labelFilter = new Label("Filter");
 				labelFilter.setLabelFor(tfFilter);
 				labelFilter.setPrefWidth(Label.USE_COMPUTED_SIZE);
 				tfFilter.setMaxWidth(Double.MAX_VALUE);
-				tfFilter.textProperty().addListener((v, o, n) -> updatePredicate(n));
+				list.predicateProperty().bind(tfFilter.predicateProperty());
 				var paneFilter = new GridPane();
 				paneFilter.add(labelFilter, 0, 0);
 				paneFilter.add(tfFilter, 1, 0);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastChannelPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastChannelPane.java
@@ -114,7 +114,7 @@ public class BrightnessContrastChannelPane extends BorderPane {
 
     private final PredicateTextField<ChannelDisplayInfo> filter;
     private final BooleanProperty useRegex = PathPrefs.createPersistentPreference("brightnessContrastFilterRegex", false);
-    private final BooleanProperty ignoreCase = PathPrefs.createPersistentPreference("brightnessContrastFilterIgnoreCase", false);
+    private final BooleanProperty ignoreCase = PathPrefs.createPersistentPreference("brightnessContrastFilterDoIgnoreCase", true);
 
     private final SelectedChannelsChangeListener selectedChannelsChangeListener = new SelectedChannelsChangeListener();
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/MeasurementMapPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/MeasurementMapPane.java
@@ -59,6 +59,7 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.TextAlignment;
+import qupath.fx.controls.PredicateTextField;
 import qupath.lib.color.ColorMaps;
 import qupath.lib.color.ColorMaps.ColorMap;
 import qupath.lib.gui.QuPathGUI;
@@ -224,17 +225,11 @@ public class MeasurementMapPane {
 		Tooltip.install(colorMapKey, new Tooltip("Measurement map key"));
 		
 		// Filter to reduce visible measurements
-		TextField tfFilter = new TextField();
-		tfFilter.setTooltip(new Tooltip("Enter text to filter measurement list"));
+		var tfFilter = new PredicateTextField<String>();
+		var tooltip = new Tooltip("Enter text to filter measurement list");
+		Tooltip.install(tfFilter, tooltip);
 		tfFilter.setPromptText("Filter measurement list");
-		tfFilter.textProperty().addListener((v, o, n) -> {
-			String val = n.trim().toLowerCase();			
-			filteredList.setPredicate(s -> {
-				if (val.isEmpty())
-					return true;
-				return s.toLowerCase().contains(val);
-			});
-		});
+		filteredList.predicateProperty().bind(tfFilter.predicateProperty());
 		BorderPane paneFilter = new BorderPane();
 		paneFilter.setPadding(new Insets(5, 0, 10, 0));
 		paneFilter.setCenter(tfFilter);


### PR DESCRIPTION
* Use intersection-over-union (IoU) for the shared boundary threshold in `ObjectMerger`
    * Previous criterion (shared intersection / minimum boundary) failed whenever a single pixel from one object would touch the other (i.e. it was cause a very weak connection to result in a merge).
* Make B/C search case-insensitive by default
* Use regex search with measurement maps & object classifier feature selection filters