### PR TITLE
Fix parameter pane focus resizing issue

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ParameterDialogWrapper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ParameterDialogWrapper.java
@@ -142,6 +142,7 @@ class ParameterDialogWrapper<T> {
 		label.setPadding(new Insets(5, 5, 5, 5));
 		label.setAlignment(Pos.CENTER);
 		label.setTextAlignment(TextAlignment.CENTER);
+		label.setMaxWidth(Double.MAX_VALUE);
 
 		btnRun.setOnAction(e -> {
 
@@ -203,7 +204,6 @@ class ParameterDialogWrapper<T> {
 
 		BorderPane pane = new BorderPane();
 		ScrollPane scrollPane = new ScrollPane();
-		label.setMaxWidth(Double.MAX_VALUE);
 		scrollPane.setContent(panel.getPane());
 		scrollPane.setFitToWidth(true);
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/ParameterPanelFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/dialogs/ParameterPanelFX.java
@@ -235,7 +235,9 @@ public class ParameterPanelFX {
 		Label label = new Label(param.getPrompt());
 		if (param.isTitle()) {
 			// Cannot change font weight for default font (at least on macOS...) - need to change the font that's used
-			label.setFont(Font.font(font.getFamily(), FontWeight.BOLD, font.getSize()));
+			// Necessary to use CSS rather than setting the font to avoid a weird focus issue that could cause the text
+			// size to change, e.g. see https://stackoverflow.com/questions/53603250/javafx-how-to-prevent-label-text-resize-during-scrollpane-focus
+			label.setStyle("-fx-font-weight: bold;");
 			if (!map.isEmpty())
 				label.setPadding(new Insets(10, 0, 0, 0));
 		}


### PR DESCRIPTION
Weird resizing bug when clicking into / out of a dialog created from `ParameterPanelFX` (e.g. the default cell detection) caused the font to change. Spotted by @finglis