### PR TITLE
Fixes & UI improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This is a work-in-progress for the next QuPath release.
   * Includes badge to highlight errors that have occurred when the log viewer is closed
   * Information about the logger class & thread
 * New extension manager to add, remove & update extensions
-* New toolbar buttons for the script editor `</>` and log viewer
+* New toolbar buttons for the script editor `</>`, log viewer, fill/unfill annotations
 * *File → Export snapshots* supports PNG, JPEG and TIFF (not just PNG)
 * Support sorting project entries by name, ID, and URI
   * Right-click on the project list to access the *Sort by...* menu

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CellIntensityClassificationCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/CellIntensityClassificationCommand.java
@@ -202,7 +202,12 @@ public class CellIntensityClassificationCommand implements Runnable {
 		histogramPanel.getYAxis().setTickLabelsVisible(false);
 		histogramPanel.setAnimated(false);
 		chartPane.setPrefSize(200, 80);
-		pane.add(chartPane, pane.getColumnCount(), 0, 1, pane.getRowCount());
+
+		// Add a log histogram checkbox below the histogram
+		pane.add(
+				SingleMeasurementClassificationCommand.SingleMeasurementPane.addLogHistogramCheckbox(
+						chartPane, histogramPanel
+				), pane.getColumnCount(), 0, 1, pane.getRowCount());
 		
 		var dialog = new Dialog<ButtonType>();
 		dialog.initOwner(qupath.getStage());

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
@@ -521,7 +521,7 @@ public class ObjectClassifierCommand implements Runnable {
 			// Determine the measurements to use
 			var measurements = getRequestedMeasurements();
 			if (measurements.isEmpty()) {
-				logger.warn("No measurements - cannot update classifier");
+				Dialogs.showWarningNotification("Object classifiers", "No measurements available - cannot update classifier");
 				return null;
 			}
 
@@ -794,6 +794,10 @@ public class ObjectClassifierCommand implements Runnable {
 				}
 			}
 			ChartTools.setPieChartData(pieChart, counts, PathClass::toString, p -> ColorToolsFX.getCachedColor(p.getColor()), true, !counts.isEmpty());
+			if (counts.isEmpty())
+				pieChart.setTitle(null);
+			else
+				pieChart.setTitle("Training data");
 		}
 
 		void updatePieChart(Map<PathClass, Set<PathObject>> map) {
@@ -1323,6 +1327,7 @@ public class ObjectClassifierCommand implements Runnable {
 			 * Training proportions (pie chart)
 			 */
 			pieChart = new PieChart();
+			pieChart.getStyleClass().add("training-chart");
 			pieChart.setAnimated(false);
 
 			pieChart.setLabelsVisible(false);

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
@@ -367,6 +367,7 @@ public class PixelClassifierPane {
 		pane.add(btnLive, 0, row++, pane.getColumnCount(), 1);
 		
 		pieChart = new PieChart();
+		pieChart.getStyleClass().add("training-chart");
 		pieChart.setAnimated(false);
 		
 //		var hierarchy = viewer.getHierarchy();
@@ -1099,6 +1100,10 @@ public class PixelClassifierPane {
 			return;
 		}
 		ChartTools.setPieChartData(pieChart, counts, PathClass::toString, p -> ColorToolsFX.getCachedColor(p.getColor()), true, !counts.isEmpty());
+		if (counts.isEmpty())
+			pieChart.setTitle(null);
+		else
+			pieChart.setTitle("Training data");
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
@@ -66,15 +66,15 @@ public class ExtensionClassLoader extends URLClassLoader {
 		if (INSTANCE == null) {
 			synchronized (ExtensionClassLoader.class) {
 				if (INSTANCE == null)
-					INSTANCE = new ExtensionClassLoader(() -> getExtensionsDirectory());
+					INSTANCE = new ExtensionClassLoader(ExtensionClassLoader::getDefaultExtensionsDirectory);
 			}
 		}
 		return INSTANCE;
 	}
 
 
-	private static Path getExtensionsDirectory() {
-		return UserDirectoryManager.getInstance().getUserPath();
+	private static Path getDefaultExtensionsDirectory() {
+		return UserDirectoryManager.getInstance().getExtensionsPath();
 	}
 
 
@@ -85,7 +85,7 @@ public class ExtensionClassLoader extends URLClassLoader {
 	 * 
 	 * @return
 	 */
-	public Path getExtensionDirectory() {
+	public Path getExtensionsDirectory() {
 		return extensionsDirectorySupplier == null ? null : extensionsDirectorySupplier.get();
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionControlPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionControlPane.java
@@ -235,13 +235,13 @@ public class ExtensionControlPane extends VBox {
     }
 
     private static Path getExtensionPath() {
-        var dir = ExtensionClassLoader.getInstance().getExtensionDirectory();
+        var dir = ExtensionClassLoader.getInstance().getExtensionsDirectory();
         if (dir == null || !Files.isDirectory(dir)) {
             logger.info("No extension directory found!");
             var dirUser = Commands.requestUserDirectory(true);
             if (dirUser == null)
                 return null;
-            dir = ExtensionClassLoader.getInstance().getExtensionDirectory();
+            dir = ExtensionClassLoader.getInstance().getExtensionsDirectory();
         }
         return dir;
     }
@@ -275,7 +275,7 @@ public class ExtensionControlPane extends VBox {
 
     @FXML
     private void openExtensionDir() {
-        var dir = ExtensionClassLoader.getInstance().getExtensionDirectory();
+        var dir = ExtensionClassLoader.getInstance().getExtensionsDirectory();
         if (dir != null) {
             GuiTools.browseDirectory(dir.toFile());
         } else {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionManager.java
@@ -220,14 +220,14 @@ public class ExtensionManager {
 		}
 
 		var extensionClassLoader = getExtensionClassLoader();
-		var dir = extensionClassLoader.getExtensionDirectory();
+		var dir = extensionClassLoader.getExtensionsDirectory();
 		
 		if (dir == null || !Files.isDirectory(dir)) {
 			logger.info("No extension directory found!");
 			var dirUser = Commands.requestUserDirectory(true);
 			if (dirUser == null)
 				return;
-			dir = extensionClassLoader.getExtensionDirectory();
+			dir = extensionClassLoader.getExtensionsDirectory();
 		}
 		// Create directory if we need it
 		if (!Files.exists(dir)) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
@@ -137,6 +137,7 @@ class ToolBarComponent {
 		nodes.add(new Separator(Orientation.VERTICAL));
 
 		nodes.add(ActionTools.createToggleButtonWithGraphicOnly(overlayActions.SHOW_ANNOTATIONS));
+		nodes.add(ActionTools.createToggleButtonWithGraphicOnly(overlayActions.FILL_ANNOTATIONS));
 		nodes.add(ActionTools.createToggleButtonWithGraphicOnly(overlayActions.SHOW_NAMES));
 		nodes.add(ActionTools.createToggleButtonWithGraphicOnly(overlayActions.SHOW_TMA_GRID));
 		nodes.add(ActionTools.createToggleButtonWithGraphicOnly(overlayActions.SHOW_DETECTIONS));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
@@ -88,7 +88,8 @@ import qupath.lib.roi.interfaces.ROI;
 public class IconFactory {
 	
 	private static final Logger logger = LoggerFactory.getLogger(IconFactory.class);
-	
+
+	private final static Color DETECTION_COLOR = javafx.scene.paint.Color.rgb(20, 180, 120, 0.9);
 	
 	static class IconSuppliers {
 
@@ -187,6 +188,34 @@ public class IconFactory {
 		static IntFunction<Node> lineToolIcon() {
 			return i -> createLineOrArrowIcon(i, "");
 		}
+
+		static IntFunction<Node> fillAnnotationsIcon() {
+			return (int i) -> new DuplicatableNode(() -> createFillAnnotationsIcon(i));
+		}
+
+		private static Node createFillAnnotationsIcon(int size) {
+			var fill = IconSuppliers.icoMoon('\ue900', PathPrefs.colorDefaultObjectsProperty()).apply(size);
+			fill.setOpacity(0.5);
+			var outline = IconSuppliers.icoMoon('\ue901', PathPrefs.colorDefaultObjectsProperty()).apply(size);
+			var group = new Group(
+					fill, outline
+			);
+			return group;
+		}
+
+		static IntFunction<Node> fillDetectionsIcon() {
+			return (int i) -> new DuplicatableNode(() -> createFillDetectionIcon(i));
+		}
+
+		private static Node createFillDetectionIcon(int size) {
+			var fill = IconSuppliers.icoMoon('\ue907', DETECTION_COLOR).apply(size);
+			fill.setOpacity(0.75);
+			var outline = IconSuppliers.icoMoon('\ue908', DETECTION_COLOR).apply(size);
+			var group = new Group(
+					fill, outline
+			);
+			return group;
+		}
 		
 		static IntFunction<Node> arrowToolIcon(String cap) {
 			return i -> createLineOrArrowIcon(i, cap);
@@ -241,7 +270,7 @@ public class IconFactory {
 	@SuppressWarnings("javadoc")
 	public enum PathIcons {	ACTIVE_SERVER(IconSuppliers.icoMoon('\ue915', ColorToolsFX.getCachedColor(0, 200, 0))),
 									ANNOTATIONS(IconSuppliers.icoMoon('\ue901', PathPrefs.colorDefaultObjectsProperty())),
-									ANNOTATIONS_FILL(IconSuppliers.icoMoon('\ue900', PathPrefs.colorDefaultObjectsProperty())),
+									ANNOTATIONS_FILL(IconSuppliers.fillAnnotationsIcon()),
 									
 									ARROW_START_TOOL(IconSuppliers.arrowToolIcon("<")),
 									ARROW_END_TOOL(IconSuppliers.arrowToolIcon(">")),
@@ -256,8 +285,8 @@ public class IconFactory {
 									COG(IconSuppliers.icoMoon('\ue905')),
 									CONTRAST(IconSuppliers.icoMoon('\ue906')),
 
-									DETECTIONS(IconSuppliers.icoMoon('\ue908', javafx.scene.paint.Color.rgb(20, 180, 120, 0.9))),
-									DETECTIONS_FILL(IconSuppliers.icoMoon('\ue907', javafx.scene.paint.Color.rgb(20, 180, 120, 0.9))),
+									DETECTIONS(IconSuppliers.icoMoon('\ue908', DETECTION_COLOR)),
+									DETECTIONS_FILL(IconSuppliers.fillDetectionsIcon()),
 									DOWNLOAD(IconSuppliers.fontAwesome(FontAwesome.Glyph.DOWNLOAD)),
 
 									ELLIPSE_TOOL(IconSuppliers.ellipseToolIcon()),

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -138,3 +138,9 @@
   -fx-text-fill: -qp-script-error-color;
 }
 
+
+/* Don't make the title for the training piechart too large */
+.training-chart .chart-title {
+  -fx-font-size: 1em;
+  -fx-font-weight: bold;
+}


### PR DESCRIPTION
* Add fill/unfill annotations toolbar button
* Reduce update check fail to a warning (rather than an error)
   * Show a more informative message is (probably) unable to connect to the internet
* Add 'Training data' title to object/pixel classifier training pie charts
   * Remove confusion about whether the pie charts refer to the training or predictions
* Support log histograms with 'single measurement classifier' and 'set cell intensity classification' commands
* Fix the extensions directory path (use 'extensions' subdirectory, not the user path)