### PR TITLE
Improve naming consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ This is a work-in-progress for the next QuPath release.
 * `MeasurementList.asMap()` returns `Map<String, Number` rather than `Map<String, Double>`
   * This enables scripts to use `pathObject.measurements['Name'] = 2` rather than `pathObject.measurements['Name'] = 2d`
 
+#### Naming & measurements
+* Improve consistency of naming, including for measurements
+  * Use 'classification' rather then 'class' (to reduce confusion with Java 'classes')
+  * Add a new 'Object type' measurement to tables, giving a readable string ('Annotation', 'Detection', 'Cell' etc.)
+  * No longer show a default 'Name' if no name has been set
+    * e.g. don't show 'PathAnnotationObject' or the classification as a placeholder, since this causes confusion for people writing scripts and requesting the name
+
 #### Processing & analysis
 * Includes *pre-release* of OpenSlide 4.0.0
   * Final OpenSlide v4.0.0 release expected to be included in QuPath v0.5.0

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -821,10 +821,11 @@ public abstract class PathObject implements Externalizable {
 		String nameDisplayed = name;
 		if (nameDisplayed == null) {
 			PathClass pathClass = getPathClass();
+			nameDisplayed = PathObjectTools.getSuitableName(getClass(), false);
+
 			if (pathClass != null)
-				nameDisplayed = pathClass.toString();
-			else
-				nameDisplayed = getClass().getSimpleName();
+				nameDisplayed = nameDisplayed + " (" + pathClass.toString() + ")";
+
 		}
 		if (getParent() != null && getParent().isTMACore())
 			nameDisplayed = getParent().getDisplayedName() + " - " + nameDisplayed;

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -75,7 +75,7 @@ public class TestPathAnnotationObject extends TestPathObjectMethods {
 	@Test
 	public void test_NamesAndColors() {
 //		test_toString(myPO, "Unassigned"); 
-		test_getDisplayedName(myPO, myPO.getClass().getSimpleName()); // name of the class by default 
+		test_getDisplayedName(myPO, "Annotation"); // name of the class by default
 		test_getName(myPO, null); // no name yet in PO
 		test_setName(myPO, "myPO");
 		test_getName(myPO, "myPO");

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathRootObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathRootObject.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -68,7 +68,7 @@ public class TestPathRootObject extends TestPathObjectMethods {
 	@Test
 	public void test_NamesAndColors() {
 		test_toString(myPO, "Image"); 
-		test_getDisplayedName(myPO, "Image"); // got it from default pathclass - is it not unclass???
+		test_getDisplayedName(myPO, "Root object (Image)"); // got it from default pathclass - is it not unclass???
 		test_getName(myPO, null); // no name yet in PO
 		test_setName(myPO, "myPO");
 		test_getName(myPO, "myPO");

--- a/qupath-core/src/test/java/qupath/lib/objects/TestTMACoreObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestTMACoreObject.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -36,7 +36,7 @@ public class TestTMACoreObject {
 	private final Double diameter = 10.0;
 	private final Boolean ismissing = Boolean.TRUE;
 	private final Double epsilon = 1e-15;
-	private final String name = "TMACoreObject";
+	private final String name = "TMA core";
 	TMACoreObject myPO = new TMACoreObject();
 	TMACoreObject myPO2 = PathObjects.createTMACoreObject(xcenter, ycenter, diameter, ismissing);
 	

--- a/qupath-core/src/test/java/qupath/lib/objects/hierarchy/TestDefaultTMAGrid.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/hierarchy/TestDefaultTMAGrid.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -39,7 +39,7 @@ import qupath.lib.objects.TMACoreObject;
 public class TestDefaultTMAGrid {
 	private final Integer w = 9;
 	private final Integer ncores = 10;
-	private final String coreName = "TMACoreObject"; // displayed name for all cores in the grid
+	private final String coreName = "TMA core"; // displayed name for all cores in the grid
 	private final String tcoreName = "core0"; // name for the first core in the grid
 	private final Double xcenter = 0.0;
 	private final Double ycenter = 0.0;

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
@@ -565,7 +565,11 @@ public class PixelClassifierPane {
 		GridPaneUtils.setMinWidth(
 				Region.USE_PREF_SIZE,
 				FXUtils.getContentsOfType(stage.getScene().getRoot(), Region.class, true).toArray(Region[]::new));
-		
+
+		// Hack... this seems to fix a bug whereby the stage would grow in size whenever
+		// this combo box (and subsequently others) was clicked on
+		comboRegionFilter.setPrefWidth(100);
+
 		stage.show();
 		stage.setOnCloseRequest(e -> destroy());
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -742,7 +742,7 @@ public class QuPathGUI {
 			activateToolsForViewer(getViewer());
 			
 			if (n == PathTools.POINTS)
-				commonActions.COUNTING_PANEL.handle(null);
+				commonActions.SHOW_POINTS_DIALOG.handle(null);
 			
 			updateCursorForSelectedTool();			
 		});

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
@@ -35,7 +35,7 @@ import qupath.lib.gui.actions.annotations.ActionIcon;
 import qupath.lib.gui.commands.BrightnessContrastCommand;
 import qupath.lib.gui.commands.Commands;
 import qupath.lib.gui.commands.ContextHelpViewer;
-import qupath.lib.gui.commands.CountingPanelCommand;
+import qupath.lib.gui.commands.CountingDialogCommand;
 import qupath.lib.gui.commands.ProjectCommands;
 import qupath.lib.gui.commands.TMACommands;
 import qupath.lib.gui.prefs.PathPrefs;
@@ -69,7 +69,7 @@ public class CommonActions {
 	
 	@ActionIcon(PathIcons.POINTS_TOOL)
 	@ActionConfig("CommonActions.showCountingTool")
-	public final Action COUNTING_PANEL;
+	public final Action SHOW_POINTS_DIALOG;
 
 	@ActionConfig("CommonActions.addTMANote")
 	public final Action TMA_ADD_NOTE;
@@ -127,7 +127,7 @@ public class CommonActions {
 		BRIGHTNESS_CONTRAST = ActionTools.createAction(brightnessCommand);
 		ActionTools.installInfoMessage(BRIGHTNESS_CONTRAST,  brightnessCommand.infoMessage());
 
-		COUNTING_PANEL = ActionTools.createAction(new CountingPanelCommand(qupath));
+		SHOW_POINTS_DIALOG = ActionTools.createAction(new CountingDialogCommand(qupath));
 		TMA_ADD_NOTE = qupath.createImageDataAction(imageData -> TMACommands.promptToAddNoteToSelectedCores(imageData));
 		CONVEX_POINTS = ActionTools.createSelectableAction(PathPrefs.showPointHullsProperty());
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPane.java
@@ -162,7 +162,7 @@ class CountingPane implements PathObjectSelectionListener, PathObjectHierarchyLi
 		}
 				);
 		ContextMenu menu = new ContextMenu();
-		Menu menuSetClass = new Menu("Set class");
+		Menu menuSetClass = new Menu("Set classification");
 		menu.setOnShowing(e -> {
 			menuSetClass.getItems().setAll(
 					qupath.getAvailablePathClasses().stream()

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -211,13 +211,16 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		if (containsAnnotations || containsDetections || containsTMACores)
 			builderMap.put("Object ID", new ObjectIdMeasurementBuilder());
 
+		// Include the object type
+		builderMap.put("Object type", new ObjectTypeMeasurementBuilder());
+
 		// Include the object displayed name
 //		if (containsDetections || containsAnnotations || containsTMACores)
 		builderMap.put("Name", new ObjectNameMeasurementBuilder());
-		
+
 		// Include the class
 		if (containsAnnotations || containsDetections) {
-			builderMap.put("Class", new PathClassMeasurementBuilder());
+			builderMap.put("Classification", new PathClassMeasurementBuilder());
 			// Get the name of the containing TMA core if we have anything other than cores
 			if (imageData != null && imageData.getHierarchy().getTMAGrid() != null) {
 				builderMap.put("TMA core", new TMACoreNameMeasurementBuilder());
@@ -1211,9 +1214,33 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 
 		@Override
 		protected String getMeasurementValue(PathObject pathObject) {
-			return pathObject == null ? null : pathObject.getDisplayedName();
+			if (pathObject == null)
+				return null;
+			// v0.5.0 change - previously used pathObject.getDisplayedName(),
+			// but this frequently led to confusion for people writing scripts
+			String name = pathObject.getName();
+			return name;
 		}
 		
+	}
+
+	static class ObjectTypeMeasurementBuilder extends StringMeasurementBuilder {
+
+		@Override
+		public String getName() {
+			return "Object type";
+		}
+
+		@Override
+		protected String getMeasurementValue(PathObject pathObject) {
+			if (pathObject == null)
+				return null;
+			else if (pathObject.isRootObject())
+				return pathObject.getDisplayedName();
+			else
+				return PathObjectTools.getSuitableName(pathObject.getClass(), false);
+		}
+
 	}
 	
 	
@@ -1221,7 +1248,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 
 		@Override
 		public String getName() {
-			return "Class";
+			return "Classification";
 		}
 
 		@Override

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
@@ -123,7 +123,8 @@ class PathClassPane {
 		
 		var filteredList = availablePathClasses.filtered(createPathClassListFilter(null));
 		listClasses.setItems(filteredList);
-		listClasses.setTooltip(new Tooltip("Annotation classes available (right-click to add or remove)"));
+		listClasses.setTooltip(new Tooltip("Available classifications (right-click to add or remove).\n" +
+				"Names ending with an Asterisk* are 'ignored' under certain circumstances - see the docs for more info."));
 		
 		listClasses.getSelectionModel().selectedItemProperty().addListener((v, o, n) -> updateAutoSetPathClassProperty());
 		
@@ -148,7 +149,7 @@ class PathClassPane {
 		BorderPane paneClasses = new BorderPane();
 		paneClasses.setCenter(listClasses);
 
-		Action setSelectedObjectClassAction = new Action("Set class", e -> promptToSetClass());
+		Action setSelectedObjectClassAction = new Action("Set selected", e -> promptToSetClass());
 		setSelectedObjectClassAction.setLongText("Set the class of the currently-selected annotation(s)");
 
 		Action autoClassifyAnnotationsAction = new Action("Auto set");

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
@@ -449,21 +449,32 @@ public class IconFactory {
 		return group;
 	}
 
-	
 	private static Node drawPointsIcon(int sizeOrig) {
+		return drawPointsIcon(sizeOrig, null);
+	}
+
+	private static Node drawPointsIcon(int sizeOrig, Color color) {
 		
 		double pad = 1.0;
 		double size = sizeOrig - pad*2;
 		double radius = size/5.0;
 		
 		var c1 = new Circle(pad+size/2.0, pad+radius, radius, Color.TRANSPARENT);
-		bindShapeColorToObjectColor(c1);
-		
+
 		var c2 = new Circle(pad+radius, pad+size-radius, radius, Color.TRANSPARENT);
-		bindShapeColorToObjectColor(c2);
-		
+
 		var c3 = new Circle(pad+size-radius, pad+size-radius, radius, Color.TRANSPARENT);
-		bindShapeColorToObjectColor(c3);
+		if (color != null) {
+			// Use fixed color
+			c1.setStroke(color);
+			c2.setStroke(color);
+			c3.setStroke(color);
+		} else {
+			// Use default object color
+			bindShapeColorToObjectColor(c1);
+			bindShapeColorToObjectColor(c2);
+			bindShapeColorToObjectColor(c3);
+		}
 
 //		return new Group(c1, c2, c3);
 		return wrapInGroup(sizeOrig, c1, c2, c3);
@@ -733,12 +744,7 @@ public class IconFactory {
 			return line;
 		} else if (roi.isPoint()) {
 			// Just show generic points
-			Node node = IconFactory.createNode(Math.min(width, height), Math.min(width, height), IconFactory.PathIcons.POINTS_TOOL);	
-			if (node instanceof Glyph) {
-				var glyph = (Glyph)node;
-				glyph.textFillProperty().unbind();
-				glyph.setColor(color);
-			}
+			var node = drawPointsIcon(Math.min(width, height), color);
 			return node;
 		} else {
 			var path = pathCache.getOrDefault(roi, null);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
@@ -1319,7 +1319,7 @@ public class ViewerManager implements QuPathViewerListener {
 		
 		
 		// Create an empty placeholder menu
-		Menu menuSetClass = MenuTools.createMenu("Set class");
+		Menu menuSetClass = MenuTools.createMenu("Set classification");
 		
 		var overlayActions = qupath.getOverlayActions();
 		Menu menuCells = MenuTools.createMenu(

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
@@ -219,7 +219,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 			} else if (!PathPrefs.selectionModeProperty().get()) {
 					List<PathObject> listSelectable = ToolUtils.getSelectableObjectList(viewer, p.getX(), p.getY());
 					PathObject objectSelectable = null;
-					for (int i = listSelectable.size()-1; i >= 0; i--) {
+					for (int i = 0; i < listSelectable.size(); i++) {
 						PathObject temp = listSelectable.get(i);
 						if (temp.isEditable() && temp instanceof PathAnnotationObject && temp.hasROI() && temp.getROI().isArea()) { //temp.getROI() instanceof AreaROI) {
 							objectSelectable = temp;


### PR DESCRIPTION
* Use 'classification' rather then 'class' (to improve consistency, and reduce confusion with Java classes)
* Add a new 'Object type' measurement to tables, giving a readable string ('Annotation', 'Detection', 'Cell' etc.)
* No longer show a default 'Name' if no name has been set
  * i.e. don't show 'PathAnnotationObject' or the classification as a placeholder, since this causes confusion for people writing scripts and requesting the name
* Renaming 'counting dialog' to 'points dialog'

Two bug fixes:
* Restore the classification colors in icons for points ROIs (regression in v0.5.0-rc1)
* Fix bug that causes the pixel classifier training dialog to increase its width when some combo boxes were clicked on