### PR TITLE
Warn when classifications are hidden

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
@@ -27,6 +27,7 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.LongBinding;
 import javafx.beans.binding.ObjectExpression;
+import javafx.beans.binding.SetBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -240,6 +241,7 @@ public class ContextHelpViewer {
 				createDetectionsHiddenEntry(),
 				createPixelClassificationOverlayHiddenEntry(),
 				createTMAGridHiddenEntry(),
+				createHiddenClassificationsEntry(),
 				createNoImageEntry(),
 				createNoProjectEntry(),
 				createOpacityZeroEntry(),
@@ -523,6 +525,13 @@ public class ContextHelpViewer {
 				createIcon(PathIcons.TMA_GRID));
 		entry.visibleProperty().bind(
 				qupath.getOverlayOptions().showTMAGridProperty().not());
+		return entry;
+	}
+
+	private HelpListEntry createHiddenClassificationsEntry() {
+		var entry = HelpListEntry.createWarning(
+				"ContextHelp.warning.classificationsHidden");
+		entry.visibleProperty().bind(Bindings.isEmpty(qupath.getOverlayOptions().hiddenClassesProperty()).not());
 		return entry;
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -250,7 +250,8 @@ public class PathObjectPainter {
 
 		// Always paint selected objects, otherwise check if the object should be hidden
 		if (!isSelected) {
-			if (overlayOptions.isPathClassHidden(pathObject.getPathClass()) || isHiddenObjectType(pathObject, overlayOptions))
+			if ((overlayOptions.isPathClassHidden(pathObject.getPathClass()) && !pathObject.isTMACore())
+					|| isHiddenObjectType(pathObject, overlayOptions))
 				return false;
 		}
 

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -5,6 +5,8 @@ ContextHelp.defaultHelpText = Move the cursor over something to view any availab
 ContextHelp.warning.selectionMode = Selection mode is active - this will switch drawing tools to become selection tools instead
 ContextHelp.warning.annotationsHidden = Annotations are hidden
 ContextHelp.warning.detectionsHidden = Detections are hidden
+ContextHelp.warning.classificationsHidden = Objects might be hidden based on their classification.\n\
+                                        You can change this in the 'Classifications' list under the 'Annotations' tab.
 ContextHelp.warning.tmaCoresHidden = The TMA grid is hidden
 ContextHelp.warning.pixelOverlayHidden = Pixel classification overlay is hidden
 ContextHelp.warning.opacityZero = Opacity slider is zero (unselected objects won't be visible)
@@ -14,8 +16,6 @@ ContextHelp.warning.gamma = Gamma value is not 1.0. This affects how the image i
                             Change the gamma with the brightness/contrast dialog.
 ContextHelp.warning.invertedBackground = Image is being shown with inverted background.\n\
                             Change this option in the brightness/contrast dialog.
-ContextHelp.warning.zoomToFit = Zoom-to-fit is active.\n\
-                            This will block normal panning & zooming in the viewer.
 ContextHelp.warning.unseenErrors = There are errors reported in the log that have not yet been seen.\n\
                             Please check the log for details.
 ContextHelp.warning.pixelSizeMissing = Pixel size information is not set.\n\


### PR DESCRIPTION
Hiding 'unclassified' objects confused me horribly before, so now include this in the context help. Also fix bug that meant that hiding unclassified annotations also resulted in TMA cores being hidden.