### PR TITLE
Improve Bio-Formats & JSON support for importing images

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/servers/JsonImageServerBuilder.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/JsonImageServerBuilder.java
@@ -31,6 +31,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +55,8 @@ public class JsonImageServerBuilder implements ImageServerBuilder<BufferedImage>
 	}
 	
 	private float supportLevel(URI uri, String...args) {
-		if (uri.toString().toLowerCase().endsWith(".json"))
+		String lower = uri.toString().toLowerCase();
+		if (lower.endsWith(".json"))
 			return 4;
 		String scheme = uri.getScheme();
 		if (scheme != null && scheme.startsWith("http")) {
@@ -61,16 +64,21 @@ public class JsonImageServerBuilder implements ImageServerBuilder<BufferedImage>
 			return 0;
 		}
 		try {
-			String type = Files.probeContentType(Paths.get(uri));
+			var path = Paths.get(uri);
+			String type = Files.probeContentType(path);
 			if (type == null)
 				return 0f;
 			if (type.endsWith("/json"))
 				return 4;
-			if (type.equals("text/plain"))
-				return 3;
-			if (type.startsWith("image"))
+			else
 				return 0;
-			return 1;
+			// TODO: We could try harder to find JSON content... but need to have a reason to
+			//       and we don't want to inadvertently try to parse JSON that doesn't exist
+//			if (type.equals("text/plain"))
+//				return 3;
+//			if (type.startsWith("image"))
+//				return 0;
+//			return 1;
 		} catch (IOException e) {
 			logger.trace("Error checking content type", e);
 			return 0;
@@ -80,10 +88,89 @@ public class JsonImageServerBuilder implements ImageServerBuilder<BufferedImage>
 	@Override
 	public ImageServer<BufferedImage> buildServer(URI uri, String...args) throws Exception {
 		try (Reader reader = new BufferedReader(new InputStreamReader(uri.toURL().openStream(), StandardCharsets.UTF_8))) {
-			ServerBuilder<BufferedImage> builder = GsonTools.getInstance().fromJson(reader, ServerBuilder.class);
-			return builder.build();
-//			return GsonTools.getGsonDefault().fromJson(reader, new TypeToken<ImageServer<BufferedImage>>() {}.getType());
+			var gson = GsonTools.getInstance();
+			var element = gson.fromJson(reader, JsonElement.class);
+			if (element.isJsonObject()) {
+				var obj = element.getAsJsonObject();
+				if (obj.has("builder") && !obj.has("builderType")) {
+					// Since v0.5.0 we serialize the server
+					return gson.fromJson(obj, ImageServer.class);
+				} else {
+					// Before v0.5.0 we serialized the builder
+					if (!obj.has("builderType")) {
+						String builderType = estimateToSetBuilderType(obj);
+						if (builderType == null)
+							logger.warn("Unknown builder type for JSON object: {}", obj);
+						else {
+							logger.debug("Adding estimated builderType property: {}", builderType);
+							obj.addProperty("builderType", builderType);
+						}
+					}
+					var builder = gson.fromJson(obj, ServerBuilder.class);
+					return builder.build();
+				}
+			}
+			// Unlikely to work... but also not expecting to reach this point
+			logger.debug("Attempting to deserialize server, but JSON is not an object: {}", element);
+			return gson.fromJson(element, ImageServer.class);
 		}
+	}
+
+	/**
+	 * Try to guess the builder type based on the JSON content.
+	 * <p>
+	 * This is used to help deserialize JSON written to 'server.json' files within projects before v0.5.0.
+	 * Here, the builder type is not included and so deserialization fails due to Gson now knowing
+	 * which deserializer to use based upon the type adapter factory.
+	 *
+	 * @param obj
+	 * @return the estimated builder type, or null if none could be found
+	 * @see ImageServers
+	 * @since v0.5.0
+	 */
+	private static String estimateToSetBuilderType(JsonObject obj) {
+		if (obj.has("builderType"))
+			return obj.get("builderType").getAsString();
+		if (hasFields(obj, "providerClassName", "uri", "args"))
+			return "uri"; // Most common
+		if (hasFields(obj, "builder", "rotation"))
+			return "rotated";
+		if (hasFields(obj, "builder", "channels"))
+			return "channels";
+		if (hasFields(obj, "regions", "path"))
+			return "sparse";
+		if (hasFields(obj, "builder", "order"))
+			return "swapRedBlue";
+		if (hasFields(obj, "builder", "transforms"))
+			return "color";
+		if (hasFields(obj, "builder", "transform"))
+			return "affine";
+		if (hasFields(obj, "builder", "region"))
+			return "cropped";
+		if (hasFields(obj, "builder", "stains", "channels"))
+			return "color_deconvolved";
+		if (hasFields(obj, "builder") && obj.asMap().size() == 1)
+			return "pyramidize";
+		// Although we don't generally support extensions in the core code, this tries to be
+		// friendly to the warpy extension
+		if (hasFields(obj, "builder", "realtransforminterpolation"))
+			return "realtransform";
+		if (hasFields(obj, "builder", "transforminterpolation"))
+			return "transforminterpolate";
+		return null;
+	}
+
+	/**
+	 * Check whether a JSON object has all of the specified fields.
+	 * @param obj
+	 * @param names
+	 * @return true if all of the fields are found, false otherwise
+	 */
+	private static boolean hasFields(JsonObject obj, String... names) {
+		for (var name : names)
+			if (!obj.has(name))
+				return false;
+		return true;
 	}
 
 	@Override

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -765,13 +765,17 @@ class DefaultProject implements Project<BufferedImage> {
 			}
 			
 			// If successful, write the server (including metadata)
-			var currentServerBuilder = imageData.getServer().getBuilder();
+			var server = imageData.getServer();
+			var currentServerBuilder = server.getBuilder();
 			if (currentServerBuilder != null && !currentServerBuilder.equals(this.serverBuilder)) {
 				this.serverBuilder = currentServerBuilder;
-				// Write the server - it isn't used, but it may enable us to rebuild the server from the data directory if the project is lost
+				// Write the server - it isn't used, but it may enable us to rebuild the server from the data directory
+				// if the project is lost.
+				// Note that before v0.5.0, this actually wrote the server builder - but this was missing type
+				// information, so recovery of the actual server was difficult.
 				var pathServer = getServerPath();
 				try (var out = Files.newBufferedWriter(pathServer, StandardCharsets.UTF_8)) {
-					GsonTools.getInstance().toJson(serverBuilder, out);
+					GsonTools.getInstance().toJson(server, out);
 				} catch (Exception e) {
 					logger.warn("Unable to write server to {}", pathServer);
 					Files.deleteIfExists(pathServer);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
@@ -349,11 +349,18 @@ class ProjectImportImagesCommand {
 						try {
 							var uri = GeneralTools.toURI(item);
 							UriImageSupport<BufferedImage> support;
-							if (requestedBuilder == null)
+							if (requestedBuilder == null) {
 								support = ImageServers.getImageSupport(uri, args);
-							else
+								if (support == null)
+									logger.warn("Unable to open {} with any reader", uri);
+							} else {
 								support = ImageServers.getImageSupport(requestedBuilder, uri, args);
-							if (support != null)
+								if (support == null)
+									logger.warn("Unable to open {} with {}", uri, requestedBuilder.getName());
+							}
+							if (support == null)
+								return Collections.emptyList();
+							else
 								return support.getBuilders();
 						} catch (Exception e) {
 							logger.error("Unable to add " + item, e);


### PR DESCRIPTION
Update logic related to reading/importing images, to try to have fewer errors and more informative messages logged when errors do occur.

## Improve checks for Bio-Formats image support

Throw an exception if unable to read a single pixel from a Bio-Formats image.
Accessing the pixel may introduce some overhead when importing images, but it avoids problems where metadata can be parsed yet the fact the image can't actually be read only becomes apparent later.

This was causing trouble with .ndpi on Apple Silicon, because skipping the use of NDPIReader was causing a fallback to a regular TIFF reader... and this didn't recognize the image as pyramidal and couldn't read the pixels. So requesting Bio-Formats for .ndpi was both adding many (~12) images to a project (for the different pyramid levels), and not actually able to open them.

Also fix the logic for determining which IFormatReader is used for a specified image. This was previously giving ImageReader rather than the specific reader, and therefore wasn't properly enabling the reader check to be skipped for readers generated in other threads.

This also had an extra issue in Apple Silicon, because these checks could cause exceptions regarding unsupported libraries being logged, even if they weren't relevant to the image itself.

## Improve use of json with image servers

Make `JSONImageServerBuilder` genuinely useful by enabling it to read the server.json files stored within projects. This could potentially help in the future if attempting to recover data from a broken project.

This involves estimating the "builderType" since that wasn't actually serialized within the server.json before.

To simplify things in the future, the server.json now serializes the `ImageServer` and not the `ServerBuilder` - so that more information is present.