### PR TITLE
Importing improvements

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
@@ -246,7 +246,8 @@ public class ContextHelpViewer {
 				createNoProjectEntry(),
 				createOpacityZeroEntry(),
 				createGammaNotDefault(),
-				createInvertedColors()
+				createInvertedColors(),
+				createNoChannelsVisible()
 				);
 	}
 
@@ -592,6 +593,20 @@ public class ContextHelpViewer {
 				qupath.viewerProperty()
 						.map(QuPathViewer::getImageDisplay)
 						.flatMap(ImageDisplay::useInvertedBackgroundProperty));
+		return entry;
+	}
+
+	private HelpListEntry createNoChannelsVisible() {
+		var entry = HelpListEntry.createWarning(
+				"ContextHelp.warning.noChannels",
+				createIcon(PathIcons.CONTRAST));
+		var emptyChannels = qupath.viewerProperty()
+				.map(QuPathViewer::getImageDisplay)
+				.map(ImageDisplay::selectedChannels)
+				.flatMap(Bindings::isEmpty);
+		entry.visibleProperty().bind(qupath.imageDataProperty().isNotNull().and(Bindings.createBooleanBinding(
+				() -> emptyChannels == null || emptyChannels.getValue() == null ? false : emptyChannels.getValue(), emptyChannels
+		)));
 		return entry;
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/UpdateUrisCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/UpdateUrisCommand.java
@@ -390,7 +390,7 @@ public class UpdateUrisCommand<T extends UriResource> {
 				return;
 			var uriReplacement = replacements.get(uriOriginal);
 			var defaultPath = uriReplacement == null ? uriOriginal.getURI().toString() : uriReplacement.getURI().toString();
-			String path = FileChoosers.promptForFilePathOrURI(FXUtils.getWindow(this), "Change URI", defaultPath, null, null);
+			String path = FileChoosers.promptForFilePathOrURI(FXUtils.getWindow(this), "Change URI", defaultPath);
 			if (path != null && !path.isBlank()) {
 				URI uri = null;
 				try {

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -16,6 +16,8 @@ ContextHelp.warning.gamma = Gamma value is not 1.0. This affects how the image i
                             Change the gamma with the brightness/contrast dialog.
 ContextHelp.warning.invertedBackground = Image is being shown with inverted background.\n\
                             Change this option in the brightness/contrast dialog.
+ContextHelp.warning.noChannels = No channels are selected!\n\
+                                 Use the 'Brightness/Contrast' command to select channels.
 ContextHelp.warning.unseenErrors = There are errors reported in the log that have not yet been seen.\n\
                             Please check the log for details.
 ContextHelp.warning.pixelSizeMissing = Pixel size information is not set.\n\


### PR DESCRIPTION
* Support `.qpdata` files in the project import dialog
   * This simplifies bringing over data from an existing project if the project file itself is missing or corrupt (assuming the images are available)
* Fix bug in the update URIs command that affected the file dialog when setting a single URI
* Show a context warning if no channels are visible