### PR TITLE
Fix extension directory handling when it doesn't yet exist

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionControlPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionControlPane.java
@@ -78,7 +78,6 @@ public class ExtensionControlPane extends VBox {
     @FXML
     private ListView<QuPathExtension> extensionListView;
 
-
     @FXML
     private Button rmBtn;
     @FXML
@@ -87,7 +86,6 @@ public class ExtensionControlPane extends VBox {
     private Button submitBtn;
     @FXML
     private Button openExtensionDirBtn;
-
     @FXML
     private Button updateBtn;
     @FXML
@@ -130,11 +128,14 @@ public class ExtensionControlPane extends VBox {
         ExtensionManager extensionManager = QuPathGUI.getInstance().getExtensionManager();
         extensionManager.getLoadedExtensions().addListener(this::handleExtensionMapChange);
         extensionManager.getFailedExtensions().addListener(this::handleExtensionMapChange);
+
         openExtensionDirBtn.disableProperty().bind(
                 UserDirectoryManager.getInstance().userDirectoryProperty().isNull());
         downloadBtn.disableProperty().bind(
             repoTextArea.textProperty().isEmpty().or(ownerTextArea.textProperty().isEmpty()));
+
         downloadBtn.setGraphic(IconFactory.createNode(12, 12, IconFactory.PathIcons.DOWNLOAD));
+
         // By default, add failed extensions at the end of the list
         extensionListView.getItems().addAll(
                 extensionManager.getLoadedExtensions().values()
@@ -147,7 +148,6 @@ public class ExtensionControlPane extends VBox {
                         .sorted(Comparator.comparing(QuPathExtension::getName))
                         .toList());
         extensionListView.setCellFactory(listView -> new ExtensionListCell(extensionManager, listView));
-
 
         ownerTextArea.addEventHandler(KeyEvent.KEY_RELEASED, e -> {
             if (e.getCode() == KeyCode.ENTER) {
@@ -242,6 +242,13 @@ public class ExtensionControlPane extends VBox {
             if (dirUser == null)
                 return null;
             dir = ExtensionClassLoader.getInstance().getExtensionsDirectory();
+            if (!Files.exists(dir)) {
+                try {
+                    Files.createDirectory(dir);
+                } catch (IOException e) {
+                    logger.error("Unable to create extension directory");
+                }
+            }
         }
         return dir;
     }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionControlPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionControlPane.java
@@ -210,6 +210,7 @@ public class ExtensionControlPane extends VBox {
         try {
             askToDownload(repo);
         } catch (IOException | URISyntaxException | InterruptedException e) {
+            logger.error("Unable to download extension", e);
             Dialogs.showErrorNotification(QuPathResources.getString("ExtensionControlPane"),
                     QuPathResources.getString("ExtensionControlPane.unableToDownload"));
         }
@@ -244,6 +245,7 @@ public class ExtensionControlPane extends VBox {
             dir = ExtensionClassLoader.getInstance().getExtensionsDirectory();
             if (!Files.exists(dir)) {
                 try {
+                    logger.info("Creating extension directory: {}", dir);
                     Files.createDirectory(dir);
                 } catch (IOException e) {
                     logger.error("Unable to create extension directory");

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -155,7 +155,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
     		logger.warn("Unexpected drag-drop event {}", event);
     		return;
     	}
-    	
+
         Dragboard dragboard = event.getDragboard();
         Object source = event.getSource();
         
@@ -195,7 +195,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 				        logger.debug("Files dragged onto {}", source);
 						handleFileDrop(viewer2, files);
 					} else if (url != null ) {
-						logger.debug("URL dragged onto {}", source);
+						logger.debug("URL {} dragged onto {}", url, source);
 						handleURLDrop(viewer2, url);
 					} else if (string != null) {
 						logger.debug("Text dragged onto {}, treating as a URL", source);
@@ -211,7 +211,6 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 			event.setDropCompleted(true);
         } else
         	event.setDropCompleted(false);
-
 		event.consume();
     }
     


### PR DESCRIPTION
Was unable to figure out the other drag & drop problem.

To reproduce the other issue:

1. Drag & drop any URL or file
2. Drag and drop another URL from the same source.

When drag&drop events come from the same source (eg, a web browser), the first URL/file/etc will persist for all following drag/drop events, on Linux at least. Clearing the dragboard programmatically has no effect (maybe expected, I'd assume it's cleared or a new one is created between events anyway).