### PR TITLE
Improve error messages on import

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
@@ -366,9 +366,15 @@ public class ImageServers {
 			}
 		}
 		if (supports.isEmpty()) {
-			var exception = new IOException(buildBaseExceptionMessage(uri, args));
-			for (var e : exceptions)
-				exception.addSuppressed(e);
+			IOException exception;
+			String message = buildBaseExceptionMessage(uri, args);
+			if (exceptions.size() == 1)
+				exception = new IOException(message, exceptions.get(0));
+			else {
+				exception = new IOException(message);
+				for (var e : exceptions)
+					exception.addSuppressed(e);
+			}
 			throw exception;
 		}
 		Comparator<UriImageSupport<BufferedImage>> comparator = Collections.reverseOrder(new UriImageSupportComparator<>());

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -247,17 +247,21 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 	 * @throws ServiceException
 	 * @throws URISyntaxException
 	 */
-	static BioFormatsImageServer checkSupport(URI uri, final BioFormatsServerOptions options, String...args) throws FormatException, IOException, DependencyException, ServiceException, URISyntaxException {
-		var server = new BioFormatsImageServer(uri, options, args);
-		// Attempt to read one pixel from the image.
-		// This is expected to throw an exception if it fails; without this check, Bio-Formats can appear to work
-		// but then fail when trying to read the first tile.
-		// The risk is that this will be slow for large, non-tiled images.
-		var reader = server.readerPool.getMainReader();
-		if (reader.getSizeX() > 0 && reader.getSizeY() > 0 && reader.openBytes(0, 0, 0, 1, 1) != null) {
-			return server;
-		} else {
-			throw new IOException("Unable to read bytes from " + uri);
+	static BioFormatsImageServer checkSupport(URI uri, final BioFormatsServerOptions options, String...args) throws IOException {
+		try {
+			var server = new BioFormatsImageServer(uri, options, args);
+			// Attempt to read one pixel from the image.
+			// This is expected to throw an exception if it fails; without this check, Bio-Formats can appear to work
+			// but then fail when trying to read the first tile.
+			// The risk is that this will be slow for large, non-tiled images.
+			var reader = server.readerPool.getMainReader();
+			if (reader.getSizeX() > 0 && reader.getSizeY() > 0 && reader.openBytes(0, 0, 0, 1, 1) != null) {
+				return server;
+			} else {
+				throw new IOException("Unable to read bytes from " + uri);
+			}
+		} catch (Throwable t) {
+			throw ReaderPool.convertToIOException(t);
 		}
 	}
 	

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerBuilder.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerBuilder.java
@@ -84,6 +84,13 @@ public class BioFormatsServerBuilder implements ImageServerBuilder<BufferedImage
 				}
 				return UriImageSupport.createInstance(this.getClass(), supportLevel, builders.values());
 			} catch (Exception e) {
+				// Special case where the issue is that Bio-Formats isn't supported on Apple Silicon -
+				// we want to make more noise so that the user knows what's going on
+				if (e instanceof IOException ioe) {
+					String msg = ioe.getLocalizedMessage();
+					if (msg != null && msg.toLowerCase().contains("apple silicon"))
+						throw ioe;
+				}
 				logger.debug("Unable to create server using Bio-Formats", e);
 			}
 		}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -1662,7 +1662,8 @@ public class QuPathGUI {
 			List<ServerBuilder<BufferedImage>> builders = support == null ? Collections.emptyList() : support.getBuilders();
 			
 			if (builders.isEmpty()) {
-				String message = "Unable to build ImageServer for " + pathNew + ".\nSee View > Show log for more details";
+				String name = fileNew == null ? pathNew : fileNew.getName();
+				String message = "No supported image reader found for " + name + ".\nSee View > Show log for more details";
 				Dialogs.showErrorMessage("Unable to build server", message);
 				return false;
 			}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
@@ -795,6 +795,8 @@ public class ViewerManager implements QuPathViewerListener {
 		// Listen to the scroll wheel
 		viewer.getView().setOnScroll(e -> {
 			if (viewer == getActiveViewer() || !getSynchronizeViewers()) {
+				if (!viewer.hasServer())
+					return;
 				double scrollUnits = e.getDeltaY() * PathPrefs.getScaledScrollSpeed();
 				
 				// Use shift down to adjust opacity


### PR DESCRIPTION
Try to propagate more meaningful errors when an image can't be opened or import to a project, especially for .czi images that don't work with Apple Silicon.

To help achieve this, don't rely on ImageJ to attempt any image - but instead query the image type first, and try only if ImageJ has a good chance of handling it.