### PR TITLE
Better handle failed delete extension jar

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -754,14 +754,15 @@ public final class GeneralTools {
 	 * 
 	 * @param fileToDelete
 	 * @param preferTrash
+	 * @return true if the file is successfully deleted, false otherwise
 	 */
-	public static void deleteFile(File fileToDelete, boolean preferTrash) {
+	public static boolean deleteFile(File fileToDelete, boolean preferTrash) {
 		if (preferTrash && Desktop.isDesktopSupported()) {
 			var desktop = Desktop.getDesktop();
 			if (desktop.isSupported(Desktop.Action.MOVE_TO_TRASH) && desktop.moveToTrash(fileToDelete))
-				return;
+				return true;
 		}
-		fileToDelete.delete();
+		return fileToDelete.delete();
 	}
 
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionControlPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionControlPane.java
@@ -35,6 +35,7 @@ import org.apache.commons.text.WordUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.fx.dialogs.Dialogs;
+import qupath.fx.utils.FXUtils;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.common.Version;
 import qupath.lib.gui.actions.ActionTools;
@@ -309,14 +310,21 @@ public class ExtensionControlPane extends VBox {
             var file = new File(url.toURI().getPath());
             if (file.exists()) {
                 logger.info("Removing extension: {}", url);
-                GeneralTools.deleteFile(new File(url.toURI().getPath()), true);
-                Dialogs.showInfoNotification(
-                        QuPathResources.getString("ExtensionControlPane"),
-                        String.format(QuPathResources.getString("ExtensionControlPane.extensionRemoved"), url));
+                if (GeneralTools.deleteFile(new File(url.toURI().getPath()), true)) {
+                    Dialogs.showInfoNotification(
+                            QuPathResources.getString("ExtensionControlPane"),
+                            String.format(QuPathResources.getString("ExtensionControlPane.extensionRemoved"), url));
+                } else {
+                    if (Dialogs.showYesNoDialog(QuPathResources.getString("ExtensionControlPane"),
+                            QuPathResources.getString("ExtensionControlPane.unableToDeletePrompt"))) {
+                        GuiTools.browseDirectory(file);
+                    }
+                    return;
+                }
             } else {
                 Dialogs.showWarningNotification(
                         QuPathResources.getString("ExtensionControlPane"),
-                        String.format(QuPathResources.getString("ExtensionControlPane.unableToDelete"), url));
+                        QuPathResources.getString("ExtensionControlPane.unableToFind"));
             }
             var manager = QuPathGUI.getInstance().getExtensionManager();
             manager.getLoadedExtensions().entrySet().removeIf(entry -> entry.getValue().equals(extension));

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -926,7 +926,10 @@ DragDrop.couldNotHandleFile = Sorry, I couldn't figure out what to do with %s
 ExtensionControlPane = Extension manager
 ExtensionControlPane.unableToOpen = Unable to open extension manager
 ExtensionControlPane.unableToDownload = Unable to download extension from GitHub
-ExtensionControlPane.unableToDelete = Extension file could not be deleted
+ExtensionControlPane.unableToFind = Extension file could not be found
+ExtensionControlPane.unableToDeletePrompt = Extension file could not be deleted.\n\
+  Do you want to open the extensions directory to remove it manually?\n\
+  You may need to close QuPath if the file is in use.
 ExtensionControlPane.confirmRemoveExtension = Are you sure you want to remove %s?
 ExtensionControlPane.extensionRemoved = Extension removed %s\nYou need to restart QuPath to see the changes reflected.
 ExtensionControlPane.unableToCheckForUpdates = Unable to check for updates


### PR DESCRIPTION
Addresses https://forum.image.sc/t/please-help-us-test-the-qupath-v0-5-0-release-candidate/87976/12

If an extension can't be deleted, inform the user and ask if the directory should be opened for manual deletion. Previously, a 'success' message was shown even if the deletion had failed.

I couldn't figure out a way to make the extension 'deletable' - although I vaguely recall @yli-hallila might know more about this.