### PR TITLE
Simplify DnnModel implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ This is a work-in-progress for the next QuPath release.
   * Much smaller `QuPathGUI` class
   * *These changes will require some extensions to be updated*
 * Initial work to support string localization
+* `DnnModel` simplified
+  * Generic parameter removed; see javadoc for details
 
 ### Bugs fixed
 * Cannot import GeoJSON with NaN measurements (https://github.com/qupath/qupath/issues/1293)

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/AbstractDnnModel.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/AbstractDnnModel.java
@@ -1,0 +1,131 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2021-2023 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.opencv.dnn;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Wrapper for a deep learning model in a pipeline using OpenCV.
+ * It can encapsulate a custom method needed to convert the input Mat(s) into the appropriate format,
+ * and the output back into one or more Mats.
+ * <p>
+ * This provides convenience methods to both convert and predict for three common scenarios:
+ * <ul>
+ *   <li>Single input, single output; batch size 1</li>
+ *   <li>Single or multiple inputs, single or multiple outputs; batch size 1</li>
+ *   <li>Single input, single output; batch size &gt; 1</li>
+ * </ul>
+ *
+ *
+ * @author Pete Bankhead
+ * @param <T>
+ * @see BlobFunction
+ * @see PredictionFunction
+ * @version 0.5.0
+ */
+public abstract class AbstractDnnModel<T> implements DnnModel {
+
+    /**
+     * Get the function that can convert one or more OpenCV Mats into a blob supported by the prediction function
+     * for the first (or only) input.
+     * @return
+     */
+    public abstract BlobFunction<T> getBlobFunction();
+
+    /**
+     * Get the function that can convert one or more OpenCV Mats into a blob supported by the prediction function for
+     * a specified input layer.
+     * @param name
+     * @return
+     */
+    public abstract BlobFunction<T> getBlobFunction(String name);
+
+    /**
+     * Get the prediction function that can apply a prediction with one or more blobs as input.
+     * @return
+     */
+    public abstract PredictionFunction<T> getPredictionFunction();
+
+    /**
+     * Convenience method to convert input image patches to a blobs, apply a {@link PredictionFunction} (optionally with multiple inputs/outputs),
+     * and convert the output to a standard {@link Mat}.
+     * <p>
+     * Note that this only supports a batch size of 1. For larger batches or more control, {@link #getBlobFunction(String)} and
+     * {@link #getPredictionFunction()} should be used directly.
+     *
+     * @param blobs
+     * @return
+     */
+    @Override
+    public Map<String, Mat> convertAndPredict(Map<String, Mat> blobs) {
+
+        var input = blobs.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), e -> getBlobFunction(e.getKey()).toBlob(e.getValue())));
+        var prediction = getPredictionFunction().predict(input);
+
+        // TODO: Consider warning for multiple outputs (although shouldn't happen because conversion is also covered within this method)
+        var output = prediction.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), e -> getBlobFunction(e.getKey()).fromBlob(e.getValue()).get(0)));
+
+        return output;
+    }
+
+    /**
+     * Convenience method to convert a single image patch to a blob, apply the {@link PredictionFunction}, and convert the output to a standard {@link Mat}.
+     * <p>
+     * Note that this only supports a batch size of 1. For larger batches or more control, {@link #getBlobFunction(String)} and
+     * {@link #getPredictionFunction()} should be used directly.
+     *
+     * @param mat
+     * @return
+     */
+    @Override
+    public Mat convertAndPredict(Mat mat) {
+        var blob = getBlobFunction().toBlob(mat);
+        var prediction = getPredictionFunction().predict(blob);
+        var output = getBlobFunction().fromBlob(prediction);
+        if (output.size() > 1)
+            LoggerFactory.getLogger(DnnModel.class).warn("Expected single output but got {} outputs - I will return the first only", output.size());
+        return output.get(0);
+    }
+
+    /**
+     * Convenience method to convert one or more image patches to a blob, apply the {@link PredictionFunction}, and convert the output to standard Mats.
+     * This method is intended for cases where the batch size should be greater than one; for a batch size of one, {@link #convertAndPredict(Mat)} can
+     * be used instead.
+     * @param mats
+     * @return
+     */
+    @Override
+    public List<Mat> batchConvertAndPredict(Mat... mats) {
+        var blob = getBlobFunction().toBlob(mats);
+        var prediction = getPredictionFunction().predict(blob);
+        var output = getBlobFunction().fromBlob(prediction);
+        return output;
+    }
+
+}

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/AbstractDnnModel.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/AbstractDnnModel.java
@@ -83,7 +83,7 @@ public abstract class AbstractDnnModel<T> implements DnnModel {
      * @return
      */
     @Override
-    public Map<String, Mat> convertAndPredict(Map<String, Mat> blobs) {
+    public Map<String, Mat> predict(Map<String, Mat> blobs) {
 
         var input = blobs.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), e -> getBlobFunction(e.getKey()).toBlob(e.getValue())));
         var prediction = getPredictionFunction().predict(input);
@@ -104,7 +104,7 @@ public abstract class AbstractDnnModel<T> implements DnnModel {
      * @return
      */
     @Override
-    public Mat convertAndPredict(Mat mat) {
+    public Mat predict(Mat mat) {
         var blob = getBlobFunction().toBlob(mat);
         var prediction = getPredictionFunction().predict(blob);
         var output = getBlobFunction().fromBlob(prediction);
@@ -115,14 +115,14 @@ public abstract class AbstractDnnModel<T> implements DnnModel {
 
     /**
      * Convenience method to convert one or more image patches to a blob, apply the {@link PredictionFunction}, and convert the output to standard Mats.
-     * This method is intended for cases where the batch size should be greater than one; for a batch size of one, {@link #convertAndPredict(Mat)} can
+     * This method is intended for cases where the batch size should be greater than one; for a batch size of one, {@link #predict(Mat)} can
      * be used instead.
      * @param mats
      * @return
      */
     @Override
-    public List<Mat> batchConvertAndPredict(Mat... mats) {
-        var blob = getBlobFunction().toBlob(mats);
+    public List<Mat> batchPredict(List<? extends Mat> mats) {
+        var blob = getBlobFunction().toBlob(mats.toArray(Mat[]::new));
         var prediction = getPredictionFunction().predict(blob);
         var output = getBlobFunction().fromBlob(prediction);
         return output;

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DefaultDnnModel.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DefaultDnnModel.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * @param <T>
  */
-class DefaultDnnModel<T> implements DnnModel<T> {
+class DefaultDnnModel<T> extends AbstractDnnModel<T> {
 	
 	private static final Logger logger = LoggerFactory.getLogger(DefaultDnnModel.class);
 	

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModel.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModel.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2021 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2021-2023 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -22,132 +22,91 @@
 
 package qupath.opencv.dnn;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.bytedeco.opencv.opencv_core.Mat;
-import org.slf4j.LoggerFactory;
 
 
 /**
- * Wrapper for a deep learning model in a pipeline using OpenCV.
+ * General interface for implementing a deep learning model in a pipeline using OpenCV.
+ * <p>
  * It can encapsulate a custom method needed to convert the input Mat(s) into the appropriate format, 
  * and the output back into one or more Mats.
  * <p>
- * This provides convenience methods to both convert and predict for three common scenarios:
+ * Implementations should provide convenience methods to both convert and predict for three common scenarios:
  * <ul>
  *   <li>Single input, single output; batch size 1</li>
  *   <li>Single or multiple inputs, single or multiple outputs; batch size 1</li>
  *   <li>Single input, single output; batch size &gt; 1</li>
  * </ul>
- * 
+ * <p>
+ * If only a single input and output are required, then only {@link #convertAndPredict(Mat)}
+ * needs to be implemented.
+ * <p>
+ * <b>Note: </b>This was originally implemented in QuPath v0.3.0, but simplified for
+ *              QuPath v0.5.0. It no longer takes a generic parameter or requires
+ *              'blob' and 'prediction' functions to be defined.
+ *              This makes it easier to implement, and also to handle memory management.
+ *              If you want the old behavior, see {@link AbstractDnnModel}.
  * 
  * @author Pete Bankhead
- * @param <T> 
  * @see BlobFunction
  * @see PredictionFunction
- * @version 0.3.0
+ * @since 0.5.0
  */
-public interface DnnModel<T> extends AutoCloseable {
+public interface DnnModel extends AutoCloseable {
 		
 	/**
 	 * Default input layer name. This should be used when the input layer name is known or 
 	 * unimportant (e.g. the common case of a single input).
 	 */
-	public static final String DEFAULT_INPUT_NAME = "input";
+	String DEFAULT_INPUT_NAME = "input";
 	
 	/**
 	 * Default output layer name. This should be used when the output layer name is known or 
 	 * unimportant (e.g. the common case of a single output).
 	 */
-	public static final String DEFAULT_OUTPUT_NAME = "output";
+	String DEFAULT_OUTPUT_NAME = "output";
 	
 	/**
-	 * Get the function that can convert one or more OpenCV Mats into a blob supported by the prediction function 
-	 * for the first (or only) input.
-	 * @return
-	 */
-	public BlobFunction<T> getBlobFunction();
-	
-	/**
-	 * Get the function that can convert one or more OpenCV Mats into a blob supported by the prediction function for 
-	 * a specified input layer.
-	 * @param name 
-	 * @return
-	 */
-	public BlobFunction<T> getBlobFunction(String name);
-	
-	/**
-	 * Get the prediction function that can apply a prediction with one or more blobs as input.
-	 * @return
-	 */
-	public PredictionFunction<T> getPredictionFunction();
-	
-	/**
-	 * Convenience method to convert input image patches to a blobs, apply a {@link PredictionFunction} (optionally with multiple inputs/outputs),
-	 * and convert the output to a standard {@link Mat}.
-	 * <p>
-	 * Note that this only supports a batch size of 1. For larger batches or more control, {@link #getBlobFunction(String)} and 
-	 * {@link #getPredictionFunction()} should be used directly.
-	 * 
+	 * Prediction function that can take multiple inputs.
 	 * @param blobs
 	 * @return
 	 */
-	public default Map<String, Mat> convertAndPredict(Map<String, Mat> blobs) {
-		
-		var input = blobs.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), e -> getBlobFunction(e.getKey()).toBlob(e.getValue())));
-		var prediction = getPredictionFunction().predict(input);
-		
-		// TODO: Consider warning for multiple outputs (although shouldn't happen because conversion is also covered within this method)
-		var output = prediction.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), e -> getBlobFunction(e.getKey()).fromBlob(e.getValue()).get(0)));
-		
-		return output;
-	}
+	Map<String, Mat> convertAndPredict(Map<String, Mat> blobs);
 
 	/**
-	 * Convenience method to convert a single image patch to a blob, apply the {@link PredictionFunction}, and convert the output to a standard {@link Mat}.
-	 * <p>
-	 * Note that this only supports a batch size of 1. For larger batches or more control, {@link #getBlobFunction(String)} and 
-	 * {@link #getPredictionFunction()} should be used directly.
-	 * 
+	 * Prediction function that takes a single input and gives a single output.
 	 * @param mat
 	 * @return
 	 */
-	public default Mat convertAndPredict(Mat mat) {
-		var blob = getBlobFunction().toBlob(mat);
-		var prediction = getPredictionFunction().predict(blob);
-		var output = getBlobFunction().fromBlob(prediction);
-		if (output.size() > 1)
-			LoggerFactory.getLogger(DnnModel.class).warn("Expected single output but got {} outputs - I will return the first only", output.size());
-		return output.get(0);
+	default Mat convertAndPredict(Mat mat) {
+		return convertAndPredict(Map.of(DEFAULT_INPUT_NAME, mat)).get(DEFAULT_OUTPUT_NAME);
 	}
 	
 	/**
-	 * Convenience method to convert one or more image patches to a blob, apply the {@link PredictionFunction}, and convert the output to standard Mats.
-	 * This method is intended for cases where the batch size should be greater than one; for a batch size of one, {@link #convertAndPredict(Mat)} can 
-	 * be used instead.
+	 * Prediction function that can take a batch of inputs and gives a corresponding
+	 * batch of outputs.
+	 * Each input is expected to have a single output.
 	 * @param mats
 	 * @return
 	 */
-	public default List<Mat> batchConvertAndPredict(Mat... mats) {
-		var blob = getBlobFunction().toBlob(mats);
-		var prediction = getPredictionFunction().predict(blob);
-		var output = getBlobFunction().fromBlob(prediction);
+	default List<Mat> batchConvertAndPredict(Mat... mats) {
+		List<Mat> output = new ArrayList<>();
+		for (var input : mats) {
+			output.add(convertAndPredict(input));
+		}
 		return output;
 	}
 	
 	/**
 	 * Close this model if it will not be needed again.
 	 * Subclasses that require cleanup may override this.
-	 * A default, do-nothing implementation implementation is provided for backwards compatibility with v0.3.0.
-	 * 
-	 * @since v0.3.1
-	 * @implNote this was introduced to provide a mechanism to deal with a GPU memory leak when 
-	 *           using OpenCV and CUDA. New code using any DnnModel should call this method if it can 
-	 *           be known that the model will not be needed again in the future.
+	 * The default implementation does nothing.
 	 */
 	@Override
-	public default void close() throws Exception {}
+	default void close() throws Exception {}
 	
 }

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModel.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModel.java
@@ -42,7 +42,7 @@ import org.bytedeco.opencv.opencv_core.Mat;
  *   <li>Single input, single output; batch size &gt; 1</li>
  * </ul>
  * <p>
- * If only a single input and output are required, then only {@link #convertAndPredict(Mat)}
+ * If only a single input and output are required, then only {@link #predict(Mat)}
  * needs to be implemented.
  * <p>
  * <b>Note: </b>This was originally implemented in QuPath v0.3.0, but simplified for
@@ -75,15 +75,15 @@ public interface DnnModel extends AutoCloseable {
 	 * @param blobs
 	 * @return
 	 */
-	Map<String, Mat> convertAndPredict(Map<String, Mat> blobs);
+	Map<String, Mat> predict(Map<String, Mat> blobs);
 
 	/**
 	 * Prediction function that takes a single input and gives a single output.
 	 * @param mat
 	 * @return
 	 */
-	default Mat convertAndPredict(Mat mat) {
-		return convertAndPredict(Map.of(DEFAULT_INPUT_NAME, mat)).get(DEFAULT_OUTPUT_NAME);
+	default Mat predict(Mat mat) {
+		return predict(Map.of(DEFAULT_INPUT_NAME, mat)).get(DEFAULT_OUTPUT_NAME);
 	}
 	
 	/**
@@ -93,10 +93,10 @@ public interface DnnModel extends AutoCloseable {
 	 * @param mats
 	 * @return
 	 */
-	default List<Mat> batchConvertAndPredict(Mat... mats) {
+	default List<Mat> batchPredict(List<? extends Mat> mats) {
 		List<Mat> output = new ArrayList<>();
 		for (var input : mats) {
-			output.add(convertAndPredict(input));
+			output.add(predict(input));
 		}
 		return output;
 	}

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModelBuilder.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModelBuilder.java
@@ -28,10 +28,9 @@ package qupath.opencv.dnn;
  * 
  * @author Pete Bankhead
  *
- * @param <T>
  * @since v0.4.0
  */
-public interface DnnModelBuilder<T> {
+public interface DnnModelBuilder {
 	
 	/**
 	 * Build a {@link DnnModel} if possible, or return null otherwise.
@@ -39,6 +38,6 @@ public interface DnnModelBuilder<T> {
 	 * @param params
 	 * @return
 	 */
-	public DnnModel<T> buildModel(DnnModelParams params);
+	DnnModel buildModel(DnnModelParams params);
 	
 }

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModels.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnModels.java
@@ -55,7 +55,7 @@ public class DnnModels {
 	@SuppressWarnings("rawtypes")
 	private static final SubTypeAdapterFactory<PredictionFunction> predictionAdapter;
 	
-	private static Set<DnnModelBuilder<?>> builders;
+	private static Set<DnnModelBuilder> builders;
 	
 	static {
 		
@@ -102,19 +102,19 @@ public class DnnModels {
 	 *           the fact that the {@link ServiceLoader} used to identify builders 
 	 *           may not see those that are added via extensions.
 	 */
-	public static boolean registerBuilder(DnnModelBuilder<?> builder) {
+	public static boolean registerBuilder(DnnModelBuilder builder) {
 		if (builder != null)
 			return getBuilders().add(builder);
 		return false;
 	}
 	
 	
-	private static Set<DnnModelBuilder<?>> getBuilders() {
+	private static Set<DnnModelBuilder> getBuilders() {
 		if (builders == null) {
 			synchronized (DnnModels.class) {
 				if (builders == null) {
 					builders = new LinkedHashSet<>();
-					for (DnnModelBuilder<?> builder : ServiceLoader.load(DnnModelBuilder.class)) {
+					for (DnnModelBuilder builder : ServiceLoader.load(DnnModelBuilder.class)) {
 						builders.add(builder);
 					}
 				}
@@ -127,16 +127,15 @@ public class DnnModels {
 	/**
 	 * Build a {@link DnnModel} from the given parameters.
 	 * This queries all available {@linkplain DnnModelBuilder DnnModelBuilders} through a service loader.
-	 * @param <T>
 	 * @param params
 	 * @return a new DnnModel, or null if no model could be built
 	 */
-	public static <T> DnnModel<T> buildModel(DnnModelParams params) {
-		for (DnnModelBuilder<?> builder : getBuilders()) {
+	public static DnnModel buildModel(DnnModelParams params) {
+		for (DnnModelBuilder builder : getBuilders()) {
 			try {
 				var model = builder.buildModel(params);
 				if (model != null)
-					return (DnnModel<T>)model;
+					return model;
 				else {
 					logger.info("Cannot build model with {}", builder);
 				}

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnObjectClassifier.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnObjectClassifier.java
@@ -141,7 +141,7 @@ public class DnnObjectClassifier extends AbstractObjectClassifier<BufferedImage>
 	protected int tryToClassify(List<? extends PathObject> pathObjects, ImageServer<BufferedImage> server, double downsample, IntFunction<PathClass> classifier) {
 		int count = 0;
 		try {			
-			Mat[] inputImages = new Mat[pathObjects.size()];
+			List<Mat> inputImages = new ArrayList<>();
 			int n = pathObjects.size();
 			int i = 0;
 			for (var pathObject : pathObjects) {
@@ -151,12 +151,12 @@ public class DnnObjectClassifier extends AbstractObjectClassifier<BufferedImage>
 					return 0;
 				}
 				Mat input = DnnTools.readPatch(server, roi, downsample, width, height);
-				inputImages[i] = input;
+				inputImages.add(input);
 				i++;
 			}
 			// TODO: Consider using batchConvertAndPredict instead
 			
-			var output = model.batchConvertAndPredict(inputImages);
+			var output = model.batchPredict(inputImages);
 //			var blob = model.getBlobFunction().toBlob(inputImages);
 //			var prediction = model.getPredictionFunction().call(blob);
 //			var output = model.getBlobFunction().fromBlob(prediction);

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnObjectClassifier.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/DnnObjectClassifier.java
@@ -57,14 +57,13 @@ import qupath.lib.objects.classes.PathClass;
  * <b>Warning!</b> This implementation is likely to change in the future.
  * 
  * @author Pete Bankhead
- * @param <T> class of the blob used by the deep learning model
  * @version 0.3.0
  */
-public class DnnObjectClassifier<T> extends AbstractObjectClassifier<BufferedImage> implements UriResource {
+public class DnnObjectClassifier extends AbstractObjectClassifier<BufferedImage> implements UriResource {
 	
 	private static final Logger logger = LoggerFactory.getLogger(DnnObjectClassifier.class);
 	
-	private DnnModel<T> model;
+	private DnnModel model;
 	private List<PathClass> pathClasses;
 	private double requestedPixelSize = 1.0;
 	private int width, height;
@@ -86,7 +85,7 @@ public class DnnObjectClassifier<T> extends AbstractObjectClassifier<BufferedIma
 	 * @param height patch height, in pixels, at the classification side
 	 * @param requestedPixelSize requested pixel size, in calibrated units, used to calculate the downsample value
 	 */
-	public DnnObjectClassifier(PathObjectFilter filter, DnnModel<T> model, List<PathClass> pathClasses, int width, int height, double requestedPixelSize) {
+	public DnnObjectClassifier(PathObjectFilter filter, DnnModel model, List<PathClass> pathClasses, int width, int height, double requestedPixelSize) {
 		super(filter);
 		this.model = model;
 		this.pathClasses = new ArrayList<>(pathClasses);

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVDnn.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVDnn.java
@@ -68,7 +68,7 @@ import qupath.opencv.ops.ImageOps;
  * @author Pete Bankhead
  *
  */
-public class OpenCVDnn implements UriResource, DnnModel<Mat> {
+public class OpenCVDnn extends AbstractDnnModel<Mat> implements UriResource {
 	
 	private static Logger logger = LoggerFactory.getLogger(OpenCVDnn.class);
 	

--- a/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVDnnModelBuilder.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/dnn/OpenCVDnnModelBuilder.java
@@ -36,7 +36,7 @@ import qupath.lib.common.GeneralTools;
  * @author Pete Bankhead
  * @since v0.4.0
  */
-public class OpenCVDnnModelBuilder implements DnnModelBuilder<Mat> {
+public class OpenCVDnnModelBuilder implements DnnModelBuilder {
 	
 	private static Set<String> weightsExtensions = Set.of(".pb", ".onnx", ".caffemodel", ".t7", ".net", ".weights", ".bin");
 	private static Set<String> configExtensions = Set.of(".prototxt", ".pbtxt", ".cfg", ".xml");
@@ -67,7 +67,7 @@ public class OpenCVDnnModelBuilder implements DnnModelBuilder<Mat> {
 	}
 
 	@Override
-	public DnnModel<Mat> buildModel(DnnModelParams params) {
+	public DnnModel buildModel(DnnModelParams params) {
 		if (!canBuild(params))
 			return null;
 		var uris = params.getURIs();

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/BioimageIoTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/BioimageIoTools.java
@@ -88,9 +88,9 @@ public class BioimageIoTools {
 	 * @param spec
 	 * @return
 	 */
-	public static DnnModel<?> buildDnnModel(BioimageIoModel spec) {
+	public static DnnModel buildDnnModel(BioimageIoModel spec) {
 		// Try to find compatible weights
-		DnnModel<?> dnn = null;
+		DnnModel dnn = null;
 		
 		// Check for weights in the order that we're likely to support them
 		// This is based upon the fact that we will most likely be relying upon 
@@ -300,7 +300,7 @@ public class BioimageIoTools {
 		}
 		
 		// Try to find compatible weights
-		DnnModel<?> dnn = buildDnnModel(modelSpec);
+		var dnn = buildDnnModel(modelSpec);
 		
 		if (dnn == null)
 			throw new UnsupportedOperationException("Unable to create a DnnModel for " + modelSpec.getName() + 

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
@@ -254,7 +254,7 @@ public class PatchClassifierParams {
 		private PatchClassifierParams params;
 		
 		private Padding dnnPadding;
-		private DnnModel<?> dnnModel;
+		private DnnModel dnnModel;
 		private String[] dnnOutputNames;
 		
 		private Builder() {
@@ -412,7 +412,7 @@ public class PatchClassifierParams {
 		 * @return
 		 * @see #prediction(ImageOp)
 		 */
-		public Builder prediction(DnnModel<?> model, Padding padding, String... outputNames) {
+		public Builder prediction(DnnModel model, Padding padding, String... outputNames) {
 			this.dnnModel = model;
 			this.dnnPadding = padding;
 			this.dnnOutputNames = outputNames;

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -2987,7 +2987,7 @@ public class ImageOps {
 
 		try (@SuppressWarnings("unchecked")var scope = new PointerScope()) {
 			
-			var output = model.convertAndPredict(Map.of(inputName, mat));
+			var output = model.predict(Map.of(inputName, mat));
 			
 			if (!output.isEmpty()) {
 				if (outputNames.length == 0 || (outputNames.length == 1 && output.containsKey(outputNames[0])))

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -70,6 +70,7 @@ import qupath.lib.io.GsonTools.SubTypeAdapterFactory;
 import qupath.lib.io.UriResource;
 import qupath.lib.regions.Padding;
 import qupath.lib.regions.RegionRequest;
+import qupath.opencv.dnn.AbstractDnnModel;
 import qupath.opencv.dnn.DnnModel;
 import qupath.opencv.dnn.DnnShape;
 import qupath.opencv.dnn.PredictionFunction;
@@ -2761,7 +2762,7 @@ public class ImageOps {
 		 *                    and they be concatenated along the channels dimension.
 		 * @return
 		 */
-		public static ImageOp dnn(DnnModel<?> model, int inputWidth, int inputHeight, Padding padding, String... outputNames) {
+		public static ImageOp dnn(DnnModel model, int inputWidth, int inputHeight, Padding padding, String... outputNames) {
 			return new DnnOp<>(model, inputWidth, inputHeight, padding, outputNames);
 		}
 				
@@ -2816,7 +2817,7 @@ public class ImageOps {
 			
 			private static final Logger logger = LoggerFactory.getLogger(DnnOp.class);
 
-			private DnnModel<T> model;
+			private DnnModel model;
 			private int inputWidth;
 			private int inputHeight;
 			
@@ -2836,7 +2837,7 @@ public class ImageOps {
 			 * @param padding
 			 * @param outputNames names of output layers; if more than one, these will be concatenated along the channels dimension
 			 */
-			DnnOp(DnnModel<T> model, int inputWidth, int inputHeight, Padding padding, String... outputNames) {
+			DnnOp(DnnModel model, int inputWidth, int inputHeight, Padding padding, String... outputNames) {
 				this.model = model;
 				this.inputWidth = inputWidth;
 				this.inputHeight = inputHeight;
@@ -2848,31 +2849,10 @@ public class ImageOps {
 			protected Padding calculatePadding() {
 				return padding;
 			}
-			
-			private String getInputName() {
-				if (inputName != null)
-					return inputName;
-				synchronized(this) {
-					if (inputName == null) {
-						var fun = model.getPredictionFunction();
-						var inputs = fun.getInputs();
-						if (inputs.isEmpty()) {
-							logger.warn("Input names empty for {}", model);
-							inputName = DnnModel.DEFAULT_INPUT_NAME;
-						} else {
-							inputName = inputs.keySet().iterator().next();
-						}
-						if (inputs.size() > 1)
-							logger.warn("DnnOp only supports single inputs, but {} expects {}", model, inputs.size());
-					}
-				}
-				return inputName;
-			}
-			
 
 			@Override
 			protected List<Mat> transformPadded(Mat input) {
-				var inputName = getInputName();
+				var inputName = DnnModel.DEFAULT_INPUT_NAME; // Only support one input
 				Mat result;
 				// TODO: Explore removing padding at an earlier stage
 				if ((inputWidth <= 0 && inputHeight <= 0) || (input.cols() == inputWidth && input.rows() == inputHeight)) {
@@ -2897,18 +2877,21 @@ public class ImageOps {
 						outChannels = outputChannels.get(channels.size());
 						if (outChannels == null) {
 							// If we have multiple outputs, try to get output names from the layers
-							var outputs = model.getPredictionFunction().getOutputs(DnnShape.of(1, channels.size(), inputHeight, inputWidth));
 							List<String> names = new ArrayList<>();
-							if (outputs.size() > 1) {
-								Collection<String> outputKeys = outputNames == null || outputNames.length == 0 ? outputs.keySet() : Arrays.asList(outputNames);
-								for (var key : outputKeys) {
-									var shape = outputs.get(key);
-									if (shape != null && !shape.isUnknown() && shape.numDimensions() > 2 && shape.get(1) != DnnShape.UNKNOWN_LENGTH) {
-										for (int c = 0; c < shape.get(1); c++) {
-											names.add(key + ": " + c);
-										}
-									} else
-										logger.warn("Unknown output shape for {} - output channels are unknown", key);
+							// We can *sometimes* get more informative names from an AbstractDnnModel
+							if (model instanceof AbstractDnnModel<?> predictionModel) {
+								var outputs = predictionModel.getPredictionFunction().getOutputs(DnnShape.of(1, channels.size(), inputHeight, inputWidth));
+								if (outputs.size() > 1) {
+									Collection<String> outputKeys = outputNames == null || outputNames.length == 0 ? outputs.keySet() : Arrays.asList(outputNames);
+									for (var key : outputKeys) {
+										var shape = outputs.get(key);
+										if (shape != null && !shape.isUnknown() && shape.numDimensions() > 2 && shape.get(1) != DnnShape.UNKNOWN_LENGTH) {
+											for (int c = 0; c < shape.get(1); c++) {
+												names.add(key + ": " + c);
+											}
+										} else
+											logger.warn("Unknown output shape for {} - output channels are unknown", key);
+									}
 								}
 							}
 							// Run an example input through
@@ -2998,7 +2981,7 @@ public class ImageOps {
 	}
 	
 	
-	private static <T> Mat doPrediction(DnnModel<T> model, Mat mat, String inputName, String... outputNames) {
+	private static Mat doPrediction(DnnModel model, Mat mat, String inputName, String... outputNames) {
 
 		var matResult = new Mat();
 


### PR DESCRIPTION
Remove generic parameter and move prediction & blob functions to `AbstractDnnModel`. The motivations are:
- make it easier to implement `DnnModel`
- make it easier to handle memory management with the DeepJavaLibrary implementation

The second is because memory management seems to work best when using a `Translator` and not working directly with `NDList` inputs and outputs for prediction. This means that it's better to predict 'all at once' rather than across multiple methods (create blob, predict, convert output).