### PR TITLE
Fix gradle test deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,7 @@ This appears to be related to time spent initializing JavaFX.
 
 ### Dependency updates
 * Bio-Formats 7.0.1
-* DeepJavaLibrary 0.24.0
+* DeepJavaLibrary 0.25.0
 * Groovy 4.0.15
 * Guava 32.1.3-jre
 * ImageJ 1.54f

--- a/buildSrc/src/main/groovy/qupath.common-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.common-conventions.gradle
@@ -101,8 +101,7 @@ dependencies {
 
 dependencies {
     testImplementation libs.junit
-    testImplementation libs.junit.api
-    testRuntimeOnly libs.junit.engine
+    testRuntimeOnly libs.junit.platform
 
     implementation libs.bundles.logging
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,9 +106,8 @@ cuda-redist   = { module = "org.bytedeco:cuda-platform-redist", version.ref = "c
 ikonli-javafx    = { module = "org.kordamp.ikonli:ikonli-javafx",         version.ref = "ikonli" }
 ikonli-ionicons4 = { module = "org.kordamp.ikonli:ikonli-ionicons4-pack", version.ref = "ikonli" }
 
-junit         = { module = "org.junit.jupiter:junit-jupiter",        version.ref = "junit" }
-junit-api     = { module = "org.junit.jupiter:junit-jupiter-api",    version.ref = "junit" }
-junit-engine  = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit            = { module = "org.junit.jupiter:junit-jupiter",        version.ref = "junit" }
+junit-platform   = { module = "org.junit.platform:junit-platform-launcher" }
 
 
 [bundles]


### PR DESCRIPTION
Addresses https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#test_framework_implementation_dependencies