### PR TITLE
Right-click command list entries to copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ This is a work-in-progress for the next QuPath release.
 * Support for regular expressions in several 'filter' fields, e.g. for projects, channels, log messages & measurements
 * `MeasurementList.asMap()` returns `Map<String, Number` rather than `Map<String, Double>`
   * This enables scripts to use `pathObject.measurements['Name'] = 2` rather than `pathObject.measurements['Name'] = 2d`
+* *View → Show command list* supports copying commands to the clipboard
+  * This helps when creating docs or answering forum posts that need specific commands
 
 #### Naming & measurements
 * Improve consistency of naming, including for measurements

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -528,7 +528,7 @@ Action.Automate.scriptInterpreter = Script interpreter
 Action.Automate.scriptInterpreter.description = Open a script interpreter to run scripts interactively, line by line.\n(In general, the Script Editor is more useful).
 Action.Automate.commandWorkflow = Show workflow command history
 Action.Automate.commandWorkflow.description = Show a history of the commands applied to the current image.\nNote that this is not fully exhaustive, because not all commands can be recorded.\nHowever, the command history is useful to help automatically generate batch-processing scripts.
-Action.Automate.commandScript = Create command  history script
+Action.Automate.commandScript = Create command history script
 Action.Automate.commandScript.description = Create a script based upon the actions recorded in the command history
 
 # Measure menu


### PR DESCRIPTION
This should help a lot when answering forum questions & needing to provide the exact name of a command, including the menu items to use. I found myself having to retype this information continually, and somehow incorporate arrows for the menu structure.