### PR TITLE
Reintroduce startup scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ This is a work-in-progress for the next QuPath release.
   * This enables scripts to use `pathObject.measurements['Name'] = 2` rather than `pathObject.measurements['Name'] = 2d`
 * *View → Show command list* supports copying commands to the clipboard
   * This helps when creating docs or answering forum posts that need specific commands
+* New *Startup script path* preference
+  * Support running a single Groovy script when QuPath launches (useful for customization)
+  * The preference can also be overridden with the system property `qupath.startup.script=/path/to/script.groovy` 
+    or blocked with `qupath.startup.script=false` (e.g. in QuPath.cfg)
 
 #### Naming & measurements
 * Improve consistency of naming, including for measurements

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ logviewer       = "0.1.1"
 openslide       = "4.0.0"
 
 picocli         = "4.7.5"
-qupath-fxtras   = "0.1.1"
+qupath-fxtras   = "0.1.2"
 
 richtextfx      = "0.11.2"
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -393,7 +393,8 @@ public class QuPathGUI {
 		}
 		try {
 			logger.info("Running startup script {}", path);
-			Dialogs.showInfoNotification("Startup script", "Running startup script\n" + file.getName());
+			Dialogs.showInfoNotification(QuPathResources.getString("Startup.scriptTitle"),
+					String.format(QuPathResources.getString("Startup.scriptRun"), file.getName()));
 			runScript(file, null);
 		} catch (ScriptException | IllegalArgumentException e) {
 			logger.warn("Exception running startup script: {}", e.getMessage());

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -360,8 +360,46 @@ public class QuPathGUI {
 		stage.setMinHeight(400);
 
 		logger.debug("{}", timeit.stop());
+
+		// Run startup script if available, posted later to ensure UI is fully initialized
+		Platform.runLater(this::maybeRunStartupScript);
 	}
-	
+
+
+	private void maybeRunStartupScript() {
+		String property = System.getProperty("qupath.startup.script", null);
+		String path = PathPrefs.startupScriptProperty().get();
+		if (property != null) {
+			// Block startup script is property is 'false' or 'block'
+			if ("false".equalsIgnoreCase(property) || "block".equalsIgnoreCase(property)) {
+				logger.debug("Startup script blocked by system property");
+				return;
+			} else {
+				if (path != null && !path.isEmpty())
+					logger.warn("Startup script is overridden by system property");
+				else
+					logger.debug("Startup script specified by system property");
+				path = property;
+			}
+		}
+		if (path == null || path.isEmpty()) {
+			logger.debug("No startup script found");
+			return;
+		}
+		var file = new File(path);
+		if (!file.exists()) {
+			logger.warn("Startup script does not exist: {}", path);
+			return;
+		}
+		try {
+			logger.info("Running startup script {}", path);
+			Dialogs.showInfoNotification("Startup script", "Running startup script\n" + file.getName());
+			runScript(file, null);
+		} catch (ScriptException | IllegalArgumentException e) {
+			logger.warn("Exception running startup script: {}", e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
 		
 	
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -49,6 +49,7 @@ import org.slf4j.event.Level;
 import qupath.fx.dialogs.Dialogs;
 import qupath.fx.localization.LocaleManager;
 import qupath.fx.localization.LocaleSnapshot;
+import qupath.fx.prefs.annotations.FilePref;
 import qupath.fx.prefs.controlsfx.PropertyEditorFactory;
 import qupath.fx.prefs.controlsfx.PropertyItemBuilder;
 import qupath.fx.prefs.controlsfx.PropertyItemParser;
@@ -221,6 +222,9 @@ public class PreferencePane {
 				
 		@BooleanPref("Prefs.General.showStartupMessage")
 		public final BooleanProperty startupMessage = PathPrefs.showStartupMessageProperty();
+
+		@FilePref(value = "Prefs.General.startupScriptPath", extensions = "*.groovy")
+		public final StringProperty startupScriptPath = PathPrefs.startupScriptProperty();
 
 		@Pref(value = "Prefs.General.checkForUpdates", type = AutoUpdateType.class)
 		public final ObjectProperty<AutoUpdateType> autoUpdate = PathPrefs.autoUpdateCheckProperty();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -326,6 +326,17 @@ public class PathPrefs {
 	}
 
 
+	private static StringProperty startupScriptPath = createPersistentPreference("startupScriptPath", null);
+
+	/**
+	 * Path to a startup script that should be run immediately after QuPath's launch.
+	 * @return
+	 */
+	public static StringProperty startupScriptProperty() {
+		return startupScriptPath;
+	}
+
+
 	private static BooleanProperty showToolBarBadges = createPersistentPreference("showToolBarBadges", true);
 
 	/**

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -722,6 +722,8 @@ Prefs.Appearance.font.description = Main font for the QuPath user interface.
 
 Prefs.General.showStartupMessage = Show welcome message
 Prefs.General.showStartupMessage.description = Show the welcome message with links to the docs, forum & code every time QuPath is launched.\nYou can access this message at any time through the 'Help' menu.
+Prefs.General.startupScriptPath = Startup script path
+Prefs.General.startupScriptPath.description = Optionally select a Groovy script file to run immediately after QuPath is launched.
 Prefs.General.checkForUpdates = Check for updates on startup
 Prefs.General.checkForUpdates.description = Automatically check for updates when QuPath is started, and show a message if a new version is available.
 Prefs.General.systemMenubar = Use system menubar

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -46,6 +46,9 @@ Welcome.getStarted = Get started!
 Welcome.defaultMessage = Find out more about QuPath, customize key options,\nor click 'Get started!' to close this message
 Welcome.macOsAarch64 = Bio-Formats does not yet fully support Apple Silicon -\nsome image formats (e.g. .czi) may not work\n{{Click here}} for more information, or try the Intel build instead.
 
+Startup.scriptTitle = Startup script
+Startup.scriptRun = Running startup script\n%s
+
 # Main analysis pane
 
 AnalysisPane.projectTab = Project


### PR DESCRIPTION
- New *Startup script path* preference
  - Support running a single Groovy script when QuPath launches (useful for customization)
  - The preference can also be overridden with the system property `qupath.startup.script=/path/to/script.groovy` or blocked with `qupath.startup.script=false` (e.g. in QuPath.cfg)

Intended to help with CUDA setup on Linux.
Likely to please @MichaelSNelson but that is unintentional.