### PR TITLE
Set system properties from command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ This is a work-in-progress for the next QuPath release.
 * New `Tiler` class to generate tiles within other objects (https://github.com/qupath/qupath/pull/1347) (https://github.com/qupath/qupath/pull/1349) (https://github.com/qupath/qupath/issues/1277)
 * Replaced `PluginRunner` with `TaskRunner` to more easily run tasks with a progress bar (https://github.com/qupath/qupath/pull/1360)
 
+#### Command line
+* System properties can be passed via the command line using Java `-D` syntax
+  * Example `QuPath -DPYTORCH_VERSION=1.13.1 -Doffline=false`
+  * These are set as QuPath is being launched, before the user interface is created
+
 #### Platforms
 * Much improved Apple Silicon support, including with OpenSlide
   * See [below](#important-info-for-mac-users) for details

--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceLoader;
 import javax.script.ScriptException;
 import org.slf4j.Logger;
@@ -107,19 +108,17 @@ public class QuPath {
 
 	@Option(names = {"-l", "--log"}, description = {"Log level (default = INFO).", "Options: ${COMPLETION-CANDIDATES}"} )
 	private LogLevel logLevel = LogLevel.INFO;
-			
-	
+
+	@Option(names = {"-D"}, description = "Pass system properties to the QuPath launcher.")
+	private Map<String, String> systemProperties;
+
+
 	/**
 	 * Main class to launch QuPath.
 	 * 
 	 * @param args
 	 */
 	public static void main(String[] args) {
-		
-		// Set offline mode - used to prevent DJL downloading anything 
-		// except when explicitly requested
-		if (System.getProperty("offline", null) == null)
-			System.setProperty("offline", "true");
 
 		initializeProperties();
 
@@ -142,6 +141,14 @@ public class QuPath {
 		} catch (Exception e) {
 			logger.error("An error has occurred, please type -h to display help message.\n" + e.getLocalizedMessage());
 			return;
+		}
+
+		// Set any system properties
+		if (qupath.systemProperties != null) {
+			for (var entry : qupath.systemProperties.entrySet()) {
+				logger.info("Setting system property {}={}", entry.getKey(), entry.getValue());
+				System.setProperty(entry.getKey(), entry.getValue());
+			}
 		}
 		
 		// Catch -h/--help and -V/--version
@@ -203,9 +210,19 @@ public class QuPath {
 	
 	
 	private static void initializeProperties() {
+		initializeDJL();
 		initializeJTS();
 	}
-	
+
+	/**
+	 * Set system properties related to Deep Java Library.
+	 */
+	private static void initializeDJL() {
+		// Set offline mode - used to prevent DJL downloading anything
+		// except when explicitly requested
+		if (System.getProperty("offline", null) == null)
+			System.setProperty("offline", "true");
+	}
 	
 	/**
 	 * Use OverlayNG with Java Topology Suite by default.


### PR DESCRIPTION
This provides more opportunities to customize QuPath at launch, rather than afterwards. It may be useful for setting paths or options for DJL or JNA, without relying on persistent preferences.

Example:
```
/path/to/QuPath -DPYTORCH_VERSION=1.13.1 -Doffline=false
```

It's also possible to do
```
/path/to/QuPath -Djava.library.path=/something/
```
but I'm not sure if that works... it should however work to set JNA paths, see https://java-native-access.github.io/jna/4.2.1/com/sun/jna/NativeLibrary.html
