### PR TITLE
Script font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ This is a work-in-progress for the next QuPath release.
 * New extension manager to add, remove & update extensions
 * New toolbar buttons for the script editor `</>`, log viewer, fill/unfill annotations
 * *File → Export snapshots* supports PNG, JPEG and TIFF (not just PNG)
+* New option to set the font size in the script editor
+  * *View → Set font size*
 * Support sorting project entries by name, ID, and URI
   * Right-click on the project list to access the *Sort by...* menu
 * Improved script editor auto-complete (https://github.com/qupath/qupath/pull/1357)

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -303,8 +303,8 @@ public class RichScriptEditor extends DefaultScriptEditor {
 					})
 					.subscribe(styles -> codeArea.setStyleSpans(0, styles));
 
-			codeArea.getStylesheets().add(getClass().getClassLoader().getResource("scripting_styles.css").toExternalForm());
-			
+			codeArea.getStylesheets().add(RichScriptEditor.class.getClassLoader().getResource("scripting_styles.css").toExternalForm());
+
 			scriptStyler.bind(Bindings.createObjectBinding(() -> ScriptStylerProvider.getStylerFromLanguage(getCurrentLanguage()), currentLanguageProperty()));
 			
 			// Triggered whenever the script styling changes (e.g. change of language)


### PR DESCRIPTION
Add *View → Set font size*

This was an increasingly common request - especially for use in training courses.

Currently, it is possible to put in any css styling code, e.g. `-fx-font-weight: bold;` (although probably isn't a good idea).