### PR TITLE
Removed depth when searching extension jars

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 public class ExtensionClassLoader extends URLClassLoader {
 
 	private static final Logger logger = LoggerFactory.getLogger(ExtensionClassLoader.class);
-	private static final int MAX_EXTENSION_JARS_DEPTH = 3;
+	private static int MAX_EXTENSION_JARS_DEPTH = 3;		// non-final to be editable with Groovy
 	private static ExtensionClassLoader INSTANCE = null;
 	private final Supplier<Path> extensionsDirectorySupplier;
 	private final Set<Path> loadedJars = new HashSet<>();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionClassLoader.java
@@ -44,13 +44,10 @@ import org.slf4j.LoggerFactory;
 public class ExtensionClassLoader extends URLClassLoader {
 
 	private static final Logger logger = LoggerFactory.getLogger(ExtensionClassLoader.class);
-
+	private static final int MAX_EXTENSION_JARS_DEPTH = 3;
 	private static ExtensionClassLoader INSTANCE = null;
-
 	private final Supplier<Path> extensionsDirectorySupplier;
-
 	private final Set<Path> loadedJars = new HashSet<>();
-
 	private boolean isClosed = false;
 
 	private ExtensionClassLoader(Supplier<Path> extensionsDirectorySupplier) {
@@ -113,7 +110,7 @@ public class ExtensionClassLoader extends URLClassLoader {
 			return;
 		}
 		try {
-			try (Stream<Path> walk = Files.walk(dirExtensions, FileVisitOption.FOLLOW_LINKS)) {
+			try (Stream<Path> walk = Files.walk(dirExtensions, MAX_EXTENSION_JARS_DEPTH, FileVisitOption.FOLLOW_LINKS)) {
 				walk
 						.filter(this::isJarFile)
 						.map(Path::toAbsolutePath)


### PR DESCRIPTION
I removed the depth parameter when searching for extension jars (it was set at 1). This corrects the bug but I don't know if it's very safe to not have a depth at all. Maybe I should just set a higher depth (like 5)?

I also implemented a try-with-resources block because `Files.walk()` needs to be closed.