### PR TITLE
Histogram not updating fix

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -141,6 +141,9 @@ public class BrightnessContrastCommand implements Runnable {
 		table.disableToggleMenuItemsProperty().bind(showGrayscale);
 
 		currentChannelProperty.addListener((v, o, n) -> chartPane.updateHistogram(imageDisplayProperty.get(), n));
+		viewerProperty.map(QuPathViewer::getImageDisplay).flatMap(ImageDisplay::getHistogramManager).addListener((v, o, n) ->
+				chartPane.updateHistogram(imageDisplayProperty.get(), currentChannelProperty.get())
+		);
 		chartPane.updateHistogram(imageDisplayProperty.get(), currentChannelProperty.get());
 
 		dialog = createDialog();


### PR DESCRIPTION
This PR attempts to fix #1459.

I **replicated** the issue by:
* Creating and opening a project containing `LuCa-7color_[13860,52919]_1x1component_data.tif` (refered as `A`) and `LuCa-7color_[17572,60173]_3x3component_data.tif` (refered as `B`), two different images but with the same channels.
* Opening `A`.
* Opening the brightness & contrast dialog. The histogram of `A` is displayed.
* Opening `B` while keeping the brightness & contrast dialog open. The histogram of `A` is still displayed.

**The issue** comes from the fact that in [ImageDisplay](https://github.com/qupath/qupath/blob/main/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java), the function [setImageData()](https://github.com/qupath/qupath/blob/13bdeed047b4d05f35f47308b36b48c0f2bb3a24/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java#L202) is called when an image is open in QuPath. This function calls the `updateChannelOptions()` function and then the `updateHistogramMap()` function (see [here](https://github.com/qupath/qupath/blob/13bdeed047b4d05f35f47308b36b48c0f2bb3a24/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java#L228C4-L228C24)):
* `updateChannelOptions()` updates the [channelOptions](https://github.com/qupath/qupath/blob/13bdeed047b4d05f35f47308b36b48c0f2bb3a24/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java#L504) variable. It's an ObservableValue and, because of listeners, the [BrightnessContrastHistogramPane.updateHistogram()](https://github.com/qupath/qupath/blob/13bdeed047b4d05f35f47308b36b48c0f2bb3a24/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastHistogramPane.java#L162C17-L162C32) function is called. This is the function responsible for displaying the histogram.
* `updateHistogramMap()` updates the `histogramManager` variable. This variable is responsible for providing the histogram values.

So the problem is that the function displaying the histogram can be called before the function updating the histogram values. It is not possible to simply switch the calls of the `updateChannelOptions()` and `updateHistogramMap()` functions.

**The solution** I found was to make `histogramManager` an ObservableValue. In this case, `BrightnessContrastHistogramPane.updateHistogram()` can be called each time the `histogramManager` value changes.

I don't like this solution as it exposes the `histogramManager` variable (which is an implementation detail). But this was the solution requiring the less amount of refactoring I found.