### PR TITLE
TMA grid viewer bug

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
@@ -213,7 +213,7 @@ public class PathObjectGridView implements ChangeListener<ImageData<BufferedImag
 	public Stage getStage() {
 		if (stage == null)
 			initializeGUI();
-			stage.setWidth(850);
+			stage.setWidth(600);
 		return stage;
 	}
 	
@@ -587,7 +587,7 @@ public class PathObjectGridView implements ChangeListener<ImageData<BufferedImag
 			nx = Math.max(1, nx);
 			int spaceX = (int)((w - (dx) * nx) / (nx)); // Space to divide equally
 			
-			int x = spaceX/2; //1 space increment to divide equally
+			int x = spaceX/2;
 			int y = padding;
 			
 			for (Node node : getChildren()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
@@ -581,23 +581,22 @@ public class PathObjectGridView implements ChangeListener<ImageData<BufferedImag
 			}
 			
 			int padding = 5;
-			
-			int w = (int)getWidth(); //Width of the stage
-			int dx = imageSize.get() + padding; //Width of the image + padding
-			int nx = (int)Math.floor(w / dx); //Number of images that can fit in a row
+			int dx = imageSize.get() + padding;
+			int w = Math.max(dx, (int)getWidth());
+			int nx = (int)Math.floor(w / dx);
 			nx = Math.max(1, nx);
 			int spaceX = (int)((w - (dx) * nx) / (nx)); // Space to divide equally
 			
-			int x = spaceX/2;
+			int x = spaceX/2; //1 space increment to divide equally
 			int y = padding;
 			
 			for (Node node : getChildren()) {
 				if (x + dx > w) {
 					x = spaceX/2;
-					if (node instanceof Label label) // If the node is a label, then the height is the height of the label
+					if (node instanceof Label label)
 						y += label.getHeight() + spaceX + 2;
 					else
-						y += imageSize.get() + spaceX + 2; // If the node is not a label, then the height is the height of the image
+						y += imageSize.get() + spaceX + 2;
 				}
 				
 				if (doAnimate.get()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
@@ -213,6 +213,7 @@ public class PathObjectGridView implements ChangeListener<ImageData<BufferedImag
 	public Stage getStage() {
 		if (stage == null)
 			initializeGUI();
+			stage.setWidth(850);
 		return stage;
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
@@ -585,9 +585,7 @@ public class PathObjectGridView implements ChangeListener<ImageData<BufferedImag
 			int w = (int)getWidth(); //Width of the stage
 			int dx = imageSize.get() + padding; //Width of the image + padding
 			int nx = (int)Math.floor(w / dx); //Number of images that can fit in a row
-			if (nx == 0) {
-				nx = 1;
-			}
+			nx = Math.max(1, nx);
 			int spaceX = (int)((w - (dx) * nx) / (nx)); // Space to divide equally
 			
 			int x = spaceX/2;
@@ -596,8 +594,8 @@ public class PathObjectGridView implements ChangeListener<ImageData<BufferedImag
 			for (Node node : getChildren()) {
 				if (x + dx > w) {
 					x = spaceX/2;
-					if (node instanceof Label) // If the node is a label, then the height is the height of the label
-						y += ((Label)node).getHeight() + spaceX + 2;
+					if (node instanceof Label label) // If the node is a label, then the height is the height of the label
+						y += label.getHeight() + spaceX + 2;
 					else
 						y += imageSize.get() + spaceX + 2; // If the node is not a label, then the height is the height of the image
 				}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
@@ -582,10 +582,12 @@ public class PathObjectGridView implements ChangeListener<ImageData<BufferedImag
 			
 			int padding = 5;
 			
-			int w = (int)getWidth();
-//			int h = (int)getHeight();
-			int dx = imageSize.get() + padding;
-			int nx = (int)Math.floor(w / dx);
+			int w = (int)getWidth(); //Width of the stage
+			int dx = imageSize.get() + padding; //Width of the image + padding
+			int nx = (int)Math.floor(w / dx); //Number of images that can fit in a row
+			if (nx == 0) {
+				nx = 1;
+			}
 			int spaceX = (int)((w - (dx) * nx) / (nx)); // Space to divide equally
 			
 			int x = spaceX/2;
@@ -594,10 +596,10 @@ public class PathObjectGridView implements ChangeListener<ImageData<BufferedImag
 			for (Node node : getChildren()) {
 				if (x + dx > w) {
 					x = spaceX/2;
-					if (node instanceof Label)
+					if (node instanceof Label) // If the node is a label, then the height is the height of the label
 						y += ((Label)node).getHeight() + spaceX + 2;
 					else
-						y += imageSize.get() + spaceX + 2;
+						y += imageSize.get() + spaceX + 2; // If the node is not a label, then the height is the height of the image
 				}
 				
 				if (doAnimate.get()) {


### PR DESCRIPTION
Updates to the grid viewer to:
1. ~~Increase default window size~~
2. Fix [#1473](https://github.com/qupath/qupath/issues/1473) that crashes the viewer when the window width is less than the image tile width and spacing issues related to that. 