### PR TITLE
Fix multi-viewer problem with reducing the grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is a *minor release* that aims to be fully compatible with v0.5.0, while fi
 * OpenSlide is not available when running from command line (https://github.com/qupath/qupath/pull/1447)
 * `convert-ome` always returns 0 even if it fails (https://github.com/qupath/qupath/issues/1451)
 * Grid views don't show objects by default if no measurements are available (https://github.com/qupath/qupath/issues/1472)
+* Reducing the number of open viewers can break QuPath & require it to be restarted (https://github.com/qupath/qupath/issues/1469)
 
 ### Enhancement
 * Add keyboard shortcuts to tooltips (https://github.com/qupath/qupath/issues/1450)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
@@ -503,10 +503,15 @@ public class ViewerManager implements QuPathViewerListener {
 			int r = splitPaneGrid.getRow(view);
 			int c = splitPaneGrid.getColumn(view);
 			if (r >= nRows || c >= nCols) {
+				// If the open viewer is outside the new grid, we need to move it
 				var nextClosedViewer = closedViewers.remove(0);
 				int rClosed = splitPaneGrid.getRow(nextClosedViewer);
 				int cClosed = splitPaneGrid.getColumn(nextClosedViewer);
+				// Add a dummy to the open viewer's position, to detach it from the scene
+				splitPaneGrid.splitPaneRows.get(r).getItems().set(c, new BorderPane());
+				// Set the open viewer to the closed viewer's position, to reattach it to the scene
 				splitPaneGrid.splitPaneRows.get(rClosed).getItems().set(cClosed, view);
+				// Remove the closed viewer from the list of all viewers
 				viewers.remove(nextClosedViewer);
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/1469 The problem was that viewers were being added to new split panes before they were removed from old ones. This didn't give an error, but also didn't work.