### PR TITLE
Fix ImageDisplay json channel update bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is a *minor release* that aims to be fully compatible with v0.5.0, while fi
 * Grid views don't show objects by default if no measurements are available (https://github.com/qupath/qupath/issues/1472)
 * Reducing the number of open viewers can break QuPath & require it to be restarted (https://github.com/qupath/qupath/issues/1469)
 * Exception when opening script if the last directory isn't available (https://github.com/qupath/qupath/issues/1441)
+* 'Show grayscale' sometimes show an extra channel when multiple viewers are used (https://github.com/qupath/qupath/issues/1468)
 
 ### Enhancement
 * Add keyboard shortcuts to tooltips (https://github.com/qupath/qupath/issues/1450)

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -479,10 +479,10 @@ public class ImageDisplay extends AbstractImageRenderer {
 			boolean colorsUpdated = false;
 			for (int c = 0; c < channelOptions.size(); c++) {
 				var option = channelOptions.get(c);
-				if (option instanceof DirectServerChannelInfo && c < server.nChannels()) {
+				if (option instanceof DirectServerChannelInfo directChannel && c < server.nChannels()) {
 					var channel = server.getChannel(c);
 					if (!Objects.equals(option.getColor(), channel.getColor())) {
-						((DirectServerChannelInfo)option).setLUTColor(channel.getColor());
+						directChannel.setLUTColor(channel.getColor());
 						colorsUpdated = true;
 					}
 				}
@@ -1081,21 +1081,21 @@ public class ImageDisplay extends AbstractImageRenderer {
 		Gson gson = new Gson();
 		Type type = new TypeToken<List<JsonHelperChannelInfo>>(){}.getType();
 		List<JsonHelperChannelInfo> helperList = gson.fromJson(json, type);
-		boolean changes = false;
 		// Try updating everything
+		List<ChannelDisplayInfo> newSelectedChannels = new ArrayList<>();
 		for (JsonHelperChannelInfo helper : helperList) {
 			for (ChannelDisplayInfo info : channelOptions) {
 				if (helper.updateInfo(info)) {
 					if (Boolean.TRUE.equals(helper.selected)) {
-						if (!selectedChannels.contains(info)) {
-							selectedChannels.add(info);
-						}
-					} else {
-						selectedChannels.remove(info);
+						newSelectedChannels.add(info);
 					}
-					changes = true;
 				}
 			}
+		}
+		boolean changes = false;
+		if (!newSelectedChannels.equals(selectedChannels)) {
+			selectedChannels.setAll(newSelectedChannels);
+			changes = true;
 		}
 		return changes;
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -147,8 +147,19 @@ public class ImageDisplay extends AbstractImageRenderer {
 				// Snapshot the names of channels active before switching to grayscale
 				selectedChannels.stream().map(ChannelDisplayInfo::getName).forEach(beforeGrayscaleChannels::add);
 				var switchToGrayscale = switchToGrayscaleChannel.get();
-				if (switchToGrayscale != null)
-					setChannelSelected(switchToGrayscale, true);
+				if (switchToGrayscale != null) {
+					if (!availableChannels.contains(switchToGrayscale)) {
+						// If we have a different object to represent the channel, search for it by name -
+						// because we need to be careful not to select a channel that isn't 'available'
+						// See https://github.com/qupath/qupath/pull/1482
+						String switchToGrayscaleChannelName = switchToGrayscale.getName();
+						switchToGrayscale = availableChannels.stream()
+								.filter(c -> Objects.equals(c.getName(), switchToGrayscaleChannelName))
+								.findFirst().orElse(null);
+					}
+					if (switchToGrayscale != null)
+						setChannelSelected(switchToGrayscale, true);
+				}
 				if (lastSelectedChannel != null)
 					setChannelSelected(lastSelectedChannel, true);
 				else if (!selectedChannels.isEmpty())

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -146,14 +146,14 @@ public class ImageDisplay extends AbstractImageRenderer {
 			if (n) {
 				// Snapshot the names of channels active before switching to grayscale
 				selectedChannels.stream().map(ChannelDisplayInfo::getName).forEach(beforeGrayscaleChannels::add);
-				var swithToGrayscale = switchToGrayscaleChannel.get();
-				if (swithToGrayscale != null)
-					setChannelSelected(swithToGrayscale, true);
+				var switchToGrayscale = switchToGrayscaleChannel.get();
+				if (switchToGrayscale != null)
+					setChannelSelected(switchToGrayscale, true);
 				if (lastSelectedChannel != null)
 					setChannelSelected(lastSelectedChannel, true);
 				else if (!selectedChannels.isEmpty())
 					setChannelSelected(selectedChannels.get(0), true);
-				else if (availableChannels.isEmpty()) {
+				else if (!availableChannels.isEmpty()) {
 					setChannelSelected(availableChannels.get(0), true);
 				}
 			} else {


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/1468

There may still be an underlying issue whenever the display is initialized with a new server.

What happened was that `selectedChannels` contained one extra channel that wasn't in `availableChannels`, so this was never removed within the `updateFromJSON` method. The bonus channel had the same name/properties as the in `availableChannels`, but the object itself was different.

The situation 'corrected itself' whenever the image's channels were manipulated directly, not via 'Apply to similar image' changes in a different viewer.

Nevertheless, anything in the selected channels list *should* always be in the available channels list - if that was truly the case, the previous implementation would have worked.