### PR TITLE
Linux tar should not be nested

### DIFF
--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -53,7 +53,7 @@
       if: matrix.name == 'Linux'
       shell: bash
       run: |
-        tar -c build/dist/QuPath/ | xz > build/dist/QuPath-v${{ env.QUPATH_VERSION }}-${{ matrix.name }}.tar.xz
+        tar -c -C build/dist/ QuPath | xz > build/dist/QuPath-v${{ env.QUPATH_VERSION }}-${{ matrix.name }}.tar.xz
         rm -r build/dist/QuPath/
 
     - name: Clean windows artifact


### PR DESCRIPTION
My fault for [trying to write a valid tar from memory](https://xkcd.com/1168/) but the current linux build ends up as a tar.xz that contains the build/dist/QuPath directory, rather than the top level being QuPath