### PR TITLE
add option to ProjectImageEntry.readImageData() to avoid accessing the file image

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
@@ -146,8 +146,13 @@ public interface ImageServerBuilder<T> {
 		 * @see #getURIs()
 		 */
 		public ServerBuilder<T> updateURIs(Map<URI, URI> updateMap);
-		
-	}
+
+		/**
+		 * Get essential metadata associated with the ImageServer as a distinct object.  This may be edited by the user.
+		 * @return
+		 */
+		public ImageServerMetadata getMetadata();
+    }
 	
 	
 	/**
@@ -164,8 +169,9 @@ public interface ImageServerBuilder<T> {
 		}
 		
 		protected abstract ImageServer<T> buildOriginal() throws Exception;
-		
-		protected ImageServerMetadata getMetadata() {
+
+		@Override
+		public ImageServerMetadata getMetadata() {
 			return metadata;
 		}
 		

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerStub.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerStub.java
@@ -1,0 +1,65 @@
+package qupath.lib.images.servers;
+
+import qupath.lib.projects.ProjectImageEntry;
+import qupath.lib.regions.RegionRequest;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+
+public class ImageServerStub extends AbstractImageServer<BufferedImage> {
+    private final ProjectImageEntry<BufferedImage> entry;
+    private final boolean enableRead;
+    private final ImageServerMetadata originalMetadata;
+
+    public ImageServerStub(ProjectImageEntry<BufferedImage> entry, boolean enableRead) {
+        super(BufferedImage.class);
+        this.entry = entry;
+        this.enableRead = enableRead;
+        this.originalMetadata = entry.getServerBuilder().getMetadata();
+    }
+
+    protected static BufferedImage createDefaultGreyImage(int width, int height) {
+        return new BufferedImage(width, height, BufferedImage.TYPE_BYTE_GRAY);
+    }
+
+    @Override
+    public BufferedImage readRegion(final RegionRequest request) throws IOException {
+        if (!enableRead)
+            throw new ImageStubNotReadableException(this.getClass()+" does not allow reading image files!");
+        int width = (int)Math.max(1, Math.round(request.getWidth() / request.getDownsample()));
+        int height = (int)Math.max(1, Math.round(request.getHeight() / request.getDownsample()));
+        return createDefaultGreyImage(width, height);
+    }
+
+    @Override
+    public String getServerType() {
+        return "BlankStubImage";
+    }
+
+    @Override
+    public ImageServerMetadata getOriginalMetadata() {
+        return this.originalMetadata;
+    }
+
+    @Override
+    public Collection<URI> getURIs() {
+        try {
+            return this.entry.getURIs();
+        } catch (IOException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected ImageServerBuilder.ServerBuilder<BufferedImage> createServerBuilder() {
+        return null;
+    }
+
+    @Override
+    protected String createID() {
+        return getClass().getSimpleName() + ": " + this.getURIs().toString();
+    }
+}

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageStubNotReadableException.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageStubNotReadableException.java
@@ -1,0 +1,7 @@
+package qupath.lib.images.servers;
+
+public class ImageStubNotReadableException extends RuntimeException {
+    public ImageStubNotReadableException(String message) {
+        super(message);
+    }
+}

--- a/qupath-core/src/main/java/qupath/lib/io/PathIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathIO.java
@@ -36,6 +36,7 @@ import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerBuilder.DefaultImageServerBuilder;
 import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
 import qupath.lib.images.servers.ImageServerProvider;
+import qupath.lib.images.servers.ImageServerStub;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
@@ -605,7 +606,7 @@ public class PathIO {
 			// Write JSON object including QuPath version and ServerBuilder
 			// Note that the builder may be null, in which case the server cannot be recreated
 			var builder = server.getBuilder();
-			if (builder == null)
+			if (builder == null && !(server instanceof ImageServerStub))
 				logger.warn("Server {} does not provide a builder - it will not be possible to recover the ImageServer from this data file", server);
 			var wrapper = ServerBuilderWrapper.create(builder, server.getPath());
 			String json = GsonTools.getInstance().toJson(wrapper);

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -63,6 +63,7 @@ import qupath.lib.common.GeneralTools;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.ImageData.ImageType;
 import qupath.lib.images.servers.ImageServer;
+import qupath.lib.images.servers.ImageServerStub;
 import qupath.lib.images.servers.ServerTools;
 import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
 import qupath.lib.io.GsonTools;
@@ -686,15 +687,19 @@ class DefaultProject implements Project<BufferedImage> {
 		}
 
 		@Override
-		public synchronized ImageData<BufferedImage> readImageData() throws IOException {
+		public synchronized ImageData<BufferedImage> readImageData(final boolean openImage) throws IOException {
 			Path path = getImageDataPath();
 			ImageServer<BufferedImage> server;
-			try {
-				server = getServerBuilder().build();
-			} catch (IOException e) {
-				throw e;
-			} catch (Exception e) {
-				throw new IOException(e);
+			if (openImage) {
+				try {
+					server = getServerBuilder().build();
+				} catch (IOException e) {
+					throw e;
+				} catch (Exception e) {
+					throw new IOException(e);
+				}
+			} else {
+				server = new ImageServerStub(this, false);
 			}
 			if (server == null)
 				return null;

--- a/qupath-core/src/main/java/qupath/lib/projects/ProjectImageEntry.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/ProjectImageEntry.java
@@ -186,12 +186,17 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * <p>
 	 * If the full data is not needed, but rather only the objects {@link #readHierarchy()} can be much faster.
 	 * 
+	 * @param openImage if true, returns an ImageData whose image server is instance of qupath.lib.projects.Project
 	 * @return
 	 * @throws IOException 
 	 * 
 	 * @see #readHierarchy()
 	 */
-	public ImageData<T> readImageData() throws IOException;
+	public ImageData<T> readImageData(final boolean openImage) throws IOException;
+	
+	public default ImageData<T> readImageData() throws IOException {
+		return readImageData(true);
+	}
 	
 	/**
 	 * Save the {@link ImageData} for this entry using the default storage location for the project.

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
@@ -444,7 +444,7 @@ public class ObjectClassifierCommand implements Runnable {
 						} else {
 							var tempData = trainingMap.get(entry);
 							if (tempData == null) {
-								tempData = entry.readImageData();
+								tempData = entry.readImageData(false);
 								trainingMap.put(entry, tempData);
 							}
 							list.add(tempData);

--- a/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
+++ b/qupath-extension-script-editor/src/main/java/qupath/lib/gui/scripting/richtextfx/RichScriptEditor.java
@@ -115,7 +115,9 @@ public class RichScriptEditor extends DefaultScriptEditor {
 						runScriptAction,
 						runSelectedAction,
 						runProjectScriptAction,
-						runProjectScriptNoSaveAction
+						runProjectScriptNoSaveAction,
+						runProjectScriptNoOpenAction,
+						runProjectScriptNoSaveNoOpenAction
 						),
 				MenuTools.createMenu("Undo/Redo...",
 					undoAction,


### PR DESCRIPTION
## WHAT
This PR improves performance when running a script that does not need to access the image files on multiple images.
Additionally, allowed to modify `ObjectClassifierCommand` too so that it can read all detections' measurements in the training set without uselessly reading the image files.
This last change alone allowed, on my projects, to improve the time when creating an object classifier from ~10/15minutes to ~5seconds.
I feel like this change is useful when a laboratory works with large projects with image locations being on a remote server. This is also possible thanks to QuPath's amazing design choice to never directly modify images.
If the scripts being run wants to access the images' pixels, it gracefully halts the execution of the all the following project entries too.

_example_:
```groovy
import qupath.imagej.tools.IJTools
import qupath.lib.images.PathImage
import ij.ImagePlus

var server = getCurrentServer()
var downsample = server.getDownsampleForResolution(Math.min(server.nResolutions()-1, 4))
PathImage<ImagePlus> pathImage = IJTools.convertToImagePlus(server, RegionRequest.createInstance(server, downsample))
```
"_Run for project (without saving and opening)_":
```
INFO: Starting script at Tue Mar 26 15:20:37 CET 2024
ERROR: The script tried to read pixels off an image while also requiring to run the script without accessing the image files.
WARN: Script cancelled with 53 image(s) remaining
INFO: Processed 54 images
INFO: Total processing time: 280 milliseconds
```

## HOW
Essentially this works by creating a `ImageServerStub` that extends `AbstractImageServer`. It retrieves metadata from the ProjectImageEntry itself (which in turn, i think, it gets them from the `.qpproj` file) and fails when `readRegion()` is being called. Additionally, it does not provide a server builder. This way, if the resulting image data are to be saved, the original ImageServer won't be overwritten/lost.
You can now pass a `openImage` boolean to `ProjectImageEntry.readImageData()` that, when false, just avoids getting the default image server, but just uses an instance of `ImageServerStub`.

When running a `ProjectTask`, it will catch whether the script tried to access the image file. If it did, it stops the execution for the current image and all the following in the queue.

### Minor proposal
Finally, i'd like to discuss whether we could initially run all scripts with `ImageServerStub` by default and, only if they fail because they need to read the image files, run them with the correct ImageServer.
This point, however, is not really important and can be addressed in a future PR as well.