### PR TITLE
fix a bug where RectangleROI would only contain() points sitting on two out of four edges

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/roi/RectangleROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RectangleROI.java
@@ -59,7 +59,7 @@ public class RectangleROI extends AbstractPathBoundedROI implements Serializable
 	
 	@Override
 	public boolean contains(double x, double y) {
-		return x >= this.x && x < x2 && y >= this.y && y < y2;
+		return x >= this.x && x <= x2 && y >= this.y && y <= y2;
 	}
 	
 	@Override

--- a/qupath-core/src/test/java/qupath/lib/roi/TestROIs.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestROIs.java
@@ -127,6 +127,20 @@ public class TestROIs {
 		}
 		
 	}
+
+	@Test
+	public void rectangleContains() {
+		ROI rectangle = ROIs.createRectangleROI(0,0,1,1, ImagePlane.getDefaultPlane());
+		assertTrue(rectangle.contains(.5, .5));
+		assertTrue(rectangle.contains(.9999, .9999));
+		assertFalse(rectangle.contains(1.0001, 1.0001));
+		assertTrue(rectangle.contains(0, 0));
+		assertTrue(rectangle.contains(.9999, 0));
+		assertTrue(rectangle.contains(0, .9999));
+		assertTrue(rectangle.contains(1, 0));
+		assertTrue(rectangle.contains(0, 1));
+		assertTrue(rectangle.contains(1, 1));
+	}
 	
 	static void checkROIMeasurements(ROI roi, double pixelWidth, double pixelHeight, double delta) {
 		if (roi.isPoint()) {


### PR DESCRIPTION
Essentially the title

the following test fails on the last three assumptions

```java
	@Test
	public void rectangleContains() {
		ROI rectangle = ROIs.createRectangleROI(0,0,1,1, ImagePlane.getDefaultPlane());
		assertTrue(rectangle.contains(.5, .5));
		assertTrue(rectangle.contains(.9999, .9999));
		assertFalse(rectangle.contains(1.0001, 1.0001));
		assertTrue(rectangle.contains(0, 0));
		assertTrue(rectangle.contains(.9999, 0));
		assertTrue(rectangle.contains(0, .9999));
		assertTrue(rectangle.contains(1, 0)); // FAILS
		assertTrue(rectangle.contains(0, 1)); // FAILS
		assertTrue(rectangle.contains(1, 1)); // FAILS
	}
```

This PR fixes this and adds a small test for it