### PR TITLE
Add IoU merger

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -382,11 +382,13 @@ public class ObjectMerger {
 
     private static BiPredicate<Geometry, Geometry> createIoUMergeTest(double iouThreshold) {
         return (geom, geomOverlap) -> {
-            double union = geomOverlap.union(geomOverlap).getArea();
+            var i = geom.intersection(geomOverlap);
+            var intersection = i.getArea();
+            double union = geom.getArea() + geomOverlap.getArea() - intersection;
             if (union == 0) {
                 return false;
             }
-            return geom.intersection(geomOverlap).getArea() / union > iouThreshold;
+            return intersection / union > iouThreshold;
         };
     }
 

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -371,7 +371,7 @@ public class ObjectMerger {
      * tile/region request.
      * You should probably also remove any objects that touch the regionRequest boundaries, as these will probably be
      * clipped, and merging them will result in weirdly shaped detections.
-     * @param iouThreshold Intersection over union threshold; any pairs with values above this are merged.
+     * @param iouThreshold Intersection over union threshold; any pairs with values greater than or equal to this are merged.
      * @return an object merger that can merge together any objects with sufficiently high IoU and the same classification
      */
     public static ObjectMerger createIoUMerger(double iouThreshold) {

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -359,6 +359,36 @@ public class ObjectMerger {
                 0);
     }
 
+    /**
+     * Create an object merger that can merge together any objects with sufficiently large intersection over union.
+     * <p>
+     * Objects must also have the same classification and be on the same image plane to be mergeable.
+     * <p>
+     * IoU is calculated using Java Topology Suite intersection, union, and getArea calls.
+     * <p>
+     * This merger assumes that you are using an OutputHandler that doesn't clip to tile boundaries (only to region
+     * requests) and that you are using sufficient padding to ensure that objects are being detected in more than on
+     * tile/region request.
+     * You should probably also remove any objects that touch the regionRequest boundaries, as these will probably be
+     * clipped, and merging them will result in weirdly shaped detections.
+     * @return an object merger that can merge together any objects with sufficiently high IoU and the same classification
+     */
+    public static ObjectMerger createIoUMerger(double iouThreshold) {
+        return new ObjectMerger(
+                ObjectMerger::sameClassTypePlaneTest,
+                createIoUMergeTest(iouThreshold),
+                0.0625);
+    }
+
+    private static BiPredicate<Geometry, Geometry> createIoUMergeTest(double iouThreshold) {
+        return (geom, geomOverlap) -> {
+            double union = geomOverlap.union(geomOverlap).getArea();
+            if (union == 0) {
+                return false;
+            }
+            return geom.intersection(geomOverlap).getArea() / union > iouThreshold;
+        };
+    }
 
     /**
      * Method to use as a predicate, indicating that two geometries have the same dimension and also touch.

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -371,6 +371,7 @@ public class ObjectMerger {
      * tile/region request.
      * You should probably also remove any objects that touch the regionRequest boundaries, as these will probably be
      * clipped, and merging them will result in weirdly shaped detections.
+     * @param iouThreshold Intersection over union threshold; any pairs with values above this are merged.
      * @return an object merger that can merge together any objects with sufficiently high IoU and the same classification
      */
     public static ObjectMerger createIoUMerger(double iouThreshold) {
@@ -388,7 +389,7 @@ public class ObjectMerger {
             if (union == 0) {
                 return false;
             }
-            return intersection / union > iouThreshold;
+            return (intersection / union) >= iouThreshold;
         };
     }
 

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -49,6 +49,7 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -119,7 +120,7 @@ public class ObjectMerger {
         // Parallelize the merging - it can be slow
         var output = clustersToMerge.stream()
                 .parallel()
-                .map(cluster -> mergeObjects(cluster))
+                .map(ObjectMerger::mergeObjects)
                 .toList();
         assert output.size() <= pathObjects.size();
         return output;
@@ -165,7 +166,7 @@ public class ObjectMerger {
 
         List<List<PathObject>> clusters = new ArrayList<>();
         Set<PathObject> alreadyVisited = new HashSet<>();
-        Queue<PathObject> pending = new ArrayDeque<>();
+        Queue<PathObject> pending = new ConcurrentLinkedDeque<>();
         for (var p : allObjects) {
             if (alreadyVisited.contains(p))
                 continue;
@@ -189,7 +190,7 @@ public class ObjectMerger {
                     else
                         allPotentialNeighbors = allObjects;
                     var neighbors = filterCompatibleNeighbors(current, allPotentialNeighbors);
-                    for (var neighbor : neighbors) {
+                    neighbors.parallelStream().forEach(neighbor -> {
                         if (!alreadyVisited.contains(neighbor)) {
                             if (mergeTest.test(
                                     currentGeometry,
@@ -197,7 +198,7 @@ public class ObjectMerger {
                                 pending.add(neighbor);
                             }
                         }
-                    }
+                    });
                 }
             }
             if (cluster.isEmpty()) {


### PR DESCRIPTION
Simple merger that checks if IoU is higher than the given threshold.

I also implemented an OutputHandler that does something like this:

1. create objects within the regionRequest
2. remove any objects within N pixels of the boundary of the regionRequest
3. mask objects based on the parent annotation (not the proxy/tile, as is usually done).

Since these are probably useful together, should I add this OutputHandler to this PR?