### PR TITLE
Use parallel merger

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Helper class for merging objects using different criteria.
@@ -190,13 +191,14 @@ public class ObjectMerger {
                     else
                         allPotentialNeighbors = allObjects;
                     var neighbors = filterCompatibleNeighbors(current, allPotentialNeighbors);
+                    // alreadyVisited is not concurrent, so do this serially
                     var addable = neighbors.stream()
-                            .filter(neighbor -> !alreadyVisited.contains(neighbor)) // alreadyVisited (set) is not thread-safe
-                            .parallel()
+                            .filter(neighbor -> !alreadyVisited.contains(neighbor)).toList();
+                    addable = addable.parallelStream()
                             .filter(neighbor -> mergeTest.test(
                                     currentGeometry,
-                                    getGeometry(neighbor, geometryMap)));
-                    pending.addAll(addable.toList());
+                                    getGeometry(neighbor, geometryMap))).toList();
+                    pending.addAll(addable);
                 }
             }
             if (cluster.isEmpty()) {
@@ -207,7 +209,6 @@ public class ObjectMerger {
         }
         return clusters;
     }
-
 
     /**
      * Recursively build a cluster of objects that can be merged.

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -49,6 +49,7 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -119,7 +120,7 @@ public class ObjectMerger {
         // Parallelize the merging - it can be slow
         var output = clustersToMerge.stream()
                 .parallel()
-                .map(cluster -> mergeObjects(cluster))
+                .map(ObjectMerger::mergeObjects)
                 .toList();
         assert output.size() <= pathObjects.size();
         return output;
@@ -165,7 +166,7 @@ public class ObjectMerger {
 
         List<List<PathObject>> clusters = new ArrayList<>();
         Set<PathObject> alreadyVisited = new HashSet<>();
-        Queue<PathObject> pending = new ArrayDeque<>();
+        Queue<PathObject> pending = new ConcurrentLinkedDeque<>();
         for (var p : allObjects) {
             if (alreadyVisited.contains(p))
                 continue;
@@ -189,7 +190,7 @@ public class ObjectMerger {
                     else
                         allPotentialNeighbors = allObjects;
                     var neighbors = filterCompatibleNeighbors(current, allPotentialNeighbors);
-                    for (var neighbor : neighbors) {
+                    neighbors.parallelStream().forEach(neighbor -> {
                         if (!alreadyVisited.contains(neighbor)) {
                             if (mergeTest.test(
                                     currentGeometry,
@@ -197,7 +198,7 @@ public class ObjectMerger {
                                 pending.add(neighbor);
                             }
                         }
-                    }
+                    });
                 }
             }
             if (cluster.isEmpty()) {


### PR DESCRIPTION
When merge tests are relatively expensive and there's a lot of objects, this provides a substantial (50% for me) improvement. Uses the ForkJoinPool.commonPool by default so won't spawn new threads (in theory).