### PR TITLE
Use logviewer and qupath-fxtras snapshots

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,12 +36,12 @@ jts             = "1.19.0"
 junit           = "5.9.2"
 
 logback         = "1.3.11"
-logviewer       = "0.1.1"
+logviewer       = "0.2.0-SNAPSHOT"
 
 openslide       = "4.0.0"
 
 picocli         = "4.7.5"
-qupath-fxtras   = "0.1.4"
+qupath-fxtras   = "0.1.5-SNAPSHOT"
 
 richtextfx      = "0.11.2"
 


### PR DESCRIPTION
Temporarily during development, until we make the final releases.