### PR TITLE
UX - Export measurements resizable UI 

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementExportCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementExportCommand.java
@@ -270,6 +270,7 @@ public class MeasurementExportCommand implements Runnable {
 		
 		dialog = Dialogs.builder()
 				.title("Export measurements")
+				.resizable()
 				.buttons(btnExport, ButtonType.CANCEL)
 				.content(mainPane)
 				.build();
@@ -281,7 +282,7 @@ public class MeasurementExportCommand implements Runnable {
 		var emptyOutputTextBinding = outputText.textProperty().isEqualTo("");
 		dialog.getDialogPane().lookupButton(btnExport).disableProperty().bind(Bindings.or(emptyOutputTextBinding, targetItemBinding));
 		
-		mainPane.setTop(imageEntryPane);
+		mainPane.setCenter(imageEntryPane);
 		mainPane.setBottom(optionPane);
 		
 		Optional<ButtonType> result = dialog.showAndWait();


### PR DESCRIPTION
Previously the export measurements window was a fixed size resulting in a small controlsfx ListSelectionView component. The interface is now resizable with the list boxes flexing to fill the space. 