### PR TITLE
Retain object colors after splitting/merging

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -1890,7 +1890,7 @@ public class PathObjectTools {
 	}
 
 	/**
-	 * Create a new object with the same type and classification as the input object, but a new ROI and ID.
+	 * Create a new object with the same type, classification, name and color as the input object, but a new ROI and ID.
 	 * This version of the method supports cell objects with a nucleus ROI.
 	 * <p>
 	 * Note that TMA core objects are not supported.
@@ -1901,16 +1901,21 @@ public class PathObjectTools {
 	 * @since v0.5.0
 	 */
 	public static PathObject createLike(PathObject pathObject, ROI roiNew, ROI roiNucleus) {
+		PathObject newObject;
 		if (pathObject.isCell()) {
-			return PathObjects.createCellObject(roiNew, roiNucleus, pathObject.getPathClass(), null);
+			newObject = PathObjects.createCellObject(roiNew, roiNucleus, pathObject.getPathClass(), null);
 		} else if (pathObject.isAnnotation()) {
-			return PathObjects.createAnnotationObject(roiNew, pathObject.getPathClass());
+			newObject = PathObjects.createAnnotationObject(roiNew, pathObject.getPathClass());
 		} else if (pathObject.isTile()) {
-			return PathObjects.createTileObject(roiNew, pathObject.getPathClass(), null);
+			newObject = PathObjects.createTileObject(roiNew, pathObject.getPathClass(), null);
 		} else if (pathObject.isDetection()) {
-			return PathObjects.createDetectionObject(roiNew, pathObject.getPathClass());
+			newObject = PathObjects.createDetectionObject(roiNew, pathObject.getPathClass());
 		} else
 			throw new IllegalArgumentException("Unsupported object type - cannot create similar object for " + pathObject);
+		// Retain name and color as well
+		newObject.setName(pathObject.getName());
+		newObject.setColor(pathObject.getColor());
+		return newObject;
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -491,21 +491,28 @@ public class ObjectMerger {
         var allROIs = pathObjects.stream().map(PathObject::getROI).filter(Objects::nonNull).collect(Collectors.toList());
         ROI mergedROI = RoiTools.union(allROIs);
 
+        PathObject mergedObject = null;
         if (pathObject.isTile()) {
-            return PathObjects.createTileObject(mergedROI, pathObject.getPathClass(), null);
+            mergedObject = PathObjects.createTileObject(mergedROI, pathObject.getPathClass(), null);
         } else if (pathObject.isCell()) {
             var nucleusROIs = pathObjects.stream()
                     .map(PathObjectTools::getNucleusROI)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
             ROI nucleusROI = nucleusROIs.isEmpty() ? null : RoiTools.union(nucleusROIs);
-            return PathObjects.createCellObject(mergedROI, nucleusROI, pathObject.getPathClass(), null);
+            mergedObject = PathObjects.createCellObject(mergedROI, nucleusROI, pathObject.getPathClass(), null);
         } else if (pathObject.isDetection()) {
-            return PathObjects.createDetectionObject(mergedROI, pathObject.getPathClass());
+            mergedObject = PathObjects.createDetectionObject(mergedROI, pathObject.getPathClass());
         } else if (pathObject.isAnnotation()) {
-            return PathObjects.createAnnotationObject(mergedROI, pathObject.getPathClass());
+            mergedObject = PathObjects.createAnnotationObject(mergedROI, pathObject.getPathClass());
         } else
             throw new IllegalArgumentException("Unsupported object type for merging: " + pathObject.getClass());
+
+        // We might need to transfer over the color as well
+        var color = pathObject.getColor();
+        if (color != null)
+            mergedObject.setColor(color);
+        return mergedObject;
     }
 
 


### PR DESCRIPTION
This won't necessarily retain object colors always, but it should with the `PixelProcessor` and via uses of `PathObjectTools.createLike`