### PR TITLE
UX - Classifier image select resizable UI

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
@@ -477,6 +477,7 @@ public class ObjectClassifierCommand implements Runnable {
 			if (Dialogs.builder()
 					.title("Object classifier training images")
 					.content(pane)
+					.resizable()
 					.buttons(ButtonType.APPLY, ButtonType.CANCEL)
 					.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.CANCEL)
 				return false;

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
@@ -1402,6 +1402,7 @@ public class PixelClassifierPane {
 		if (Dialogs.builder()
 				.title("Pixel classifier training images")
 				.content(pane)
+				.resizable()
 				.buttons(ButtonType.APPLY, ButtonType.CANCEL)
 				.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.CANCEL)
 			return false;


### PR DESCRIPTION
Makes the "Select project images" window for pixel and object classifier resizable so image names can be viewed without scrolling. To access: Classify -> Object classification -> train object classifier -> load training button 

Other `listSelectionView` uses within QuPath are resizable windows already (eg. script editor -> run -> run for project).