### PR TITLE
Update PixelProcessorUtils.java

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessorUtils.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessorUtils.java
@@ -137,8 +137,9 @@ public class PixelProcessorUtils {
                 var nucleusGeom = nucleusROI.getGeometry();
                 var nucleusOutput = GeometryTools.homogenizeGeometryCollection(geom.intersection(nucleusGeom));
                 if (nucleusOutput.isEmpty() || nucleusOutput.getDimension() < nucleusGeom.getDimension())
-                    return Collections.emptyList();
-                nucleusROI = GeometryTools.geometryToROI(nucleusOutput, child.getROI().getImagePlane());
+                    nucleusROI = null;
+                else
+                    nucleusROI = GeometryTools.geometryToROI(nucleusOutput, child.getROI().getImagePlane());
             }
             return Collections.singletonList(PathObjectTools.createLike(child, newROI, nucleusROI));
         }

--- a/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessorUtils.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessorUtils.java
@@ -129,8 +129,18 @@ public class PixelProcessorUtils {
         else if (childGeom.equals(geomOutput))
             return Collections.singletonList(child);
         else {
+            // Handle a nucleus if necessary
+            // We assume that the nucleus *must* be inside the cell, so don't check it elsewhere
             var newROI = GeometryTools.geometryToROI(geomOutput, child.getROI().getImagePlane());
-            return Collections.singletonList(PathObjectTools.createLike(child, newROI));
+            var nucleusROI = PathObjectTools.getNucleusROI(child);
+            if (nucleusROI != null) {
+                var nucleusGeom = nucleusROI.getGeometry();
+                var nucleusOutput = GeometryTools.homogenizeGeometryCollection(geom.intersection(nucleusGeom));
+                if (nucleusOutput.isEmpty() || nucleusOutput.getDimension() < nucleusGeom.getDimension())
+                    return Collections.emptyList();
+                nucleusROI = GeometryTools.geometryToROI(nucleusOutput, child.getROI().getImagePlane());
+            }
+            return Collections.singletonList(PathObjectTools.createLike(child, newROI, nucleusROI));
         }
     }
 


### PR DESCRIPTION
Handle clipping cells with nuclei.
This assumes that the nucleus is always inside the cell.