### PR TITLE
Fix uncalibrated ImagePlus dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is a *work in progress* for the next major release.
 * Brightness/Contrast 'Apply to similar images' fails to update settings immediately across viewers (https://github.com/qupath/qupath/issues/1499)
 * Full image annotation for Sparse training image throws errors for detections (https://github.com/qupath/qupath/issues/1443)
   Channel name can sometimes change when using the quick channel color selector (https://github.com/qupath/qupath/issues/1500)
+* TileExporter exports ImageJ TIFFs with channels converted to z-stacks (https://github.com/qupath/qupath/issues/1503)
 
 ### Dependency updates
 * Bio-Formats 7.3.0

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
@@ -787,7 +787,7 @@ public class IJTools {
 	 * @return
 	 */
 	public static ImagePlus convertToUncalibratedImagePlus(String title, BufferedImage img) {
-		ImagePlus imp = null;
+		ImagePlus imp;
 		int nBands = img.getSampleModel().getNumBands();
 		// Let ImageJ handle indexed & 8-bit color images
 		if ((img.getType() == BufferedImage.TYPE_BYTE_INDEXED && nBands == 1) || BufferedImageTools.is8bitColorType(img.getType()))
@@ -798,6 +798,7 @@ public class IJTools {
 				stack.addSlice(convertToImageProcessor(img, b));
 			}
 			imp = new ImagePlus(title, stack);
+			imp.setDimensions(nBands, 1, 1);
 		}
 		return imp;
 	}


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/1503 (at least the dimensions bit).

We can still lose the calibration information and channel colors.