### PR TITLE
Ensure downsample is set to finite value

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -2474,6 +2474,13 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 			yCenter = p2.getY() - dy;
 		}
 
+		// Downsample might not be finite if the width and height are 0
+		// (and this method has been called too early) - we need a finite
+		// value to avoid the UI becoming unstable
+		if (!Double.isFinite(downsampleFactor)) {
+			logger.debug("Setting non-finite downsample {} to 1.0", downsampleFactor);
+			downsampleFactor = 1.0;
+		}
 		this.downsampleFactor.set(downsampleFactor);
 		updateAffineTransform();
 


### PR DESCRIPTION
This was causing trouble in https://forum.image.sc/t/how-can-display-more-than-one-images-in-qupath-viewer-using-scripting/96156/ initially because the width and height here zero, leading to an infinite downsample value... and persistent JavaFX complaints upon all interactions with the viewer.

This happened when setting the viewer grid size and then *immediately* setting the image in the viewer; somehow this resulted in wrong values being calculated, and a non-invertible AffineTransform that caused trouble indefinitely.

The workaround here avoids many repeated exceptions, although still results in the image being opened at full resolution rather than the expected (fitted) downsample.