### PR TITLE
Send cells to ImageJ macro runner

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/IJExtension.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/IJExtension.java
@@ -420,14 +420,16 @@ public class IJExtension implements QuPathExtension {
 				boolean isCell = child instanceof PathCellObject;
 				
 				Color color = ColorToolsAwt.getCachedColor(ColorToolsFX.getDisplayedColorARGB(child));
-				if (!(isCell && (options == null || !options.getShowCellBoundaries()))) {
+				boolean showOuterRoi = !isCell || (options == null || options.getShowCellBoundaries());
+				boolean showNucleusRoi = isCell && (options == null || options.getShowCellNuclei());
+				if (showOuterRoi) {
 					Roi roi = IJTools.convertToIJRoi(child.getROI(), xOrigin, yOrigin, downsample);
 					roi.setStrokeColor(color);
 					roi.setName(child.getDisplayedName());
 					//						roi.setStrokeWidth(2);
 					overlay.add(roi);
 				}
-				if (isCell && (options == null || options.getShowCellNuclei())) {
+				if (showNucleusRoi) {
 					ROI nucleus = ((PathCellObject)child).getNucleusROI();
 					if (nucleus == null)
 						continue;


### PR DESCRIPTION
A step towards fixing https://github.com/qupath/qupath/issues/1522

Incomplete, because it behaves inconsistently depending upon whether the macro is being run on a selected object or across all annotations / TMA cores. In the first case, the `ImageDisplay` and `OverlayOptions` may be used, but in the second case they are unavailable.