### PR TITLE
Add "prompt to close" method to script editor interface

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -1015,13 +1015,13 @@ public class QuPathGUI {
 		}
 
 		// should prompt users to save changes if desired.
-		if (!scriptEditor.promptToClose()) {
+		if (!scriptEditor.requestClose()) {
 			e.consume();
 			return;
 		}
 		
 		// Warn if there is a script running
-		if (scriptRunning.get()) {
+        if (scriptRunning.get()) {
 			if (!Dialogs.showYesNoDialog("Quit QuPath", "A script is currently running! Quit anyway?")) {
 				logger.trace("Pressed no to quit window with script running!");
 				e.consume();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -1015,7 +1015,10 @@ public class QuPathGUI {
 		}
 
 		// should prompt users to save changes if desired.
-		scriptEditor.promptToClose();
+		if (!scriptEditor.promptToClose()) {
+			e.consume();
+			return;
+		}
 		
 		// Warn if there is a script running
 		if (scriptRunning.get()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -1013,6 +1013,9 @@ public class QuPathGUI {
 				return;
 			}
 		}
+
+		// should prompt users to save changes if desired.
+		scriptEditor.promptToClose();
 		
 		// Warn if there is a script running
 		if (scriptRunning.get()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -1980,7 +1980,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 			requestClose();
 			e.consume();
 		});
-		action.setAccelerator(new KeyCodeCombination(KeyCode.W, KeyCombination.SHORTCUT_DOWN, KeyCombination.CONTROL_DOWN));
+		action.setAccelerator(new KeyCodeCombination(KeyCode.W, KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN));
 		return action;
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -522,8 +522,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 			if (tab == null) {
 				break;
 			}
-			boolean bb = promptToClose(tab);
-			ret &= bb;
+			ret = promptToClose(tab);
 		}
 		return ret;
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -1980,7 +1980,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 			requestClose();
 			e.consume();
 		});
-		action.setAccelerator(new KeyCodeCombination(KeyCode.Q, KeyCombination.SHORTCUT_DOWN));
+		action.setAccelerator(new KeyCodeCombination(KeyCode.W, KeyCombination.SHORTCUT_DOWN, KeyCombination.CONTROL_DOWN));
 		return action;
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -2076,15 +2076,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 			
 		return action;
 	}
-	
-	
-	void attemptToQuitScriptEditor() {
-		if (listScripts.getItems().isEmpty())
-			dialog.close();
-		while (promptToClose(getCurrentScriptTab()))
-			continue;
-	}
-	
+
 	boolean promptToClose(final ScriptTab tab) {
 		int ind = listScripts.getItems().indexOf(tab);
 		if (ind < 0) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -517,8 +517,14 @@ public class DefaultScriptEditor implements ScriptEditor {
 		if (listScripts.getItems().isEmpty())
 			dialog.close();
 		var ret = true;
-		while (ret &= promptToClose(getCurrentScriptTab()))
-			continue;
+		while (ret) {
+			var tab = getCurrentScriptTab();
+			if (tab == null) {
+				break;
+			}
+			boolean bb = promptToClose(tab);
+			ret &= bb;
+		}
 		return ret;
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -516,10 +516,10 @@ public class DefaultScriptEditor implements ScriptEditor {
 	public boolean promptToClose() {
 		if (listScripts.getItems().isEmpty())
 			dialog.close();
-		while (promptToClose(getCurrentScriptTab())) {
+		var ret = true;
+		while (ret &= promptToClose(getCurrentScriptTab()))
 			continue;
-		}
-		return true;
+		return ret;
 	}
 
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -514,9 +514,6 @@ public class DefaultScriptEditor implements ScriptEditor {
 
 	@Override
 	public boolean requestClose() {
-		if (listScripts.getItems().isEmpty() && dialog != null) {
-			dialog.close();
-		}
 		var ret = true;
 		while (ret) {
 			var tab = getCurrentScriptTab();
@@ -524,6 +521,9 @@ public class DefaultScriptEditor implements ScriptEditor {
 				break;
 			}
 			ret = promptToClose(tab);
+		}
+		if (ret && dialog != null) {
+			dialog.close();
 		}
 		return ret;
 	}
@@ -717,7 +717,11 @@ public class DefaultScriptEditor implements ScriptEditor {
 				maybeRefreshTab(getCurrentScriptTab(), false);
 		});
 
-		dialog.setOnCloseRequest(e -> requestClose());
+		dialog.setOnCloseRequest(e -> {
+			if (!requestClose()) {
+				e.consume();
+			}
+		});
 		if (qupath != null)
 			dialog.initOwner(qupath.getStage());
 		dialog.titleProperty().bind(title);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -511,7 +511,16 @@ public class DefaultScriptEditor implements ScriptEditor {
 		}
 		return false;
 	}
-	
+
+	@Override
+	public boolean promptToClose() {
+		if (listScripts.getItems().isEmpty())
+			dialog.close();
+		while (promptToClose(getCurrentScriptTab())) {
+			continue;
+		}
+		return true;
+	}
 
 
 	void maybeRefreshTab(final ScriptTab tab, boolean updateLanguage) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptEditor.java
@@ -62,6 +62,6 @@ public interface ScriptEditor {
 	 * @return True if the editor can be closed without losing changes,
 	 * unless the user consents to losing changes.
 	 */
-	public boolean promptToClose();
+	public boolean requestClose();
 	
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/ScriptEditor.java
@@ -56,5 +56,12 @@ public interface ScriptEditor {
 	 * @return
 	 */
 	public boolean supportsFile(File file);
+
+	/**
+	 * Attempt to close the editor, saving changes if requested.
+	 * @return True if the editor can be closed without losing changes,
+	 * unless the user consents to losing changes.
+	 */
+	public boolean promptToClose();
 	
 }


### PR DESCRIPTION
This means that when a user attempts to close QuPath, we can check if there are any open scripts with unsaved changes and handle these as with other types of unsaved changes.

Unsure if changing the editor interface is a big deal, presumably there aren't too many implementations out there

Raised by @finglis 