### PR TITLE
Added homogenizeGeometryCollection

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -182,7 +182,7 @@ public class RoiTools {
 		Geometry first = geometries.remove(0);
 		for (var geom : geometries)
 			first = first.intersection(geom);
-		return GeometryTools.geometryToROI(first, plane);
+		return GeometryTools.geometryToROI(GeometryTools.homogenizeGeometryCollection(first), plane);
 	}
 	
 	


### PR DESCRIPTION
In the `RoiTools.intersection(Collection<? extends ROI> rois)` function (see [here](https://github.com/qupath/qupath/blob/5066159c6e4fa197c28d003662798dbf08804f08/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java#L185C10-L185C23)), the `GeometryTools.geometryToROI(Geometry geometry, ImagePlane plane)` (see [here](https://github.com/qupath/qupath/blob/5066159c6e4fa197c28d003662798dbf08804f08/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java#L1278)) is called with the `first` and `plane` local variables.

In some situations, the `first` variable is a non homogeneous geometry collection, [which triggers a warning in `GeometryTools.geometryToROI()`](https://github.com/qupath/qupath/blob/5066159c6e4fa197c28d003662798dbf08804f08/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java#L1285).

This PR simply homogenizes the `first` parameter before calling `GeometryTools.geometryToROI()`. This only prevents the warning log from appearing and doesn't change anything else, [as the geometry was homogenized anyway](https://github.com/qupath/qupath/blob/5066159c6e4fa197c28d003662798dbf08804f08/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java#L1286).