### PR TITLE
Decreased size of downsampled image

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -296,8 +296,8 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 		
 		long startTime = System.currentTimeMillis();
 		// Handle the general case for RGB
-		int width = (int)Math.max(1, Math.round(request.getWidth() / request.getDownsample()));
-		int height = (int)Math.max(1, Math.round(request.getHeight() / request.getDownsample()));
+		int width = Math.max(1, (int) (request.getWidth() / request.getDownsample()));
+		int height = Math.max(1, (int) (request.getHeight() / request.getDownsample()));
 		if (isRGB()) {
 			BufferedImage imgResult = createDefaultRGBImage(width, height);
 			Graphics2D g2d = imgResult.createGraphics();


### PR DESCRIPTION
A proposal to fix #1527. It simply consists in reducing the size of the downsampled image by rounding down its width and height, instead of rounding it.