### PR TITLE
Fix black columns with downsampled images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is a *work in progress* for the next major release.
 * Full image annotation for Sparse training image throws errors for detections (https://github.com/qupath/qupath/issues/1443)
   Channel name can sometimes change when using the quick channel color selector (https://github.com/qupath/qupath/issues/1500)
 * TileExporter exports ImageJ TIFFs with channels converted to z-stacks (https://github.com/qupath/qupath/issues/1503)
+* Black row or column appears on some downsampled images (https://github.com/qupath/qupath/issues/1527)
 
 ### Dependency updates
 * Bio-Formats 7.3.0

--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -298,33 +298,10 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 		int width = (int)Math.max(1, Math.round(request.getWidth() / request.getDownsample()));
 		int height = (int)Math.max(1, Math.round(request.getHeight() / request.getDownsample()));
 
-		// Fix output size to handle right/bottom edge issue caused by rounding/flooring within image pyramid
-		// See https://github.com/qupath/qupath/issues/1527
-		// The problem is that a black border can be created when there aren't quite enough pixels to fill the region,
-		// which happens if the lower-resolution levels have been truncated (even by a fraction of a pixel)
-		if (request.getDownsample() > 1 && nResolutions() > 1
-				&& request.getMaxX() == getWidth() || request.getMaxY() ==  getHeight()) {
-			int maxX = -Integer.MAX_VALUE;
-			int maxY = -Integer.MAX_VALUE;
-			for (var tile : tiles) {
-				maxX = Math.max(maxX, tile.getRegionRequest().getMaxX());
-				maxY = Math.max(maxY, tile.getRegionRequest().getMaxY());
-			}
-			if (maxX < request.getMaxX() || maxY < request.getMaxY()) {
-				int width2 = (int)Math.max(1, Math.round((maxX - request.getMinX()) / request.getDownsample() - 1e-9));
-				int height2 = (int)Math.max(1, Math.round((maxY - request.getMinY()) / request.getDownsample() - 1e-9));
-				if (width != width2 || height != height2) {
-					logger.debug("Region size updated from {}x{} to {}x{}", width, height, width2, height2);
-					width = width2;
-					height = height2;
-				}
-			}
-		}
-
 		long startTime = System.currentTimeMillis();
 		// Handle the general case for RGB
 		if (isRGB()) {
-			BufferedImage imgResult = createDefaultRGBImage(width, height);
+			BufferedImage imgResult = createRGBImage(request, tiles, width, height);
 			Graphics2D g2d = imgResult.createGraphics();
 			g2d.scale(1.0/request.getDownsample(), 1.0/request.getDownsample());
 			g2d.translate(-request.getX(), -request.getY());
@@ -341,9 +318,9 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 			long endTime = System.currentTimeMillis();
 			logger.trace("Requested " + tiles.size() + " tiles in " + (endTime - startTime) + " ms (RGB)");
 
-			return imgResult;
+			return resizeIfNeeded(imgResult, width, height);
 		} else {
-			// Request all of the tiles we need & figure out image dimensions
+			// Request all the tiles we need & figure out image dimensions
 			// Do all this at the pyramid level of the tiles
 			WritableRaster raster = null;
 			ColorModel colorModel = null;
@@ -398,11 +375,6 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 							continue;
 						
 						copyPixels(imgTile.getRaster(), dx, dy, raster);
-
-//						raster.setRect(
-//								dx,
-//								dy,
-//								imgTile.getRaster());
 					}
 				}
 			}
@@ -435,26 +407,89 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 				int w = xEnd - xStart;
 				int h = yEnd - yStart;
 				
-//				int w = Math.min(raster.getWidth() - xStart, xEnd - xStart);
-//				int h = Math.min(raster.getHeight() - yStart, yEnd - yStart);
 				var raster2 = raster.createCompatibleWritableRaster(w, h);
 				copyPixels(raster, -x, -y, raster2);
 				raster = raster2;
 			}
 
-			// Return the image, resizing if necessary
+			// Return the image, resizing if necessary (we determined the raster size based on tiles, not the request)
 			BufferedImage imgResult = new BufferedImage(colorModel, raster, alphaPremultiplied, null);
-			int currentWidth = imgResult.getWidth();
-			int currentHeight = imgResult.getHeight();
-			if (currentWidth != width || currentHeight != height) {
-				imgResult = BufferedImageTools.resize(imgResult, width, height, allowSmoothInterpolation());
-			}
-			
+			imgResult = resizeIfNeeded(imgResult, width, height);
+
 			long endTime = System.currentTimeMillis();
 			logger.trace("Requested " + tiles.size() + " tiles in " + (endTime - startTime) + " ms (non-RGB)");
 			return imgResult;
 		}
 	}
+
+	/**
+	 * Resize an image if it doesn't match the expected dimensions, and log a debug message.
+	 * @param img the input image
+	 * @param width the required width
+	 * @param height the required height
+	 * @return the resized image if necessary, or the original image otherwise
+	 */
+	private BufferedImage resizeIfNeeded(BufferedImage img, int width, int height) {
+		int currentWidth = img.getWidth();
+		int currentHeight = img.getHeight();
+		if (currentWidth != width || currentHeight != height) {
+			logger.debug("Region size updated from {}x{} to {}x{}", currentWidth, currentHeight, width, height);
+			return BufferedImageTools.resize(img, width, height, allowSmoothInterpolation());
+		} else
+			return img;
+	}
+
+
+	/**
+	 * Create an RGB image to fulfill a request with the given tiles.
+	 * This method exists because of https://github.com/qupath/qupath/issues/1527
+	 * <p>
+	 * The problem is that a black border can be created when there aren't quite enough pixels to fill the region,
+	 * which happens if the lower-resolution levels have been truncated (even by a fraction of a pixel).
+	 * <p>
+	 * In this case, we want to paint to a small enough image that <i>does</i> fit, and handle resizing later if needed.
+	 * <p>
+	 * This method tries to be conservative in making these adjustments; it is better to allow a border than to
+	 * create an image that is of a very different size.
+	 * Therefore we only permit changing the size by one pixel in each dimension.
+	 *
+	 * @param request the region being requested
+	 * @param tiles the tiles to fulfil the request
+	 * @param expectedWidth the expected width of the image (computed from the request)
+	 * @param expectedHeight the expected height of the image (computed from the request)
+	 * @return a blank RGB image that can be used to draw the requested image
+	 */
+	private BufferedImage createRGBImage(RegionRequest request, Collection<TileRequest> tiles, int expectedWidth, int expectedHeight) {
+		int imgWidth = expectedWidth;
+		int imgHeight = expectedHeight;
+		// Fix output size to handle right/bottom edge issue caused by rounding/flooring within image pyramid
+		// See https://github.com/qupath/qupath/issues/1527
+		// Only permit adjustments if we expect to be fulfilling the request from only pixels within the image
+		// (don't change anything if the request is already known to be out-of-bounds at the full resolution)
+		if (request.getDownsample() > 1 && nResolutions() > 1
+				&& (request.getMaxX() == getWidth() || request.getMaxY() == getHeight())
+				&& (request.getMinX() >= 0 && request.getMinY() >= 0)) {
+			int maxX = -Integer.MAX_VALUE;
+			int maxY = -Integer.MAX_VALUE;
+			for (var tile : tiles) {
+				maxX = Math.max(maxX, tile.getRegionRequest().getMaxX());
+				maxY = Math.max(maxY, tile.getRegionRequest().getMaxY());
+			}
+			if (maxX < request.getMaxX() || maxY < request.getMaxY()) {
+				int width2 = (int)Math.max(1, Math.round((maxX - request.getMinX()) / request.getDownsample() - 1e-9));
+				int height2 = (int)Math.max(1, Math.round((maxY - request.getMinY()) / request.getDownsample() - 1e-9));
+				// Be cautious with size adjustments - only permit changing by one pixel
+				if (expectedWidth == width2+1 || expectedHeight == height2+1) {
+					logger.trace("RGB image size updated from {}x{} to {}x{} to avoid border problems",
+							expectedWidth, expectedHeight, width2, height2);
+					imgWidth = width2;
+					imgHeight = height2;
+				}
+			}
+		}
+		return createDefaultRGBImage(imgWidth, imgHeight);
+	}
+
 	
 	/**
 	 * Ensure all tiles in a list are either cached or requested.

--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -476,6 +476,8 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 				maxY = Math.max(maxY, tile.getRegionRequest().getMaxY());
 			}
 			if (maxX < request.getMaxX() || maxY < request.getMaxY()) {
+				// Compute the expected size of the image based on what the tiles can cover
+				// (the subtraction is so that x.5 is rounded down, not up)
 				int width2 = (int)Math.max(1, Math.round((maxX - request.getMinX()) / request.getDownsample() - 1e-9));
 				int height2 = (int)Math.max(1, Math.round((maxY - request.getMinY()) / request.getDownsample() - 1e-9));
 				// Be cautious with size adjustments - only permit changing by one pixel

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -494,10 +494,16 @@ public class Commands {
 		
 		try {
 			if (request == null) {
-				if (exportDownsample.get() == 1.0)
+				if (exportDownsample.get() == 1.0) {
 					writer.writeImage(server, fileOutput.getAbsolutePath());
-				else
+				} else {
+					// On rare (hopefully?) occasions this can be problematic, including a black line as the final
+					// row and/or column. The workaround is to create a RegionRequest and use that instead.
+					// (The benefit of pyramidalization is that it can potentially do a better job of writing tiled
+					// images... or at least, I presume that's why I did this)
+					// See https://github.com/qupath/qupath/pull/1531
 					writer.writeImage(ImageServers.pyramidalize(server, exportDownsample.get()), fileOutput.getAbsolutePath());
+				}
 			} else
 				writer.writeImage(server, request, fileOutput.getAbsolutePath());
 			lastWriter = writer;


### PR DESCRIPTION
Attempts to fix https://github.com/qupath/qupath/issues/1527

This tries to take a conservative approach that should fix the most common occurrence of this: basically, if a request is made for to get the 'last' pixels on the right or bottom of the image, then a check is made to see if this can be fulfilled using the available lower resolution tiles.

If the tiles don't quite make it (due to the lower pyramid levels being truncated), then a slightly smaller image can be returned - typically missing the last row and/or column.

The unfortunate consequence would be that we can't compute the returned image size based upon the  `RegionRequest` (width, height and downsample) - because this might have been internally adjusted. To handle that, we resize then to fit expectations.

It feels messy and suboptimal, but failing to do this can result in black rows or columns appearing - which can thwart thresholds and image statistics and certain resolutions, and this is more problematic.