### PR TITLE
Faster union of polygons & display of very complex ROIs

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
@@ -54,8 +54,9 @@ import qupath.lib.roi.interfaces.ROI;
  * (e.g. java.awt.Area or some JavaFX alternative.)
  * 
  * @author Pete Bankhead
- *
+ * @deprecated since v0.6.0 (but really not used in recent versions)
  */
+@Deprecated
 public class AreaROI extends AbstractPathROI implements Serializable {
 	
 //	private static final Logger logger = LoggerFactory.getLogger(AreaROI.class);

--- a/qupath-core/src/main/java/qupath/lib/roi/FastPolygonUnion.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/FastPolygonUnion.java
@@ -1,0 +1,246 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2024 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.roi;
+
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.util.PolygonExtracter;
+import org.locationtech.jts.index.SpatialIndex;
+import org.locationtech.jts.index.hprtree.HPRtree;
+import org.locationtech.jts.operation.overlayng.UnaryUnionNG;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+/**
+ * Compute a faster union of large numbers of polygons.
+ * <p>
+ * This is a sufficiently common requirement, especially with pixel classification,
+ * to require its own method.
+ * <p>
+ * The algorithm is:
+ * <ol>
+ *     <li>
+ *         Extract all polygons from the input.
+ *     </li>
+ *     <li>
+ *         Identify intersecting and non-intersecting polygons
+ *     </li>
+ *     <li>
+ *         Group all polygons that should potentially be merged, because they intersect
+ *         (directly or indirectly) with other polygons in the group;
+ *         each polygon should be represented in only one group
+ *     </li>
+ *     <li>
+ *         Union all the polygon groups
+ *     </li>
+ *     <li>
+ *         Combine all resulting polygons into a single polygon or multipolygon
+ *     </lI>
+ * </ol>
+ * This partitioning of the problem makes it possible to parallelize checking for intersections
+ * and computing the union of groups.
+ *
+ * @author Pete Bankhead
+ */
+public class FastPolygonUnion {
+
+    private static final Logger logger = LoggerFactory.getLogger(FastPolygonUnion.class);
+
+    private static void populateAdjacencyMatrix(List<Polygon> allPolygons, AdjacencyMatrix matrix, SpatialIndex tree, int ind) {
+        var poly = allPolygons.get(ind);
+        for (int ind2 : (List<Integer>)tree.query(poly.getEnvelopeInternal())) {
+            // Matrix is symmetric, so only test where needed
+            if (ind2 <= ind || matrix.isAdjacent(ind, ind2))
+                continue;
+            // Check if polygons intersect
+            var poly2 = allPolygons.get(ind2);
+            if (poly.intersects(poly2)) {
+                matrix.setAdjacent(ind, ind2);
+            }
+        }
+    }
+
+    public static Geometry union(Geometry... geoms) {
+        return union(Arrays.asList(geoms));
+    }
+
+    private static List<Polygon> extractAllPolygons(Collection<? extends Geometry> geoms) {
+        List<Polygon> allPolygons = new ArrayList<>();
+        for (var g : geoms) {
+            PolygonExtracter.getPolygons(g, allPolygons);
+        }
+        return allPolygons;
+    }
+
+    public static Geometry union(Collection<? extends Geometry> geoms) {
+        List<Polygon> allPolygons = extractAllPolygons(geoms);
+
+        // Create a tree of envelopes and polygon indices
+        var tree = new HPRtree();
+        int n = allPolygons.size();
+        for (int i = 0; i < n; i++) {
+            tree.insert(allPolygons.get(i).getEnvelopeInternal(), i);
+        }
+
+        // Check for adjacent objects, restricting search using the tree
+        var matrix = new AdjacencyMatrix(n);
+        IntStream.range(0, n)
+                .parallel()
+                .forEach(i -> populateAdjacencyMatrix(allPolygons, matrix, tree, i));
+
+        // Gather all the polygons that should be merged
+        var groupsToMerge = new ArrayList<List<Geometry>>();
+        var toKeep = new ArrayList<Geometry>();
+        var visited = new HashSet<Integer>();
+        for (int i = 0; i < n; i++) {
+            if (matrix.getAdjacentCount(i) == 0) {
+                // Nothing to merge, keep unchanged
+                toKeep.add(allPolygons.get(i));
+                visited.add(i);
+            } else if (visited.contains(i)) {
+                // Already in a group, skip
+                continue;
+            } else {
+                // Generate a new group for merging
+                List<Geometry> temp = new ArrayList<>();
+                for (Integer ind : matrix.getAdjacencyGroup(i)) {
+                    temp.add(allPolygons.get(ind));
+                    if (!visited.add(ind))
+                        logger.warn("Polygon added more than once!");
+                }
+                groupsToMerge.add(temp);
+            }
+        }
+        logger.debug("Number of polygon collections to merge: {}", groupsToMerge.size());
+
+        toKeep.addAll(groupsToMerge.parallelStream()
+                .map(list -> unionOpNg(list))
+                .toList());
+
+       return createPolygonalGeometry(toKeep);
+    }
+
+    private static Geometry unionOpNg(Collection<Geometry> geoms) {
+        var factory = GeometryTools.getDefaultFactory();
+        return UnaryUnionNG.union(geoms, factory, factory.getPrecisionModel());
+    }
+
+    /**
+     * Create a polygonal geometry after extracting all polygons from a list of geometries.
+     * @param geoms
+     * @return a Polygon or MultiPolygon (may be empty)
+     */
+    private static Geometry createPolygonalGeometry(Collection<? extends Geometry> geoms) {
+        var list = extractAllPolygons(geoms);
+        if (list.isEmpty())
+            return GeometryTools.getDefaultFactory().createPolygon();
+        else if (list.size() == 1)
+            return list.get(0);
+        else
+            return GeometryTools.getDefaultFactory().createMultiPolygon(list.toArray(Polygon[]::new));
+    }
+
+    /**
+     * Simple adjacency matrix to help identify polygons that should be merged.
+     */
+    private static class AdjacencyMatrix {
+
+        private List<BitSet> bits = new ArrayList<>();
+
+        private AdjacencyMatrix(int n) {
+            for (int i = 0; i < n; i++) {
+                bits.add(new BitSet(n));
+            }
+        }
+
+        /**
+         * Flag that two entries are adjacent.
+         * @param i
+         * @param j
+         * @return true if a change was made, false if the entries were already
+         *         flagged as adjacent.
+         */
+        public boolean setAdjacent(int i, int j) {
+            if (bits.get(i).get(j))
+                return false;
+            bits.get(i).set(j);
+            bits.get(j).set(i);
+            return true;
+        }
+
+        /**
+         * Get indices for all entries that are directly or indirectly adjacent,
+         * i.e. polygons that may need to be merged.
+         * @param i
+         * @return
+         */
+        public Set<Integer> getAdjacencyGroup(int i) {
+            var set = new HashSet<Integer>();
+            accumulateAdjacencyGroup(i, set);
+            return set;
+        }
+
+        /**
+         * Ensure an item is part of a group; if it has not already been added,
+         * any additional adjacent items will be added as well.
+         * @param i
+         * @param group
+         */
+        private void accumulateAdjacencyGroup(int i, Set<Integer> group) {
+            if (group.add(i)) {
+                for (int j : bits.get(i).stream().toArray()) {
+                    accumulateAdjacencyGroup(j, group);
+                }
+            }
+        }
+
+        /**
+         * Get the number of directly-adjacent items for the given item index.
+         * @param i
+         * @return
+         */
+        public int getAdjacentCount(int i) {
+            return bits.get(i).cardinality();
+        }
+
+        /**
+         * Query whether two items are flagged as adjacent.
+         * @param i
+         * @param j
+         * @return
+         */
+        public boolean isAdjacent(int i, int j) {
+            return bits.get(i).get(j);
+        }
+
+    }
+
+}

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -374,7 +374,7 @@ public class GeometryTools {
 				return UnaryUnionNG.union(new ArrayList<>(geometries), getDefaultFactory().getPrecisionModel());
 			}
 		} catch (Exception e) {
-			logger.warn("Geometry union failed - attempting with buffer(0)");
+			logger.warn("Geometry union failed - attempting with buffer(0)", e);
 			return getDefaultFactory().buildGeometry(geometries).buffer(0);
 		}
     }

--- a/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
@@ -28,6 +28,7 @@ import java.awt.geom.Path2D;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.lang.ref.SoftReference;
 import java.util.List;
 import org.locationtech.jts.geom.Geometry;
 
@@ -54,7 +55,12 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 	private Vertices vertices;
 	
 	private transient ClosedShapeStatistics stats = null;
-	
+
+	/**
+	 * Cache a soft reference to the geometry because calculating a valid
+	 * geometry can be a performance bottleneck (e.g. if there are self-intersections).
+	 */
+	private transient SoftReference<Geometry> cachedGeometry;
 
 	PolygonROI() {
 		super();
@@ -123,13 +129,18 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 //		setPoints(vertices.getPoints()); // TODO: Implement this more efficiency, if it remains...
 //		isAdjusting = false;
 //	}
-	
-	
+
+
 	@Override
 	public Geometry getGeometry() {
-		// This can be a performance bottleneck - consider caching in the future
-		// (at least for complex polygons)
-		return super.getGeometry();
+		// Cache a soft reference because converting polygons to
+		// (valid) geometries can be expensive
+		var geom = cachedGeometry == null ? null : cachedGeometry.get();
+		if (geom == null) {
+			geom = super.getGeometry();
+			cachedGeometry = new SoftReference<>(geom);
+		}
+		return geom.copy();
 	}
 	
 	/**

--- a/qupath-core/src/test/java/qupath/lib/roi/TestGeometryTools.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestGeometryTools.java
@@ -133,6 +133,45 @@ public class TestGeometryTools {
 		}
 		
 	}
+
+	@Test
+	public void testUnion() {
+		var g1 = GeometryTools.createRectangle(0, 0, 100, 200).norm();
+		var gBeside = GeometryTools.createRectangle(100, 0, 100, 200).norm();
+		var gDiagonal = GeometryTools.createRectangle(100, 200, 100, 200).norm();
+		var gDisconnected = GeometryTools.createRectangle(400, 400, 100, 200).norm();
+		var gOverlapping = GeometryTools.createRectangle(0, 100, 100, 200).norm();
+		var gLine = GeometryTools.createLineString(1000, 2000, 3000, 4000).norm();
+
+		assertEquals(g1.copy().norm(), GeometryTools.union(g1, g1.copy()).norm());
+		assertEquals(g1.copy().norm(), FastPolygonUnion.union(g1, g1.copy()).norm());
+		assertEquals(1, FastPolygonUnion.union(g1, g1).getNumGeometries());
+
+		assertEquals(g1.union(gBeside).norm(), GeometryTools.union(g1, gBeside).norm());
+		assertEquals(g1.union(gBeside).norm(), FastPolygonUnion.union(g1, gBeside).norm());
+		assertEquals(1, FastPolygonUnion.union(g1, gBeside).getNumGeometries());
+
+		assertEquals(g1.union(gDiagonal).norm(), GeometryTools.union(g1, gDiagonal).norm());
+		assertEquals(g1.union(gDiagonal).norm(), FastPolygonUnion.union(g1, gDiagonal).norm());
+		assertEquals(2, FastPolygonUnion.union(g1, gDiagonal).getNumGeometries());
+
+		assertEquals(g1.union(gDisconnected).norm(), GeometryTools.union(g1, gDisconnected).norm());
+		assertEquals(g1.union(gDisconnected).norm(), FastPolygonUnion.union(g1, gDisconnected).norm());
+		assertEquals(2, FastPolygonUnion.union(g1, gDisconnected).getNumGeometries());
+
+		assertEquals(g1.union(gOverlapping).norm(), GeometryTools.union(g1, gOverlapping).norm());
+		assertEquals(g1.union(gOverlapping).norm(), FastPolygonUnion.union(g1, gOverlapping).norm());
+		assertEquals(1, FastPolygonUnion.union(g1, gOverlapping).getNumGeometries());
+
+		var unionAll = g1.union(gOverlapping).union(gDisconnected).union(gBeside).union(gDiagonal).norm();
+		assertEquals(unionAll, GeometryTools.union(g1, gOverlapping, gDisconnected, gBeside, gDiagonal).norm());
+		assertEquals(unionAll, FastPolygonUnion.union(g1, gOverlapping, gDisconnected, gBeside, gDiagonal).norm());
+
+		// We can compute a union with a line string
+		assertEquals(2, GeometryTools.union(g1, gLine).getNumGeometries());
+		// The fast polygon union discards lines
+		assertEquals(1, FastPolygonUnion.union(g1, gLine).getNumGeometries());
+	}
 	
 
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
@@ -749,7 +749,8 @@ public class IconFactory {
 		} else {
 			var path = pathCache.getOrDefault(roi, null);
 			if (path == null) {
-				var shape = roi.isArea() ? RoiTools.getArea(roi) : RoiTools.getShape(roi);
+				var shape = RoiTools.getShape(roi);
+//				var shape = roi.isArea() ? RoiTools.getArea(roi) : RoiTools.getShape(roi);
 				if (shape != null) {
 					var transform = new AffineTransform();
 					transform.translate(-roi.getBoundsX(), -roi.getBoundsY());


### PR DESCRIPTION
Implement a much faster approach to computing the union of large numbers of polygons when they are not all connected, including parallelisation. The algorithm is:
1.  Extract all polygons from the input.
2. Identify intersecting and non-intersecting polygons
3. Group all polygons that should potentially be merged, because they intersect (directly or indirectly) with other polygons in the group; each polygon should be represented in only one group
4. Union all the polygon groups
5. Combine all resulting polygons into a single polygon or multipolygon

This addressing the pixel classification performance bottleneck described at https://forum.image.sc/t/can-creating-detections-from-pixel-classifier-be-made-to-run-faster/96745

When implementing this, it became clear that extremely complex polygons couldn't be displayed in the viewer because generating an `Area` object failed (ultimately with out-of-memory error).

Also, `PolygonROI.getGeometry()` was slow when called repeatedly because the geometry is recomputed each time. So the PR uses a `SoftReference` to avoid this, while still allowing references to be dropped when memory is low. When the geometry isn't needed, the overhead should be avoided.

This PR also addresses this problem by using JTS' shape representation instead.

## To test

### Union of many objects

A simple test:
* Detect cells in an image
* Run the following script

```groovy
import qupath.lib.common.Timeit
import qupath.lib.roi.GeometryTools

import static qupath.lib.scripting.QP.*

def detections = getDetectionObjects()

List<GeometryTools> geoms = detections.collect {it.getROI().getGeometry()}

def timeit = new Timeit()
    .start()
def geomUnion = GeometryTools.union(geoms)
println timeit.stop()

double sumArea = geoms.sum {g -> g.getArea()}
println "Sum area: \t${sumArea}"
println "Num geometries: \t${geoms.size()}"
def roi = GeometryTools.geometryToROI(geomUnion, ImagePlane.getDefaultPlane())
def pathClass = getPathClass("Merged geometries")
removeObjects(getAnnotationObjects().findAll(p -> p.getPathClass() == pathClass), true)
addObject(PathObjects.createAnnotationObject(roi, pathClass))
```

### Pixel classification

One approach to test with CMU-1.svs is to save the following pixel classifier:
* [Nuclei.json](https://github.com/user-attachments/files/15809355/Nuclei.json)

and run a simple script to generate detections in a large region, e.g.
```groovy
createDetectionsFromPixelClassifier("Nuclei", 5.0, 5.0, "SPLIT")
```