### PR TITLE
Handle Bio-Formats pyramid level changes

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -879,6 +879,20 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		}
 		return id;
 	}
+
+	@Override
+	public void setMetadata(ImageServerMetadata metadata) {
+		var currentMetadata = getMetadata();
+		super.setMetadata(metadata);
+		if (currentMetadata != metadata && !currentMetadata.getLevels().equals(metadata.getLevels())) {
+			logger.warn("Can't set metadata to use incompatible pyramid levels - reverting to original pyramid levels");
+			super.setMetadata(
+					new ImageServerMetadata.Builder(metadata)
+					.levels(currentMetadata.getLevels())
+					.build()
+			);
+		}
+	}
 	
 	/**
 	 * Returns a builder capable of creating a server like this one.


### PR DESCRIPTION
See https://forum.image.sc/t/can-creating-detections-from-pixel-classifier-be-made-to-run-faster/96745/25 Bio-Formats 7.2.0 handles pyramid levels differently for SVS images, which would break compatibility with the metadata stored in QuPath projects. Basically, the levels stored in the project would override the levels that Bio-Formats expects to find.

Consequence: if a project was created in v0.5.1 (or earlier), including SVS images read using Bio-Formats, these images could not be opened in v0.6.0.

This PR logs a warning when this occurs, and uses the 'new' pyramid levels are used instead of the ones stored in the saved metadata.