### PR TITLE
Rename JavadocViewer

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/JavadocViewerRunner.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/JavadocViewerRunner.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.tools.WebViews;
+import qupath.ui.javadocviewer.gui.viewer.JavadocViewer;
 import qupath.ui.javadocviewer.gui.viewer.JavadocViewerCommand;
 
 import java.net.URI;
@@ -53,9 +54,9 @@ import java.util.stream.Stream;
  *     </ul>
  * </p>
  */
-public class JavadocViewer implements Runnable {
+public class JavadocViewerRunner implements Runnable {
 
-    private static final Logger logger = LoggerFactory.getLogger(JavadocViewer.class);
+    private static final Logger logger = LoggerFactory.getLogger(JavadocViewerRunner.class);
     private static final String JAVADOC_PATH_SYSTEM_PROPERTY = "javadoc";
     private static final String JAVADOC_PATH_PREFERENCE = "javadocPath";
     private static final StringProperty javadocPath = PathPrefs.createPersistentPreference(JAVADOC_PATH_PREFERENCE, null);
@@ -66,7 +67,7 @@ public class JavadocViewer implements Runnable {
      *
      * @param owner  the stage that should own the viewer window. Can be null
      */
-    public JavadocViewer(Stage owner) {
+    public JavadocViewerRunner(Stage owner) {
         command = new JavadocViewerCommand(
                 owner,
                 WebViews.getStyleSheet(),
@@ -90,6 +91,14 @@ public class JavadocViewer implements Runnable {
         );
     }
 
+    /**
+     * Get a reference to the viewer launched by the {@link JavadocViewerCommand}.
+     * @return A reference to the Javadoc viewer.
+     */
+    public JavadocViewer getJavadocViewer() {
+        return command.getJavadocViewer();
+    }
+
     @Override
     public void run() {
         command.run();
@@ -98,7 +107,7 @@ public class JavadocViewer implements Runnable {
     private static String findJavadocUriAroundExecutable() {
         URI codeUri;
         try {
-            codeUri = JavadocViewer.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+            codeUri = JavadocViewerRunner.class.getProtectionDomain().getCodeSource().getLocation().toURI();
         } catch (URISyntaxException e) {
             logger.debug("Could not convert URI", e);
             return null;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -114,7 +114,7 @@ import javafx.stage.Stage;
 import javafx.util.Callback;
 import qupath.fx.dialogs.FileChoosers;
 import qupath.lib.common.GeneralTools;
-import qupath.lib.gui.JavadocViewer;
+import qupath.lib.gui.JavadocViewerRunner;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.actions.ActionTools;
 import qupath.fx.dialogs.Dialogs;
@@ -430,7 +430,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 		paneCode.setStyle(style);
 		paneConsole.setStyle(style);
 
-		showJavadocsAction = ActionTools.createAction(new JavadocViewer(qupath.getStage()), "Show Javadocs");
+		showJavadocsAction = ActionTools.createAction(new JavadocViewerRunner(qupath.getStage()), "Show Javadocs");
 	}
 	
 	private void setToggle(ScriptLanguage language) {


### PR DESCRIPTION
This is to avoid the current `JavadocViewer -> JavadocViewerCommand -> JavadocViewer` chain of objects, with the same class name in both `qupath.ui.javadocviewer.gui.viewer` and `qupath.lib.gui`.

See https://github.com/qupath/javadoc-viewer/pull/6