### PR TITLE
Linear combination color transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a *work in progress* for the next major release.
   * Images remain sorted after adding new metadata values
   * A warning indicator is shown if image files are missing
     * Use the 'Skip file checks in projects' preference if you need to turn this off (e.g. your images are on a slow network)
+* Create a new channel as a linear combination of other channels (https://github.com/qupath/qupath/pull/1566)
 
 ### Bugs fixed
 * Tile export to .ome.tif can convert to 8-bit unnecessarily (https://github.com/qupath/qupath/issues/1494)

--- a/qupath-core/src/main/java/qupath/lib/color/ColorDeconvolutionStains.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorDeconvolutionStains.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.StringTokenizer;
 
 import org.slf4j.Logger;
@@ -418,6 +419,31 @@ public class ColorDeconvolutionStains implements Externalizable {
 	@Override
 	public String toString() {
 		return "Color deconvolution stains: " + stain1 + ", " + stain2 + ", " + stain3;
+	}
+
+	public int hashCode() {
+		int hash = 7;
+		hash = 31 * hash + (int) maxRed;
+		hash = 31 * hash + (int) maxGreen;
+		hash = 31 * hash + (int) maxBlue;
+		hash = 31 * hash + (name == null ? 0 : name.hashCode());
+		hash = 31 * hash + (stain1 == null ? 0 : stain1.hashCode());
+		hash = 31 * hash + (stain2 == null ? 0 : stain2.hashCode());
+		hash = 31 * hash + (stain3 == null ? 0 : stain3.hashCode());
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!(obj instanceof ColorDeconvolutionStains colorDeconvolutionStains))
+			return false;
+		return maxRed == colorDeconvolutionStains.maxRed && maxGreen == colorDeconvolutionStains.maxGreen && maxBlue == colorDeconvolutionStains.maxBlue &&
+				Objects.equals(stain1, colorDeconvolutionStains.stain1) &&
+				Objects.equals(stain2, colorDeconvolutionStains.stain2) &&
+				Objects.equals(stain3, colorDeconvolutionStains.stain3) &&
+				Objects.equals(name, colorDeconvolutionStains.name);
 	}
 
 

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
@@ -52,6 +52,10 @@ import qupath.lib.io.GsonTools;
  * @author Pete Bankhead
  */
 public class ColorTransforms {
+
+	private ColorTransforms() {
+		throw new AssertionError("This class is not instantiable.");
+	}
 	
 	/**
 	 * Interface defining a color transform that can extract a float value from a BufferedImage.
@@ -172,8 +176,8 @@ public class ColorTransforms {
 
 	/**
 	 * Create a ColorTransform that apply a linear combination to the channels.
-	 * For example, calling this function with the list [0.5, 0.9, 0.2]
-	 * will create a new channel with values "0.5*channel1 + 0.9*channel2 + 0.2*channel3".
+	 * For example, calling this function with the list [0.5, 0.9]
+	 * will create a new channel with values "0.5*firstChannel + 0.9*secondChannel".
 	 *
 	 * @param coefficients the list of coefficients to apply to each channel
 	 * @return a ColorTransform computing the provided linear combination

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
@@ -23,10 +23,13 @@ package qupath.lib.images.servers;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import com.google.gson.Strictness;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -50,27 +53,28 @@ public class ColorTransforms {
 	 * The simplest example of this is to extract a single channel (band) from an image.
 	 */
 	public interface ColorTransform {
-		
+
 		/**
 		 * Extract a (row-wise) array containing the pixels extracted from a BufferedImage.
+		 *
 		 * @param server the server from which the image was read; can be necessary for some transforms (e.g. to request color deconvolution stains)
 		 * @param img the image
 		 * @param pixels optional preallocated array; will be used if it is long enough to hold the transformed pixels
-		 * @return
+		 * @return a (row-wise) array containing the transformed pixels of the provided image
 		 */
 		float[] extractChannel(ImageServer<BufferedImage> server, BufferedImage img, float[] pixels);
-		
+
 		/**
 		 * Query whether this transform can be applied to the specified image.
-		 * Reasons why it may not be include the type or channel number being incompatible.
-		 * @param server
-		 * @return
+		 * Reasons why it may not be supported include the type or channel number being incompatible.
+		 *
+		 * @param server the server from which the image will be read
+		 * @return whether this transform can be applied to the provided image
 		 */
 		boolean supportsImage(ImageServer<BufferedImage> server);
 		
 		/**
-		 * Get a displayable name for the transform.
-		 * @return
+		 * Get a displayable name for the transform. Can be null
 		 */
 		String getName();
 		
@@ -80,8 +84,8 @@ public class ColorTransforms {
 	 * {@link TypeAdapter} to support serializing a {@link ColorTransform}.
 	 */
 	public static class ColorTransformTypeAdapter extends TypeAdapter<ColorTransform> {
-		
-		private static Gson gson = new GsonBuilder().setLenient().create();
+
+		private static final Gson gson = new GsonBuilder().setStrictness(Strictness.LENIENT).create();
 
 		@Override
 		public void write(JsonWriter out, ColorTransform value) throws IOException {
@@ -114,23 +118,24 @@ public class ColorTransforms {
 			}
 			throw new IOException("Unknown ColorTransform " + obj);
 		}
-		
 	}
-	
-	
+
 	/**
-	 * Create ColorTransform to extract a channel based on its number (0-based index, although result of {@link ColorTransform#getName()} is 1-based).
-	 * @param channel
-	 * @return
+	 * Create a ColorTransform that extracts a channel based on its index.
+	 *
+	 * @param channel the index of the channel to extract. It must be 0-based, although
+	 *                the result of {@link ColorTransform#getName()} will be 1-based
+	 * @return a ColorTransform extracting the provided channel
 	 */
 	public static ColorTransform createChannelExtractor(int channel) {
 		return new ExtractChannel(channel);
 	}
 
 	/**
-	 * Create ColorTransform to extract a channel based on its name.
-	 * @param channelName
-	 * @return
+	 * Create a ColorTransform that extracts a channel based on its name.
+	 *
+	 * @param channelName the name of the channel to extract
+	 * @return a ColorTransform extracting the provided channel
 	 */
 	public static ColorTransform createChannelExtractor(String channelName) {
 		return new ExtractChannelByName(channelName);
@@ -138,77 +143,304 @@ public class ColorTransforms {
 	
 	/**
 	 * Create a ColorTransform that calculates the mean of all channels.
-	 * @return
 	 */
 	public static ColorTransform createMeanChannelTransform() {
 		return new AverageChannels();
 	}
-	
-	/**
-	 * Create a ColorTransform that applies color deconvolution.
-	 * @param stains the stains (this will be 'fixed', and not adapted for each image)
-	 * @param stainNumber number of the stain (1, 2 or 3)
-	 * @return
-	 */
-	public static ColorTransform createColorDeconvolvedChannel(ColorDeconvolutionStains stains, int stainNumber) {
-		return new ColorDeconvolvedChannel(stains, stainNumber);
-	}
-	
+
 	/**
 	 * Create a ColorTransform that calculates the maximum of all channels.
-	 * @return
 	 */
 	public static ColorTransform createMaximumChannelTransform() {
 		return new MaxChannels();
 	}
 
-	
+
 	/**
 	 * Create a ColorTransform that calculates the minimum of all channels.
-	 * @return
 	 */
 	public static ColorTransform createMinimumChannelTransform() {
 		return new MinChannels();
 	}
 
-
-	
-	
-	static float[] ensureArrayLength(BufferedImage img, float[] pixels) {
-		int n = img.getWidth() * img.getHeight();
-		if (pixels == null || pixels.length < n)
-			return new float[n];
-		return pixels;
+	/**
+	 * Create a ColorTransform that applies color deconvolution.
+	 *
+	 * @param stains the stains (this will be 'fixed', and not adapted for each image)
+	 * @param stainNumber number of the stain (1, 2 or 3)
+	 * @return a ColorTransform applying color deconvolution with the provided parameters
+	 * @throws IllegalArgumentException when the stain number is incorrect
+	 */
+	public static ColorTransform createColorDeconvolvedChannel(ColorDeconvolutionStains stains, int stainNumber) {
+		return new ColorDeconvolvedChannel(stains, stainNumber);
 	}
-	
+
+	static class ExtractChannel implements ColorTransform {
+
+		private final int channel;
+
+		public ExtractChannel(int channel) {
+			this.channel = channel;
+		}
+
+		@Override
+		public float[] extractChannel(ImageServer<BufferedImage> server, BufferedImage img, float[] pixels) {
+			pixels = ensureArrayLength(img, pixels);
+			return img.getRaster().getSamples(0, 0, img.getWidth(), img.getHeight(), channel, pixels);
+		}
+
+		@Override
+		public String getName() {
+			return "Channel " + (channel + 1);
+		}
+
+		@Override
+		public boolean supportsImage(ImageServer<BufferedImage> server) {
+			return channel < server.nChannels();
+		}
+
+		@Override
+		public String toString() {
+			return getName();
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + channel;
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (!(obj instanceof ExtractChannel extractChannel))
+				return false;
+			return channel == extractChannel.channel;
+		}
+
+		/**
+		 * Get the channel number to extract (0-based index).
+		 */
+		public int getChannelNumber() {
+			return channel;
+		}
+	}
+
+	static class ExtractChannelByName implements ColorTransform {
+
+		private final String channelName;
+
+		public ExtractChannelByName(String channel) {
+			this.channelName = channel;
+		}
+
+		@Override
+		public float[] extractChannel(ImageServer<BufferedImage> server, BufferedImage img, float[] pixels) {
+			pixels = ensureArrayLength(img, pixels);
+			int c = getChannelNumber(server);
+			if (c >= 0) {
+				return img.getRaster().getSamples(0, 0, img.getWidth(), img.getHeight(), c, pixels);
+			}
+			throw new IllegalArgumentException("No channel found with name " + channelName);
+		}
+
+		@Override
+		public String getName() {
+			return channelName;
+		}
+
+		@Override
+		public boolean supportsImage(ImageServer<BufferedImage> server) {
+			return getChannelNumber(server) >= 0;
+		}
+
+		@Override
+		public String toString() {
+			return getName();
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((channelName == null) ? 0 : channelName.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (!(obj instanceof ExtractChannelByName extractChannel))
+				return false;
+			return Objects.equals(channelName, extractChannel.channelName);
+		}
+
+		/**
+		 * Get the channel name to extract. Can be null
+		 */
+		public String getChannelName() {
+			return channelName;
+		}
+
+		private int getChannelNumber(ImageServer<BufferedImage> server) {
+			return server.getMetadata().getChannels()
+					.stream()
+					.map(ImageChannel::getName)
+					.toList()
+					.indexOf(channelName);
+		}
+	}
+
+	abstract static class CombineChannels implements ColorTransform {
+
+		@Override
+		public float[] extractChannel(ImageServer<BufferedImage> server, BufferedImage img, float[] pixels) {
+			pixels = ensureArrayLength(img, pixels);
+			int w = img.getWidth();
+			int h = img.getHeight();
+			var raster = img.getRaster();
+			double[] vals = null;
+			for (int y = 0; y < h; y++) {
+				for (int x = 0; x < w; x++) {
+					vals = raster.getPixel(x, y, vals);
+					pixels[y*w+x] = (float)computeValue(vals);
+				}
+			}
+			return pixels;
+		}
+
+		abstract double computeValue(double[] values);
+
+		@Override
+		public boolean supportsImage(ImageServer<BufferedImage> server) {
+			return true;
+		}
+
+		@Override
+		public String toString() {
+			return getName();
+		}
+	}
+
+	static class AverageChannels extends CombineChannels {
+
+		@SuppressWarnings("unused")		// used for JSON serialization
+		private final CombineType combineType = CombineType.MEAN;
+
+		@Override
+		public double computeValue(double[] values) {
+			return Arrays.stream(values).average().orElse(Double.NaN);
+		}
+
+		@Override
+		public String getName() {
+			return "Average channels";
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + combineType.hashCode();
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			return obj instanceof AverageChannels;
+		}
+	}
+
+	static class MaxChannels extends CombineChannels {
+
+		@SuppressWarnings("unused")		// used for JSON serialization
+		private final CombineType combineType = CombineType.MAXIMUM;
+
+		@Override
+		public double computeValue(double[] values) {
+			return Arrays.stream(values).max().orElse(Double.NaN);
+		}
+
+		@Override
+		public String getName() {
+			return "Max channels";
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + combineType.hashCode();
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			return obj instanceof MaxChannels;
+		}
+	}
+
+	static class MinChannels extends CombineChannels {
+
+		@SuppressWarnings("unused")		// used for JSON serialization
+		private final CombineType combineType = CombineType.MINIMUM;
+
+		@Override
+		public double computeValue(double[] values) {
+			return Arrays.stream(values).min().orElse(Double.NaN);
+		}
+
+		@Override
+		public String getName() {
+			return "Min channels";
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + combineType.hashCode();
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			return obj instanceof MinChannels;
+		}
+	}
 	
 	static class ColorDeconvolvedChannel implements ColorTransform {
 		
-		private ColorDeconvolutionStains stains;
-		private int stainNumber;
-		private transient ColorTransformMethod method;
+		private final ColorDeconvolutionStains stains;
+		private final int stainNumber;
+		private final transient ColorTransformMethod method;
 		
-		ColorDeconvolvedChannel(ColorDeconvolutionStains stains, int stainNumber) {
+		public ColorDeconvolvedChannel(ColorDeconvolutionStains stains, int stainNumber) {
 			this.stains = stains;
 			this.stainNumber = stainNumber;
+			this.method = switch (stainNumber) {
+				case 1 -> ColorTransformMethod.Stain_1;
+				case 2 -> ColorTransformMethod.Stain_2;
+				case 3 -> ColorTransformMethod.Stain_3;
+				default ->
+						throw new IllegalArgumentException("Stain number is " + stainNumber + ", but must be between 1 and 3!");
+			};
 		}
 
 		@Override
 		public float[] extractChannel(ImageServer<BufferedImage> server, BufferedImage img, float[] pixels) {
 			int[] rgb = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
-			return ColorTransformer.getTransformedPixels(rgb, getMethod(), pixels, stains);
-		}
-		
-		private ColorTransformMethod getMethod() {
-			if (method == null) {
-				switch (stainNumber) {
-				case 1: return ColorTransformMethod.Stain_1;
-				case 2: return ColorTransformMethod.Stain_2;
-				case 3: return ColorTransformMethod.Stain_3;
-				default: throw new IllegalArgumentException("Stain number is " + stainNumber + ", but must be between 1 and 3!");
-				}
-			}
-			return method;
+			return ColorTransformer.getTransformedPixels(rgb, method, pixels, stains);
 		}
 
 		@Override
@@ -218,9 +450,9 @@ public class ColorTransforms {
 
 		@Override
 		public String getName() {
-			return stains.getStain(stainNumber).getName();
+			return stains == null ? null : stains.getStain(stainNumber).getName();
 		}
-		
+
 		@Override
 		public String toString() {
 			return getName();
@@ -239,347 +471,21 @@ public class ColorTransforms {
 		public boolean equals(Object obj) {
 			if (this == obj)
 				return true;
-			if (obj == null)
+			if (!(obj instanceof ColorDeconvolvedChannel colorDeconvolvedChannel))
 				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			ColorDeconvolvedChannel other = (ColorDeconvolvedChannel) obj;
-			if (stainNumber != other.stainNumber)
-				return false;
-			if (stains == null) {
-				if (other.stains != null)
-					return false;
-			} else if (!stains.equals(other.stains))
-				return false;
-			return true;
+			return Objects.equals(stains, colorDeconvolvedChannel.stains) && stainNumber == colorDeconvolvedChannel.stainNumber;
 		}
-		
-		
-		
-	}
-	
-	
-	static class ExtractChannel implements ColorTransform {
-		
-		private int channel;
-		
-		ExtractChannel(int channel) {
-			this.channel = channel;
-		}
-	
-		@Override
-		public float[] extractChannel(ImageServer<BufferedImage> server, BufferedImage img, float[] pixels) {
-			pixels = ensureArrayLength(img, pixels);
-			return img.getRaster().getSamples(0, 0, img.getWidth(), img.getHeight(), channel, pixels);
-		}
-		
-		@Override
-		public String getName() {
-			return "Channel " + (channel + 1);
-		}
-		
-		@Override
-		public String toString() {
-			return getName();
-		}
-		
-		/**
-		 * Get the channel number to extract (0-based index).
-		 * @return
-		 */
-		public int getChannelNumber() {
-			return channel;
-		}
-
-		@Override
-		public boolean supportsImage(ImageServer<BufferedImage> server) {
-			return channel < server.nChannels();
-		}
-
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + channel;
-			return result;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			ExtractChannel other = (ExtractChannel) obj;
-			if (channel != other.channel)
-				return false;
-			return true;
-		}
-		
-		
-		
-	}
-	
-	static class ExtractChannelByName implements ColorTransform {
-		
-		private String channelName;
-		
-		ExtractChannelByName(String channel) {
-			this.channelName = channel;
-		}
-	
-		@Override
-		public float[] extractChannel(ImageServer<BufferedImage> server, BufferedImage img, float[] pixels) {
-			pixels = ensureArrayLength(img, pixels);
-			int c = getChannelNumber(server);
-			if (c >= 0) {
-				return img.getRaster().getSamples(0, 0, img.getWidth(), img.getHeight(), c, pixels);
-			}
-			throw new IllegalArgumentException("No channel found with name " + channelName);
-		}
-		
-		@Override
-		public String getName() {
-			return channelName;
-		}
-		
-		/**
-		 * Get the channel name to extract.
-		 * @return
-		 */
-		public String getChannelName() {
-			return channelName;
-		}
-	
-		@Override
-		public String toString() {
-			return getName();
-		}
-		
-		private int getChannelNumber(ImageServer<BufferedImage> server) {
-			int i = 0;
-			for (ImageChannel channel : server.getMetadata().getChannels()) {
-				if (channelName.equals(channel.getName())) {
-					return i;
-				}
-				i++;
-			}
-			return -1;
-		}
-
-		@Override
-		public boolean supportsImage(ImageServer<BufferedImage> server) {
-			return getChannelNumber(server) >= 0;
-		}
-
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((channelName == null) ? 0 : channelName.hashCode());
-			return result;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			ExtractChannelByName other = (ExtractChannelByName) obj;
-			if (channelName == null) {
-				if (other.channelName != null)
-					return false;
-			} else if (!channelName.equals(other.channelName))
-				return false;
-			return true;
-		}
-		
-		
-		
-	}
-	
-	
-	abstract static class CombineChannels implements ColorTransform {
-				
-		@Override
-		public float[] extractChannel(ImageServer<BufferedImage> server, BufferedImage img, float[] pixels) {
-			pixels = ensureArrayLength(img, pixels);
-			int w = img.getWidth();
-			int h = img.getHeight();
-			var raster = img.getRaster();
-			double[] vals = null;
-			for (int y = 0; y < h; y++) {
-				for (int x = 0; x < w; x++) {
-					vals = raster.getPixel(x, y, vals);
-					pixels[y*w+x] = (float)computeValue(vals);
-				}
-			}
-			return pixels;
-		}
-		
-		abstract double computeValue(double[] values);
-
-		@Override
-		public boolean supportsImage(ImageServer<BufferedImage> server) {
-			return true;
-		}
-		
-		@Override
-		public String toString() {
-			return getName();
-		}
-		
 	}
 	
 	/**
 	 * Store the {@link CombineType}. This is really to add deserialization from JSON.
 	 */
-	private static enum CombineType {MEAN, MINIMUM, MAXIMUM}
-	
-	
-	static class AverageChannels extends CombineChannels {
-		
-		@SuppressWarnings("unused")
-		private CombineType combineType = CombineType.MEAN;
-		
-		@Override
-		public double computeValue(double[] values) {
-			int n = values.length;
-			double mean = 0;
-			for (double v : values)
-				mean += v/n;
-			return mean;
-		}
+	private enum CombineType {MEAN, MINIMUM, MAXIMUM}
 
-		@Override
-		public String getName() {
-			return "Average channels";
-		}
-
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((combineType == null) ? 0 : combineType.hashCode());
-			return result;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			AverageChannels other = (AverageChannels) obj;
-			if (combineType != other.combineType)
-				return false;
-			return true;
-		}
-		
+	private static float[] ensureArrayLength(BufferedImage img, float[] pixels) {
+		int n = img.getWidth() * img.getHeight();
+		if (pixels == null || pixels.length < n)
+			return new float[n];
+		return pixels;
 	}
-	
-	static class MaxChannels extends CombineChannels {
-		
-		@SuppressWarnings("unused")
-		private CombineType combineType = CombineType.MAXIMUM;
-		
-		@Override
-		public double computeValue(double[] values) {
-			int n = values.length;
-			if (n == 0)
-				return Double.NaN;
-			double max = Double.NEGATIVE_INFINITY;
-			for (double v : values) {
-				if (v > max)
-					max = v;
-			}
-			return max;
-		}
-
-		@Override
-		public String getName() {
-			return "Max channels";
-		}
-
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((combineType == null) ? 0 : combineType.hashCode());
-			return result;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			MaxChannels other = (MaxChannels) obj;
-			if (combineType != other.combineType)
-				return false;
-			return true;
-		}
-		
-		
-	}
-	
-	static class MinChannels extends CombineChannels {
-		
-		@SuppressWarnings("unused")
-		private CombineType combineType = CombineType.MINIMUM;
-		
-		@Override
-		public double computeValue(double[] values) {
-			int n = values.length;
-			if (n == 0)
-				return Double.NaN;
-			double min = Double.POSITIVE_INFINITY;
-			for (double v : values) {
-				if (v < min)
-					min = v;
-			}
-			return min;
-		}
-
-		@Override
-		public String getName() {
-			return "Min channels";
-		}
-
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((combineType == null) ? 0 : combineType.hashCode());
-			return result;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			MinChannels other = (MinChannels) obj;
-			if (combineType != other.combineType)
-				return false;
-			return true;
-		}
-		
-		
-		
-	}
-	
 }

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
@@ -118,7 +118,7 @@ public class ColorTransforms {
 				List<Float> channelIndicesToCoefficients = null;
 
 				if (obj.get("channelNamesToCoefficients") != null) {
-					channelNamesToCoefficients = gson.fromJson(obj.get("channelNamesToCoefficients").getAsString(), new TypeToken<Map<String, Float>>() {}.getType());
+					channelNamesToCoefficients = gson.fromJson(obj.get("channelNamesToCoefficients"), new TypeToken<Map<String, Float>>() {}.getType());
 				}
 				if (obj.get("channelIndicesToCoefficients") != null) {
 					channelIndicesToCoefficients = obj.get("channelIndicesToCoefficients").getAsJsonArray().asList().stream().map(JsonElement::getAsFloat).toList();
@@ -209,7 +209,7 @@ public class ColorTransforms {
 	}
 
 	/**
-	 * Create a ColorTransform that applies color deconvolution.
+	 * Create a ColorTransform that applies color deconvolution. It only works on RGB images.
 	 *
 	 * @param stains the stains (this will be 'fixed', and not adapted for each image)
 	 * @param stainNumber number of the stain (1, 2 or 3)

--- a/qupath-core/src/main/java/qupath/lib/images/servers/TransformedServerBuilder.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/TransformedServerBuilder.java
@@ -55,9 +55,10 @@ public class TransformedServerBuilder {
 	}
 	
 	/**
-	 * Crop an specified region based on a bounding box.
-	 * @param region
-	 * @return
+	 * Crop a specified region based on a bounding box.
+	 *
+	 * @param region the region to crop
+	 * @return this builder
 	 */
 	public TransformedServerBuilder crop(ImageRegion region) {
 		server = new CroppedImageServer(server, region);
@@ -67,8 +68,9 @@ public class TransformedServerBuilder {
 	/**
 	 * Apply an {@link AffineTransform} to the server. 
 	 * Note that the transform must be invertible, otherwise and {@link IllegalArgumentException} will be thrown.
-	 * @param transform
-	 * @return
+	 *
+	 * @param transform the transform to apply to the image
+	 * @return this builder
 	 */
 	public TransformedServerBuilder transform(AffineTransform transform) {
 		try {
@@ -80,10 +82,11 @@ public class TransformedServerBuilder {
 	}
 	
 	/**
-	 * Apply color deconvolution to the brightfield image, so that deconvolved stains behave as separate channels/
+	 * Apply color deconvolution to the brightfield image, so that deconvolved stains behave as separate channels.
+	 *
 	 * @param stains the stains to apply for color deconvolution
 	 * @param stainNumbers the indices of the stains that should be use (an array compressing values that are 1, 2 or 3); if not specified, all 3 stains will be used.
-	 * @return
+	 * @return this builder
 	 */
 	public TransformedServerBuilder deconvolveStains(ColorDeconvolutionStains stains, int...stainNumbers) {
 		server = new ColorDeconvolutionImageServer(server, stains, stainNumbers);
@@ -93,8 +96,9 @@ public class TransformedServerBuilder {
 	/**
 	 * Rearrange the channel order of an RGB image.
 	 * This is intended for cases where an image has wrongly been interpreted as RGB or BGR.
-	 * @param order
-	 * @return
+	 *
+	 * @param order a text containing the letters R, G, and B in any order
+	 * @return this builder
 	 */
 	public TransformedServerBuilder reorderRGB(String order) {
 		server = new RearrangeRGBImageServer(server, order);
@@ -103,8 +107,9 @@ public class TransformedServerBuilder {
 	
 	/**
 	 * Rotate the image, using an increment of 90 degrees.
-	 * @param rotation
-	 * @return
+	 *
+	 * @param rotation the rotation to apply
+	 * @return this image
 	 */
 	public TransformedServerBuilder rotate(Rotation rotation) {
 		server = new RotatedImageServer(server, rotation);
@@ -113,8 +118,9 @@ public class TransformedServerBuilder {
 	
 	/**
 	 * Extract specified channels for an image.
+	 *
 	 * @param channels indices (0-based) of channels to extract.
-	 * @return
+	 * @return this builder
 	 */
 	public TransformedServerBuilder extractChannels(int... channels) {
 		var transforms = new ArrayList<ColorTransform>();
@@ -127,8 +133,9 @@ public class TransformedServerBuilder {
 	
 	/**
 	 * Extract specified channels for an image.
+	 *
 	 * @param names names of channels to extract.
-	 * @return
+	 * @return this builder
 	 */
 	public TransformedServerBuilder extractChannels(String... names) {
 		var transforms = new ArrayList<ColorTransform>();
@@ -141,48 +148,42 @@ public class TransformedServerBuilder {
 	
 	/**
 	 * Perform a maximum projection of the channels.
-	 * @return
+	 *
+	 * @return this builder
 	 */
 	public TransformedServerBuilder maxChannelProject() {
-		server = new ChannelTransformFeatureServer(server, 
-				Arrays.asList(ColorTransforms.createMaximumChannelTransform()));
+		server = new ChannelTransformFeatureServer(server, List.of(ColorTransforms.createMaximumChannelTransform()));
 		return this;
 	}
 	
 	/**
 	 * Perform an average (mean) projection of the channels.
-	 * @return
+	 *
+	 * @return this builder
 	 */
 	public TransformedServerBuilder averageChannelProject() {
-		server = new ChannelTransformFeatureServer(server, 
-				Arrays.asList(ColorTransforms.createMeanChannelTransform()));
+		server = new ChannelTransformFeatureServer(server, List.of(ColorTransforms.createMeanChannelTransform()));
 		return this;
 	}
 	
 	/**
 	 * Perform a minimum projection of the channels.
-	 * @return
+	 *
+	 * @return this builder
 	 */
 	public TransformedServerBuilder minChannelProject() {
-		server = new ChannelTransformFeatureServer(server, 
-				Arrays.asList(ColorTransforms.createMinimumChannelTransform()));
+		server = new ChannelTransformFeatureServer(server, List.of(ColorTransforms.createMinimumChannelTransform()));
 		return this;
 	}
 	
 	/**
 	 * Concatenate a collection of additional servers along the 'channels' dimension (iteration order is used).
-	 * @param additionalChannels additional servers that will be applied as channels; note that these should be 
-	 * 								of an appropriate type and dimension for concatenation.
-	 * @return
+	 *
+	 * @param additionalChannels additional servers that will be applied as channels; note that these should be
+	 *                           of an appropriate type and dimension for concatenation.
+	 * @return this builder
 	 */
 	public TransformedServerBuilder concatChannels(Collection<ImageServer<BufferedImage>> additionalChannels) {
-//		// Try to avoid wrapping more than necessary
-//		if (server instanceof ConcatChannelsImageServer) {
-//			var temp = new ArrayList<>(((ConcatChannelsImageServer)server).getAllServers());
-//			temp.addAll(additionalChannels);
-//			server = new ConcatChannelsImageServer(((ConcatChannelsImageServer)server).getWrappedServer(), temp);
-//		} else
-		
 		List<ImageServer<BufferedImage>> allChannels = new ArrayList<>(additionalChannels);
 		// Make sure that the current server is included
 		if (!allChannels.contains(server))
@@ -193,9 +194,10 @@ public class TransformedServerBuilder {
 	
 	/**
 	 * Concatenate additional servers along the 'channels' dimension.
-	 * @param additionalChannels additional servers from which channels will be added; note that the servers should be 
-	 * 								of an appropriate type and dimension for concatenation.
-	 * @return
+	 *
+	 * @param additionalChannels additional servers from which channels will be added; note that the servers should be
+	 *                           of an appropriate type and dimension for concatenation.
+	 * @return this builder
 	 */
 	public TransformedServerBuilder concatChannels(ImageServer<BufferedImage>... additionalChannels) {
 		for (var temp : additionalChannels) {
@@ -204,20 +206,30 @@ public class TransformedServerBuilder {
 		}
 		return concatChannels(Arrays.asList(additionalChannels));
 	}
-	
-//	/**
-//	 * Concatenate additional server along the 'channels' dimension.
-//	 * @param additionalChannel additional server from which channels will be added; note that the server should be 
-//	 * 								of an appropriate type and dimension for concatenation.
-//	 * @return
-//	 */
-//	public TransformedServerBuilder concatChannel(ImageServer<BufferedImage> additionalChannel) {
-//		return concatChannels(Arrays.asList(additionalChannel));
-//	}
+
+	/**
+	 * Apply color transforms to the image.
+	 *
+	 * @param transforms the transforms to apply
+	 * @return this builder
+	 */
+	public TransformedServerBuilder applyColorTransforms(Collection<? extends ColorTransform> transforms) {
+		server = new ChannelTransformFeatureServer(server, new ArrayList<>(transforms));
+		return this;
+	}
+
+	/**
+	 * Apply color transforms to the image.
+	 *
+	 * @param transforms the transforms to apply
+	 * @return this builder
+	 */
+	public TransformedServerBuilder applyColorTransforms(ColorTransform... transforms) {
+		return applyColorTransforms(Arrays.asList(transforms));
+	}
 	
 	/**
 	 * Get the {@link ImageServer} that applies all the requested transforms.
-	 * @return
 	 */
 	public ImageServer<BufferedImage> build() {
 		return server;

--- a/qupath-core/src/test/java/qupath/lib/images/servers/TestColorTransforms.java
+++ b/qupath-core/src/test/java/qupath/lib/images/servers/TestColorTransforms.java
@@ -1,7 +1,10 @@
 package qupath.lib.images.servers;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import qupath.lib.color.ColorDeconvolutionStains;
 import qupath.lib.color.ColorModelFactory;
 import qupath.lib.regions.RegionRequest;
 
@@ -13,6 +16,8 @@ import java.awt.image.WritableRaster;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 public class TestColorTransforms {
 
@@ -20,9 +25,9 @@ public class TestColorTransforms {
     void Check_Channel_Index_Extractor_Supported() throws Exception {
         ImageServer<BufferedImage> sampleServer = new SampleImageServer();
         int channelIndex = sampleServer.nChannels() - 1;
-        ColorTransforms.ColorTransform channelExtractor = ColorTransforms.createChannelExtractor(channelIndex);
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createChannelExtractor(channelIndex);
 
-        boolean supported = channelExtractor.supportsImage(sampleServer);
+        boolean supported = colorTransform.supportsImage(sampleServer);
 
         Assertions.assertTrue(supported);
 
@@ -30,12 +35,12 @@ public class TestColorTransforms {
     }
 
     @Test
-    void Check_Channel_Index_Extractor_Unsupported() throws Exception {
+    void Check_Channel_Index_Extractor_Not_Supported() throws Exception {
         ImageServer<BufferedImage> sampleServer = new SampleImageServer();
         int channelIndex = sampleServer.nChannels() + 1;
-        ColorTransforms.ColorTransform channelExtractor = ColorTransforms.createChannelExtractor(channelIndex);
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createChannelExtractor(channelIndex);
 
-        boolean supported = channelExtractor.supportsImage(sampleServer);
+        boolean supported = colorTransform.supportsImage(sampleServer);
 
         Assertions.assertFalse(supported);
 
@@ -43,18 +48,456 @@ public class TestColorTransforms {
     }
 
     @Test
-    void Check_Channel_Index_Extractor() throws Exception {
+    void Check_Channel_Index_Extractor_Pixels() throws Exception {
         ImageServer<BufferedImage> sampleServer = new SampleImageServer();
         int channelIndex = sampleServer.nChannels() - 1;
-        ColorTransforms.ColorTransform channelExtractor = ColorTransforms.createChannelExtractor(channelIndex);
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createChannelExtractor(channelIndex);
         BufferedImage image = sampleServer.readRegion(1, 0, 0, 10, 10);
+        float[] expectedPixels = new float[image.getWidth() * image.getHeight()];
+        for (int y=0; y<image.getHeight(); y++) {
+            for (int x=0; x<image.getWidth(); x++) {
+                expectedPixels[y*image.getWidth() + x] = (float) SampleImageServer.getPixel(x, y, channelIndex);
+            }
+        }
 
-        float[] pixels = channelExtractor.extractChannel(sampleServer, image, null);
+        float[] pixels = colorTransform.extractChannel(sampleServer, image, null);
+
+        Assertions.assertArrayEquals(expectedPixels, pixels);
 
         sampleServer.close();
     }
 
+    @Test
+    void Check_Channel_Index_Extractor_To_And_From_JSON() {
+        ColorTransforms.ColorTransform expectedColorTransform = ColorTransforms.createChannelExtractor(2);
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(ColorTransforms.ColorTransform.class, new ColorTransforms.ColorTransformTypeAdapter())
+                .create();
+
+        ColorTransforms.ColorTransform colorTransform = gson.fromJson(
+                gson.toJson(expectedColorTransform),
+                ColorTransforms.ColorTransform.class
+        );
+
+        Assertions.assertEquals(expectedColorTransform, colorTransform);
+    }
+
+    @Test
+    void Check_Channel_Name_Extractor_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        int channelIndex = sampleServer.nChannels() - 1;
+        String channelName = sampleServer.getChannel(channelIndex).getName();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createChannelExtractor(channelName);
+
+        boolean supported = colorTransform.supportsImage(sampleServer);
+
+        Assertions.assertTrue(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Channel_Name_Extractor_Not_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        String channelName = "channel not present in sample image server";
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createChannelExtractor(channelName);
+
+        boolean supported = colorTransform.supportsImage(sampleServer);
+
+        Assertions.assertFalse(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Channel_Name_Extractor_Pixels() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        int channelIndex = sampleServer.nChannels() - 2;
+        String channelName = sampleServer.getChannel(channelIndex).getName();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createChannelExtractor(channelName);
+        BufferedImage image = sampleServer.readRegion(1, 0, 0, 10, 10);
+        float[] expectedPixels = new float[image.getWidth() * image.getHeight()];
+        for (int y=0; y<image.getHeight(); y++) {
+            for (int x=0; x<image.getWidth(); x++) {
+                expectedPixels[y*image.getWidth() + x] = (float) SampleImageServer.getPixel(x, y, channelIndex);
+            }
+        }
+
+        float[] pixels = colorTransform.extractChannel(sampleServer, image, null);
+
+        Assertions.assertArrayEquals(expectedPixels, pixels);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Channel_Name_Extractor_To_And_From_JSON() {
+        ColorTransforms.ColorTransform expectedColorTransform = ColorTransforms.createChannelExtractor("some channel");
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(ColorTransforms.ColorTransform.class, new ColorTransforms.ColorTransformTypeAdapter())
+                .create();
+
+        ColorTransforms.ColorTransform colorTransform = gson.fromJson(
+                gson.toJson(expectedColorTransform),
+                ColorTransforms.ColorTransform.class
+        );
+
+        Assertions.assertEquals(expectedColorTransform, colorTransform);
+    }
+
+    @Test
+    void Check_Map_Linear_Combination_Channel_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createLinearCombinationChannelTransform(Map.of(
+                sampleServer.getChannel(0).getName(), 0.5f,
+                sampleServer.getChannel(1).getName(), 0.1f
+        ));
+
+        boolean supported = colorTransform.supportsImage(sampleServer);
+
+        Assertions.assertTrue(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Map_Linear_Combination_Channel_Not_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createLinearCombinationChannelTransform(Map.of(
+                "channel not present in sample image server", 0.5f,
+                sampleServer.getChannel(1).getName(), 0.1f
+        ));
+
+        boolean supported = colorTransform.supportsImage(sampleServer);
+
+        Assertions.assertFalse(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Map_Linear_Combination_Channel_Pixels() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        Map<String, Float> coefficients = Map.of(
+                sampleServer.getChannel(0).getName(), 0.4f,
+                sampleServer.getChannel(2).getName(), 0.6f
+        );
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createLinearCombinationChannelTransform(coefficients);
+        BufferedImage image = sampleServer.readRegion(1, 0, 0, 10, 10);
+        float[] expectedPixels = new float[image.getWidth() * image.getHeight()];
+        for (int y=0; y<image.getHeight(); y++) {
+            for (int x=0; x<image.getWidth(); x++) {
+                for (Map.Entry<String, Float> entry: coefficients.entrySet()) {
+                    int channelIndex = sampleServer.getMetadata().getChannels().stream()
+                            .map(ImageChannel::getName)
+                            .toList()
+                            .indexOf(entry.getKey());
+
+                    expectedPixels[y*image.getWidth() + x] += entry.getValue() * SampleImageServer.getPixel(x, y, channelIndex);
+                }
+            }
+        }
+
+        float[] pixels = colorTransform.extractChannel(sampleServer, image, null);
+
+        Assertions.assertArrayEquals(expectedPixels, pixels, 0.001f);   // delta for rounding errors
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Map_Linear_Combination_Channel_To_And_From_JSON() {
+        ColorTransforms.ColorTransform expectedColorTransform = ColorTransforms.createLinearCombinationChannelTransform(Map.of(
+                "some channel", 0.5f,
+                "some other channel", 0.1f
+        ));
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(ColorTransforms.ColorTransform.class, new ColorTransforms.ColorTransformTypeAdapter())
+                .create();
+
+        ColorTransforms.ColorTransform colorTransform = gson.fromJson(
+                gson.toJson(expectedColorTransform),
+                ColorTransforms.ColorTransform.class
+        );
+
+        Assertions.assertEquals(expectedColorTransform, colorTransform);
+    }
+
+    @Test
+    void Check_List_Linear_Combination_Channel_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createLinearCombinationChannelTransform(
+                sampleServer.getMetadata().getChannels().stream().map(c -> 1f).toList()
+        );
+
+        boolean supported = colorTransform.supportsImage(sampleServer);
+
+        Assertions.assertTrue(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_List_Linear_Combination_Channel_Not_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createLinearCombinationChannelTransform(
+                Stream.concat(
+                        sampleServer.getMetadata().getChannels().stream().map(c -> 1f),
+                        Stream.of(3f)
+                ).toList()
+        );
+
+        boolean supported = colorTransform.supportsImage(sampleServer);
+
+        Assertions.assertFalse(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_List_Linear_Combination_Channel_Pixels() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        List<Float> coefficients = List.of(0.2f, 0.5f, 2f);
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createLinearCombinationChannelTransform(coefficients);
+        BufferedImage image = sampleServer.readRegion(1, 0, 0, 10, 10);
+        float[] expectedPixels = new float[image.getWidth() * image.getHeight()];
+        for (int y=0; y<image.getHeight(); y++) {
+            for (int x=0; x<image.getWidth(); x++) {
+                for (int i=0; i<coefficients.size(); i++) {
+                    expectedPixels[y*image.getWidth() + x] += coefficients.get(i) * SampleImageServer.getPixel(x, y, i);
+                }
+            }
+        }
+
+        float[] pixels = colorTransform.extractChannel(sampleServer, image, null);
+
+        Assertions.assertArrayEquals(expectedPixels, pixels, 0.001f);   // delta for rounding errors
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_List_Linear_Combination_Channel_To_And_From_JSON() {
+        ColorTransforms.ColorTransform expectedColorTransform = ColorTransforms.createLinearCombinationChannelTransform(List.of(
+                0.5f, 0.1f
+        ));
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(ColorTransforms.ColorTransform.class, new ColorTransforms.ColorTransformTypeAdapter())
+                .create();
+
+        ColorTransforms.ColorTransform colorTransform = gson.fromJson(
+                gson.toJson(expectedColorTransform),
+                ColorTransforms.ColorTransform.class
+        );
+
+        Assertions.assertEquals(expectedColorTransform, colorTransform);
+    }
+
+    @Test
+    void Check_Mean_Channel_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createMeanChannelTransform();
+
+        boolean supported = colorTransform.supportsImage(sampleServer);
+
+        Assertions.assertTrue(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Mean_Channel_Pixels() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createMeanChannelTransform();
+        BufferedImage image = sampleServer.readRegion(1, 0, 0, 10, 10);
+        float[] expectedPixels = new float[image.getWidth() * image.getHeight()];
+        for (int y=0; y<image.getHeight(); y++) {
+            for (int x=0; x<image.getWidth(); x++) {
+                for (int c=0; c<sampleServer.nChannels(); c++) {
+                    expectedPixels[y*image.getWidth() + x] += SampleImageServer.getPixel(x, y, c);
+                }
+                expectedPixels[y*image.getWidth() + x] /= sampleServer.nChannels();
+            }
+        }
+
+        float[] pixels = colorTransform.extractChannel(sampleServer, image, null);
+
+        Assertions.assertArrayEquals(expectedPixels, pixels, 0.001f);   // delta for rounding errors
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Mean_Channel_To_And_From_JSON() {
+        ColorTransforms.ColorTransform expectedColorTransform = ColorTransforms.createMeanChannelTransform();
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(ColorTransforms.ColorTransform.class, new ColorTransforms.ColorTransformTypeAdapter())
+                .create();
+
+        ColorTransforms.ColorTransform colorTransform = gson.fromJson(
+                gson.toJson(expectedColorTransform),
+                ColorTransforms.ColorTransform.class
+        );
+
+        Assertions.assertEquals(expectedColorTransform, colorTransform);
+    }
+
+    @Test
+    void Check_Maximum_Channel_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createMaximumChannelTransform();
+
+        boolean supported = colorTransform.supportsImage(sampleServer);
+
+        Assertions.assertTrue(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Maximum_Channel_Pixels() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createMaximumChannelTransform();
+        BufferedImage image = sampleServer.readRegion(1, 0, 0, 10, 10);
+        float[] expectedPixels = new float[image.getWidth() * image.getHeight()];
+        for (int y=0; y<image.getHeight(); y++) {
+            for (int x=0; x<image.getWidth(); x++) {
+                expectedPixels[y*image.getWidth() + x] = Float.NEGATIVE_INFINITY;
+                for (int c=0; c<sampleServer.nChannels(); c++) {
+                    expectedPixels[y*image.getWidth() + x] = (float) Math.max(
+                            expectedPixels[y*image.getWidth() + x],
+                            SampleImageServer.getPixel(x, y, c)
+                    );
+                }
+            }
+        }
+
+        float[] pixels = colorTransform.extractChannel(sampleServer, image, null);
+
+        Assertions.assertArrayEquals(expectedPixels, pixels, 0.001f);   // delta for rounding errors
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Maximum_Channel_To_And_From_JSON() {
+        ColorTransforms.ColorTransform expectedColorTransform = ColorTransforms.createMaximumChannelTransform();
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(ColorTransforms.ColorTransform.class, new ColorTransforms.ColorTransformTypeAdapter())
+                .create();
+
+        ColorTransforms.ColorTransform colorTransform = gson.fromJson(
+                gson.toJson(expectedColorTransform),
+                ColorTransforms.ColorTransform.class
+        );
+
+        Assertions.assertEquals(expectedColorTransform, colorTransform);
+    }
+
+    @Test
+    void Check_Minimum_Channel_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createMinimumChannelTransform();
+
+        boolean supported = colorTransform.supportsImage(sampleServer);
+
+        Assertions.assertTrue(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Minimum_Channel_Pixels() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createMinimumChannelTransform();
+        BufferedImage image = sampleServer.readRegion(1, 0, 0, 10, 10);
+        float[] expectedPixels = new float[image.getWidth() * image.getHeight()];
+        for (int y=0; y<image.getHeight(); y++) {
+            for (int x=0; x<image.getWidth(); x++) {
+                expectedPixels[y*image.getWidth() + x] = Float.POSITIVE_INFINITY;
+                for (int c=0; c<sampleServer.nChannels(); c++) {
+                    expectedPixels[y*image.getWidth() + x] = (float) Math.min(
+                            expectedPixels[y*image.getWidth() + x],
+                            SampleImageServer.getPixel(x, y, c)
+                    );
+                }
+            }
+        }
+
+        float[] pixels = colorTransform.extractChannel(sampleServer, image, null);
+
+        Assertions.assertArrayEquals(expectedPixels, pixels, 0.001f);   // delta for rounding errors
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Minimum_Channel_To_And_From_JSON() {
+        ColorTransforms.ColorTransform expectedColorTransform = ColorTransforms.createMinimumChannelTransform();
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(ColorTransforms.ColorTransform.class, new ColorTransforms.ColorTransformTypeAdapter())
+                .create();
+
+        ColorTransforms.ColorTransform colorTransform = gson.fromJson(
+                gson.toJson(expectedColorTransform),
+                ColorTransforms.ColorTransform.class
+        );
+
+        Assertions.assertEquals(expectedColorTransform, colorTransform);
+    }
+
+    @Test
+    void Check_Color_Deconvolved_Channel_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleRGBImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createColorDeconvolvedChannel(
+                new ColorDeconvolutionStains(),
+                2
+        );
+
+        boolean supported = colorTransform.supportsImage(sampleServer);
+
+        Assertions.assertTrue(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Color_Deconvolved_Channel_Not_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        ColorTransforms.ColorTransform colorTransform = ColorTransforms.createColorDeconvolvedChannel(
+                new ColorDeconvolutionStains(),
+                2
+        );
+
+        boolean supported = colorTransform.supportsImage(sampleServer);
+
+        Assertions.assertFalse(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Color_Deconvolved_Channel_To_And_From_JSON() {
+        ColorTransforms.ColorTransform expectedColorTransform = ColorTransforms.createColorDeconvolvedChannel(
+                new ColorDeconvolutionStains(),
+                2
+        );
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(ColorTransforms.ColorTransform.class, new ColorTransforms.ColorTransformTypeAdapter())
+                .create();
+
+        ColorTransforms.ColorTransform colorTransform = gson.fromJson(
+                gson.toJson(expectedColorTransform),
+                ColorTransforms.ColorTransform.class
+        );
+
+        Assertions.assertEquals(expectedColorTransform, colorTransform);
+    }
+
     private static class SampleImageServer extends AbstractImageServer<BufferedImage> {
+
+        private static final int IMAGE_WIDTH = 50;
+        private static final int IMAGE_HEIGHT = 25;
 
         public SampleImageServer() {
             super(BufferedImage.class);
@@ -83,8 +526,8 @@ public class TestColorTransforms {
         @Override
         public ImageServerMetadata getOriginalMetadata() {
             return new ImageServerMetadata.Builder()
-                    .width(50)
-                    .height(25)
+                    .width(IMAGE_WIDTH)
+                    .height(IMAGE_HEIGHT)
                     .pixelType(PixelType.FLOAT64)
                     .channels(List.of(
                             ImageChannel.getInstance("c1", 1),
@@ -128,11 +571,52 @@ public class TestColorTransforms {
 
             for (int y=0; y<request.getHeight(); y++) {
                 for (int x=0; x<request.getWidth(); x++) {
-                    pixels[y*request.getWidth() + x] = channel + ((double) x + request.getX()) / getWidth();
+                    pixels[y*request.getWidth() + x] = getPixel(x + request.getX(), y + request.getY(), channel);
                 }
             }
 
             return pixels;
+        }
+
+        private static double getPixel(int x, int y, int channel) {
+            return channel + ((double) x / SampleImageServer.IMAGE_WIDTH + (double) y / SampleImageServer.IMAGE_HEIGHT) / 2;
+        }
+    }
+
+    private static class SampleRGBImageServer extends AbstractImageServer<BufferedImage> {
+
+        public SampleRGBImageServer() {
+            super(BufferedImage.class);
+        }
+
+        @Override
+        protected ImageServerBuilder.ServerBuilder<BufferedImage> createServerBuilder() {
+            return null;
+        }
+
+        @Override
+        protected String createID() {
+            return getClass().getName() + ": " + getURIs();
+        }
+
+        @Override
+        public Collection<URI> getURIs() {
+            return List.of(URI.create(""));
+        }
+
+        @Override
+        public String getServerType() {
+            return "Sample RGB server";
+        }
+
+        @Override
+        public ImageServerMetadata getOriginalMetadata() {
+            return new ImageServerMetadata.Builder()
+                    .width(50)
+                    .height(20)
+                    .rgb(true)
+                    .name("name")
+                    .build();
         }
     }
 }

--- a/qupath-core/src/test/java/qupath/lib/images/servers/TestColorTransforms.java
+++ b/qupath-core/src/test/java/qupath/lib/images/servers/TestColorTransforms.java
@@ -1,0 +1,138 @@
+package qupath.lib.images.servers;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import qupath.lib.color.ColorModelFactory;
+import qupath.lib.regions.RegionRequest;
+
+import java.awt.image.BandedSampleModel;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferDouble;
+import java.awt.image.WritableRaster;
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+
+public class TestColorTransforms {
+
+    @Test
+    void Check_Channel_Index_Extractor_Supported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        int channelIndex = sampleServer.nChannels() - 1;
+        ColorTransforms.ColorTransform channelExtractor = ColorTransforms.createChannelExtractor(channelIndex);
+
+        boolean supported = channelExtractor.supportsImage(sampleServer);
+
+        Assertions.assertTrue(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Channel_Index_Extractor_Unsupported() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        int channelIndex = sampleServer.nChannels() + 1;
+        ColorTransforms.ColorTransform channelExtractor = ColorTransforms.createChannelExtractor(channelIndex);
+
+        boolean supported = channelExtractor.supportsImage(sampleServer);
+
+        Assertions.assertFalse(supported);
+
+        sampleServer.close();
+    }
+
+    @Test
+    void Check_Channel_Index_Extractor() throws Exception {
+        ImageServer<BufferedImage> sampleServer = new SampleImageServer();
+        int channelIndex = sampleServer.nChannels() - 1;
+        ColorTransforms.ColorTransform channelExtractor = ColorTransforms.createChannelExtractor(channelIndex);
+        BufferedImage image = sampleServer.readRegion(1, 0, 0, 10, 10);
+
+        float[] pixels = channelExtractor.extractChannel(sampleServer, image, null);
+
+        sampleServer.close();
+    }
+
+    private static class SampleImageServer extends AbstractImageServer<BufferedImage> {
+
+        public SampleImageServer() {
+            super(BufferedImage.class);
+        }
+
+        @Override
+        protected ImageServerBuilder.ServerBuilder<BufferedImage> createServerBuilder() {
+            return null;
+        }
+
+        @Override
+        protected String createID() {
+            return getClass().getName() + ": " + getURIs();
+        }
+
+        @Override
+        public Collection<URI> getURIs() {
+            return List.of(URI.create(""));
+        }
+
+        @Override
+        public String getServerType() {
+            return "Sample server";
+        }
+
+        @Override
+        public ImageServerMetadata getOriginalMetadata() {
+            return new ImageServerMetadata.Builder()
+                    .width(50)
+                    .height(25)
+                    .pixelType(PixelType.FLOAT64)
+                    .channels(List.of(
+                            ImageChannel.getInstance("c1", 1),
+                            ImageChannel.getInstance("c2", 2),
+                            ImageChannel.getInstance("c3", 3),
+                            ImageChannel.getInstance("c4", 4),
+                            ImageChannel.getInstance("c5", 5)
+                    ))
+                    .name("name")
+                    .build();
+        }
+
+        @Override
+        public BufferedImage readRegion(RegionRequest request) {
+            DataBuffer dataBuffer = createDataBuffer(request);
+
+            return new BufferedImage(
+                    ColorModelFactory.createColorModel(getMetadata().getPixelType(), getMetadata().getChannels()),
+                    WritableRaster.createWritableRaster(
+                            new BandedSampleModel(dataBuffer.getDataType(), request.getWidth(), request.getHeight(), nChannels()),
+                            dataBuffer,
+                            null
+                    ),
+                    false,
+                    null
+            );
+        }
+
+        private DataBuffer createDataBuffer(RegionRequest request) {
+            double[][] array = new double[nChannels()][];
+
+            for (int c = 0; c < array.length; c++) {
+                array[c] = getPixels(request, c);
+            }
+
+            return new DataBufferDouble(array, request.getWidth() * request.getHeight() / 8);
+        }
+
+        private double[] getPixels(RegionRequest request, int channel) {
+            double[] pixels = new double[request.getWidth() * request.getHeight()];
+
+            for (int y=0; y<request.getHeight(); y++) {
+                for (int x=0; x<request.getWidth(); x++) {
+                    pixels[y*request.getWidth() + x] = channel + ((double) x + request.getX()) / getWidth();
+                }
+            }
+
+            return pixels;
+        }
+    }
+}


### PR DESCRIPTION
The goal of this PR was to find a good solution for [this issue](https://forum.image.sc/t/add-additional-channel-in-fluorescence-image-after-scanning/99174/) (in short, creating a new channel by linearly combining existing channels). 

This was done by adding a new `ColorTransforms` called `LinearCombinationChannel` that applies a linear combination to the channels.

The existing  `ColorTransforms` were a bit refactored to remove the warnings and improve null safety (but their behaviors stay the same).

Tests were added for all existing `ColorTransforms` and the new `LinearCombinationChannel`.

Implementations for `hashCode` and `equals` in `ColorDeconvolutionStains` were also added because it was needed for unit tests.