### PR TITLE
Support TMA core classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This is a *work in progress* for the next major release.
 * Create a new channel as a linear combination of other channels (https://github.com/qupath/qupath/pull/1566)
 * Simplify `TileClassificationsToAnnotationsPlugin` implementation (https://github.com/qupath/qupath/pull/1563)
 * Add methods to `PathObjectHierarchy` to simplify requesting objects for regions (https://github.com/qupath/qupath/pull/1563)
+* TMA cores can now have classifications assigned to them
+  * Default color for TMA cores is lighter (to make it easier to see on both bright and dark backgrounds)
+  * TMA core 'missing' status is now shown using opacity, not a different color, to preserve any classification color
 
 ### Bugs fixed
 * Tile export to .ome.tif can convert to 8-bit unnecessarily (https://github.com/qupath/qupath/issues/1494)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMADataImporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMADataImporter.java
@@ -383,11 +383,8 @@ class TMADataImporter {
 				setTooltip(null);
 				return;
 			}
-			if (item.isMissing())
-				setTextFill(ColorToolsFX.getCachedColor(PathPrefs.colorTMAMissingProperty().get()));
-			else
-				setTextFill(ColorToolsFX.getCachedColor(PathPrefs.colorTMAProperty().get()));
-			
+			setTextFill(ColorToolsFX.getDisplayedColor(item));
+
 			setAlignment(Pos.CENTER);
 			setTextAlignment(TextAlignment.CENTER);
 			setContentDisplay(ContentDisplay.CENTER);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -219,7 +219,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		builderMap.put("Name", new ObjectNameMeasurementBuilder());
 
 		// Include the class
-		if (containsAnnotations || containsDetections) {
+		if (containsAnnotations || containsDetections || containsTMACores) {
 			builderMap.put("Classification", new PathClassMeasurementBuilder());
 			// Get the name of the containing TMA core if we have anything other than cores
 			if (imageData != null && imageData.getHierarchy().getTMAGrid() != null) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
@@ -195,8 +195,8 @@ class PathClassPane {
 		var pathObjects = new ArrayList<>(hierarchy.getSelectionModel().getSelectedObjects());
 		List<PathObject> changed = new ArrayList<>();
 		for (PathObject pathObject : pathObjects) {
-			if (pathObject.isTMACore())
-				continue;
+			// Previously we didn't allow TMA core objects to be classified this way,
+			// but since v0.6.0 we do
 			if (pathObject.getPathClass() == pathClass)
 				continue;				
 			pathObject.setPathClass(pathClass);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathObjectHierarchyView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathObjectHierarchyView.java
@@ -107,7 +107,7 @@ public class PathObjectHierarchyView implements ChangeListener<ImageData<Buffere
 		
 		PathPrefs.colorDefaultObjectsProperty().addListener((v, o, n) -> treeView.refresh());
 		PathPrefs.colorTMAProperty().addListener((v, o, n) -> treeView.refresh());
-		PathPrefs.colorTMAMissingProperty().addListener((v, o, n) -> treeView.refresh());
+		PathPrefs.opacityTMAMissingProperty().addListener((v, o, n) -> treeView.refresh());
 		PathPrefs.colorTileProperty().addListener((v, o, n) -> treeView.refresh());
 		
 		treeView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -507,8 +507,8 @@ public class PreferencePane {
 		@ColorPref("Prefs.Objects.tmaCoreColor")
 		public final IntegerProperty tmaColor = PathPrefs.colorTMAProperty();
 
-		@ColorPref("Prefs.Objects.tmaCoreMissingColor")
-		public final IntegerProperty tmaMissingColor = PathPrefs.colorTMAMissingProperty();
+		@DoublePref("Prefs.Objects.tmaCoreMissingOpacity")
+		public final DoubleProperty tmaMissingOpacity = PathPrefs.opacityTMAMissingProperty();
 
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -1258,8 +1258,8 @@ public class PathPrefs {
 	private static IntegerProperty colorDefaultObjects = createPersistentPreference("colorDefaultAnnotations", ColorTools.packRGB(255, 0, 0));
 		
 	private static IntegerProperty colorSelectedObject = createPersistentPreference("colorSelectedObject", ColorTools.packRGB(255, 255, 0));
-	private static IntegerProperty colorTMA = createPersistentPreference("colorTMA", ColorTools.packRGB(20, 20, 180));
-	private static IntegerProperty colorTMAMissing = createPersistentPreference("colorTMAMissing", ColorTools.packARGB(50, 20, 20, 180));
+	private static IntegerProperty colorTMA = createPersistentPreference("colorTMA", ColorTools.packRGB(102, 128, 230));
+	private static DoubleProperty opacityTMAMissing = createPersistentPreference("opacityTMAMissing", 0.4);
 	private static IntegerProperty colorTile = createPersistentPreference("colorTile", ColorTools.packRGB(80, 80, 80));
 	
 	/**
@@ -1286,13 +1286,13 @@ public class PathPrefs {
 	public static IntegerProperty colorTMAProperty() {
 		return colorTMA;
 	}
-	
+
 	/**
-	 * The default color used to display missing TMA core objects.
+	 * The default opacity to use when display TMA core objects, between 0 and 1.
 	 * @return
 	 */
-	public static IntegerProperty colorTMAMissingProperty() {
-		return colorTMAMissing;
+	public static DoubleProperty opacityTMAMissingProperty() {
+		return opacityTMAMissing;
 	}
 	
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/ColorToolsFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/ColorToolsFX.java
@@ -30,6 +30,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javafx.scene.paint.Color;
 import qupath.lib.common.ColorTools;
+import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathTileObject;
@@ -233,17 +234,21 @@ public class ColorToolsFX {
 		PathClass pathClass = pathObject.getPathClass();
 		if (pathClass != null)
 			color = pathClass.getColor();
-		if (color != null)
+		else if (pathObject instanceof TMACoreObject)
+			color = PathPrefs.colorTMAProperty().getValue();;
+
+		if (color != null) {
+			// Make missing TMA cores translucent
+			if (pathObject instanceof TMACoreObject core && core.isMissing()) {
+				color = ColorTools.packARGB(
+						GeneralTools.clipValue((int)Math.round(255 * PathPrefs.opacityTMAMissingProperty().get()), 0, 255),
+						ColorTools.red(color), ColorTools.green(color), ColorTools.blue(color)
+				);
+			}
 			return color;
-	
+		}
 		if (pathObject instanceof PathTileObject)
 			return PathPrefs.colorTileProperty().getValue();
-		if (pathObject instanceof TMACoreObject) {
-			if (((TMACoreObject)pathObject).isMissing())
-				return PathPrefs.colorTMAMissingProperty().getValue();
-			else
-				return PathPrefs.colorTMAProperty().getValue();
-		}
 		return PathPrefs.colorDefaultObjectsProperty().getValue();
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -789,7 +789,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 		manager.attachListener(PathPrefs.colorSelectedObjectProperty(), repainter);
 		manager.attachListener(PathPrefs.colorTileProperty(), repainter);
 		manager.attachListener(PathPrefs.colorTMAProperty(), repainter);
-		manager.attachListener(PathPrefs.colorTMAMissingProperty(), repainter);
+		manager.attachListener(PathPrefs.opacityTMAMissingProperty(), repainter);
 		manager.attachListener(PathPrefs.alwaysPaintSelectedObjectsProperty(), repainter);
 		manager.attachListener(PathPrefs.locationFontSizeProperty(), repainter);
 		manager.attachListener(PathPrefs.scalebarFontSizeProperty(), repainter);
@@ -2716,8 +2716,18 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 		TMAGrid tmaGrid = getHierarchy().getTMAGrid();
 		if (tmaGrid != null) {
 			TMACoreObject core = PathObjectTools.getTMACoreForPixel(tmaGrid, xx, yy);
-			if (core != null && core.getName() != null)
-				prefix = "Core: " + core.getName() + "\n";
+			if (core != null) {
+				if (core.getName() != null)
+					prefix = "Core: " + core.getName();
+				else
+					prefix = "TMA core";
+				var pathClass = core.getPathClass();
+				if (pathClass != null)
+					prefix += " (" + pathClass + ")";
+				if (core.isMissing())
+					prefix += " (missing)";
+				prefix += "\n";
+			}
 		}
 
 		String s = null;

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -828,8 +828,8 @@ Prefs.Objects.defaultColor = Default object color
 Prefs.Objects.defaultColor.description = Set the default color for any objects that don't have a color of classification set
 Prefs.Objects.tmaCoreColor = TMA core color
 Prefs.Objects.tmaCoreColor.description = Set the default color for TMA core objects
-Prefs.Objects.tmaCoreMissingColor = TMA missing color color
-Prefs.Objects.tmaCoreMissingColor.description = Set the default color for missing TMA core objects
+Prefs.Objects.tmaCoreMissingOpacity = TMA missing opacity
+Prefs.Objects.tmaCoreMissingOpacity.description = Set the opacity to use when drawing missing TMA core objects
 
 
 Prefs.Viewer.backgroundColor = Viewer background color


### PR DESCRIPTION
* TMA cores can now have classifications assigned to them
  * Default color for TMA cores is lighter (to make it easier to see on both bright and dark backgrounds)
  * TMA core 'missing' status is now shown using opacity, not a different color, to preserve any classification color
  * Viewer location string shows TMA core classifications, where available