### PR TITLE
Set Javadoc viewer scrollbars to light mode

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/JavadocViewerRunner.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/JavadocViewerRunner.java
@@ -34,6 +34,7 @@ import qupath.ui.javadocviewer.gui.viewer.JavadocViewerCommand;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
@@ -61,6 +62,7 @@ public class JavadocViewerRunner implements Runnable {
     private static final String JAVADOC_PATH_PREFERENCE = "javadocPath";
     private static final StringProperty javadocPath = PathPrefs.createPersistentPreference(JAVADOC_PATH_PREFERENCE, null);
     private final JavadocViewerCommand command;
+    private boolean stylesheetAdded = false;
 
     /**
      * Create the command. This will not create the viewer yet.
@@ -101,6 +103,14 @@ public class JavadocViewerRunner implements Runnable {
 
     @Override
     public void run() {
+        if (!stylesheetAdded) {
+            URL stylesheetURL = JavadocViewerRunner.class.getResource("/css/javadoc.css");
+            if (stylesheetURL != null) {
+                command.getJavadocViewer().getStylesheets().add(stylesheetURL.toExternalForm());
+            }
+            stylesheetAdded = true;
+        }
+
         command.run();
     }
 

--- a/qupath-gui-fx/src/main/resources/css/javadoc.css
+++ b/qupath-gui-fx/src/main/resources/css/javadoc.css
@@ -1,0 +1,54 @@
+/* Set scroll bars to light mode as they may appear within the Javadocs */
+
+.scroll-bar {
+    -fx-base: #ececec;
+    -fx-color: -fx-base;
+    -fx-background: derive(-fx-base,26.4%);
+    -fx-box-border: ladder(
+        -fx-color,
+        black 20%,
+        derive(-fx-color,-15%) 30%
+    );
+    -fx-focus-color: #039ED3;
+    -fx-faint-focus-color: #039ED322;
+    -fx-outer-border: derive(-fx-color,-23%);
+    -fx-inner-border: linear-gradient(to bottom,
+        ladder(
+            -fx-color,
+            derive(-fx-color,30%) 0%,
+            derive(-fx-color,20%) 40%,
+            derive(-fx-color,25%) 60%,
+            derive(-fx-color,55%) 80%,
+            derive(-fx-color,55%) 90%,
+            derive(-fx-color,75%) 100%
+        ),
+        ladder(
+            -fx-color,
+            derive(-fx-color,20%) 0%,
+            derive(-fx-color,10%) 20%,
+            derive(-fx-color,5%) 40%,
+            derive(-fx-color,-2%) 60%,
+            derive(-fx-color,-5%) 100%
+        ));
+    -fx-body-color: linear-gradient(to bottom,
+        ladder(
+            -fx-color,
+            derive(-fx-color,8%) 75%,
+            derive(-fx-color,10%) 80%
+        ),
+        derive(-fx-color,-8%));
+    -fx-body-color-to-right: linear-gradient(to right, derive(-fx-color,10%) ,derive(-fx-color,-6%));
+    -fx-mark-highlight-color: ladder(
+        -fx-color,
+        derive(-fx-color,80%) 60%,
+        white 70%
+    );
+    -fx-shadow-highlight-color: ladder(
+        -fx-background,
+        rgba(255,255,255,0.07) 0%,
+        rgba(255,255,255,0.07) 20%,
+        rgba(255,255,255,0.07) 70%,
+        rgba(255,255,255,0.7) 90%,
+        rgba(255,255,255,0.75) 100%
+    );
+}


### PR DESCRIPTION
Set Javadoc viewer scrollbars to always use light mode to avoid this:
 
![image](https://github.com/user-attachments/assets/633fa351-876f-4800-9414-dd9ea6858f15)

This was done by redefining the main JavaFX CSS variable.