### PR TITLE
Use light scrollbars with javadocs

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/JavadocViewerRunner.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/JavadocViewerRunner.java
@@ -62,6 +62,8 @@ public class JavadocViewerRunner implements Runnable {
     private static final StringProperty javadocPath = PathPrefs.createPersistentPreference(JAVADOC_PATH_PREFERENCE, null);
     private final JavadocViewerCommand command;
 
+    private static final String JAVADOCS_STYLE_CLASS = "javadoc-viewer";
+
     /**
      * Create the command. This will not create the viewer yet.
      *
@@ -89,6 +91,8 @@ public class JavadocViewerRunner implements Runnable {
                         .filter(Objects::nonNull)
                         .toArray(URI[]::new)
         );
+        if (!command.getJavadocViewer().getStyleClass().contains(JAVADOCS_STYLE_CLASS))
+            command.getJavadocViewer().getStyleClass().add("javadoc-viewer");
     }
 
     /**

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -45,6 +45,10 @@
 
 }
 
+/* Default to using a very light scrollbar with javadocs */
+.javadoc-viewer .scroll-bar {
+  -fx-base: #fcfcfc;
+}
 
 /* Soften the main toolbar icons */
 .tool-bar .qupath-icon * {


### PR DESCRIPTION
Alternative approach to https://github.com/qupath/qupath/pull/1574

#1575 creates a better separation of the stylesheet, but the advantages of the approach proposed here are:
* It requires very little code (and, in particular, doesn't involve replicating anything from modena)
* It's possible for other QuPath-wide themes to override the styles if they need to