### PR TITLE
Changed fireHierarchyChangedEvent to fireObjectAddedEvent

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
@@ -623,7 +623,7 @@ public final class PathObjectHierarchy implements Serializable {
 			counter++;
 		}
 		if (changes)
-			fireObjectAddedEvent(getRootObject(), pathObjects.iterator().next());
+			fireHierarchyChangedEvent(getRootObject());
 //			fireChangeEvent(getRootObject());
 		return changes;
 	}

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
@@ -623,7 +623,7 @@ public final class PathObjectHierarchy implements Serializable {
 			counter++;
 		}
 		if (changes)
-			fireHierarchyChangedEvent(getRootObject());
+			fireObjectAddedEvent(getRootObject(), pathObjects.iterator().next());
 //			fireChangeEvent(getRootObject());
 		return changes;
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/UndoRedoManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/UndoRedoManager.java
@@ -471,7 +471,12 @@ public class UndoRedoManager implements ChangeListener<QuPathViewer>, QuPathView
 	@Override
 	public void hierarchyChanged(PathObjectHierarchyEvent event) {
 		// Try to avoid calling too often
-		if (undoingOrRedoing || event.isChanging() || maxUndoHierarchySize.get() <= 0 || event.getChangedObjects().stream().allMatch(p -> p instanceof ParallelTileObject))
+		if (undoingOrRedoing || event.isChanging() || maxUndoHierarchySize.get() <= 0)
+			return;
+
+		// During processing, we have ParallelTileObjects changing to show which part of the image is being handled
+		// - but we don't want to record these
+		if (!event.getChangedObjects().isEmpty() && event.getChangedObjects().stream().allMatch(p -> p instanceof ParallelTileObject))
 			return;
 		
 		// *Potentially* we might have the same hierarchy in multiple viewers


### PR DESCRIPTION
A proposal to fix #1487.

The [`UndoRedoManager.hierarchyChanged()`](https://github.com/qupath/qupath/blob/3544e613b40fd123236936d76e2cb5ee08d855f7/qupath-gui-fx/src/main/java/qupath/lib/gui/UndoRedoManager.java#L472) function is called each time the hierarchy changes and is supposed to update the `UndoRedoManager` state. However, when loading objects using `Import objects from file`, the `PathObjectHierarchyEvent` parameter of this function contains no changed objects (`PathObjectHierarchyEvent.getChangedObjects()` function). So, [this condition](https://github.com/qupath/qupath/blob/3544e613b40fd123236936d76e2cb5ee08d855f7/qupath-gui-fx/src/main/java/qupath/lib/gui/UndoRedoManager.java#L474) is `true`, the event is ignored, and the `UndoRedoManager` doesn't update its state. This creates the issues described in #1487.

Therefore, the issue is not coming from the `UndoRedoManager`, but from the function that created the event.

The event is created in [`PathObjectHierarchy.addObjects()`](https://github.com/qupath/qupath/blob/3544e613b40fd123236936d76e2cb5ee08d855f7/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java#L626). I'm sure there is reason behind it, but here a hierarchy changed event is emitted, instead of an object added event. This PR simply emits an object added event instead of a hierarchy changed event.

The `PathObjectHierarchy.addObjects()` function add several objects, but in the PR only one object event is emitted. It seems to be enough still.