### PR TITLE
Convert pixel type for BufferedImage and ImageServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is a *work in progress* for the next major release.
   * This can substantially speed up _some_ scripts that don't need to access the image data (e.g. for some measurement export)
 * Initial core support for stain normalization and background subtraction (https://github.com/qupath/qupath/pull/1554)
   * Experimental - not yet a full feature or available through the user interface!
+* Add `TransformedServerBuilder.convertType(PixelType)` to convert pixel types
 
 ### Bugs fixed
 * Tile export to .ome.tif can convert to 8-bit unnecessarily (https://github.com/qupath/qupath/issues/1494)

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -96,6 +96,7 @@ import qupath.lib.images.servers.ImageServers;
 import qupath.lib.images.servers.LabeledImageServer;
 import qupath.lib.images.servers.PixelType;
 import qupath.lib.images.servers.ServerTools;
+import qupath.lib.images.servers.TransformedServerBuilder;
 import qupath.lib.images.writers.ImageWriterTools;
 import qupath.lib.images.writers.TileExporter;
 import qupath.lib.io.GsonTools;
@@ -265,6 +266,8 @@ public class QP {
 			PathObject.class,
 			PathObjectHierarchy.class,
 			PathClass.class,
+
+			TransformedServerBuilder.class,
 			
 			ImageRegion.class,
 			RegionRequest.class,

--- a/qupath-core/src/main/java/qupath/lib/awt/common/BufferedImageTools.java
+++ b/qupath-core/src/main/java/qupath/lib/awt/common/BufferedImageTools.java
@@ -28,19 +28,26 @@ import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Rectangle;
 import java.awt.Shape;
+import java.awt.image.BandedSampleModel;
 import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
 import java.awt.image.DataBuffer;
+import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.util.Hashtable;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ij.process.FloatProcessor;
 import ij.process.ImageProcessor;
+import qupath.lib.color.ColorModelFactory;
 import qupath.lib.common.ColorTools;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.images.servers.AbstractTileableImageServer;
+import qupath.lib.images.servers.ImageChannel;
+import qupath.lib.images.servers.PixelType;
 import qupath.lib.regions.RegionRequest;
 import qupath.lib.roi.RoiTools;
 import qupath.lib.roi.interfaces.ROI;
@@ -655,6 +662,121 @@ public final class BufferedImageTools {
 		}
 		return count;
 	}
+
+	/**
+	 * Convert a raster to have a specified pixel type.
+	 * Note that this is not intended for RGB images, and the output will not be a specific RGB type.
+	 * @param img the input image
+	 * @param targetPixelType the required pixel type of the output
+	 * @param channels the channels used to create the color model; if null, the default channels for the pixel type will be used
+	 * @return a new image containing pixels converted to the required type
+	 * @throws UnsupportedOperationException if the pixel type is not supported (e.g. INT8 or UINT32).
+	 */
+	public static BufferedImage convertImageType(BufferedImage img, PixelType targetPixelType, List<? extends ImageChannel> channels) {
+		var raster = img.getRaster();
+		var newRaster = convertRasterType(raster, targetPixelType);
+		if (channels == null) {
+			channels = ImageChannel.getDefaultChannelList(newRaster.getNumBands());
+		}
+		var colorModel = ColorModelFactory.createColorModel(targetPixelType, channels);
+		return new BufferedImage(colorModel, newRaster, img.isAlphaPremultiplied(), null);
+	}
+
+	/**
+	 * Convert a raster to have a specified pixel type.
+	 * If the output is an integer type, rounding will be applied and values will be clipped to the permitted range.
+	 * @param inputRaster raster containing the input pixels
+	 * @param targetPixelType pixel type to which the raster should be converted
+	 * @return a new raster containing pixels converted to the required type
+	 * @throws UnsupportedOperationException if the pixel type is not supported (e.g. INT8 or UINT32).
+	 */
+	public static WritableRaster convertRasterType(Raster inputRaster, PixelType targetPixelType) throws UnsupportedOperationException  {
+		int width = inputRaster.getWidth();
+		int height = inputRaster.getHeight();
+		int numBands = inputRaster.getNumBands();
+
+		var sampleModel = new BandedSampleModel(getDataBufferType(targetPixelType), width, height, numBands);
+		var buffer = sampleModel.createDataBuffer();
+		var outputRaster = WritableRaster.createWritableRaster(sampleModel, buffer, null);
+
+		double[] values = null;
+		double minValue = targetPixelType.isFloatingPoint() ? Double.NEGATIVE_INFINITY : targetPixelType.getLowerBound().doubleValue();
+		double maxValue = targetPixelType.isFloatingPoint() ? Double.POSITIVE_INFINITY : targetPixelType.getUpperBound().doubleValue();
+		boolean doRounding = targetPixelType.isSignedInteger() || targetPixelType.isUnsignedInteger();
+		for (int i = 0; i < numBands; i++) {
+			values = inputRaster.getSamples(0, 0, width, height, i, values);
+			if (doRounding)
+				roundAndClip(values, minValue, maxValue);
+			outputRaster.setSamples(0, 0, width, height, i, values);
+		}
+		return outputRaster;
+	}
+
+	/**
+	 * Get the appropriate DataBuffer type for a given PixelType.
+	 * @param pixelType the pixel type for which the DataBuffer type is required
+	 * @return the integer corresponding to the DataBuffer type.
+	 * @see DataBuffer
+	 * @throws UnsupportedOperationException if the pixel type is not supported (e.g. INT8 or UINT32).
+	 */
+	public static int getDataBufferType(PixelType pixelType) throws UnsupportedOperationException {
+		switch (pixelType) {
+			case UINT8:
+				return DataBuffer.TYPE_BYTE;
+			case INT16:
+				return DataBuffer.TYPE_SHORT;
+			case UINT16:
+				return DataBuffer.TYPE_USHORT;
+			case INT32:
+				return DataBuffer.TYPE_INT;
+			case FLOAT32:
+				return DataBuffer.TYPE_FLOAT;
+			case FLOAT64:
+				return DataBuffer.TYPE_DOUBLE;
+			case INT8:
+			case UINT32:
+			default:
+				throw new IllegalArgumentException("DataBuffer does not support " + pixelType);
+		}
+	}
+
+
+	private static void roundAndClip(double[] values, double min, double max) {
+		for (int i = 0; i < values.length; i++) {
+			values[i] = GeneralTools.clipValue(Math.round(values[i]), min, max);
+		}
+	}
+
+	/**
+	 * Create a new image with the specified width, height, pixel type, and number of channels.
+	 * Note that this is not intended for RGB images, which already have straightforward BufferedImage constructors.
+	 * @param width the width of the image
+	 * @param height the height of the image
+	 * @param pixelType the pixel type of the image
+	 * @param nChannels the number of channels to use in the image; the default channel colors will be used
+	 * @return a new image with the specified properties
+	 */
+	public static BufferedImage createImage(int width, int height, PixelType pixelType, int nChannels) {
+		return createImage(width, height, pixelType, ImageChannel.getDefaultChannelList(nChannels));
+	}
+
+	/**
+	 * Create a new image with the specified width, height, pixel type, and channels.
+	 * Note that this is not intended for RGB images, which already have straightforward BufferedImage constructors.
+	 * @param width the width of the image
+	 * @param height the height of the image
+	 * @param pixelType the pixel type of the image
+	 * @param channels the channels to use in the image
+	 * @return a new image with the specified properties
+	 */
+	public static BufferedImage createImage(int width, int height, PixelType pixelType, List<? extends ImageChannel> channels) {
+		var sampleModel = new BandedSampleModel(getDataBufferType(pixelType), width, height, channels.size());
+		var buffer = sampleModel.createDataBuffer();
+		var raster = WritableRaster.createWritableRaster(sampleModel, buffer, null);
+		var colorModel = ColorModelFactory.createColorModel(pixelType, channels);
+		return new BufferedImage(colorModel, raster, false, null);
+	}
+
 
 //	/**
 //	 * Resize the image to have the requested width/height, using area averaging and bilinear interpolation.

--- a/qupath-core/src/main/java/qupath/lib/color/ColorModelFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorModelFactory.java
@@ -325,7 +325,7 @@ public final class ColorModelFactory {
 	 * @param channels
 	 * @return
 	 */
-	public static ColorModel createColorModel(final PixelType type, final List<ImageChannel> channels) {
+	public static ColorModel createColorModel(final PixelType type, final List<? extends ImageChannel> channels) {
 		return new DefaultColorModel(type, channels.size(), false, channels.stream().mapToInt(c -> {
 			Integer color = c.getColor();
 			if (color == null)

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
@@ -747,6 +747,37 @@ public class ImageServers {
 		}
 
 	}
+
+	static class TypeConvertImageServerBuilder extends AbstractServerBuilder<BufferedImage> {
+
+		private ServerBuilder<BufferedImage> builder;
+		private PixelType pixelType;
+
+		TypeConvertImageServerBuilder(ImageServerMetadata metadata, ServerBuilder<BufferedImage> builder, PixelType pixelType) {
+			super(metadata);
+			this.builder = builder;
+			this.pixelType = pixelType;
+		}
+
+		@Override
+		protected ImageServer<BufferedImage> buildOriginal() throws Exception {
+			return new TypeConvertImageServer(builder.build(), pixelType);
+		}
+
+		@Override
+		public Collection<URI> getURIs() {
+			return builder.getURIs();
+		}
+
+		@Override
+		public ServerBuilder<BufferedImage> updateURIs(Map<URI, URI> updateMap) {
+			ServerBuilder<BufferedImage> newBuilder = builder.updateURIs(updateMap);
+			if (newBuilder == builder)
+				return this;
+			return new TypeConvertImageServerBuilder(getMetadata().orElse(null), newBuilder, pixelType);
+		}
+
+	}
 	
 	static class ReorderRGBServerBuilder extends AbstractServerBuilder<BufferedImage> {
 		

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServers.java
@@ -100,6 +100,7 @@ public class ImageServers {
 			.registerSubtype(ReorderRGBServerBuilder.class, "swapRedBlue")
 			.registerSubtype(ColorDeconvolutionServerBuilder.class, "color_deconvolved")
 			.registerSubtype(NormalizedImageServerBuilder.class, "normalized")
+			.registerSubtype(TypeConvertImageServerBuilder.class, "typeConvert")
 			;
 
 	private static GsonTools.SubTypeAdapterFactory<BufferedImageNormalizer> normalizerFactory =

--- a/qupath-core/src/main/java/qupath/lib/images/servers/TransformedServerBuilder.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/TransformedServerBuilder.java
@@ -43,7 +43,6 @@ import qupath.lib.regions.ImageRegion;
  * Note: This is an early-stage experimental class, which may well change!
  * 
  * @author Pete Bankhead
- *
  */
 public class TransformedServerBuilder {
 	
@@ -214,6 +213,7 @@ public class TransformedServerBuilder {
 	 * Subtract a constant offset from all channels, without clipping.
 	 * @param offsets a single offset to subtract from all channels, or an array of offsets to subtract from each channel.
 	 * @return
+	 * @since v0.6.0
 	 */
 	public TransformedServerBuilder subtractOffset(double... offsets) {
 		return normalize(SubtractOffsetAndScaleNormalizer.createSubtractOffset(offsets));
@@ -223,6 +223,7 @@ public class TransformedServerBuilder {
 	 * Subtract a constant offset from all channels, clipping the result to be &geq; 0.
 	 * @param offsets a single offset to subtract from all channels, or an array of offsets to subtract from each channel.
 	 * @return
+	 * @since v0.6.0
 	 */
 	public TransformedServerBuilder subtractOffsetAndClipZero(double... offsets) {
 		return normalize(SubtractOffsetAndScaleNormalizer.createSubtractOffsetAndClipZero(offsets));
@@ -233,6 +234,7 @@ public class TransformedServerBuilder {
 	 * @param offsets a single offset to subtract from all channels, or an array of offsets to subtract from each channel.
 	 * @param scales a single scale factor to apply to all channels, or an array of scale factors to apply to each channel.
 	 * @return
+	 * @since v0.6.0
 	 */
 	public TransformedServerBuilder subtractOffsetAndScale(double[] offsets, double[] scales) {
 		return normalize(SubtractOffsetAndScaleNormalizer.create(offsets, scales));
@@ -242,6 +244,7 @@ public class TransformedServerBuilder {
 	 * Scale all channels by a constant factor.
 	 * @param scales a single scale factor to apply to all channels, or an array of scale factors to apply to each channel.
 	 * @return
+	 * @since v0.6.0
 	 */
 	public TransformedServerBuilder scaleChannels(double... scales) {
 		return normalize(SubtractOffsetAndScaleNormalizer.create(null, scales));
@@ -254,6 +257,7 @@ public class TransformedServerBuilder {
 	 * @param scales optional array of scale factors to apply to each deconvolved channel.
 	 *               A scale factor of 1.0 will leave the channel unchanged, while a scale of 0.0 will suppress the channel.
 	 * @return
+	 * @since v0.6.0
 	 */
 	public TransformedServerBuilder stainNormalize(ColorDeconvolutionStains stainsInput, ColorDeconvolutionStains stainsOutput, double... scales) {
 		return normalize(ColorDeconvolutionNormalizer.create(stainsInput, stainsOutput, scales));
@@ -265,6 +269,7 @@ public class TransformedServerBuilder {
 	 * @return
 	 * @ImplNote To use this method to create an image that can be added to a project, the normalizers must be JSON-serializable
 	 *           and registered under {@link ImageServers#getNormalizerFactory()}.
+	 * @since v0.6.0
 	 */
 	public TransformedServerBuilder normalize(BufferedImageNormalizer normalizer) {
 		this.server = new NormalizedImageServer(server, normalizer);
@@ -276,6 +281,7 @@ public class TransformedServerBuilder {
 	 *
 	 * @param transforms the transforms to apply
 	 * @return this builder
+	 * @since v0.6.0
 	 */
 	public TransformedServerBuilder applyColorTransforms(Collection<? extends ColorTransform> transforms) {
 		server = new ChannelTransformFeatureServer(server, new ArrayList<>(transforms));
@@ -287,14 +293,27 @@ public class TransformedServerBuilder {
 	 *
 	 * @param transforms the transforms to apply
 	 * @return this builder
+	 * @since v0.6.0
 	 */
 	public TransformedServerBuilder applyColorTransforms(ColorTransform... transforms) {
 		return applyColorTransforms(Arrays.asList(transforms));
 	}
 
+	/**
+	 * Convert to the specified pixel type.
+	 *
+	 * @param pixelType the target pixel type
+	 * @return this builder
+	 * @since v0.6.0
+	 */
+	public TransformedServerBuilder convertType(PixelType pixelType) {
+		server = new TypeConvertImageServer(server, pixelType);
+		return this;
+	}
+
 	
 	/**
-	 * Get the {@link ImageServer} that applies all the requested transforms.
+	 * Get the {@link ImageServer} that applies the requested transforms sequentially.
 	 */
 	public ImageServer<BufferedImage> build() {
 		return server;

--- a/qupath-core/src/main/java/qupath/lib/images/servers/TypeConvertImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/TypeConvertImageServer.java
@@ -1,0 +1,99 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2024 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.images.servers;
+
+import qupath.lib.awt.common.BufferedImageTools;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * An ImageServer implementation that converts the pixel type of an image.
+ *
+ * @since v0.6.0
+ */
+public class TypeConvertImageServer extends AbstractTileableImageServer {
+
+    private static final Set<PixelType> INVALID_TYPES = Set.of(
+            PixelType.INT8, PixelType.UINT32
+    );
+
+    private final ImageServer<BufferedImage> server;
+    private final PixelType pixelType;
+    private final ImageServerMetadata metadata;
+//
+    protected TypeConvertImageServer(ImageServer<BufferedImage> server, PixelType outputType) {
+        super();
+        if (INVALID_TYPES.contains(outputType)) {
+            throw new IllegalArgumentException("Invalid pixel type: " + outputType);
+        }
+        this.server = server;
+        this.pixelType = outputType;
+        this.metadata = new ImageServerMetadata.Builder(server.getMetadata())
+                .pixelType(outputType)
+                .name(server.getMetadata().getName() + " (" + outputType + ")")
+                .build();
+    }
+
+    /**
+     * Get underlying ImageServer, i.e. the one that is being wrapped.
+     *
+     * @return
+     */
+    protected ImageServer<BufferedImage> getWrappedServer() {
+        return server;
+    }
+
+    @Override
+    public Collection<URI> getURIs() {
+        return getWrappedServer().getURIs();
+    }
+
+    @Override
+    public String getServerType() {
+        return "Type convert image server (" + pixelType + ")";
+    }
+
+    @Override
+    public ImageServerMetadata getOriginalMetadata() {
+        return metadata;
+    }
+
+    @Override
+    protected BufferedImage readTile(TileRequest tileRequest) throws IOException {
+        var img = getWrappedServer().readRegion(tileRequest.getRegionRequest());
+        return BufferedImageTools.convertImageType(img, pixelType, getMetadata().getChannels());
+    }
+
+    @Override
+    protected ImageServerBuilder.ServerBuilder<BufferedImage> createServerBuilder() {
+        return new ImageServers.TypeConvertImageServerBuilder(getMetadata(), getWrappedServer().getBuilder(), pixelType);
+    }
+
+    @Override
+    protected String createID() {
+        return "Type converted: " + getWrappedServer().getPath() + " (" + pixelType + ")";
+    }
+}

--- a/qupath-core/src/main/java/qupath/lib/images/servers/TypeConvertImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/TypeConvertImageServer.java
@@ -27,6 +27,7 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -53,6 +54,8 @@ public class TypeConvertImageServer extends AbstractTileableImageServer {
         this.pixelType = outputType;
         this.metadata = new ImageServerMetadata.Builder(server.getMetadata())
                 .pixelType(outputType)
+                .rgb(outputType == PixelType.UINT8 &&
+                        Objects.equals(server.getMetadata().getChannels(), ImageChannel.getDefaultRGBChannels()))
                 .name(server.getMetadata().getName() + " (" + outputType + ")")
                 .build();
     }
@@ -73,7 +76,7 @@ public class TypeConvertImageServer extends AbstractTileableImageServer {
 
     @Override
     public String getServerType() {
-        return "Type convert image server (" + pixelType + ")";
+        return "Type convert (" + pixelType + ")";
     }
 
     @Override


### PR DESCRIPTION
Add support for converting the `PixelType` of an image.

Here is an example that converts the pixel type of the current image to float32, and opens it in the current viewer:
```groovy
def server = getCurrentServer()
def server2 = new TransformedServerBuilder(server)
    .convertType(PixelType.FLOAT32)
    .build()

def imageData2 = new ImageData<>(server2)
Platform.runLater {getCurrentViewer().setImageData(imageData2)}
```

Note that no scaling is performed, but this may be done using other methods in `TransformedServerBuilder`.

This is most useful when exporting transformed images. It provides a workaround to the fact that color transforms (like color deconvolution, but also channel extraction) enforce conversion to float32.