### PR TITLE
Added possibility to copy measurement map color map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This is a *work in progress* for the next major release.
 * Initial core support for stain normalization and background subtraction (https://github.com/qupath/qupath/pull/1554)
   * Experimental - not yet a full feature or available through the user interface!
 * Add `TransformedServerBuilder.convertType(PixelType)` to convert pixel types
+* Right-click on 'Measurement map' colorbar to copy it to the system clipboard (https://github.com/qupath/qupath/pull/1583)
 
 ### Bugs fixed
 * Tile export to .ome.tif can convert to 8-bit unnecessarily (https://github.com/qupath/qupath/issues/1494)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/MeasurementMapPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/MeasurementMapPane.java
@@ -31,6 +31,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +55,6 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.Slider;
-import javafx.scene.control.TextField;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
@@ -223,7 +227,28 @@ public class MeasurementMapPane {
 			}
 		};
 		Tooltip.install(colorMapKey, new Tooltip("Measurement map key"));
-		
+
+		ContextMenu colorMapContextMenu = new ContextMenu();
+		MenuItem copyColorMap = new MenuItem("Copy");
+		copyColorMap.setOnAction(event -> {
+			if (colorMapKeyImage != null) {
+				Clipboard clipboard = Clipboard.getSystemClipboard();
+				ClipboardContent content = new ClipboardContent();
+				content.putImage(colorMapKeyImage);
+				clipboard.setContent(content);
+				Dialogs.showInfoNotification(
+						"Color map",
+						"Color map copied to clipboard"
+				);
+			}
+		});
+		colorMapContextMenu.getItems().add(copyColorMap);
+		colorMapKey.setOnMousePressed(event -> {
+            if (event.isSecondaryButtonDown()) {
+                colorMapContextMenu.show(pane, event.getScreenX(), event.getScreenY());
+            }
+        });
+
 		// Filter to reduce visible measurements
 		var tfFilter = new PredicateTextField<String>();
 		var tooltip = new Tooltip("Enter text to filter measurement list");


### PR DESCRIPTION
A proposal to fix #1221.

It simply adds the possibility to right click on the color map of the measurement map window, this opens a context menu with a `Copy` option, and clicking on this option will copy the color map to the clipboard.