### PR TITLE
Project sorting improvements

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
@@ -408,8 +408,7 @@ class QuPathTypeAdapters {
 						out.value(measurements.getMeasurementValue(i));
 					}
 				}
-				if (value instanceof MetadataStore) {
-					MetadataStore store = (MetadataStore)value;
+				if (value instanceof MetadataStore store) {
 					Set<String> keys = store.getMetadataKeys();
 					if (!keys.isEmpty()) {
 						out.name("Metadata count");
@@ -428,7 +427,7 @@ class QuPathTypeAdapters {
 				
 				if (value instanceof MetadataStore) {
 					MetadataStore store = (MetadataStore)value;
-					Map<String, String> map = store.getMetadataMap();
+					Map<String, String> map = store.getMetadata();
 					if (!map.isEmpty()) {
 						out.name("metadata");
 						gson.toJson(map, Map.class, out);

--- a/qupath-core/src/main/java/qupath/lib/objects/MetadataStore.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/MetadataStore.java
@@ -37,6 +37,9 @@ public interface MetadataStore {
 
 	/**
 	 * Returns a modifiable map containing the metadata.
+	 * <p>
+	 * The returned map may or may not be thread-safe. Implementing classes must
+	 * document the thread-safeness of the map.
 	 *
 	 * @return the metadata of this store
 	 */

--- a/qupath-core/src/main/java/qupath/lib/objects/MetadataStore.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/MetadataStore.java
@@ -27,50 +27,70 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Interface that may be used to indicate that a {@link PathObject} (or other object) can store metadata.
+ * Interface indicating that an object can store metadata.
  * <p>
  * Implementing classes should ensure that entries are stored in insertion order.
  * 
  * @author Pete Bankhead
- *
  */
 public interface MetadataStore {
+
+	/**
+	 * Returns a modifiable map containing the metadata.
+	 *
+	 * @return the metadata of this store
+	 */
+	Map<String, String> getMetadata();
 	
 	/**
 	 * Store a new metadata value.
+	 *
 	 * @param key
 	 * @param value
 	 * @return
+	 * @deprecated as of v0.6.0. Use {@link #getMetadata()} with the {@link Map#put(Object, Object)}
+	 * method instead
 	 */
-	public Object putMetadataValue(final String key, final String value);
+	@Deprecated
+	default Object putMetadataValue(String key, String value) {
+		return getMetadata().put(key, value);
+	}
 	
 	/**
 	 * Get a metadata value, cast as a String if possible.
 	 * @param key
 	 * @return
+	 * @deprecated as of v0.6.0. Use {@link #getMetadata()} with the {@link Map#get(Object)}
+	 * method instead
 	 */
-	public String getMetadataString(final String key);
+	@Deprecated
+	default String getMetadataString(String key) {
+		return getMetadata().get(key);
+	}
 	
 	/**
 	 * Get a metadata value of any kind.
 	 * 
 	 * @param key
 	 * @return
+	 * @deprecated as of v0.6.0. Use {@link #getMetadata()} with the {@link Map#get(Object)}
+	 * method instead
 	 */
-	public Object getMetadataValue(final String key);
+	@Deprecated
+	default Object getMetadataValue(String key) {
+		return getMetadata().get(key);
+	}
 	
 	/**
 	 * Get all metadata keys.
 	 * 
 	 * @return
+	 * @deprecated as of v0.6.0. Use {@link #getMetadata()} with the {@link Map#keySet()}
+	 * method instead
 	 */
-	public Set<String> getMetadataKeys();
-	
-	/**
-	 * Returns an unmodifiable map containing the metadata.
-	 * 
-	 * @return
-	 */
-	public Map<String, String> getMetadataMap();
+	@Deprecated
+	default Set<String> getMetadataKeys() {
+		return getMetadata().keySet();
+	}
 	
 }

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -1525,7 +1525,7 @@ public class PathObjectTools {
 		newObject.setLocked(pathObject.isLocked());
 		// Copy over metadata if we have it
 		if (copyMeasurements && newObject instanceof MetadataStore)
-			((MetadataStore)newObject).getMetadataMap().putAll(pathObject.getUnmodifiableMetadataMap());
+			((MetadataStore)newObject).getMetadata().putAll(pathObject.getUnmodifiableMetadataMap());
 		// Retain the ID, if needed
 		if (!createNewIDs)
 			newObject.setID(pathObject.getID());

--- a/qupath-core/src/main/java/qupath/lib/objects/TMACoreObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/TMACoreObject.java
@@ -157,7 +157,7 @@ public class TMACoreObject extends PathROIObject implements MetadataStore {
 	}
 	
 	@Override
-	public Map<String, String> getMetadataMap() {
+	public Map<String, String> getMetadata() {
 		return super.getUnmodifiableMetadataMap();
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -1292,7 +1292,7 @@ class DefaultProject implements Project<BufferedImage> {
 				GsonTools.getInstance().toJson(metadata, writer);
 			}
 		} catch (IOException e) {
-			logger.error("Error while creating project data directory", e);
+			logger.error("Error while saving project metadata", e);
 		}
 	}
 

--- a/qupath-core/src/main/java/qupath/lib/projects/Project.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/Project.java
@@ -268,6 +268,20 @@ public interface Project<T> {
 	public default Manager<PixelClassifier> getPixelClassifiers() {
 		return getResources(PixelClassifier.PROJECT_LOCATION, PixelClassifier.class, "json");
 	}
+
+	/**
+	 * Get the manager for sort keys saved within this project.
+	 * <p>
+	 * Sort keys can be used to group and sort project entries.
+	 * <p>
+	 * The names of this manager correspond to keys, while their values are string representations
+	 * of booleans corresponding to whether the key is in ascending or descending order.
+	 *
+	 * @return the manager for sort keys
+	 */
+	default Manager<String> getSortKeys() {
+		return getResources("sort_keys", String.class, "txt");
+	}
 	
 	/**
 	 * Get a manager for objects of a specified class within this project.

--- a/qupath-core/src/main/java/qupath/lib/projects/Project.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/Project.java
@@ -277,7 +277,7 @@ public interface Project<T> {
 	 * The names of this manager correspond to keys, while their values are string representations
 	 * of booleans corresponding to whether the key is in ascending or descending order.
 	 *
-	 * @return the manager for sort keys
+	 * @return the manager for sort keys, or {@code null} if the project does not support storing sort keys
 	 */
 	default Manager<String> getSortKeys() {
 		return getResources("sort_keys", String.class, "txt");

--- a/qupath-core/src/main/java/qupath/lib/projects/Project.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/Project.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import qupath.lib.classifiers.object.ObjectClassifier;
 import qupath.lib.classifiers.pixel.PixelClassifier;
@@ -268,20 +269,6 @@ public interface Project<T> {
 	public default Manager<PixelClassifier> getPixelClassifiers() {
 		return getResources(PixelClassifier.PROJECT_LOCATION, PixelClassifier.class, "json");
 	}
-
-	/**
-	 * Get the manager for sorting keys saved within this project.
-	 * <p>
-	 * Sorting keys can be used to group and sort project entries.
-	 * <p>
-	 * The names of this manager correspond to sorting keys, while their values are string representations
-	 * of booleans corresponding to whether the key is in ascending or descending order.
-	 *
-	 * @return the manager for sorting keys, or {@code null} if the project does not support storing sorting keys
-	 */
-	default Manager<String> getSortingKeys() {
-		return getResources("sorting_keys", String.class, "txt");
-	}
 	
 	/**
 	 * Get a manager for objects of a specified class within this project.
@@ -297,13 +284,29 @@ public interface Project<T> {
 	public default <S, R extends S> Manager<R> getResources(String location, Class<S> cls, String ext) {
 		return null;
 	}
-	
-	
-//	public List<String> listPixelClassifiers();
-//	
-//	public PixelClassifier loadPixelClassifier(String name);
-//	
-//	public void savePixelClassifier(String name, String PixelClassifier);
 
-	
+	/**
+	 * Store a metadata key-value pair in this project.
+	 * If a value already exists for the provided key, it will be overridden.
+	 *
+	 * @param key the key to store
+	 * @param value the value to store
+     */
+	void putMetadataValue(String key, String value);
+
+	/**
+	 * Request a metadata value stored in this project.
+	 *
+	 * @param key the key associated with the value to retrieve
+	 * @return the value associated with the provided key, or an empty Optional if no such value exists
+	 */
+	Optional<String> getMetadataValue(String key);
+
+	/**
+	 * Remove a metadata key-value pair from this project.
+	 * This function does nothing if the provided key is not present in this project.
+	 *
+	 * @param key the key associated with the value to remove
+	 */
+	void removeMetadataValue(String key);
 }

--- a/qupath-core/src/main/java/qupath/lib/projects/Project.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/Project.java
@@ -28,12 +28,12 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 import qupath.lib.classifiers.object.ObjectClassifier;
 import qupath.lib.classifiers.pixel.PixelClassifier;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
+import qupath.lib.objects.MetadataStore;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.projects.ResourceManager.Manager;
 
@@ -44,7 +44,7 @@ import qupath.lib.projects.ResourceManager.Manager;
  *
  * @param <T>
  */
-public interface Project<T> {
+public interface Project<T> extends MetadataStore {
 		
 	/**
 	 * Get an unmodifiable list representing the <code>PathClass</code>es associated with this project.
@@ -284,29 +284,4 @@ public interface Project<T> {
 	public default <S, R extends S> Manager<R> getResources(String location, Class<S> cls, String ext) {
 		return null;
 	}
-
-	/**
-	 * Store a metadata key-value pair in this project.
-	 * If a value already exists for the provided key, it will be overridden.
-	 *
-	 * @param key the key to store
-	 * @param value the value to store
-     */
-	void putMetadataValue(String key, String value);
-
-	/**
-	 * Request a metadata value stored in this project.
-	 *
-	 * @param key the key associated with the value to retrieve
-	 * @return the value associated with the provided key, or an empty Optional if no such value exists
-	 */
-	Optional<String> getMetadataValue(String key);
-
-	/**
-	 * Remove a metadata key-value pair from this project.
-	 * This function does nothing if the provided key is not present in this project.
-	 *
-	 * @param key the key associated with the value to remove
-	 */
-	void removeMetadataValue(String key);
 }

--- a/qupath-core/src/main/java/qupath/lib/projects/Project.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/Project.java
@@ -270,17 +270,17 @@ public interface Project<T> {
 	}
 
 	/**
-	 * Get the manager for sort keys saved within this project.
+	 * Get the manager for sorting keys saved within this project.
 	 * <p>
-	 * Sort keys can be used to group and sort project entries.
+	 * Sorting keys can be used to group and sort project entries.
 	 * <p>
-	 * The names of this manager correspond to keys, while their values are string representations
+	 * The names of this manager correspond to sorting keys, while their values are string representations
 	 * of booleans corresponding to whether the key is in ascending or descending order.
 	 *
-	 * @return the manager for sort keys, or {@code null} if the project does not support storing sort keys
+	 * @return the manager for sorting keys, or {@code null} if the project does not support storing sorting keys
 	 */
-	default Manager<String> getSortKeys() {
-		return getResources("sort_keys", String.class, "txt");
+	default Manager<String> getSortingKeys() {
+		return getResources("sorting_keys", String.class, "txt");
 	}
 	
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMACommands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMACommands.java
@@ -107,7 +107,7 @@ public class TMACommands {
 		if (selectedCores.size() == 1) {
 			var core = selectedCores.get(0);
 			prompt = core.getName() == null || core.getName().trim().isEmpty() ? "Core" : core.getName();
-			currentText = core.getMetadataMap().get(NOTE_NAME);
+			currentText = core.getMetadata().get(NOTE_NAME);
 		} else {
 			prompt = selectedCores.size() + " cores";
 		}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMADataImporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMADataImporter.java
@@ -59,7 +59,6 @@ import qupath.fx.dialogs.FileChoosers;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.fx.dialogs.Dialogs;
-import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.tools.ColorToolsFX;
 import qupath.fx.utils.GridPaneUtils;
 import qupath.lib.gui.tools.GuiTools;
@@ -547,7 +546,7 @@ class TMADataImporter {
 				core.getMeasurementList().put(name, getMeasurementList().get(name));
 			}
 			core.getMeasurementList().close();
-			for (Entry<String, String> entry : getMetadataMap().entrySet()) {
+			for (Entry<String, String> entry : this.getMetadata().entrySet()) {
 				core.putMetadataValue(entry.getKey(), (String)entry.getValue());
 			}
 		}
@@ -591,7 +590,7 @@ class TMADataImporter {
 //		else
 //			sb.append("-");
 		sb.append("\n");
-		for (Entry<String, String> entry : core.getMetadataMap().entrySet()) {
+		for (Entry<String, String> entry : core.getMetadata().entrySet()) {
 			sb.append(entry.getKey()).append("\t").append(entry.getValue()).append("\n");
 		}
 		for (String name : core.getMeasurementList().getMeasurementNames()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -1172,6 +1172,14 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 		
 		private ProjectImageTreeModel(final Project<?> project) {
 			this.root = new ProjectTreeRowItem(new ProjectTreeRow.RootRow(project));
+
+			try {
+				if (project != null && !project.getSortKeys().getNames().isEmpty()) {
+					this.metadataKey = project.getSortKeys().getNames().iterator().next();
+				}
+			} catch (IOException e) {
+				logger.warn("Error while getting metadata key", e);
+			}
 		}
 		
 		private String getMetadataKey() {
@@ -1184,6 +1192,17 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 		 */
 		private void setMetadataKey(String metadataKey) {
 			this.metadataKey = metadataKey;
+
+			try {
+				for (String keyName: project.getSortKeys().getNames()) {
+					project.getSortKeys().remove(keyName);
+				}
+				if (metadataKey != null) {
+					project.getSortKeys().put(metadataKey, String.valueOf(true));
+				}
+			} catch (IOException e) {
+				logger.warn("Error while setting new metadata key", e);
+			}
 		}
 		
 		private ProjectTreeRowItem getRoot() {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -1175,7 +1175,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			this.root = new ProjectTreeRowItem(new ProjectTreeRow.RootRow(project));
 
 			if (project != null) {
-				this.metadataKey = project.getMetadataValue(SORTING_KEY).orElse(null);
+				this.metadataKey = project.getMetadata().get(SORTING_KEY);
 			}
 		}
 		
@@ -1191,9 +1191,9 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			this.metadataKey = metadataKey;
 
 			if (metadataKey == null) {
-				project.removeMetadataValue(SORTING_KEY);
+				project.getMetadata().remove(SORTING_KEY);
 			} else {
-				project.putMetadataValue(SORTING_KEY, metadataKey);
+				project.getMetadata().put(SORTING_KEY, metadataKey);
 			}
 		}
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -1174,8 +1174,8 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			this.root = new ProjectTreeRowItem(new ProjectTreeRow.RootRow(project));
 
 			try {
-				if (project != null && project.getSortKeys() != null && !project.getSortKeys().getNames().isEmpty()) {
-					this.metadataKey = project.getSortKeys().getNames().iterator().next();
+				if (project != null && project.getSortingKeys() != null && !project.getSortingKeys().getNames().isEmpty()) {
+					this.metadataKey = project.getSortingKeys().getNames().iterator().next();
 				}
 			} catch (IOException e) {
 				logger.warn("Error while getting metadata key", e);
@@ -1194,12 +1194,12 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			this.metadataKey = metadataKey;
 
 			try {
-				if (project != null && project.getSortKeys() != null) {
-					for (String keyName: project.getSortKeys().getNames()) {
-						project.getSortKeys().remove(keyName);
+				if (project != null && project.getSortingKeys() != null) {
+					for (String keyName: project.getSortingKeys().getNames()) {
+						project.getSortingKeys().remove(keyName);
 					}
 					if (metadataKey != null) {
-						project.getSortKeys().put(metadataKey, String.valueOf(true));
+						project.getSortingKeys().put(metadataKey, String.valueOf(true));
 					}
 				}
 			} catch (IOException e) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -1174,7 +1174,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			this.root = new ProjectTreeRowItem(new ProjectTreeRow.RootRow(project));
 
 			try {
-				if (project != null && !project.getSortKeys().getNames().isEmpty()) {
+				if (project != null && project.getSortKeys() != null && !project.getSortKeys().getNames().isEmpty()) {
 					this.metadataKey = project.getSortKeys().getNames().iterator().next();
 				}
 			} catch (IOException e) {
@@ -1194,11 +1194,13 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			this.metadataKey = metadataKey;
 
 			try {
-				for (String keyName: project.getSortKeys().getNames()) {
-					project.getSortKeys().remove(keyName);
-				}
-				if (metadataKey != null) {
-					project.getSortKeys().put(metadataKey, String.valueOf(true));
+				if (project != null && project.getSortKeys() != null) {
+					for (String keyName: project.getSortKeys().getNames()) {
+						project.getSortKeys().remove(keyName);
+					}
+					if (metadataKey != null) {
+						project.getSortKeys().put(metadataKey, String.valueOf(true));
+					}
 				}
 			} catch (IOException e) {
 				logger.warn("Error while setting new metadata key", e);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -1166,19 +1166,16 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 	}
 
 	private class ProjectImageTreeModel {
-		
-		private ProjectTreeRowItem root;
+
+		private static final String SORTING_KEY = "sortingKey";
+		private final ProjectTreeRowItem root;
 		private String metadataKey;
 		
 		private ProjectImageTreeModel(final Project<?> project) {
 			this.root = new ProjectTreeRowItem(new ProjectTreeRow.RootRow(project));
 
-			try {
-				if (project != null && project.getSortingKeys() != null && !project.getSortingKeys().getNames().isEmpty()) {
-					this.metadataKey = project.getSortingKeys().getNames().iterator().next();
-				}
-			} catch (IOException e) {
-				logger.warn("Error while getting metadata key", e);
+			if (project != null) {
+				this.metadataKey = project.getMetadataValue(SORTING_KEY).orElse(null);
 			}
 		}
 		
@@ -1193,17 +1190,10 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 		private void setMetadataKey(String metadataKey) {
 			this.metadataKey = metadataKey;
 
-			try {
-				if (project != null && project.getSortingKeys() != null) {
-					for (String keyName: project.getSortingKeys().getNames()) {
-						project.getSortingKeys().remove(keyName);
-					}
-					if (metadataKey != null) {
-						project.getSortingKeys().put(metadataKey, String.valueOf(true));
-					}
-				}
-			} catch (IOException e) {
-				logger.warn("Error while setting new metadata key", e);
+			if (metadataKey == null) {
+				project.removeMetadataValue(SORTING_KEY);
+			} else {
+				project.putMetadataValue(SORTING_KEY, metadataKey);
 			}
 		}
 		


### PR DESCRIPTION
This PR is linked with issues #1537 and #1289 and implements [Alan's idea](https://github.com/qupath/qupath/issues/1537#issuecomment-2141451238).

It adds a [`Manager`](https://github.com/qupath/qupath/blob/7b272e5ee4c79d27dcf4e332d26ea4d0e5c80e3a/qupath-core/src/main/java/qupath/lib/projects/ResourceManager.java#L69) to the [`Project`](https://github.com/qupath/qupath/blob/main/qupath-core/src/main/java/qupath/lib/projects/Project.java) interface through the `Project.getSortingKeys()` function. The names of this manager correspond to sorting keys, while their values are string representations of booleans corresponding to whether the key is in ascending or descending order.

The current state of this PR makes project sorting persists when projects are closed / reopened.

It also enable to store several sorting keys and to define the sorting order (ascending or descending) for each of these keys, so that we could achieve this:
![image](https://github.com/user-attachments/assets/a7f6c570-dc2f-40f4-8d85-d88bdb392871)
 
However, the UI has to be changed to allow this. I can work on it, but I wanted to have your opinions on the current state of this PR first.