### PR TITLE
Improve metadata handling for projects and PathObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a *work in progress* for the next major release.
   * Images remain sorted after adding new metadata values
   * A warning indicator is shown if image files are missing
     * Use the 'Skip file checks in projects' preference if you need to turn this off (e.g. your images are on a slow network)
+* Project sorting is persistent when projects are re-opened (https://github.com/qupath/qupath/pull/1584)
 * Create a new channel as a linear combination of other channels (https://github.com/qupath/qupath/pull/1566)
 * Simplify `TileClassificationsToAnnotationsPlugin` implementation (https://github.com/qupath/qupath/pull/1563)
 * Add methods to `PathObjectHierarchy` to simplify requesting objects for regions (https://github.com/qupath/qupath/pull/1563)
@@ -40,12 +41,14 @@ This is a *work in progress* for the next major release.
 * QuPath doesn't always use the specified file extension when exporting snapshots (https://github.com/qupath/qupath/issues/1567)
 
 ### API changes
-* `PathObject` now has a `getMetadata()` method to access key/value `String` pairs
-  * Use judiciously! Adding metadata to any object can increase its memory footprint - 
+* New `Map<String, String> getMetadata()` method added to `PathObject`, `Project` and `ProjectImageEntry` (https://github.com/qupath/qupath/pull/1587)
+  * Supports storing key/value `String` pairs
+  * Use judiciously with `PathObject`! Adding metadata to any object can increase its memory footprint - 
     for detections, it is best to try to avoid adding even a single value because then no 
     storage needs to be created.
   * `qupath.lib.objects.MetadataStore` is deprecated and will be removed in the next release - 
-    along with older metadata-related methods in `PathObject`.
+    along with older metadata-related methods in `PathObject` and `ProjectImageEntry`
+  * _Extensions with subclasses may need updated for compatibity by implementing `getMetadata()`_
 
 ### Dependency updates
 * Bio-Formats 7.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ This is a *work in progress* for the next major release.
 * `ImageOps.Core.replace()` does not work as expected (https://github.com/qupath/qupath/issues/1564)
 * QuPath doesn't always use the specified file extension when exporting snapshots (https://github.com/qupath/qupath/issues/1567)
 
+### API changes
+* `PathObject` now has a `getMetadata()` method to access key/value `String` pairs
+  * Use judiciously! Adding metadata to any object can increase its memory footprint - 
+    for detections, it is best to try to avoid adding even a single value because then no 
+    storage needs to be created.
+  * `qupath.lib.objects.MetadataStore` is deprecated and will be removed in the next release - 
+    along with older metadata-related methods in `PathObject`.
+
 ### Dependency updates
 * Bio-Formats 7.3.1
 * Commonmark 0.22.0

--- a/qupath-core/src/main/java/qupath/lib/interfaces/MinimalMetadataStore.java
+++ b/qupath-core/src/main/java/qupath/lib/interfaces/MinimalMetadataStore.java
@@ -1,0 +1,41 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2024 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.interfaces;
+
+import java.util.Map;
+
+/**
+ * Minimal interface to indicate that an object can provide a map of metadata key/value pairs.
+ */
+public interface MinimalMetadataStore {
+
+    /**
+     * Returns a modifiable map containing the metadata.
+     * <p>
+     * The returned map may or may not be thread-safe. Implementing classes must
+     * document the thread-safeness of the map.
+     *
+     * @return the metadata of this store
+     */
+    Map<String, String> getMetadata();
+
+}

--- a/qupath-core/src/main/java/qupath/lib/interfaces/MinimalMetadataStore.java
+++ b/qupath-core/src/main/java/qupath/lib/interfaces/MinimalMetadataStore.java
@@ -25,6 +25,11 @@ import java.util.Map;
 
 /**
  * Minimal interface to indicate that an object can provide a map of metadata key/value pairs.
+ * <p>
+ * In some use-cases, there will be a need to store some metadata values for internal use
+ * and others that should be visible to the user.
+ * When this is the case, it is suggested to use the convention that metadata keys that start with {@code "_"}
+ * are to be used internally, but this is not enforced by this interface.
  */
 public interface MinimalMetadataStore {
 

--- a/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
@@ -34,9 +34,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
-import java.util.Set;
 import java.util.UUID;
 
+import com.google.gson.Strictness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +57,6 @@ import qupath.lib.io.GsonTools.PathClassTypeAdapter;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.measurements.MeasurementList.MeasurementListType;
 import qupath.lib.measurements.MeasurementListFactory;
-import qupath.lib.objects.MetadataStore;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathCellObject;
 import qupath.lib.objects.PathDetectionObject;
@@ -75,7 +74,7 @@ import qupath.lib.roi.interfaces.ROI;
 class QuPathTypeAdapters {
 	
 	static Gson gson = new GsonBuilder()
-			.setLenient()
+			.setStrictness(Strictness.LENIENT)
 			.serializeSpecialFloatingPointValues()
 			.create();
 		
@@ -408,15 +407,13 @@ class QuPathTypeAdapters {
 						out.value(measurements.getMeasurementValue(i));
 					}
 				}
-				if (value instanceof MetadataStore store) {
-					Set<String> keys = store.getMetadataKeys();
-					if (!keys.isEmpty()) {
-						out.name("Metadata count");
-						out.value(keys.size());
-						for (String key : keys) {
-							out.name(key);
-							out.value(store.getMetadataString(key));
-						}
+				var map = value.getMetadata();
+				if (!map.isEmpty()) {
+					out.name("Metadata count");
+					out.value(map.size());
+					for (var entry : map.entrySet()) {
+						out.name(entry.getKey());
+						out.value(entry.getValue());
 					}
 				}
 			} else {
@@ -425,13 +422,10 @@ class QuPathTypeAdapters {
 					MeasurementListTypeAdapter.INSTANCE.write(out, measurements);
 				}
 				
-				if (value instanceof MetadataStore) {
-					MetadataStore store = (MetadataStore)value;
-					Map<String, String> map = store.getMetadata();
-					if (!map.isEmpty()) {
-						out.name("metadata");
-						gson.toJson(map, Map.class, out);
-					}
+				Map<String, String> map = value.getMetadata();
+				if (!map.isEmpty()) {
+					out.name("metadata");
+					gson.toJson(map, Map.class, out);
 				}
 			}
 			

--- a/qupath-core/src/main/java/qupath/lib/objects/MetadataMap.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/MetadataMap.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -39,12 +39,14 @@ import org.slf4j.LoggerFactory;
 /**
  * Helper class for storing metadata key/value pairs.
  * <p>
- * Currently wraps a {@link LinkedHashMap}, but this implementation may change.
+ * This currently wraps a synchronized {@link LinkedHashMap}, but the implementation may change.
  * <p>
- * Serializes itself reasonably efficiently by using Object arrays.
- * 
- * @author Pete Bankhead
- *
+ * The main features of this class are:
+ * <ul>
+ *     <li>It can be serialized reasonably efficiently using Object arrays</li>
+ *     <li>It tries to minimize overhead by creating its internal map implementation lazily,
+ *     only whenever anything is being added.</li>
+ * </ul>
  */
 class MetadataMap implements Map<String, String>, Externalizable {
 	
@@ -58,12 +60,12 @@ class MetadataMap implements Map<String, String>, Externalizable {
 
 	@Override
 	public int size() {
-		return getMapInternal().size();
+		return map == null ? 0 : getMapInternal().size();
 	}
 
 	@Override
 	public boolean isEmpty() {
-		return getMapInternal().isEmpty();
+		return map == null || getMapInternal().isEmpty();
 	}
 
 	@Override
@@ -105,22 +107,24 @@ class MetadataMap implements Map<String, String>, Externalizable {
 		if (map == null)
 			return;
 		map.clear();
-		map = null;
 	}
 
 	@Override
 	public Set<String> keySet() {
-		return getMapInternalOrCreate().keySet();
+		// Returned set does only needs to support removal, so Collections.emptyMap() is ok
+		return getMapInternal().keySet();
 	}
 
 	@Override
 	public Collection<String> values() {
-		return getMapInternalOrCreate().values();
+		// Returned set does only needs to support removal, so Collections.emptyMap() is ok
+		return getMapInternal().values();
 	}
 
 	@Override
 	public Set<java.util.Map.Entry<String, String>> entrySet() {
-		return getMapInternalOrCreate().entrySet();
+		// Returned set does only needs to support removal, so Collections.emptyMap() is ok
+		return getMapInternal().entrySet();
 	}
 
 	@Override

--- a/qupath-core/src/main/java/qupath/lib/objects/MetadataStore.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/MetadataStore.java
@@ -23,6 +23,9 @@
 
 package qupath.lib.objects;
 
+import qupath.lib.interfaces.MinimalMetadataStore;
+
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,19 +34,11 @@ import java.util.Set;
  * <p>
  * Implementing classes should ensure that entries are stored in insertion order.
  * 
- * @author Pete Bankhead
+ * @deprecated v0.6.0. Use {@link MinimalMetadataStore} instead.
  */
-public interface MetadataStore {
+@Deprecated
+public interface MetadataStore extends MinimalMetadataStore {
 
-	/**
-	 * Returns a modifiable map containing the metadata.
-	 * <p>
-	 * The returned map may or may not be thread-safe. Implementing classes must
-	 * document the thread-safeness of the map.
-	 *
-	 * @return the metadata of this store
-	 */
-	Map<String, String> getMetadata();
 	
 	/**
 	 * Store a new metadata value.
@@ -94,6 +89,16 @@ public interface MetadataStore {
 	@Deprecated
 	default Set<String> getMetadataKeys() {
 		return getMetadata().keySet();
+	}
+
+	/**
+	 * Returns an unmodifiable map containing the metadata.
+	 *
+	 * @return
+	 */
+	@Deprecated
+	default Map<String, String> getMetadataMap() {
+		return Collections.unmodifiableMap(getMetadata());
 	}
 	
 }

--- a/qupath-core/src/main/java/qupath/lib/objects/PathAnnotationObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathAnnotationObject.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -22,8 +22,6 @@
  */
 
 package qupath.lib.objects;
-
-import java.util.Objects;
 
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.classes.PathClass;
@@ -69,14 +67,14 @@ public class PathAnnotationObject extends PathROIObject {
 	/**
 	 * Set a free text description for this annotation.
 	 * 
-	 * @param text
+	 * @param text to use as a description; if null, any existing description will be removed
 	 */
 	public void setDescription(final String text) {
 		// Don't store unless we need to (which can also help avoid creating unnecessary metadata stores)
-		Object existing = retrieveMetadataValue(KEY_ANNOTATION_TEXT);
-		if (Objects.equals(text, existing))
-			return;
-		this.storeMetadataValue(KEY_ANNOTATION_TEXT, text);
+		if (text == null)
+			getMetadata().remove(KEY_ANNOTATION_TEXT);
+		else
+			getMetadata().put(KEY_ANNOTATION_TEXT, text);
 	}
 
 	/**
@@ -84,11 +82,7 @@ public class PathAnnotationObject extends PathROIObject {
 	 * @return 
 	 */
 	public String getDescription() {
-		return (String)retrieveMetadataValue(KEY_ANNOTATION_TEXT);
+		return getMetadata().get(KEY_ANNOTATION_TEXT);
 	}
-
-//	PathAnnotationObject(PathAnnotationObject pathObject, PathROI pathROI) {
-//		super(pathROI, pathObject.getPathClass(), pathObject.getMeasurementList());
-//	}
 
 }

--- a/qupath-core/src/main/java/qupath/lib/objects/PathDetectionObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathDetectionObject.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -22,8 +22,6 @@
  */
 
 package qupath.lib.objects;
-
-import java.util.Map;
 
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.measurements.MeasurementList.MeasurementListType;
@@ -73,10 +71,6 @@ public class PathDetectionObject extends PathROIObject {
 		super(pathROI, pathClass);
 	}
 	
-	PathDetectionObject(ROI pathROI) {
-		this(pathROI, null);
-	}
-	
 	/**
 	 * Always returns false - detection objects shouldn't be edited.
 	 */
@@ -92,16 +86,5 @@ public class PathDetectionObject extends PathROIObject {
 	protected MeasurementList createEmptyMeasurementList() {
 		return MeasurementListFactory.createMeasurementList(0, MeasurementListType.FLOAT);
 	}
-	
-	/**
-	 * Get a map of metadata values.
-	 * Note that, for detection objects, this map is unmodifiable to avoid excessive memory use.
-	 * @since v0.5.0
-	 */
-	@Override
-	public Map<String, String> getMetadata() {
-		return getUnmodifiableMetadataMap();
-	}
-
 	
 }

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -73,7 +73,7 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 	private Collection<PathObject> childList = null; // Collections.synchronizedList(new ArrayList<>(0));
 	private MeasurementList measurements = null;
 	
-	private MetadataMap metadata = null;
+	private volatile MetadataMap metadata = null;
 	
 	private String name = null;
 	private Integer color;
@@ -1080,15 +1080,24 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 	
 	/**
 	 * Get a key/value pair map for object metadata.
+	 * <p>
+	 * Note that the returned map currently is <i>not</i> threadsafe.
+	 * This may change in future versions.
+	 * <p>
+	 * When adding metadata,
 	 * @return
 	 * @since v0.5.0
-	 * @implNote This is an experimental API change that may be further modified before v0.5.0 is available.
 	 */
 	@Override
 	public Map<String, String> getMetadata() {
-		if (metadata == null)
-			metadata = new MetadataMap();
-		return metadata;
+		var map = metadata;
+		if (map == null) {
+			synchronized (this) {
+				if (metadata == null)
+					metadata = map = new MetadataMap();
+			}
+		}
+		return map;
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import qupath.lib.common.ColorTools;
 import qupath.lib.common.LogTools;
+import qupath.lib.interfaces.MinimalMetadataStore;
 import qupath.lib.io.PathIO;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.measurements.MeasurementListFactory;
@@ -58,7 +59,7 @@ import qupath.lib.roi.interfaces.ROI;
  * @author Pete Bankhead
  *
  */
-public abstract class PathObject implements Externalizable {
+public abstract class PathObject implements Externalizable, MinimalMetadataStore {
 	
 	private static final long serialVersionUID = 1L;
 		
@@ -1022,7 +1023,9 @@ public abstract class PathObject implements Externalizable {
 	 * @return 
 	 * 
 	 * @see #retrieveMetadataValue
+	 * @deprecated v0.6.0, use {@link #getMetadata()} to directly access the metadata instead.
 	 */
+	@Deprecated
 	protected Object storeMetadataValue(final String key, final String value) {
 		if (metadata == null)
 			metadata = new MetadataMap();
@@ -1036,7 +1039,9 @@ public abstract class PathObject implements Externalizable {
 	 * @return the metadata value if set, or null if not
 	 * 
 	 * @see #storeMetadataValue
+	 * @deprecated v0.6.0, use {@link #getMetadata()} to directly access the metadata instead.
 	 */
+	@Deprecated
 	protected Object retrieveMetadataValue(final String key) {
 		return metadata == null ? null : metadata.get(key);
 	}
@@ -1045,7 +1050,9 @@ public abstract class PathObject implements Externalizable {
 	 * Get the set of metadata keys.
 	 * 
 	 * @return
+	 * @deprecated v0.6.0, use {@link #getMetadata()} to directly access the metadata instead.
 	 */
+	@Deprecated
 	protected Set<String> retrieveMetadataKeys() {
 		return metadata == null ? Collections.emptySet() : metadata.keySet();
 	}
@@ -1054,14 +1061,18 @@ public abstract class PathObject implements Externalizable {
 	 * Get an unmodifiable map of the metadata.
 	 * 
 	 * @return
+	 * @deprecated v0.6.0, use {@link #getMetadata()} to directly access the metadata instead.
 	 */
+	@Deprecated
 	protected Map<String, String> getUnmodifiableMetadataMap() {
 		return metadata == null ? Collections.emptyMap() : Collections.unmodifiableMap(metadata);
 	}
 	
 	/**
 	 * Remove all stored metadata values.
+	 * @deprecated v0.6.0, use {@link #getMetadata()} to directly access the metadata instead.
 	 */
+	@Deprecated
 	protected void clearMetadataMap() {
 		if (metadata != null)
 			metadata.clear();
@@ -1073,6 +1084,7 @@ public abstract class PathObject implements Externalizable {
 	 * @since v0.5.0
 	 * @implNote This is an experimental API change that may be further modified before v0.5.0 is available.
 	 */
+	@Override
 	public Map<String, String> getMetadata() {
 		if (metadata == null)
 			metadata = new MetadataMap();
@@ -1097,7 +1109,7 @@ public abstract class PathObject implements Externalizable {
 				nFields++;
 			}
 			out.writeInt(nFields);
-			if (metadata != null)
+			if (metadata != null && !metadata.isEmpty())
 				out.writeObject(metadata);
 			out.writeObject(measurements);
 		} else {
@@ -1155,13 +1167,14 @@ public abstract class PathObject implements Externalizable {
 			int nFields = in.readInt();
 			for (int i = 0; i < nFields; i++) {
 				nextObject = in.readObject();
-				if (nextObject instanceof MetadataMap) {
+				if (nextObject instanceof MetadataMap mm) {
 					// Read metadata, if we have it
-					metadata = (MetadataMap)nextObject;
-				} else if (nextObject instanceof MeasurementList) {
+					if (!mm.isEmpty())
+						metadata = mm;
+				} else if (nextObject instanceof MeasurementList ml) {
 					// Read a measurement list, if we have one
 					// This is rather hack-ish... but re-closing a list can prompt it to be stored more efficiently
-					measurements = (MeasurementList)nextObject;
+					measurements = ml;
 					measurements.close();
 				} else if (nextObject != null) {
 					logger.debug("Unsupported field during deserialization {}", nextObject);

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 import qupath.lib.geom.Point2;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
+import qupath.lib.interfaces.MinimalMetadataStore;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.classes.PathClassTools;
@@ -1524,8 +1525,8 @@ public class PathObjectTools {
 		newObject.setColor(pathObject.getColor());
 		newObject.setLocked(pathObject.isLocked());
 		// Copy over metadata if we have it
-		if (copyMeasurements && newObject instanceof MetadataStore)
-			((MetadataStore)newObject).getMetadata().putAll(pathObject.getUnmodifiableMetadataMap());
+		if (copyMeasurements && !pathObject.getMetadata().isEmpty())
+			newObject.getMetadata().putAll(pathObject.getMetadata());
 		// Retain the ID, if needed
 		if (!createNewIDs)
 			newObject.setID(pathObject.getID());

--- a/qupath-core/src/main/java/qupath/lib/objects/TMACoreObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/TMACoreObject.java
@@ -26,7 +26,6 @@ package qupath.lib.objects;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.util.Map;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -133,37 +132,62 @@ public class TMACoreObject extends PathROIObject implements MetadataStore {
 		putMetadataValue(KEY_CASE_ID, caseID);
 	}
 
+	/**
+	 * Put a metadata value
+	 * @param key
+	 * @param value
+	 * @return any previous metadata value, or null if none
+	 * @deprecated v0.6.0. Use {@link #putMetadataValue(String, String)} instead.
+	 */
 	@Override
+	@Deprecated
 	public Object putMetadataValue(final String key, final String value) {
 		return storeMetadataValue(key, value);
 	}
-	
+
+	/**
+	 * Get a string metadata value
+	 * @param key
+	 * @return
+	 * @deprecated v0.6.0. Use {@link #getMetadata()} to directly access metadata instead.
+	 */
 	@Override
+	@Deprecated
 	public String getMetadataString(final String key) {
 		Object value = getMetadataValue(key);
 		if (value instanceof String)
 			return (String)value;
 		return null;
 	}
-	
+
+	/**
+	 * Get a metadata value of any kind.
+	 * @param key
+	 * @return
+	 * @deprecated v0.6.0. Use {@link #getMetadata()} to directly access metadata instead.
+	 */
 	@Override
+	@Deprecated
 	public Object getMetadataValue(final String key) {
 		return super.retrieveMetadataValue(key);
 	}
-	
+
+	/**
+	 * Get all metadata keys.
+	 * @return
+	 * @deprecated v0.6.0. Use {@link #getMetadata()} to directly access metadata instead.
+	 */
 	@Override
+	@Deprecated
 	public Set<String> getMetadataKeys() {
 		return super.retrieveMetadataKeys();
 	}
 	
-	@Override
-	public Map<String, String> getMetadata() {
-		return super.getUnmodifiableMetadataMap();
-	}
-	
 	/**
 	 * Clear all associated metadata.
+	 * @deprecated v0.6.0. Use {@link #getMetadata()} to directly access metadata instead.
 	 */
+	@Deprecated
 	public void clearMetadata() {
 		super.clearMetadataMap();
 	}
@@ -173,27 +197,6 @@ public class TMACoreObject extends PathROIObject implements MetadataStore {
 	public String toString() {
 		return getDisplayedName() + objectCountPostfix();
 	}
-	
-	
-//	/**
-//	 * TMA core cannot be edited if it contains any detections.
-//	 * (Removed for v0.4.0 to rely on locking like other objects instead - 
-//	 * see https://github.com/qupath/qupath/issues/1021
-//	 */
-//	@Override
-//	public boolean isEditable() {
-//		return super.isEditable() && !containsChildOfClass(this, PathDetectionObject.class, true);
-//	}
-//	
-//	private static boolean containsChildOfClass(final PathObject pathObject, final Class<? extends PathObject> cls, final boolean allDescendants) {
-//		for (PathObject childObject : pathObject.getChildObjectsAsArray()) {
-//			if (cls.isAssignableFrom(childObject.getClass()))
-//				return true;
-//			if (childObject.hasChildren() && allDescendants && containsChildOfClass(childObject, cls, allDescendants))
-//				return true;
-//		}
-//		return false;
-//	}
 	
 	@Override
 	public void writeExternal(ObjectOutput out) throws IOException {

--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -593,7 +593,14 @@ class DefaultProject implements Project<BufferedImage> {
 		public void setDescription(final String description) {
 			this.description = description;
 		}
-		
+		/**
+		 * Returns a thread-safe and modifiable map containing the metadata
+		 * of this entry.
+		 * <p>
+		 * Modifications to this map are saved when calling {@link #syncChanges()}.
+		 *
+		 * @return the metadata of this entry
+		 */
 		@Override
 		public Map<String, String> getMetadata() {
 			return metadata;

--- a/qupath-core/src/main/java/qupath/lib/projects/Project.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/Project.java
@@ -33,7 +33,7 @@ import qupath.lib.classifiers.object.ObjectClassifier;
 import qupath.lib.classifiers.pixel.PixelClassifier;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
-import qupath.lib.objects.MetadataStore;
+import qupath.lib.interfaces.MinimalMetadataStore;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.projects.ResourceManager.Manager;
 
@@ -44,13 +44,13 @@ import qupath.lib.projects.ResourceManager.Manager;
  *
  * @param <T>
  */
-public interface Project<T> extends MetadataStore {
+public interface Project<T> extends MinimalMetadataStore {
 		
 	/**
 	 * Get an unmodifiable list representing the <code>PathClass</code>es associated with this project.
 	 * @return
 	 */
-	public List<PathClass> getPathClasses();
+	List<PathClass> getPathClasses();
 	
 	/**
 	 * Query whether 'true' or masked image names are being returned.
@@ -59,7 +59,7 @@ public interface Project<T> extends MetadataStore {
 	 * 
 	 * @see #setMaskImageNames(boolean)
 	 */
-	public boolean getMaskImageNames();
+	boolean getMaskImageNames();
 	
 	/**
 	 * Request that entries return masked image names, rather than the 'true' image names.
@@ -71,7 +71,7 @@ public interface Project<T> extends MetadataStore {
 	 * 
 	 * @see #getMaskImageNames()
 	 */
-	public void setMaskImageNames(boolean maskNames);
+	void setMaskImageNames(boolean maskNames);
 	
 	/**
 	 * Update the available PathClasses.
@@ -79,14 +79,14 @@ public interface Project<T> extends MetadataStore {
 	 * @param pathClasses
 	 * @return <code>true</code> if the stored values changed, false otherwise.
 	 */
-	public boolean setPathClasses(Collection<? extends PathClass> pathClasses);
+	boolean setPathClasses(Collection<? extends PathClass> pathClasses);
 	
 	/**
 	 * Get a URI that can be used when saving/reloading this project.
 	 * 
 	 * @return
 	 */
-	public URI getURI();
+	URI getURI();
 	
 	/**
 	 * Sometimes projects move (unfortunately). This returns the previous URI, if known - 
@@ -95,7 +95,7 @@ public interface Project<T> extends MetadataStore {
 	 * 
 	 * @return
 	 */
-	public URI getPreviousURI();
+	URI getPreviousURI();
 	
 	/**
 	 * Extract a usable project name from a URI.
@@ -128,7 +128,7 @@ public interface Project<T> extends MetadataStore {
 	 * 
 	 * @return
 	 */
-	public String getVersion();
+	String getVersion();
 	
 	/**
 	 * Get a path to this project, or null if this project is not on a local file system.
@@ -138,7 +138,7 @@ public interface Project<T> extends MetadataStore {
 	 * @return
 	 * @see ProjectImageEntry#getEntryPath()
 	 */
-	public Path getPath();
+	Path getPath();
 	
 	/**
 	 * Create a sub-project that provides a view on the specified entries.
@@ -150,13 +150,13 @@ public interface Project<T> extends MetadataStore {
 	 * @param entries the entries to retain within the sub-project
 	 * @return
 	 */
-	public Project<T> createSubProject(final String name, final Collection<ProjectImageEntry<T>> entries);
+	Project<T> createSubProject(final String name, final Collection<ProjectImageEntry<T>> entries);
 	
 	/**
 	 * Test if the project contains any images.
 	 * @return
 	 */
-	public boolean isEmpty();
+	boolean isEmpty();
 
 	/**
 	 * Add an image for a particular ImageServer.
@@ -164,7 +164,7 @@ public interface Project<T> extends MetadataStore {
 	 * @return
 	 * @throws IOException 
 	 */
-	public ProjectImageEntry<T> addImage(final ServerBuilder<T> server) throws IOException;
+	ProjectImageEntry<T> addImage(final ServerBuilder<T> server) throws IOException;
 	
 	/**
 	 * Add an image by duplicating an existing entry.
@@ -176,14 +176,14 @@ public interface Project<T> extends MetadataStore {
 	 * @return the new entry that has been added to the project
 	 * @throws IOException
 	 */
-	public ProjectImageEntry<T> addDuplicate(final ProjectImageEntry<T> entry, boolean copyData) throws IOException;
+	ProjectImageEntry<T> addDuplicate(final ProjectImageEntry<T> entry, boolean copyData) throws IOException;
 		
 	/**
 	 * Request a {@link ProjectImageEntry} associated with an {@link ImageData}
 	 * @param imageData
 	 * @return
 	 */
-	public ProjectImageEntry<T> getEntry(final ImageData<T> imageData);
+	ProjectImageEntry<T> getEntry(final ImageData<T> imageData);
 	
 	/**
 	 * Remove an image from the project, optionally including associated data.
@@ -191,7 +191,7 @@ public interface Project<T> extends MetadataStore {
 	 * @param entry
 	 * @param removeAllData 
 	 */
-	public void removeImage(final ProjectImageEntry<?> entry, boolean removeAllData);
+	void removeImage(final ProjectImageEntry<?> entry, boolean removeAllData);
 
 	/**
 	 * Remove multiple images from the project, optionally including associated data.
@@ -199,34 +199,34 @@ public interface Project<T> extends MetadataStore {
 	 * @param entries
 	 * @param removeAllData
 	 */
-	public void removeAllImages(final Collection<ProjectImageEntry<T>> entries, boolean removeAllData);
+	void removeAllImages(final Collection<ProjectImageEntry<T>> entries, boolean removeAllData);
 	
 	/**
 	 * Save the project.
 	 * 
 	 * @throws IOException
 	 */
-	public void syncChanges() throws IOException;
+	void syncChanges() throws IOException;
 	
 	/**
 	 * Get a list of image entries for the project.
 	 * 
 	 * @return
 	 */
-	public List<ProjectImageEntry<T>> getImageList();
+	List<ProjectImageEntry<T>> getImageList();
 	
 	/**
 	 * Get the name of the project.
 	 * 
 	 * @return
 	 */
-	public String getName();
+	String getName();
 	
 	/**
 	 * Request a timestamp from when the project was created.
 	 * @return
 	 */
-	public long getCreationTimestamp();
+	long getCreationTimestamp();
 	
 	/**
 	 * Request a timestamp from when the project was last synchronized.
@@ -234,7 +234,7 @@ public interface Project<T> extends MetadataStore {
 	 * 
 	 * @see #syncChanges()
 	 */
-	public long getModificationTimestamp();
+	long getModificationTimestamp();
 	
 	
 	
@@ -246,7 +246,7 @@ public interface Project<T> extends MetadataStore {
 	 * @return
 	 * @see #getResources(String, Class, String)
 	 */
-	public default Manager<String> getScripts() {
+	default Manager<String> getScripts() {
 		return getResources("scripts", String.class, "groovy");
 	}
 	
@@ -256,7 +256,7 @@ public interface Project<T> extends MetadataStore {
 	 * @return
 	 * @see #getResources(String, Class, String)
 	 */
-	public default Manager<ObjectClassifier<T>> getObjectClassifiers() {
+	default Manager<ObjectClassifier<T>> getObjectClassifiers() {
 		return getResources(ObjectClassifier.PROJECT_LOCATION, ObjectClassifier.class, "json");
 	}
 	
@@ -266,7 +266,7 @@ public interface Project<T> extends MetadataStore {
 	 * @return
 	 * @see #getResources(String, Class, String)
 	 */
-	public default Manager<PixelClassifier> getPixelClassifiers() {
+	default Manager<PixelClassifier> getPixelClassifiers() {
 		return getResources(PixelClassifier.PROJECT_LOCATION, PixelClassifier.class, "json");
 	}
 	
@@ -281,7 +281,7 @@ public interface Project<T> extends MetadataStore {
 	 * @return a {@link Manager} for the specified resource, or {@code null} if the project does not support the resource or extension.
 	 * @implNote the default implementation returns null. Subclasses should override this.
 	 */
-	public default <S, R extends S> Manager<R> getResources(String location, Class<S> cls, String ext) {
+	default <S, R extends S> Manager<R> getResources(String location, Class<S> cls, String ext) {
 		return null;
 	}
 }

--- a/qupath-core/src/main/java/qupath/lib/projects/ProjectImageEntry.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/ProjectImageEntry.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -24,15 +24,16 @@
 package qupath.lib.projects;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
+import qupath.lib.interfaces.MinimalMetadataStore;
 import qupath.lib.io.UriResource;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.projects.ResourceManager.Manager;
@@ -46,27 +47,20 @@ import qupath.lib.projects.ResourceManager.Manager;
  *
  * @param <T> Depends upon the project used; typically BufferedImage for QuPath
  */
-public interface ProjectImageEntry<T> extends UriResource {
-	
-//	/**
-//	 * Get the path used to represent this image, which can be used to construct an <code>ImageServer</code>.
-//	 * 
-//	 * @return
-//	 */
-//	public String getServerPath();
+public interface ProjectImageEntry<T> extends UriResource, MinimalMetadataStore {
 	
 	/**
 	 * Get a unique ID to represent this entry.
 	 * @return
 	 */
-	public String getID();
+	String getID();
 	
 	/**
 	 * Set the image name for this project entry.
 	 * 
 	 * @param name
 	 */
-	public void setImageName(String name);
+	void setImageName(String name);
 
 	/**
 	 * Get a name that may be used for this entry.
@@ -80,7 +74,7 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * @see qupath.lib.projects.Project#setMaskImageNames(boolean)
 	 * @see qupath.lib.projects.Project#getMaskImageNames()
 	 */
-	public String getImageName();
+	String getImageName();
 	
 	/**
 	 * Get the original image name, without any randomization.  Most UI elements should prefer {@link #getImageName} to 
@@ -88,7 +82,7 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * 
 	 * @return
 	 */
-	public String getOriginalImageName();
+	String getOriginalImageName();
 		
 	
 	/**
@@ -100,7 +94,7 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * 
 	 * @return
 	 */
-	public Path getEntryPath();
+	Path getEntryPath();
 	
 	
 	/**
@@ -108,8 +102,12 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * 
 	 * @param key
 	 * @return
+	 * @deprecated v0.6.0, use {@link #getMetadata()} instead to directly access the metadata.
 	 */
-	public String removeMetadataValue(final String key);
+	@Deprecated
+	default String removeMetadataValue(final String key) {
+		return getMetadata().remove(key);
+	}
 	
 	/**
 	 * Request a metadata value.
@@ -118,8 +116,12 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * 
 	 * @param key
 	 * @return
+	 * @deprecated v0.6.0, use {@link #getMetadata()} instead to directly access the metadata.
 	 */
-	public String getMetadataValue(final String key);
+	@Deprecated
+	default String getMetadataValue(final String key) {
+		return getMetadata().get(key);
+	}
 
 	/**
 	 * Store a metadata value.
@@ -130,22 +132,30 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * @param key
 	 * @param value
 	 * @return
+	 * @deprecated v0.6.0, use {@link #getMetadata()} instead to directly access the metadata.
 	 */
-	public String putMetadataValue(final String key, final String value);
+	@Deprecated
+	default String putMetadataValue(final String key, final String value) {
+		return getMetadata().put(key, value);
+	}
 	
 	/**
 	 * Check if a metadata value is present for a specified key.
 	 * 
 	 * @param key
 	 * @return <code>true</code> if <code>getDescription()</code> does not return null or an empty string, <code>false</code> otherwise.
+	 * @deprecated v0.6.0, use {@link #getMetadata()} instead to directly access the metadata.
 	 */
-	public boolean containsMetadata(final String key);
+	@Deprecated
+	default boolean containsMetadata(final String key) {
+		return getMetadata().containsKey(key);
+	}
 	
 	/**
 	 * Get a description; this is free text describing the image.
 	 * @return
 	 */
-	public String getDescription();
+	String getDescription();
 	
 	/**
 	 * Set the description.
@@ -153,33 +163,45 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * @see #getDescription
 	 * @param description
 	 */
-	public void setDescription(final String description);
+	void setDescription(final String description);
 	
 	/**
 	 * Remove all metadata.
+	 * @deprecated v0.6.0, use {@link #getMetadata()} instead to directly access the metadata.
 	 */
-	public void clearMetadata();
+	@Deprecated
+	default void clearMetadata() {
+		getMetadata().clear();
+	}
 	
 	/**
 	 * Get an unmodifiable view of the underlying metadata map.
 	 * 
 	 * @return
+	 * @deprecated v0.6.0, use {@link #getMetadata()} instead to directly access the metadata.
 	 */
-	public Map<String, String> getMetadataMap();
+	@Deprecated
+	default Map<String, String> getMetadataMap() {
+		return Collections.unmodifiableMap(getMetadata());
+	}
 	
 	/**
 	 * Get an unmodifiable collection of the metadata map's keys.
 	 * 
 	 * @return
+	 * @deprecated v0.6.0, use {@link #getMetadata()} instead to directly access the metadata.
 	 */
-	public Collection<String> getMetadataKeys();
+	@Deprecated
+	default Collection<String> getMetadataKeys() {
+		return getMetadata().keySet();
+	}
 
 	/**
 	 * Get a {@link ServerBuilder} that can be used to open this image.
 	 * 
 	 * @return
 	 */
-	public ServerBuilder<T> getServerBuilder();
+	ServerBuilder<T> getServerBuilder();
 	
 	/**
 	 * Read the {@link ImageData} associated with this entry, or create a new ImageData if none is currently present.
@@ -191,14 +213,14 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * 
 	 * @see #readHierarchy()
 	 */
-	public ImageData<T> readImageData() throws IOException;
+	ImageData<T> readImageData() throws IOException;
 	
 	/**
 	 * Save the {@link ImageData} for this entry using the default storage location for the project.
 	 * @param imageData 
 	 * @throws IOException 
 	 */
-	public void saveImageData(ImageData<T> imageData) throws IOException;
+	void saveImageData(ImageData<T> imageData) throws IOException;
 	
 	/**
 	 * Read the {@link PathObjectHierarchy} for this entry, or return an empty hierarchy if none is available.
@@ -208,20 +230,20 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * @see #readImageData()
 	 * @see #hasImageData()
 	 */
-	public PathObjectHierarchy readHierarchy() throws IOException;
+	PathObjectHierarchy readHierarchy() throws IOException;
 	
 	/**
 	 * Check if this entry has saved {@link ImageData} already available.
 	 * 
 	 * @return
 	 */
-	public boolean hasImageData();
+	boolean hasImageData();
 	
 	/**
 	 * Get a summary string representing this image entry.
 	 * @return
 	 */
-	public String getSummary();
+	String getSummary();
 	
 	/**
 	 * Request a thumbnail for the image.
@@ -229,7 +251,7 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * @return a thumbnail if one has already been set, otherwise null.
 	 * @throws IOException
 	 */
-	public T getThumbnail() throws IOException;
+	T getThumbnail() throws IOException;
 	
 	/**
 	 * Set a thumbnail for the image. This will replace any existing thumbnail.
@@ -237,45 +259,17 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * @param img
 	 * @throws IOException
 	 */
-	public void setThumbnail(T img) throws IOException;	
-	
-	/**
-	 * Get a collection of the URIs required by this project's ImageServer.
-	 * <p>
-	 * The purpose of this is to help query if they can be found. They might not be 
-	 * e.g. if the images have been moved.
-	 * 
-	 * @return
-	 * @throws IOException
-	 * @deprecated use instead {@link #getURIs()}
-	 */
-	@Deprecated
-	public default Collection<URI> getServerURIs() throws IOException {
-		return getURIs();
-	}
-	
-	/**
-	 * Update the URIs for the server (optional operation).
-	 * 
-	 * @param replacements a map with current URIs as keys, and desired URIs as values.
-	 * @return true if changes were made
-	 * @throws IOException
-	 * @deprecated use instead {@link #updateURIs(Map)}
-	 */
-	@Deprecated
-	public default boolean updateServerURIs(Map<URI, URI> replacements) throws IOException {
-		return updateURIs(replacements);
-	}
+	void setThumbnail(T img) throws IOException;
 	
 	/**
 	 * Get a formatted string representation of the metadata map's contents.
 	 * 
 	 * @return
 	 */
-	public default String getMetadataSummaryString() {
+	default String getMetadataSummaryString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("{");
-		for (Entry<String, String> entry : getMetadataMap().entrySet()) {
+		for (Entry<String, String> entry : getMetadata().entrySet()) {
 			if (sb.length() > 1)
 				sb.append(", ");
 			sb.append(entry.getKey());
@@ -293,7 +287,7 @@ public interface ProjectImageEntry<T> extends UriResource {
 	 * 
 	 * @return
 	 */
-	public Manager<ImageServer<T>> getImages();
+	Manager<ImageServer<T>> getImages();
 	
 	
 

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -251,7 +251,7 @@ public class TestPathObject {
 
 			// Set the legacy ID - don't automatically update it
 			var core3 = PathObjects.createTMACoreObject(0, 10, 20, 30, false);
-			((MetadataStore)core).putMetadataValue(TMACoreObject.LEGACY_KEY_UNIQUE_ID, id);
+			core.getMetadata().put(TMACoreObject.LEGACY_KEY_UNIQUE_ID, id);
 			assertNull(core3.getCaseID());
 
 			// Update legacy ID during deserialization

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -264,9 +264,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		Set<String> metadataNames = new LinkedHashSet<>();
 		metadataNames.addAll(builderMap.keySet());
 		for (PathObject pathObject : pathObjectListCopy) {
-			if (pathObject instanceof MinimalMetadataStore metadataStore) {
-				metadataNames.addAll(metadataStore.getMetadata().keySet());
-			}
+			metadataNames.addAll(pathObject.getMetadata().keySet());
 		}
 		// Ensure we have suitable builders
 		for (String name : metadataNames) {
@@ -1347,8 +1345,8 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 
 		@Override
 		public String getMeasurementValue(PathObject pathObject) {
-			if (pathObject instanceof MinimalMetadataStore store) {
-				return store.getMetadata().getOrDefault(name, null);
+			if (pathObject != null) {
+				return pathObject.getMetadata().getOrDefault(name, null);
 			}
 			return null;
 		}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -61,7 +61,7 @@ import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerMetadata;
 import qupath.lib.images.servers.PixelCalibration;
-import qupath.lib.objects.MetadataStore;
+import qupath.lib.interfaces.MinimalMetadataStore;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathDetectionObject;
 import qupath.lib.objects.PathObject;
@@ -264,8 +264,8 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		Set<String> metadataNames = new LinkedHashSet<>();
 		metadataNames.addAll(builderMap.keySet());
 		for (PathObject pathObject : pathObjectListCopy) {
-			if (pathObject instanceof MetadataStore) {
-				metadataNames.addAll(((MetadataStore)pathObject).getMetadataKeys());
+			if (pathObject instanceof MinimalMetadataStore metadataStore) {
+				metadataNames.addAll(metadataStore.getMetadata().keySet());
 			}
 		}
 		// Ensure we have suitable builders
@@ -1347,9 +1347,8 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 
 		@Override
 		public String getMeasurementValue(PathObject pathObject) {
-			if (pathObject instanceof MetadataStore) {
-				MetadataStore store = (MetadataStore)pathObject;
-				return store.getMetadataString(name);
+			if (pathObject instanceof MinimalMetadataStore store) {
+				return store.getMetadata().getOrDefault(name, null);
 			}
 			return null;
 		}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -264,7 +264,12 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		Set<String> metadataNames = new LinkedHashSet<>();
 		metadataNames.addAll(builderMap.keySet());
 		for (PathObject pathObject : pathObjectListCopy) {
-			metadataNames.addAll(pathObject.getMetadata().keySet());
+			// Don't show metadata keys that start with "_"
+			pathObject.getMetadata()
+					.keySet()
+							.stream()
+									.filter(key -> key != null && !key.startsWith("_"))
+											.forEach(metadataNames::add);
 		}
 		// Ensure we have suitable builders
 		for (String name : metadataNames) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -1167,7 +1167,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 
 	private class ProjectImageTreeModel {
 
-		private static final String SORTING_KEY = "sortingKey";
+		private static final String SORT_KEY = "_SORT_KEY";
 		private final ProjectTreeRowItem root;
 		private String metadataKey;
 		
@@ -1175,7 +1175,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			this.root = new ProjectTreeRowItem(new ProjectTreeRow.RootRow(project));
 
 			if (project != null) {
-				this.metadataKey = project.getMetadata().get(SORTING_KEY);
+				this.metadataKey = project.getMetadata().get(SORT_KEY);
 			}
 		}
 		
@@ -1191,9 +1191,9 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			this.metadataKey = metadataKey;
 
 			if (metadataKey == null) {
-				project.getMetadata().remove(SORTING_KEY);
+				project.getMetadata().remove(SORT_KEY);
 			} else {
-				project.getMetadata().put(SORTING_KEY, metadataKey);
+				project.getMetadata().put(SORT_KEY, metadataKey);
 			}
 		}
 		


### PR DESCRIPTION
Introduce a `MinimalMetadataStore` interface (may be renamed) and use it with `PathObject`, `Project` and `ProjectImageEntry`.

This adds support for `String` key/value metadata, and enables us to deprecate some old metadata-related code.

## Use

Because a standard modifiable `Map<String, String>` is returned, we can use a convenient Groovy syntax, e.g.
```groovy
getProject().metadata['key'] = 'value'
getProjectEntry().metadata['key'] = 'value'
getSelectedObject().metadata['key'] = 'value'
```

## Don't use metadata too much!
For `PathObject`, the metadata is generated lazily on demand - so imposes no overhead if it isn't needed.

This means that *it's generally a bad idea to start adding metadata to detections* - especially if we may have a huge number.
It introduces considerable overhead to store a `Map` for each object.
This is typically find for other kinds of `PathObject`, but we don't want to store millions of additional maps if they are not needed.

## Use `"_key"` format for internal use
A documented convention for `MinimalMetadataStore` is to use `"_"` as the first character for metadata values that are used internally.

The practical implication is that values starting with `"_"` aren't typically shown to the user, e.g. within measurement tables.

## Thread safety
The maps returned by `DefaultProject` and its image entries are synchronized.

The map returned by `PathObject.getMetadata()` is currently *not* thread-safe.

This can be confirmed with the following script:
```groovy
def pathObject = PathObjects.createAnnotationObject(ROIs.createEmptyROI())

// Control synchronization
boolean doSynchronize = true

// Make sure we have no metadata at the start
pathObject.metadata.clear()
int before = pathObject.metadata.size()

java.util.stream.IntStream.range(0, 1000)
    .parallel()
    .forEach(i -> {
        def map = pathObject.metadata
        if (doSynchronize) {
            synchronized (map) {
                map[UUID.randomUUID().toString()] = "Yes"
            }
        } else {
            map[UUID.randomUUID().toString()] = "Yes"
        }

})
    
int after = pathObject.metadata.size()
print "Metadata added: ${after - before}"
```
If using `synchronized (map)` for the updates, then 1000 values should be added. But otherwise, you will likely see fewer values at the end.

> It is probably worth synchronizing the map in a future version.