### PR TITLE
Improve MeasurementList implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ This is a *work in progress* for the next major release.
   * `qupath.lib.objects.MetadataStore` is deprecated and will be removed in the next release - 
     along with older metadata-related methods in `PathObject` and `ProjectImageEntry`
   * _Extensions with subclasses may need updated for compatibity by implementing `getMetadata()`_
+* The `MeasurementList` interface has been substantially revised (https://github.com/qupath/qupath/pulls)
+  * Removed methods had been deprecated since v0.4.0; the changes mostly focus on simplifying the API, improving 
+    thread-safety, and squashing some bugs.
 
 ### Dependency updates
 * Bio-Formats 7.3.1

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
@@ -196,7 +196,7 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 		// Ensure we have no existing subcellular detection measurements - if we do, remove them
 		String[] existingMeasurements = pathObject.getMeasurementList().getNames().stream().filter(n -> n.startsWith("Subcellular:")).toArray(n -> new String[n]);
 		if (existingMeasurements.length > 0) {
-			pathObject.getMeasurementList().removeMeasurements(existingMeasurements);
+			pathObject.getMeasurementList().removeAll(existingMeasurements);
 			pathObject.getMeasurementList().close();
 		}
 

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
@@ -194,7 +194,7 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 		pathObject.clearChildObjects();
 
 		// Ensure we have no existing subcellular detection measurements - if we do, remove them
-		String[] existingMeasurements = pathObject.getMeasurementList().getMeasurementNames().stream().filter(n -> n.startsWith("Subcellular:")).toArray(n -> new String[n]);
+		String[] existingMeasurements = pathObject.getMeasurementList().getNames().stream().filter(n -> n.startsWith("Subcellular:")).toArray(n -> new String[n]);
 		if (existingMeasurements.length > 0) {
 			pathObject.getMeasurementList().removeMeasurements(existingMeasurements);
 			pathObject.getMeasurementList().close();

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -2975,7 +2975,7 @@ public class QP {
 				continue;
 			// Remove the measurements
 			try (var ml = pathObject.getMeasurementList()) {
-				ml.removeMeasurements(measurementNames);
+				ml.removeAll(measurementNames);
 			}
 		}
 		hierarchy.fireObjectMeasurementsChangedEvent(null, pathObjects);

--- a/qupath-core-processing/src/main/java/qupath/opencv/features/DelaunayTriangulation.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/features/DelaunayTriangulation.java
@@ -502,7 +502,7 @@ public class DelaunayTriangulation implements PathObjectConnectionGroup {
 				node.addNeighborsToSet(neighborSet, averagingSeparation);
 				
 				// Get the smoothed measurements now, since access is likely to be much faster we start modifying it
-				measurementNames = measurementList.getMeasurementNames().toArray(measurementNames);
+				measurementNames = measurementList.getNames().toArray(measurementNames);
 				if (averagedMeasurements.length < measurementNames.length)
 					averagedMeasurements = new double[measurementNames.length];
 				for (int i = 0; i < measurementNames.length; i++) {

--- a/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
+++ b/qupath-core/src/main/java/qupath/lib/io/QuPathTypeAdapters.java
@@ -402,9 +402,9 @@ class QuPathTypeAdapters {
 				if (!measurements.isEmpty()) {
 					out.name("Measurement count");
 					out.value(measurements.size());
-					for (int i = 0; i < measurements.size(); i++) {
-						out.name(measurements.getMeasurementName(i));
-						out.value(measurements.getMeasurementValue(i));
+					for (var m : measurements.getMeasurements()) {
+						out.name(m.getName());
+						out.value(m.getValue());
 					}
 				}
 				var map = value.getMetadata();

--- a/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
@@ -74,7 +74,7 @@ class DefaultMeasurementList implements MeasurementList {
 	}
 
 	@Override
-	public Measurement getMeasurement(int ind) {
+	public Measurement getByIndex(int ind) {
 		return list.get(ind);
 	}
 
@@ -153,7 +153,7 @@ class DefaultMeasurementList implements MeasurementList {
 	}
 
 	@Override
-	public synchronized void removeMeasurements(String... measurementNames) {
+	public synchronized void removeAll(String... measurementNames) {
 		for (String name : measurementNames) {
 			int ind = 0;
 			for (Measurement m : list) {

--- a/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
@@ -127,8 +127,9 @@ class DefaultMeasurementList implements MeasurementList {
 		}
 		if (ind < list.size()) {
 			list.set(ind, measurement);
+		} else {
+			list.add(measurement);
 		}
-		list.add(measurement);
 	}
 
 	@Override

--- a/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
@@ -62,7 +62,7 @@ class DefaultMeasurementList implements MeasurementList {
 	}
 	
 	@Override
-	public synchronized List<String> getMeasurementNames() {
+	public synchronized List<String> getNames() {
 		return list.stream()
 				.map(Measurement::getName)
 				.toList();

--- a/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
@@ -24,6 +24,7 @@
 package qupath.lib.measurements;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -46,7 +47,7 @@ class DefaultMeasurementList implements MeasurementList {
 	
 	private ArrayList<Measurement> list;
 	
-	private transient Map<String, Number> mapView;
+	private transient volatile Map<String, Number> mapView;
 	
 	DefaultMeasurementList() {
 		list = new ArrayList<>();
@@ -172,7 +173,7 @@ class DefaultMeasurementList implements MeasurementList {
 		if (mapView == null) {
 			synchronized(this) {
 				if (mapView == null)
-					mapView = new MeasurementsMap(this);
+					mapView = Collections.synchronizedMap(new MeasurementsMap(this));
 			}
 		}
 		return mapView;

--- a/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/DefaultMeasurementList.java
@@ -26,6 +26,7 @@ package qupath.lib.measurements;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -68,14 +69,32 @@ class DefaultMeasurementList implements MeasurementList {
 	}
 
 	@Override
-	public synchronized String getMeasurementName(int ind) {
-		return list.get(ind).getName();
+	public List<Measurement> getMeasurements() {
+		return List.copyOf(list);
 	}
-	
+
 	@Override
-	public synchronized double getMeasurementValue(int ind) {
-		if (ind >= 0 && ind < size())
-			return list.get(ind).getValue();
+	public Measurement getMeasurement(int ind) {
+		return list.get(ind);
+	}
+
+	@Override
+	public synchronized double[] values() {
+		return list.stream()
+				.mapToDouble(Measurement::getValue)
+				.toArray();
+	}
+
+	@Override
+	public synchronized double remove(String name) {
+		var iter = list.iterator();
+		while (iter.hasNext()) {
+			var next = iter.next();
+			if (next.getName().equals(name)) {
+				iter.remove();
+				return next.getValue();
+			}
+		}
 		return Double.NaN;
 	}
 
@@ -117,6 +136,7 @@ class DefaultMeasurementList implements MeasurementList {
 
 	@Override
 	public synchronized void put(String name, double value) {
+		Objects.requireNonNull(name, "Measurement name cannot be null");
 		// Ensure we aren't adding duplicate measurements
 		var measurement = MeasurementFactory.createMeasurement(name, value);
 		int ind = 0;

--- a/qupath-core/src/main/java/qupath/lib/measurements/Measurement.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/Measurement.java
@@ -40,20 +40,12 @@ public interface Measurement extends Serializable {
 	 * Get the name of the measurement.
 	 * @return
 	 */
-     public String getName();
+    String getName();
 
-     /**
-      * Get the numeric value of the measurement.
-      * @return
-      */
-     public double getValue();
-	 
-     /**
-      * Returns true if a measurement can change its value, for example because of changes in 
-      * a object or hierarchy.
-      * @return
-      */
-     @Deprecated
-	 public boolean isDynamic();
+    /**
+     * Get the numeric value of the measurement.
+     * @return
+     */
+    double getValue();
 	
 }

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementFactory.java
@@ -23,6 +23,8 @@
 
 package qupath.lib.measurements;
 
+import java.util.Objects;
+
 /**
  * Factory for creating new Measurement objects.
  * <p>
@@ -33,8 +35,7 @@ package qupath.lib.measurements;
  * @author Pete Bankhead
  *
  */
-@Deprecated
-public class MeasurementFactory {
+class MeasurementFactory {
 	
 	/**
 	 * Create a measurement with a double value.
@@ -54,6 +55,16 @@ public class MeasurementFactory {
 	 */
 	public static Measurement createMeasurement(final String name, final float value) {
 		return new FloatMeasurement(name, (float)value);
+	}
+
+	static boolean isEqual(Measurement m1, Measurement m2) {
+		if (m1 == m2)
+			return true;
+		return Objects.equals(m1.getName(), m2.getName()) && m1.getValue() == m2.getValue();
+	}
+
+	static int hash(Measurement m) {
+		return Objects.hash(m.getName(), m.getValue());
 	}
 	
 }
@@ -78,7 +89,7 @@ class DoubleMeasurement implements Measurement {
 
 	@Override
 	public String toString() {
-		return getName() + ": " + Double.toString(getValue());
+		return getName() + ": " + getValue();
 	}
 
 	@Override
@@ -87,10 +98,20 @@ class DoubleMeasurement implements Measurement {
 	}
 
 	@Override
-	public boolean isDynamic() {
-		return false;
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o instanceof Measurement that) {
+			return MeasurementFactory.isEqual(this, that);
+		} else {
+			return false;
+		}
 	}
 
+	@Override
+	public int hashCode() {
+		return MeasurementFactory.hash(this);
+	}
 }
 
 
@@ -115,7 +136,7 @@ class FloatMeasurement implements Measurement {
 
 	@Override
 	public String toString() {
-		return getName() + ": " + Double.toString(getValue());
+		return getName() + ": " + getValue();
 	}
 
 	@Override
@@ -124,8 +145,19 @@ class FloatMeasurement implements Measurement {
 	}
 
 	@Override
-	public boolean isDynamic() {
-		return false;
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o instanceof Measurement that) {
+			return MeasurementFactory.isEqual(this, that);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return MeasurementFactory.hash(this);
 	}
 
 }

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
@@ -199,6 +199,8 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 
 	/**
 	 * Get the names of all measurements currently in the list.
+	 * Note that this method should return an unmodifiable snapshot of the current names, and not be affected by
+	 * changes to the list.
 	 * @return
 	 */
 	List<String> getMeasurementNames();

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
@@ -280,9 +280,7 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * @return a map view of this measurement list
 	 * @implSpec The returned map should already be synchronized.
 	 */
-	default Map<String, Number> asMap() {
-		return Collections.synchronizedMap(new MeasurementsMap(this));
-	}
-	
+	Map<String, Number> asMap();
+
 
 }

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
@@ -167,7 +167,7 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	/**
 	 * Get all available names as a set.
 	 * @return
-	 * @implNote the current implementation is much less efficient than {@link #getMeasurementNames()}, 
+	 * @implNote the current implementation is much less efficient than {@link #getNames()},
 	 *           but is included to more closely resemble Map behavior.
 	 *           The list of names and size of the returned set here should be identical; if they aren't, 
 	 *           duplicate names seem to be present and a warning is logged.
@@ -176,8 +176,8 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 *           please report it!).
 	 */
 	default Set<String> keySet() {
-		var names = getMeasurementNames();
-		var set = Set.copyOf(getMeasurementNames());
+		var names = getNames();
+		var set = Set.copyOf(getNames());
 		// Shouldn't ever happen, but we certainly want to know if it does...
 		if (set.size() < names.size()) {
 			LoggerFactory.getLogger(getClass()).warn("Duplicate measurement names detected! Set size {}, list size {}", set.size(), names.size());
@@ -191,7 +191,19 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * changes to the list.
 	 * @return
 	 */
-	List<String> getMeasurementNames();
+	List<String> getNames();
+
+	/**
+	 * Get the names of all measurements currently in the list.
+	 * Note that this method should return an unmodifiable snapshot of the current names, and not be affected by
+	 * changes to the list.
+	 * @return
+	 * @deprecated v0.6.0 use {@link #getNames()} instead
+	 */
+	@Deprecated
+	default List<String> getMeasurementNames() {
+		return getNames();
+	}
 
 	/**
 	 * Get value for the measurement with the specified name.
@@ -209,7 +221,7 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * @since v0.4.0
 	 */
 	default boolean containsKey(String name) {
-		return getMeasurementNames().contains(name);
+		return getNames().contains(name);
 	}
 
 	/**
@@ -225,7 +237,7 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * @return
 	 */
 	default int size() {
-		return getMeasurementNames().size();
+		return getNames().size();
 	}
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
@@ -90,7 +90,7 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * This provides a snapshot of the current measurement, and should not be affected by changes to the list.
 	 * @return
 	 */
-	Measurement getMeasurement(int ind);
+	Measurement getByIndex(int ind);
 
 	/**
 	 * Get the specified measurement, or the provided default value if it is not contained in the list.
@@ -254,7 +254,17 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * Remove all the measurements with the specified names.
 	 * @param measurementNames
 	 */
-	void removeMeasurements(String... measurementNames);
+	void removeAll(String... measurementNames);
+
+	/**
+	 * Remove all the measurements with the specified names.
+	 * @param measurementNames
+	 * @deprecated v0.6.0 use {@link #removeAll(String...)} instead
+	 */
+	@Deprecated
+	default void removeMeasurements(String... measurementNames) {
+		removeAll(measurementNames);
+	}
 	
 	/**
 	 * Remove all the measurements from the list.

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementList.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -25,14 +25,11 @@ package qupath.lib.measurements;
 
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.slf4j.LoggerFactory;
-
-import qupath.lib.common.LogTools;
 
 /**
  * Interface defining a feature measurement list, consisting of key value pairs.
@@ -40,13 +37,8 @@ import qupath.lib.common.LogTools;
  * To help enable efficiency for large sets of PathObjects requiring measurement lists,
  * only String keys and numeric values are included.
  * <p>
- * <b>QuPath v0.4.0: </b> MeasurementList was updated to have more map-like behavior, 
- * while still using primitive values. In particular, {@link #addMeasurement(String, double)} 
- * was deprecated and now simply defers to {@link #put(String, double)}.
- * <p>
- * Additionally, the wordy {@link #putMeasurement(String, double)} and {@link #getMeasurementValue(String)} 
- * were deprecated in favor of {@link #put(String, double)} and {@link #get(String)} - which do the same thing, 
- * but with more familiar syntax.
+ * In QuPath v0.4.0 several methods were deprecated, and these were removed in v0.6.0.
+ * The main aim was to make the API more consistent and easier to use.
  * 
  * @author Pete Bankhead
  *
@@ -57,7 +49,7 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * Enum representing different types of measurement list, with different priorities regarding 
 	 * flexibility and efficiency.
 	 */
-	public enum MeasurementListType {
+	enum MeasurementListType {
 		/**
 		 * A general list, which can contain any kind of measurement - at the expense of 
 		 * being rather memory-hungry.
@@ -74,55 +66,6 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	}
 	
 	/**
-	 * Add a new measurement. No check is made to ensure the name is unique, and 
-	 * in general {@link #put(String, double)} is to be preferred.
-	 * @param name
-	 * @param value
-	 * @return
-	 * 
-	 * @see #put(String, double)
-	 * @deprecated v0.4.0 use {@link #put(String, double)} instead
-	 * @implNote Since v0.4.0 the default implementation delegates to {@link #put(String, double)}, 
-	 *           and will therefore replace any existing value with the same name.
-	 *           This different behavior is introduced to facilitate moving measurement lists towards 
-	 *           a map implementation for improved performance, consistency and scripting.
-	 */
-	@Deprecated
-	public default boolean addMeasurement(String name, double value) {
-		synchronized (this) {
-			boolean contains = containsKey(name);
-			var logger = LoggerFactory.getLogger(getClass());
-			if (contains) {
-				logger.warn("Duplicate '{}' not allowed - previous measurement will be dropped (duplicate names no longer permitted since v0.4.0)", name);
-				logger.warn("MeasurementList.addMeasurement(String, double) is deprecated in QuPath v0.4.0 - calling putMeasurement(String, double) instead");
-			} else {
-				LogTools.warnOnce(logger,
-						"MeasurementList.addMeasurement(String, double) is deprecated in QuPath v0.4.0 - calling putMeasurement(String, double) instead");
-			}
-			put(name, value);
-			return contains;
-		}
-	}
-	
-	/**
-	 * Put a measurement into the list, replacing any previous measurement with the same name.
-	 * <p>
-	 * This is similar to add, but with a check to remove any existing measurement with the same name
-	 * (if multiple measurements have the same name, the first will be replaced).
-	 * <p>
-	 * While it's probably a good idea for measurements to always have unique names, for some implementations
-	 * putMeasurement can be must slower than add or addMeasurement - so adding should be preferred if it is
-	 * known that a measurement with the same name is not present.
-	 * 
-	 * @param measurement
-	 * @return
-	 * @deprecated since v0.4.0, since there is no real need to create a {@link Measurement} object and 
-	 *             we don't currently use dynamic measurements
-	 */
-	@Deprecated
-	public Measurement putMeasurement(Measurement measurement);
-	
-	/**
 	 * Put a measurement value into the list, replacing any previous measurement with the same name.
 	 * <p>
 	 * This is similar to adding, but with a check to remove any existing measurement with the same name
@@ -132,8 +75,26 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * @param value
 	 * @since v0.4.0
 	 */
-	public void put(String name, double value);
-	
+	void put(String name, double value);
+
+	/**
+	 * Get name for the measurement at the specified index in the list.
+	 * @param ind
+	 * @return
+	 * @deprecated since v0.4.0; using names is preferred over indexing but {@link #getMeasurementNames()} can still be used
+	 */
+	@Deprecated
+	String getMeasurementName(int ind);
+
+	/**
+	 * Get value for the measurement at the specified index in the list.
+	 * @param ind
+	 * @return
+	 * @deprecated since v0.4.0; using {@link #get(String)} is preferred over using an index
+	 */
+	@Deprecated
+	double getMeasurementValue(int ind);
+
 	/**
 	 * Get the specified measurement, or the provided default value if it is not contained in the list.
 	 * <p>
@@ -144,7 +105,7 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * @return
 	 * @since v0.4.0
 	 */
-	public default double getOrDefault(String name, double defaultValue) {
+	default double getOrDefault(String name, double defaultValue) {
 		synchronized (this) {
 			double val = get(name);
 			if (Double.isNaN(val)) {
@@ -158,22 +119,11 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	}
 	
 	/**
-	 * Query if a value with the specified name is in the list.
-	 * @param name
-	 * @return
-	 * @deprecated since v0.4.0; replaced by {@link #containsKey(String)}
-	 */
-	@Deprecated
-	public default boolean containsNamedMeasurement(String name) {
-		return containsKey(name);
-	}
-	
-	/**
 	 * Get all measurement values as a double array
 	 * @return
 	 * @since v0.4.0
 	 */
-	public default double[] values() {
+	default double[] values() {
 		synchronized(this) {
 			double[] values = new double[size()];
 			for (int i = 0; i < size(); i++)
@@ -183,34 +133,12 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	}
 	
 	/**
-	 * Get the measurement with the specified name.
-	 * @param name
-	 * @return the value, or Double.NaN if no measurement is available with the specified name
-	 * @deprecated since v0.4.0; use {@link #get(String)} instead
-	 */
-	@Deprecated
-	public default double getMeasurementValue(String name) {
-		return get(name);
-	}
-	
-	/**
-	 * Alternative method to call {@link #putMeasurement(String, double)}
-	 * @param name
-	 * @param value 
-	 * @deprecated since v0.4.0; replaced by {@link #put(String, double)}
-	 */
-	@Deprecated
-	public default void putMeasurement(String name, double value) {
-		put(name, value);
-	}
-	
-	/**
 	 * Remove a named measurement
 	 * @param name
 	 * @return the value that was removed, or Double.NaN if the value was not in the list
 	 * @since v0.4.0
 	 */
-	public default double remove(String name) {
+	default double remove(String name) {
 		synchronized (this) {
 			int sizeBefore = size();
 			int ind = getMeasurementNames().indexOf(name);
@@ -225,11 +153,11 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	}
 	
 	/**
-	 * Put all the values from the specified  map into this list
+	 * Put all the values from the specified map into this list
 	 * @param map
 	 * @since v0.4.0
 	 */
-	public default void putAll(Map<String, ? extends Number> map) {
+	default void putAll(Map<String, ? extends Number> map) {
 		for (var entry : map.entrySet()) {
 			put(entry.getKey(), entry.getValue().doubleValue());			
 		}
@@ -240,10 +168,10 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * @param list
 	 * @since v0.4.0
 	 */
-	public default void putAll(MeasurementList list) {
+	default void putAll(MeasurementList list) {
 		synchronized (list) {
 			for (String name : list.getMeasurementNames()) {
-				put(name, list.getMeasurementValue(name));			
+				put(name, list.get(name));
 			}
 		}
 	}
@@ -259,39 +187,21 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 *           a pre-v0.4.0 QuPath version is deserialized (or there is a bad bug somewhere here - if so, 
 	 *           please report it!).
 	 */
-	public default Set<String> keySet() {
+	default Set<String> keySet() {
 		var names = getMeasurementNames();
-		var set = new LinkedHashSet<>(names);
-		// Shouldn't happen now that addMeasurements is ineffective... but conceivably could with legacy lists
+		var set = Set.copyOf(getMeasurementNames());
+		// Shouldn't ever happen, but we certainly want to know if it does...
 		if (set.size() < names.size()) {
 			LoggerFactory.getLogger(getClass()).warn("Duplicate measurement names detected! Set size {}, list size {}", set.size(), names.size());
 		}
-		return Collections.unmodifiableSet(set);
+		return set;
 	}
 
 	/**
 	 * Get the names of all measurements currently in the list.
 	 * @return
 	 */
-	public List<String> getMeasurementNames();
-
-	/**
-	 * Get name for the measurement at the specified index in the list.
-	 * @param ind
-	 * @return
-	 * @deprecated since v0.4.0; using names is preferred over indexing but {@link #getMeasurementNames()} can still be used
-	 */
-	@Deprecated
-	public String getMeasurementName(int ind);
-
-	/**
-	 * Get value for the measurement at the specified index in the list.
-	 * @param ind
-	 * @return
-	 * @deprecated since v0.4.0; using {@link #get(String)} is preferred over using an index
-	 */
-	@Deprecated
-	public double getMeasurementValue(int ind);
+	List<String> getMeasurementNames();
 
 	/**
 	 * Get value for the measurement with the specified name.
@@ -300,7 +210,7 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * @see #put(String, double)
 	 * @since v0.4.0
 	 */
-	public double get(String name);
+	double get(String name);
 
 	/**
 	 * Returns true if this list contains a measurement with the specified name.
@@ -308,50 +218,46 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * @return
 	 * @since v0.4.0
 	 */
-	public boolean containsKey(String name);
+	default boolean containsKey(String name) {
+		return getMeasurementNames().contains(name);
+	}
 
 	/**
 	 * Returns true if the list does not contain any measurements.
 	 * @return
 	 */
-	public boolean isEmpty();
+	default boolean isEmpty() {
+		return size() == 0;
+	}
 	
 	/**
 	 * Returns the number of measurements in the list.
 	 * @return
 	 */
-	public int size();
+	default int size() {
+		return getMeasurementNames().size();
+	}
 	
 	/**
-	 * Returns true if the list supports dynamic measurements. 
-	 * Dynamic measurements can change their values, and in the interests of efficiency 
-	 * are not supported by all MeasurementList implementations.
-	 * <p>
-	 * Use of this is strongly discouraged.
-	 * 
-	 * @return
-	 * @deprecated since v0.4.0; the initial implementation of dynamic measurements was never used
-	 */
-	@Deprecated
-	public boolean supportsDynamicMeasurements();
-	
-	/**
-	 * Close the list. Depending on the implementation, the list may then adjust its internal storage to be
+	 * Close the list.
+	 * Depending on the implementation, the list may then adjust its internal storage to be
 	 * more efficient.
 	 */
 	@Override
-	public void close();
+	default void close() {
+		// Default implementation does nothing
+	}
 	
 	/**
 	 * Remove all the measurements with the specified names.
 	 * @param measurementNames
 	 */
-	public void removeMeasurements(String... measurementNames);
+	void removeMeasurements(String... measurementNames);
 	
 	/**
 	 * Remove all the measurements from the list.
 	 */
-	public void clear();
+	void clear();
 	
 	/**
 	 * Get a map view of this measurements list. 
@@ -362,15 +268,9 @@ public interface MeasurementList extends Serializable, AutoCloseable {
 	 * @return a map view of this measurement list
 	 * @implSpec The returned map should already be synchronized.
 	 */
-	public default Map<String, Number> asMap() {
+	default Map<String, Number> asMap() {
 		return Collections.synchronizedMap(new MeasurementsMap(this));
 	}
-	
-//	/**
-//	 * Return a Map view over this list. Changes made to the map will be stored in the list.
-//	 * @return
-//	 */
-//	public Map<String, Double> asMap();
 	
 
 }

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
@@ -158,7 +158,7 @@ class MeasurementsMap extends AbstractMap<String, Number> implements Map<String,
 
 				@Override
 				public Entry<String, Number> next() {
-					var measurement = list.getMeasurement(i);
+					var measurement = list.getByIndex(i);
 					Entry<String, Number> entry = new SimpleImmutableEntry<>(
 							measurement.getName(), measurement.getValue());
 					i++;

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2022-2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -37,7 +37,7 @@ import java.util.Set;
  */
 class MeasurementsMap extends AbstractMap<String, Number> implements Map<String, Number> {
 	
-	private MeasurementList list;
+	private final MeasurementList list;
 	
 	public MeasurementsMap(MeasurementList list) {
 		this.list = list;
@@ -87,12 +87,11 @@ class MeasurementsMap extends AbstractMap<String, Number> implements Map<String,
 	
 	@Override
 	public Double get(Object key) {
-		if (!(key instanceof String))
-			return null;
-		String name = (String)key;
-		synchronized(list) {
-			if (list.containsKey(name))
-				return list.get(name);
+		if (key instanceof String name) {
+			synchronized (list) {
+				if (list.containsKey(name))
+					return list.get(name);
+			}
 		}
 		return null;
 	}
@@ -108,7 +107,7 @@ class MeasurementsMap extends AbstractMap<String, Number> implements Map<String,
 	public Number put(String name, Number value) {
 		Objects.requireNonNull(value);
 		Number current = null;
-		synchronized(list) {
+		synchronized (list) {
 			if (list.containsKey(name))
 				current = list.get(name);
 			list.put(name, value.doubleValue());
@@ -164,7 +163,9 @@ class MeasurementsMap extends AbstractMap<String, Number> implements Map<String,
 
 				@Override
 				public Entry<String, Number> next() {
-					SimpleEntry<String, Number> entry = new SimpleEntry<>(list.getMeasurementName(i), list.getMeasurementValue(i));
+					SimpleEntry<String, Number> entry = new SimpleEntry<>(
+							list.getMeasurementName(i),
+							list.getMeasurementValue(i));
 					i++;
 					return entry;
 				}
@@ -178,6 +179,5 @@ class MeasurementsMap extends AbstractMap<String, Number> implements Map<String,
 		}
 		
 	}
-	
 
 }

--- a/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/MeasurementsMap.java
@@ -169,7 +169,7 @@ class MeasurementsMap extends AbstractMap<String, Number> implements Map<String,
 				public void remove() {
 					if (i <= 0)
 						throw new IllegalStateException();
-					list.remove(list.getMeasurementNames().get(i - 1));
+					list.remove(list.getNames().get(i - 1));
 					i--;
 				}
 				

--- a/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
@@ -282,7 +282,7 @@ class NumericMeasurementList {
 		}
 
 		@Override
-		public synchronized void removeMeasurements(String... measurementNames) {
+		public synchronized void removeAll(String... measurementNames) {
 			isClosed = isClosed();
 			for (String name : measurementNames) {
 				remove(name);
@@ -322,15 +322,15 @@ class NumericMeasurementList {
 			if (n == 0)
 				return Collections.emptyList();
 			else if (n == 1)
-				return List.of(getMeasurement(0));
+				return List.of(getByIndex(0));
 			else
 				return IntStream.range(0, n)
-					.mapToObj(this::getMeasurement)
+					.mapToObj(this::getByIndex)
 					.toList();
 		}
 
 		@Override
-		public synchronized Measurement getMeasurement(int ind) {
+		public synchronized Measurement getByIndex(int ind) {
 			return MeasurementFactory.createMeasurement(names.get(ind), values[ind]);
 		}
 
@@ -411,15 +411,15 @@ class NumericMeasurementList {
 			if (n == 0)
 				return Collections.emptyList();
 			else if (n == 1)
-				return List.of(getMeasurement(0));
+				return List.of(getByIndex(0));
 			else
 				return IntStream.range(0, n)
-						.mapToObj(this::getMeasurement)
+						.mapToObj(this::getByIndex)
 						.toList();
 		}
 
 		@Override
-		public synchronized Measurement getMeasurement(int ind) {
+		public synchronized Measurement getByIndex(int ind) {
 			return MeasurementFactory.createMeasurement(names.get(ind), values[ind]);
 		}
 		

--- a/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
@@ -232,7 +232,7 @@ class NumericMeasurementList {
 			else {
 				// If the list is closed, we have to reopen it
 				ensureListOpen();
-				names.add(name);
+				names.add(name.intern());
 				setValue(size()-1, value);
 			}
 		}

--- a/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
@@ -250,7 +250,7 @@ class NumericMeasurementList {
 			if (mapView == null) {
 				synchronized(this) {
 					if (mapView == null)
-						mapView = new MeasurementsMap(this);
+						mapView = Collections.synchronizedMap(new MeasurementsMap(this));
 				}
 			}
 			return mapView;

--- a/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
+++ b/qupath-core/src/main/java/qupath/lib/measurements/NumericMeasurementList.java
@@ -181,7 +181,7 @@ class NumericMeasurementList {
 		}
 
 		@Override
-		public synchronized List<String> getMeasurementNames() {
+		public synchronized List<String> getNames() {
 			if (names.isEmpty())
 				return Collections.emptyList();
 			// Try to return the same unmodifiable list of names if we can - this speeds up comparisons

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -54,7 +54,6 @@ import org.slf4j.LoggerFactory;
 import qupath.lib.geom.Point2;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
-import qupath.lib.interfaces.MinimalMetadataStore;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.classes.PathClass;
 import qupath.lib.objects.classes.PathClassTools;
@@ -2057,7 +2056,7 @@ public class PathObjectTools {
 		for (PathObject pathObject : pathObjects) {
 			if (!pathObject.hasMeasurements())
 				continue;
-			List<String> list = pathObject.getMeasurementList().getMeasurementNames();
+			List<String> list = pathObject.getMeasurementList().getNames();
 			if (lastNames != list)
 				featureSet.addAll(list);
 			lastNames = list;

--- a/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
@@ -169,7 +169,7 @@ public class TestPathObjectIO {
 	
 	private static void assertSameMeasurements(MeasurementList ml1, MeasurementList ml2) {
 		assertEquals(ml1.size(), ml2.size());
-		assertEquals(ml1.getMeasurementNames(), ml2.getMeasurementNames());
+		assertEquals(ml1.getNames(), ml2.getNames());
 		for (int i = 0; i < ml1.size(); i++) {
 			double val1 = ml1.getMeasurement(i).getValue();
 			double val2 = ml2.getMeasurement(i).getValue();

--- a/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
@@ -171,8 +171,8 @@ public class TestPathObjectIO {
 		assertEquals(ml1.size(), ml2.size());
 		assertEquals(ml1.getMeasurementNames(), ml2.getMeasurementNames());
 		for (int i = 0; i < ml1.size(); i++) {
-			double val1 = ml1.getMeasurementValue(i);
-			double val2 = ml2.getMeasurementValue(i);
+			double val1 = ml1.getMeasurement(i).getValue();
+			double val2 = ml2.getMeasurement(i).getValue();
 			if (Double.isNaN(val1))
 				assertTrue(Double.isNaN(val2));
 			else

--- a/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
+++ b/qupath-core/src/test/java/qupath/lib/io/TestPathObjectIO.java
@@ -171,8 +171,8 @@ public class TestPathObjectIO {
 		assertEquals(ml1.size(), ml2.size());
 		assertEquals(ml1.getNames(), ml2.getNames());
 		for (int i = 0; i < ml1.size(); i++) {
-			double val1 = ml1.getMeasurement(i).getValue();
-			double val2 = ml2.getMeasurement(i).getValue();
+			double val1 = ml1.getByIndex(i).getValue();
+			double val2 = ml2.getByIndex(i).getValue();
 			if (Double.isNaN(val1))
 				assertTrue(Double.isNaN(val2));
 			else

--- a/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementList.java
+++ b/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementList.java
@@ -1,0 +1,142 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2024 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.lib.measurements;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestMeasurementList {
+
+    enum ListType {
+        GENERAL,
+        DOUBLE,
+        FLOAT,
+        GENERAL_CLOSED,
+        DOUBLE_CLOSED,
+        FLOAT_CLOSED;
+
+        private MeasurementList.MeasurementListType toMeasurementListType() {
+            return switch (this) {
+                case GENERAL, GENERAL_CLOSED -> MeasurementList.MeasurementListType.GENERAL;
+                case DOUBLE, DOUBLE_CLOSED -> MeasurementList.MeasurementListType.DOUBLE;
+                case FLOAT, FLOAT_CLOSED -> MeasurementList.MeasurementListType.FLOAT;
+            };
+        }
+
+        private boolean isClosed() {
+            return switch (this) {
+                case FLOAT_CLOSED, DOUBLE_CLOSED, GENERAL_CLOSED -> true;
+                default -> false;
+            };
+        }
+    }
+
+    private static MeasurementList createMeasurementList(ListType type, int nMeasurements) {
+        // Create list, permitting resize
+        var list = MeasurementListFactory.createMeasurementList(Math.max(1, nMeasurements / 2), type.toMeasurementListType());
+        for (int i = 0; i < nMeasurements; i++) {
+            list.put("Measurement " + (i+1), i+1);
+        }
+        if (type.isClosed())
+            list.close();
+        return list;
+    }
+
+    @ParameterizedTest
+    @EnumSource(ListType.class)
+    void checkNamesUnchanged(ListType type) {
+        var list = createMeasurementList(type, 5);
+        // This should give an unmodifiable snapshot of names
+        var names = list.getMeasurementNames();
+        list.put(UUID.randomUUID().toString(), 1.0);
+        var names2 = list.getMeasurementNames();
+        assertNotEquals(names, names2);
+        assertEquals(5, names.size());
+        assertEquals(6, names2.size());
+    }
+
+    @ParameterizedTest
+    @EnumSource(ListType.class)
+    void test_noDuplicates(ListType type) {
+        var list = createMeasurementList(type, 0);
+        list.put("First", 1.0);
+        list.put("Second", 2.0);
+        list.put("Third", 3.0);
+        assertEquals(3, list.size());
+
+        list.put("Third", 6.0);
+        list.put("Second", 5.0);
+        list.put("First", 4.0);
+        assertEquals(3, list.size());
+
+        assertEquals(4.0, list.get("First"));
+        assertEquals(5.0, list.get("Second"));
+        assertEquals(6.0, list.get("Third"));
+    }
+
+
+    @ParameterizedTest
+    @EnumSource(ListType.class)
+    void test_mapAccess(ListType type) {
+        var list = createMeasurementList(type, 0);
+        var mapOriginal = list.asMap();
+
+        list.put("First", 1.0);
+        list.put("Second", 2.0);
+        list.put("Third", 3.0);
+        assertEquals(3, list.size());
+
+        // Ensure map requested before modification is correct
+        assertEquals(Set.of("First", "Second", "Third"), mapOriginal.keySet());
+        assertArrayEquals(new double[]{1.0, 2.0, 3.0}, mapOriginal.values().stream().mapToDouble(Number::doubleValue).toArray());
+
+        // Ensure map requested after modification is correct
+        var map = list.asMap();
+        assertEquals(Set.of("First", "Second", "Third"), map.keySet());
+        assertEquals(list.keySet(), map.keySet());
+        assertArrayEquals(new double[]{1.0, 2.0, 3.0}, map.values().stream().mapToDouble(Number::doubleValue).toArray());
+    }
+
+    @ParameterizedTest
+    @EnumSource(ListType.class)
+    void test_clear(ListType type) {
+        int n = 5;
+        var list = createMeasurementList(type, n);
+        assertEquals(n, list.size());
+        assertFalse(list.isEmpty());
+        list.clear();
+        assertEquals(0, list.size());
+        assertTrue(list.isEmpty());
+        assertTrue(list.getMeasurementNames().isEmpty());
+    }
+
+}

--- a/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementList.java
+++ b/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementList.java
@@ -219,7 +219,7 @@ public class TestMeasurementList {
         // Successful remove
         var names = list.getNames();
         var toRemove = names.subList(1, 3);
-        list.removeMeasurements(toRemove.toArray(String[]::new));
+        list.removeAll(toRemove.toArray(String[]::new));
         var newNames = list.getNames();
         assertEquals(n - toRemove.size(), list.size());
         for (var name : toRemove) {

--- a/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementList.java
+++ b/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementList.java
@@ -336,4 +336,17 @@ public class TestMeasurementList {
         assertTrue(values.isEmpty());
     }
 
+    @ParameterizedTest
+    @EnumSource(ListType.class)
+    void test_stringInterning(ListType type) {
+        var list = createMeasurementList(type, 1);
+        var list2 = createMeasurementList(type, 1);
+        // Shouldn't normally test strings like this!
+        // But here we want to make sure that String.intern() has been called to keep
+        // memory usage down.
+        // Interning is less important when lists are 'closed', so names are reused,
+        // but if the user forgets to do this then memory usage could become *much* higher.
+        assertTrue(list.getNames().get(0) == list2.getNames().get(0));
+    }
+
 }

--- a/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementList.java
+++ b/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementList.java
@@ -286,4 +286,54 @@ public class TestMeasurementList {
         assertTrue(entries.isEmpty());
     }
 
+    @ParameterizedTest
+    @EnumSource(ListType.class)
+    void test_mapKeyIteration(ListType type) {
+        int n = 5;
+        var list = createMeasurementList(type, n);
+        var keys = list.asMap().keySet();
+        var iter = keys.iterator();
+        int i = 0;
+        while (iter.hasNext()) {
+            assertEquals(n - i, list.size());
+            var entry = iter.next();
+            iter.remove();
+            i++;
+            assertEquals(n - i, list.size());
+        }
+        assertEquals(n, i);
+        assertTrue(keys.isEmpty());
+    }
+
+    @ParameterizedTest
+    @EnumSource(ListType.class)
+    void test_mapKeyRemoval(ListType type) {
+        int n = 5;
+        var list = createMeasurementList(type, n);
+        var names = list.getNames();
+        var toRemove = names.subList(1, 3);
+        var keys = list.asMap().keySet();
+        keys.removeAll(toRemove);
+        assertEquals(n-2, list.size());
+    }
+
+    @ParameterizedTest
+    @EnumSource(ListType.class)
+    void test_mapValueIteration(ListType type) {
+        int n = 5;
+        var list = createMeasurementList(type, n);
+        var values = list.asMap().values();
+        var iter = values.iterator();
+        int i = 0;
+        while (iter.hasNext()) {
+            assertEquals(n - i, list.size());
+            var entry = iter.next();
+            iter.remove();
+            i++;
+            assertEquals(n - i, list.size());
+        }
+        assertEquals(n, i);
+        assertTrue(values.isEmpty());
+    }
+
 }

--- a/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementList.java
+++ b/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementList.java
@@ -82,9 +82,9 @@ public class TestMeasurementList {
     void test_namesSnapshot(ListType type) {
         var list = createMeasurementList(type, 5);
         // This should give an unmodifiable snapshot of names
-        var names = list.getMeasurementNames();
+        var names = list.getNames();
         list.put(UUID.randomUUID().toString(), 1.0);
-        var names2 = list.getMeasurementNames();
+        var names2 = list.getNames();
         assertNotEquals(names, names2);
         assertEquals(5, names.size());
         assertEquals(6, names2.size());
@@ -142,7 +142,7 @@ public class TestMeasurementList {
         list.clear();
         assertEquals(0, list.size());
         assertTrue(list.isEmpty());
-        assertTrue(list.getMeasurementNames().isEmpty());
+        assertTrue(list.getNames().isEmpty());
     }
 
     @ParameterizedTest
@@ -217,10 +217,10 @@ public class TestMeasurementList {
         var list = createMeasurementList(type, n);
         assertEquals(n, list.size());
         // Successful remove
-        var names = list.getMeasurementNames();
+        var names = list.getNames();
         var toRemove = names.subList(1, 3);
         list.removeMeasurements(toRemove.toArray(String[]::new));
-        var newNames = list.getMeasurementNames();
+        var newNames = list.getNames();
         assertEquals(n - toRemove.size(), list.size());
         for (var name : toRemove) {
             assertFalse(newNames.contains(name));

--- a/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementListFactory.java
+++ b/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementListFactory.java
@@ -65,7 +65,7 @@ public class TestMeasurementListFactory {
 		}
 		
 		// Change same names
-		assertEquals(names, list.getMeasurementNames());
+		assertEquals(names, list.getNames());
 		
 		// Check access
 		Collections.shuffle(names, rand);
@@ -82,7 +82,7 @@ public class TestMeasurementListFactory {
 			list.removeMeasurements(name);
 		}
 		assertTrue(list.size() == names.size());
-		assertTrue(list.getMeasurementNames().containsAll(names));
+		assertTrue(list.getNames().containsAll(names));
 		assertTrue(checkAgreement(list, map, names));	
 		
 		// Check list after adding (some with same name as previously)
@@ -102,11 +102,11 @@ public class TestMeasurementListFactory {
 		assertTrue(checkAgreement(list, map, names));
 		
 		assertTrue(list.size() == names.size());
-		assertTrue(list.getMeasurementNames().containsAll(names));
+		assertTrue(list.getNames().containsAll(names));
 		
 		list.clear();
 		assertTrue(list.isEmpty());
-		assertTrue(list.getMeasurementNames().isEmpty());
+		assertTrue(list.getNames().isEmpty());
 	}
 	
 	

--- a/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementListFactory.java
+++ b/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurementListFactory.java
@@ -79,7 +79,7 @@ public class TestMeasurementListFactory {
 		// Check access after removing
 		for (int i = 0; i < 10; i++) {
 			String name = names.remove(i);
-			list.removeMeasurements(name);
+			list.removeAll(name);
 		}
 		assertTrue(list.size() == names.size());
 		assertTrue(list.getNames().containsAll(names));

--- a/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurements.java
+++ b/qupath-core/src/test/java/qupath/lib/measurements/TestMeasurements.java
@@ -1,0 +1,81 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2024 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.measurements;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class TestMeasurements {
+
+    @Test
+    void test_MeasurementsEquals() {
+        var mDouble = MeasurementFactory.createMeasurement("m1", 1.0d);
+        var mDouble2 = MeasurementFactory.createMeasurement("m1", 1.0f);
+        var mFloat = MeasurementFactory.createMeasurement("m1", 1.0d);
+        var mFloat2 = MeasurementFactory.createMeasurement("m1", 1.0f);
+        assertEquals(mDouble, mDouble);
+        assertEquals(mDouble, mDouble2);
+        assertEquals(mFloat, mFloat);
+        assertEquals(mFloat, mFloat2);
+        assertEquals(mDouble, mFloat);
+        assertEquals(mDouble.hashCode(), mFloat.hashCode());
+    }
+
+    @Test
+    void test_MeasurementsDoubleDifferentNames() {
+        var mDouble = MeasurementFactory.createMeasurement("m1", 1.0d);
+        var mDouble2 = MeasurementFactory.createMeasurement("m2", 1.0d);
+        assertNotEquals(mDouble.getName(), mDouble2.getName());
+        assertEquals(mDouble.getValue(), mDouble2.getValue());
+        assertNotEquals(mDouble, mDouble2);
+    }
+
+    @Test
+    void test_MeasurementsFloatDifferentNames() {
+        var mFloat = MeasurementFactory.createMeasurement("m1", 1.0f);
+        var mFloat2 = MeasurementFactory.createMeasurement("m2", 1.0f);
+        assertNotEquals(mFloat.getName(), mFloat2.getName());
+        assertEquals(mFloat.getValue(), mFloat2.getValue());
+        assertNotEquals(mFloat, mFloat2);
+    }
+
+    @Test
+    void test_MeasurementsDoubleDifferentValues() {
+        var mDouble = MeasurementFactory.createMeasurement("m1", 1.0d);
+        var mDouble2 = MeasurementFactory.createMeasurement("m1", 2.0d);
+        assertEquals(mDouble.getName(), mDouble2.getName());
+        assertNotEquals(mDouble.getValue(), mDouble2.getValue());
+        assertNotEquals(mDouble, mDouble2);
+    }
+
+    @Test
+    void test_MeasurementsFloatDifferentValues() {
+        var mFloat = MeasurementFactory.createMeasurement("m1", 1.0f);
+        var mFloat2 = MeasurementFactory.createMeasurement("m1", 2.0f);
+        assertEquals(mFloat.getName(), mFloat2.getName());
+        assertNotEquals(mFloat.getValue(), mFloat2.getValue());
+        assertNotEquals(mFloat, mFloat2);
+    }
+
+}

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
@@ -86,7 +86,7 @@ public class TestPathAnnotationObject extends TestPathObjectMethods {
 	@Test
 	public void test_MeasurementList() {
 		MeasurementList tML = MeasurementListFactory.createMeasurementList(16, MeasurementList.MeasurementListType.GENERAL);
-		tML.putMeasurement(MeasurementFactory.createMeasurement(nameML, valueML));
+		tML.put(nameML, valueML);
 		PathAnnotationObject tPO = new PathAnnotationObject(myROI, myPC, tML);
 		test_hasMeasurements(myPO, Boolean.FALSE); // no measurements
 		test_nMeasurements(myPO, 0); // no measurements

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathAnnotationObject.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import qupath.lib.measurements.MeasurementFactory;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.measurements.MeasurementListFactory;
 import qupath.lib.objects.classes.PathClass;

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -134,9 +134,9 @@ public class TestPathObject {
 	@MethodSource("provideObjects")
 	public void test_measurementMapAndList(PathObject p) {
 		
-		p.getMeasurementList().addMeasurement("added", 1);
+		p.getMeasurementList().put("added", 1);
 		assertEquals(1, p.getMeasurementList().size());
-		p.getMeasurementList().addMeasurement("added", 2);
+		p.getMeasurementList().put("added", 2);
 		assertEquals(1, p.getMeasurementList().size());
 		assertEquals(2, p.getMeasurementList().get("added"));
 		

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -196,8 +196,9 @@ public class TestPathObject {
 		double[] listValuesByName = new double[p.getMeasurementList().size()];
 		double[] listValuesAsArray = p.getMeasurementList().values();
 		for (int i = 0; i < listValues.length; i++) {
-			listValues[i] = p.getMeasurementList().getMeasurementValue(i);
-			listValuesByName[i] = p.getMeasurementList().get(p.getMeasurementList().getMeasurementName(i));
+			var m = p.getMeasurementList().getMeasurement(i);
+			listValues[i] = m.getValue();
+			listValuesByName[i] = p.getMeasurementList().get(m.getName());
 		}
 		double[] mapValues = p.getMeasurements().values().stream().mapToDouble(v -> v.doubleValue()).toArray();
 		double[] mapValuesByIterator = new double[p.getMeasurements().size()];

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -189,8 +189,8 @@ public class TestPathObject {
 	 * @param p
 	 */
 	private static void checkSameKeysAndValues(PathObject p) {
-		assertEquals(p.getMeasurementList().getMeasurementNames(), new ArrayList<>(p.getMeasurements().keySet()));
-		assertEquals(new LinkedHashSet<>(p.getMeasurementList().getMeasurementNames()), p.getMeasurements().keySet());
+		assertEquals(p.getMeasurementList().getNames(), new ArrayList<>(p.getMeasurements().keySet()));
+		assertEquals(new LinkedHashSet<>(p.getMeasurementList().getNames()), p.getMeasurements().keySet());
 		
 		double[] listValues = new double[p.getMeasurementList().size()];
 		double[] listValuesByName = new double[p.getMeasurementList().size()];

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -162,11 +162,11 @@ public class TestPathObject {
 		// Not expected to pass! val is unboxed internally, precise value not stored
 //		assertSame(val, p.getMeasurements().get("mapAdded"));
 		
-		p.getMeasurementList().removeMeasurements("Not there");
+		p.getMeasurementList().removeAll("Not there");
 		assertEquals(3, p.getMeasurementList().size());
 		assertEquals(3, p.getMeasurements().size());
 		
-		p.getMeasurementList().removeMeasurements("put");
+		p.getMeasurementList().removeAll("put");
 		assertEquals(2, p.getMeasurementList().size());
 		assertEquals(2, p.getMeasurements().size());
 
@@ -196,7 +196,7 @@ public class TestPathObject {
 		double[] listValuesByName = new double[p.getMeasurementList().size()];
 		double[] listValuesAsArray = p.getMeasurementList().values();
 		for (int i = 0; i < listValues.length; i++) {
-			var m = p.getMeasurementList().getMeasurement(i);
+			var m = p.getMeasurementList().getByIndex(i);
 			listValues[i] = m.getValue();
 			listValuesByName[i] = p.getMeasurementList().get(m.getName());
 		}

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectMethods.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectMethods.java
@@ -69,8 +69,8 @@ class TestPathObjectMethods {
 	}
 	//@Test
 	public void test_equalMeasurementListContent(MeasurementList ML, MeasurementList ML2) {
-		var keys = ML.getMeasurementNames();
-		assertArrayEquals(keys.toArray(), ML2.getMeasurementNames().toArray());
+		var keys = ML.getNames();
+		assertArrayEquals(keys.toArray(), ML2.getNames().toArray());
 		for (String name: keys) {
 			assertEquals(ML.get(name), ML2.get(name));
 		}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementManager.java
@@ -146,7 +146,7 @@ class MeasurementManager {
 		for (var entry : map.entrySet()) {
 			var set = new LinkedHashSet<String>();
 			for (var pathObject : entry.getValue())
-				set.addAll(pathObject.getMeasurementList().getMeasurementNames());
+				set.addAll(pathObject.getMeasurementList().getNames());
 			mapMeasurements.put(entry.getKey(), set);
 		}
 		if (comboBox != null) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMADataImporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/TMADataImporter.java
@@ -542,7 +542,7 @@ class TMADataImporter {
 			core.setMissing(isMissing());
 			core.setName(getName());
 			core.setCaseID(getCaseID());
-			for (String name : getMeasurementList().getMeasurementNames()) {
+			for (String name : getMeasurementList().getNames()) {
 				core.getMeasurementList().put(name, getMeasurementList().get(name));
 			}
 			core.getMeasurementList().close();
@@ -593,7 +593,7 @@ class TMADataImporter {
 		for (Entry<String, String> entry : core.getMetadata().entrySet()) {
 			sb.append(entry.getKey()).append("\t").append(entry.getValue()).append("\n");
 		}
-		for (String name : core.getMeasurementList().getMeasurementNames()) {
+		for (String name : core.getMeasurementList().getNames()) {
 			sb.append(name).append("\t").append(core.getMeasurementList().get(name)).append("\n");
 		}
 		return sb.toString();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -2040,7 +2040,7 @@ public class DefaultScriptEditor implements ScriptEditor {
 					measurements = imageData.getHierarchy()
 							.getDetectionObjects()
 							.stream()
-							.flatMap(d -> d.getMeasurementList().getMeasurementNames().stream())
+							.flatMap(d -> d.getMeasurementList().getNames().stream())
 							.distinct()
 							.map(m -> "\"" + m + "\"")
 							.collect(Collectors.joining(join))

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMAExplorer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMAExplorer.java
@@ -154,17 +154,13 @@ public class TMAExplorer implements Runnable {
 							core.isMissing());
 					
 					MeasurementList ml = core.getMeasurementList();
-					for (int i = 0; i < ml.size(); i++) {
-						String measurement = ml.getMeasurementName(i);
-						double val = ml.getMeasurementValue(i);
+					for (var m : ml.getMeasurements()) {
+						String measurement = m.getName();
+						double val = m.getValue();
 						entry.putMeasurement(measurement, val);
 						if (!Double.isNaN(val)) {
-							RunningStatistics stats = statsMap.get(measurement);
-							if (stats == null) {
-								stats = new RunningStatistics();
-								statsMap.put(measurement, stats);
-							}
-							stats.addValue(val);
+                            RunningStatistics stats = statsMap.computeIfAbsent(measurement, k -> new RunningStatistics());
+                            stats.addValue(val);
 						}
 					}
 					entries.add(entry);


### PR DESCRIPTION
Relates to
* https://github.com/qupath/qupath/issues/1444
* https://github.com/qupath/qupath/issues/1591 

and incorporates synchronization from
* https://github.com/qupath/qupath/pull/1466

---

This substantially updates the `MeasurementList` API, while avoiding any serialization-breaking changes.
It also adds many new tests to help improve the robustness of both the `MeasurementList` directly and any associated `Map` view.

Methods that were deprecated since v0.4.0 have now been removed, and there are 2 more deprecations.
The replacement methods have shorter names and should have reliable performance.
`MeasurementList` implementations should also now be threadsafe (if they prove not to be, please report a bug).

Several other key changes:
* `getNames()` (previously `getMeasurementNames()`) returns a defensive copy of the measurement. Before, it would sometimes return an unmodifiable list that wrapped a list that could still change - and that was sometimes responsible for #1444 and #1591
* `List<Measurement> getMeasurements()` and `Measurement getByIndex(int)` now provide ways to access a snapshot of one or more measurements. Previously, `getMeasurementName(int)` and `getMeasurementValue(int)` were used - but when requesting these sequentially, there was no way to guarantee that the values were properly in sync.
* `String.intern()` is now used with all `MeasurementList` implementations. Previously, it was only used for the 'general' list used for annotations. It wasn't important if other lists were closed, but if they weren't then we could end up with huge numbers of duplicate strings greatly increasing memory use.

In general, the goal of `MeasurementList` is to optimize mostly for memory use and good behavior.
Updating and querying measurements is generally rare enough that small computational costs (e.g. synchronization, defensive copying) shouldn't matter a great deal - but if we are to cope with millions of objects having hundreds of measurements each, we need to keep memory under control.