### PR TITLE
Streamline PathObject and simplify working with classifications

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -646,16 +646,36 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 	
 	/**
 	 * Get the classification of the object.
+	 * <p>
+	 * The {@code PathClass} object is used as the internal representation of the object's classification,
+	 * encapsulating both the different string components of the classification and the color used for display.
+	 * <p>
+	 * For convenience, {@link #getClassification()} and {@link }{@link #getClassifications()} provide a simpler way to interact with
+	 * classifications as one or more strings.
 	 * @return
+	 * @see #setPathClass(PathClass)
+	 * @see #getClassification()
+	 * @see #getClassifications()
 	 */
 	public abstract PathClass getPathClass();
 		
 	/**
 	 * Set the classification of the object, without specifying any classification probability.
-	 * @param pc
+	 * <p>
+	 * The {@code PathClass} object is used as the internal representation of the object's classification,
+	 * encapsulating both the different string components of the classification and the color used for display.
+	 * <p>
+	 * If the classification is null, the object is considered to be unclassified.
+	 * <p>
+	 * For convenience, {@link #setClassification(String)} ()} and {@link }{@link #setClassifications(Collection)} ()}
+	 * provide alternative ways to set classifications using strings - but this does not allow for setting the color,
+	 * and internally a {@code PathClass} object will still be used.
+	 * @param pathClass
+	 * @see #setClassification(String)
+	 * @see #setClassifications(Collection)
 	 */
-	public void setPathClass(PathClass pc) {
-		setPathClass(pc, Double.NaN);
+	public void setPathClass(PathClass pathClass) {
+		setPathClass(pathClass, Double.NaN);
 	}
 	
 	/**
@@ -666,7 +686,7 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 		var previous = getPathClass();
 		if (previous == null)
 			return false;
-		setPathClass((PathClass)null);
+		setPathClass(null);
 		return true;
 	}
 	
@@ -736,7 +756,39 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 		else
 			return pc.toSet();
 	}
-	
+
+	/**
+	 * Convenience method to get a string representation of the classification (PathClass).
+	 * <p>
+	 * It returns null if there is no classification; otherwise, it is equivalent to calling
+	 * {@code getPathClass().toString()}
+	 * @return
+	 * @see #setClassification(String)
+	 * @see #getPathClass()
+	 * @see #getClassifications()
+	 * @since v0.6.0
+	 */
+	public String getClassification() {
+		var pc = getPathClass();
+		return pc == null || pc == PathClass.NULL_CLASS ? null : pc.toString();
+	}
+
+	/**
+	 * Convenience method to et the classification of the object from a string representation.
+	 * If the string is null or empty, the classification is reset.
+	 * Otherwise, it is equivalent to calling {@code setPathClass(PathClass.fromString(classification))}
+	 * @param classification
+	 * @see #getClassification()
+	 * @see #setPathClass(PathClass)
+	 * @see #setClassifications(Collection)
+	 * @since v0.6.0
+	 */
+	public void setClassification(String classification) {
+		if (classification == null || classification.isEmpty())
+			resetPathClass();
+		else
+			setPathClass(PathClass.fromString(classification));
+	}
 
 	/**
 	 * Set the classification of the object, specifying a classification probability.
@@ -744,6 +796,9 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 	 * The probability is expected to be between 0 and 1, or Double.NaN if no probability should be set.
 	 * @param pathClass
 	 * @param classProbability
+	 * @see #setPathClass(PathClass)
+	 * @see #setClassification(String) 
+	 * @see #setClassifications(Collection)
 	 */
 	public abstract void setPathClass(PathClass pathClass, double classProbability);
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -301,17 +301,7 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 			throw new IllegalArgumentException("PathRootObject cannot be added as child to another PathObject"); //J 
 		addChildObjectImpl(pathObject);
 	}
-	
-	/**
-	 * Legacy method to add a single child object.
-	 * @param pathObject
-	 * @deprecated since v0.4.0, replaced by {@link #addChildObject(PathObject)}
-	 */
-	@Deprecated
-	public void addPathObject(PathObject pathObject) {
-		LogTools.warnOnce(logger, "addPathObject(Collection) is deprecated - use addChildObject(Collection) instead");
-		addChildObject(pathObject);
-	}
+
 	
 	private synchronized void addChildObjectImpl(PathObject pathObject) {
 		ensureChildList(nChildObjects() + 1);
@@ -411,17 +401,7 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 	public synchronized void addChildObjects(Collection<? extends PathObject> pathObjects) {
 		addChildObjectsImpl(pathObjects);
 	}
-	
-	/**
-	 * Legacy method to add child objects.
-	 * @param pathObjects
-	 * @deprecated since v0.4.0, replaced by {@link #addChildObjects(Collection)}
-	 */
-	@Deprecated
-	public void addPathObjects(Collection<? extends PathObject> pathObjects) {
-		LogTools.warnOnce(logger, "addPathObjects(Collection) is deprecated - use addChildObjects(Collection) instead");
-		addChildObjects(pathObjects);
-	}
+
 
 	/**
 	 * Remove a single object from the child list of this object.
@@ -435,17 +415,7 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 			pathObject.parent = null; //.setParent(null);
 		childList.remove(pathObject);
 	}
-	
-	/**
-	 * Legacy method to remove a single child object.
-	 * @param pathObject
-	 * @deprecated since v0.4.0, replaced by {@link #removeChildObject(PathObject)}
-	 */
-	@Deprecated
-	public void removePathObject(PathObject pathObject) {
-		LogTools.warnOnce(logger, "removePathObject(PathObject) is deprecated - use removeChildObject(PathObject) instead");
-		removeChildObject(pathObject);
-	}
+
 	
 	/**
 	 * Remove multiple objects from the child list of this object.
@@ -463,17 +433,7 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 			removeAllQuickly(childList, pathObjects);
 		}
 	}
-	
-	/**
-	 * Legacy method to remove specified child objects.
-	 * @param pathObjects 
-	 * @deprecated since v0.4.0, replaced by {@link #removeChildObjects(Collection)}
-	 */
-	@Deprecated
-	public void removePathObjects(Collection<PathObject> pathObjects) {
-		LogTools.warnOnce(logger, "removePathObjects(Collection) is deprecated - use removeChildObjects(Collection) instead");
-		removeChildObjects(pathObjects);
-	}
+
 	
 	/**
 	 * Remove all child objects.
@@ -490,16 +450,7 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 			childList.clear();
 		}
 	}
-	
-	/**
-	 * Legacy method to remove all child objects.
-	 * @deprecated since v0.4.0, replaced by {@link #clearChildObjects()}
-	 */
-	@Deprecated
-	public void clearPathObjects() {
-		LogTools.warnOnce(logger, "clearPathObjects() is deprecated, use clearChildObjects() instead");
-		clearChildObjects();
-	}
+
 	
 	/**
 	 * Total number of child objects.
@@ -535,22 +486,12 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 	/**
 	 * Check if this object has children, or if its child object list is empty.
 	 * @return
-	 * @since v0.4.0, replaces {@link #hasChildren()} for more consistent naming
+	 * @since v0.4.0
 	 */
 	public boolean hasChildObjects() {
 		return childList != null && !childList.isEmpty();
 	}
-	
-	/**
-	 * Legacy method to check for child objects.
-	 * @return
-	 * @deprecated since v0.4.0, replaced by {@link #hasChildObjects()}
-	 */
-	@Deprecated
-	public boolean hasChildren() {
-		LogTools.warnOnce(logger, "hasChildren() is deprecated - use hasChildObjects() instead");
-		return hasChildObjects();
-	}
+
 	
 	/**
 	 * Returns true if this object has a ROI.
@@ -871,7 +812,6 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 	 * <p>
 	 * This may be null if no color has been set.
 	 * @return
-	 * @see #setColorRGB(Integer)
 	 * @see ColorTools#red(int)
 	 * @see ColorTools#green(int)
 	 * @see ColorTools#blue(int)
@@ -879,30 +819,6 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 	 */
 	public Integer getColor() {
 		return color;
-	}
-	
-	/**
-	 * Return any stored color as a packed RGB value.
-	 * <p>
-	 * This may be null if no color has been set
-	 * @return
-	 * @deprecated since v0.4.0, use {@link #getColor()} instead.
-	 */
-	@Deprecated
-	public Integer getColorRGB() {
-		LogTools.warnOnce(logger, "PathObject.getColorRGB() is deprecated since v0.4.0 - use getColor() instead");
-		return getColor();
-	}
-	
-	/**
-	 * Set the display color.
-	 * @param color
-	 * @deprecated since v0.4.0, use {@link #setColor(Integer)} instead.
-	 */
-	@Deprecated
-	public void setColorRGB(Integer color) {
-		LogTools.warnOnce(logger, "PathObject.setColorRGB(Integer) is deprecated since v0.4.0 - use setColor(Integer) instead");
-		setColor(color);
 	}
 	
 	/**

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObject.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2022-2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import qupath.lib.measurements.MeasurementList.MeasurementListType;
 import qupath.lib.measurements.MeasurementListFactory;
+import qupath.lib.objects.classes.PathClass;
 import qupath.lib.roi.ROIs;
 
 public class TestPathObject {
@@ -314,7 +316,51 @@ public class TestPathObject {
 			pathObject.addChildObject(child);
 		}
 	}
-	
+
+
+	@Test
+	void test_setClassification() {
+		var pathObject = PathObjects.createAnnotationObject(ROIs.createEmptyROI());
+		assertNull(pathObject.getClassification());
+		assertNull(pathObject.getPathClass());
+		assertTrue(pathObject.getClassifications().isEmpty());
+
+		pathObject.setClassification("Something");
+		assertEquals("Something", pathObject.getClassification());
+		assertEquals(PathClass.getInstance("Something"), pathObject.getPathClass());
+		assertEquals(Set.of("Something"), pathObject.getClassifications());
+
+		pathObject.setClassification("Something:    else");
+		assertEquals("Something: else", pathObject.getClassification());
+		assertEquals(PathClass.fromString("Something: else"), pathObject.getPathClass());
+		assertEquals(PathClass.getInstance("Something"), pathObject.getPathClass().getBaseClass());
+		assertEquals(Set.of("Something", "else"), pathObject.getClassifications());
+
+		pathObject.setClassification(null);
+		assertNull(pathObject.getClassification());
+		assertNull(pathObject.getPathClass());
+		assertTrue(pathObject.getClassifications().isEmpty());
+
+		pathObject.setClassification("");
+		assertNull(pathObject.getClassification());
+		assertNull(pathObject.getPathClass());
+		assertTrue(pathObject.getClassifications().isEmpty());
+
+		pathObject.setClassifications(Set.of());
+		assertNull(pathObject.getClassification());
+		assertNull(pathObject.getPathClass());
+		assertTrue(pathObject.getClassifications().isEmpty());
+
+		pathObject.setPathClass(null);
+		assertNull(pathObject.getClassification());
+		assertNull(pathObject.getPathClass());
+		assertTrue(pathObject.getClassifications().isEmpty());
+
+		pathObject.setPathClass(PathClass.NULL_CLASS);
+		assertNull(pathObject.getClassification());
+		assertNull(pathObject.getPathClass());
+		assertTrue(pathObject.getClassifications().isEmpty());
+	}
 	
 	
 	


### PR DESCRIPTION
This PR removes some methods from `PathObject` that were previously deprecated.

It also introduces
```java
public void setClassification(String classification)
public void getClassification()
```
which now exist alongside the earlier methods
```java
// The originals
public void setPathClass(PathClass pathClass)
public PathClass getPathClass()

// New in v0.4.0
public void setClassifications(Collection<String> classifications)
public Set<String> getClassifications()
```

Having 3 different ways to set/get classifications may seem a bit much, but the intention is to make scripting as intuitive as possible. Each method has a different purpose:
1. `PathClass` encapsulates everything about the classification: the different pieces (e.g. subclassifications) and the color; this is used internally
2. The 'classification' is simply a `String` representation of the `PathClass`; it can represent the key pieces (with a colon delimiter for subclassifications), but *not* the color
3. The 'classifications' are a set that represents the different part of the classification, but *not* the color; this is intended for cases when you'd really like to have *multiple* classifications, and what to treat the 'derived' parts of a classification as if they are basically separate classifications (e.g. `CD3: CD8`)

In Groovy, checking if a cell has the derived classification "Tumor: Positive", and setting it to "Tumor: Negative" if not, would look like this:
```groovy
// Original Java way (used in QuPath for all of the early years)
if (pathObject.getPathClass() != getPathClass("Tumor: Positive")) {
    pathObject.setPathClass(getPathClass("Tumor: Negative"))
}

// Using Groovy's way to avoid get/set
if (pathObject.pathClass != getPathClass("Tumor: Positive")) {
    pathObject.pathClass = getPathClass("Tumor: Negative")
}

// With strings
if (pathObject.classification != "Tumor: Positive") {
    pathObject.classification = "Tumor: Negative"
}

// With classifications
if (pathObject.classifications != ["Tumor: Positive"] as Set) {
    pathObject.classifications = ["Tumor", "Negative"]
}
```
I think the working with string is a bit less cumbersome and confusing than needing to add lots of `getPathClass()` lines. But it is more powerful with tricks like this

```groovy
// Set all cells to be classified as 'Tumor'
getCellObjects().each {it.classification = 'Tumor'}

// And 'Negative' as a (sub?) classification to all cells
getCellObjects().each {it.classifications += 'Negative'}

// Remove 'Negative' as a (sub?) classification from all cells
getCellObjects().each {it.classifications -= 'Negative'}

// Select all the objects classification *exactly* as tumor
selectObjects {it.classification == 'Tumor'}

// Select all the objects with 'Tumor' *somewhere* in their classification
selectObjects {'Tumor' in it.classifications}
```

The fact that `classification` and `classifications` differ by only a letter might be a bit confusing, but getting it wrong should throw an exception.... so hopefully the benefits are worth it.