### PR TITLE
Fix display of underscores in class names

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPane.java
@@ -196,6 +196,7 @@ class CountingPane implements PathObjectSelectionListener, PathObjectHierarchyLi
 	
 	MenuItem createPathClassMenuItem(PathClass pathClass) {
 		var mi = new MenuItem(pathClass.toString());
+		mi.setMnemonicParsing(false); // Fix display of underscores in menu items
 		var color = pathClass.getColor();
 		var rect = new Rectangle(8, 8, color == null ? ColorToolsFX.TRANSLUCENT_WHITE_FX : ColorToolsFX.getCachedColor(color));
 		mi.setGraphic(rect);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
@@ -1557,6 +1557,7 @@ public class ViewerManager implements QuPathViewerListener {
 			}
 //			actionSetClass.setGraphic(r);
 			RadioMenuItem item = ActionUtils.createRadioMenuItem(actionSetClass);
+			item.setMnemonicParsing(false); // Fix display of underscores in classification names
 			item.graphicProperty().unbind();
 			item.setGraphic(shape);
 			item.setToggleGroup(group);


### PR DESCRIPTION
Fixes https://forum.image.sc/t/a-minor-issue-with-underscore-in-class-name-of-annotation-in-qupath/100602