### PR TITLE
Support temporary selection mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This is a *work in progress* for the next major release.
 * Improvements to 'Selection mode'
   * New icon & other drawing icons change to indicate when they are active in selection mode
   * Selection mode works with line ROIs, selecting any intersecting objects
+  * Temporarily active 'Selection mode' by pressing the `S` key while interacting with a viewer
 
 ### Bugs fixed
 * Tile export to .ome.tif can convert to 8-bit unnecessarily (https://github.com/qupath/qupath/issues/1494)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -888,6 +888,10 @@ public class QuPathGUI {
 					if (active != null)
 						active.setSpaceDown(pressed.booleanValue());
 				}
+			} else if (e.getCode() == KeyCode.S && e.getEventType() == KeyEvent.KEY_PRESSED) {
+				PathPrefs.tempSelectionModeProperty().set(true);
+			} else if (e.getEventType() == KeyEvent.KEY_RELEASED) {
+				PathPrefs.tempSelectionModeProperty().set(false);
 			}
 		}
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -199,7 +199,7 @@ public class Commands {
 	 */
 	public static void createFullImageAnnotation(QuPathViewer viewer) {
 		// If we are using selection mode, we should select objects rather that create an annotation
-		if (PathPrefs.selectionModeProperty().get()) {
+		if (PathPrefs.selectionModeStatus().get()) {
 			logger.debug("Select all objects (create full image annotation with selection mode on)");
 			selectObjectsOnCurrentPlane(viewer);
 			return;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -43,7 +43,9 @@ import java.util.prefs.BackingStoreException;
 import java.util.prefs.InvalidPreferencesFormatException;
 import java.util.prefs.Preferences;
 
+import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.*;
+import javafx.beans.value.ObservableBooleanValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -659,9 +661,28 @@ public class PathPrefs {
 	/**
 	 * Convert drawing tools to select objects, rather than creating new objects.
 	 * @return
+	 * @see #tempSelectionModeProperty()
 	 */
 	public static BooleanProperty selectionModeProperty() {
 		return selectionMode;
+	}
+
+	private static BooleanProperty tempSelectionMode = MANAGER.createTransientBooleanProperty("tempSelectionMode", false);
+
+	/**
+	 * Temporarily request selection mode, without changing the value of #selectionModeProperty().
+	 * This can be used by a key-down shortcut to temporarily switch to selection mode, without changing the main toggle.
+	 * @return
+	 * @see #selectionModeProperty()
+	 */
+	public static BooleanProperty tempSelectionModeProperty() {
+		return tempSelectionMode;
+	}
+
+	private static BooleanBinding selectionModeStatus = selectionModeProperty().or(tempSelectionModeProperty());
+
+	public static ObservableBooleanValue selectionModeStatus() {
+		return selectionModeStatus;
 	}
 
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/IconFactory.java
@@ -432,7 +432,7 @@ public class IconFactory {
 	}
 
 	private static void bindStrokeToSelectionMode(ObservableList<Double> dashList) {
-		PathPrefs.selectionModeProperty().addListener((obs, oldVal, newVal) -> {
+		PathPrefs.selectionModeStatus().addListener((obs, oldVal, newVal) -> {
 			if (newVal) {
 				dashList.setAll(3.0, 3.0);
 			} else {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -374,7 +374,7 @@ public class PathObjectPainter {
 		} else {
 			double thicknessScale = downsample * (isSelected && !PathPrefs.useSelectedColorProperty().get() ? 1.6 : 1);
 			float thickness = (float)(PathPrefs.annotationStrokeThicknessProperty().get() * thicknessScale);
-			if (isSelected && pathObject.getParent() == null && PathPrefs.selectionModeProperty().get()) {
+			if (isSelected && pathObject.getParent() == null && PathPrefs.selectionModeStatus().get()) {
 				return getCachedStrokeDashed(thickness);
 			} else {
 				return getCachedStroke(thickness);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
@@ -846,8 +846,10 @@ public class ViewerManager implements QuPathViewerListener {
 		
 		
 		viewer.getView().addEventHandler(KeyEvent.KEY_PRESSED, e -> {
+			if (e.isConsumed())
+				return;
 			PathObject pathObject = viewer.getSelectedObject();
-			if (!e.isConsumed() && pathObject != null) {
+			if (pathObject != null) {
 				if (pathObject.isTMACore()) {
 					TMACoreObject core = (TMACoreObject)pathObject;
 					if (e.getCode() == KeyCode.ENTER) {
@@ -865,6 +867,16 @@ public class ViewerManager implements QuPathViewerListener {
 					}
 				}
 			}
+			// For temporarily setting selection mode, we want to grab any S key presses eagerly
+			if (e.getCode() == KeyCode.S && e.getEventType() == KeyEvent.KEY_PRESSED) {
+				PathPrefs.tempSelectionModeProperty().set(true);
+				e.consume();
+			}
+		});
+		viewer.getView().addEventHandler(KeyEvent.KEY_RELEASED, e -> {
+			// For temporarily setting selection mode, we want to switch off the mode quickly for any key release events -
+			// to reduce the risk of accidentally leaving selection mode 'stuck' on if the S key release is missed
+			PathPrefs.tempSelectionModeProperty().set(false);
 		});
 
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathROIToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathROIToolEventHandler.java
@@ -100,7 +100,7 @@ abstract class AbstractPathROIToolEventHandler extends AbstractPathToolEventHand
 		
 		PathObject pathObject = PathObjects.createAnnotationObject(roi, PathPrefs.autoSetAnnotationClassProperty().get());
 		var selectionModel = hierarchy.getSelectionModel();
-		if (PathPrefs.selectionModeProperty().get() && !selectionModel.noSelection())
+		if (PathPrefs.selectionModeStatus().get() && !selectionModel.noSelection())
 			viewer.setSelectedObject(pathObject, true);		
 		else
 			viewer.setSelectedObject(pathObject);
@@ -144,7 +144,7 @@ abstract class AbstractPathROIToolEventHandler extends AbstractPathToolEventHand
 			return;
 						
 		// If we are double-clicking & we don't have a polygon, see if we can access a ROI
-		if (!PathPrefs.selectionModeProperty().get() && e.getClickCount() > 1) {
+		if (!PathPrefs.selectionModeStatus().get() && e.getClickCount() > 1) {
 			// Reset parent... for now
 			resetConstrainingObjects();
 			ToolUtils.tryToSelect(viewer, xx, yy, e.getClickCount()-2, false);
@@ -199,7 +199,7 @@ abstract class AbstractPathROIToolEventHandler extends AbstractPathToolEventHand
 		var currentROI = pathObject.getROI();
 		
 		// If we are in selection mode, try to get objects to select
-		if (PathPrefs.selectionModeProperty().get()) {
+		if (PathPrefs.selectionModeStatus().get()) {
 			var pathClass = PathPrefs.autoSetAnnotationClassProperty().get();
 			Collection<PathObject> toSelect;
 			if (currentROI.isArea()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
@@ -170,7 +170,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 		
 		// Ignore the current object if it belongs to a different image plane
 		if (currentObject == null ||
-				PathPrefs.selectionModeProperty().get() || 
+				PathPrefs.selectionModeStatus().get() ||
 				!(currentObject instanceof PathAnnotationObject) || 
 				(!currentObject.isEditable()) || 
 				currentObject.getROI().getZ() != viewer.getZPosition() || 
@@ -204,7 +204,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 		
 		// See if, rather than creating something, we can instead reactivate a current object
 		boolean multipleClicks = e.getClickCount() > 1;
-		if (!PathPrefs.selectionModeProperty().get() && (multipleClicks || (createNew && !e.isShiftDown()))) {
+		if (!PathPrefs.selectionModeStatus().get() && (multipleClicks || (createNew && !e.isShiftDown()))) {
 			// See if, rather than creating something, we can instead reactivate a current object
 			if (multipleClicks) {
 				PathObject objectSelectable = ToolUtils.getSelectableObject(viewer, p.getX(), p.getY(), e.getClickCount() - 1);
@@ -216,7 +216,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 					viewer.setSelectedObject(null);
 					currentObject = null;
 				}
-			} else if (!PathPrefs.selectionModeProperty().get()) {
+			} else if (!PathPrefs.selectionModeStatus().get()) {
 					List<PathObject> listSelectable = ToolUtils.getSelectableObjectList(viewer, p.getX(), p.getY());
 					PathObject objectSelectable = null;
 					for (int i = 0; i < listSelectable.size(); i++) {
@@ -308,7 +308,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 		PathObject pathObjectUpdated = getUpdatedObject(e, shapeROI, pathObject, -1);
 
 		if (pathObject != pathObjectUpdated) {
-			viewer.setSelectedObject(pathObjectUpdated, PathPrefs.selectionModeProperty().get());
+			viewer.setSelectedObject(pathObjectUpdated, PathPrefs.selectionModeStatus().get());
 		} else {
 			viewer.repaint();
 		}


### PR DESCRIPTION
Temporarily active 'Selection mode' by holding down the `S` key while interacting with a viewer