### PR TITLE
Warn if similar classification & default colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This is a *work in progress* for the next major release.
   * Experimental - not yet a full feature or available through the user interface!
 * Add `TransformedServerBuilder.convertType(PixelType)` to convert pixel types
 * Right-click on 'Measurement map' colorbar to copy it to the system clipboard (https://github.com/qupath/qupath/pull/1583)
+* Context help can warn if a classification color is similar to the default object color
 * Improvements to 'Selection mode'
   * New icon & other drawing icons change to indicate when they are active in selection mode
   * Selection mode works with line ROIs, selecting any intersecting objects

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
@@ -57,16 +57,19 @@ import javafx.stage.Stage;
 import javafx.stage.Window;
 import qupath.fx.utils.FXUtils;
 import qupath.fx.utils.GridPaneUtils;
+import qupath.lib.common.ColorTools;
 import qupath.lib.display.ImageDisplay;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.actions.InfoMessage;
 import qupath.lib.gui.localization.QuPathResources;
 import qupath.lib.gui.prefs.PathPrefs;
+import qupath.lib.gui.tools.ColorToolsFX;
 import qupath.lib.gui.tools.IconFactory;
 import qupath.lib.gui.tools.IconFactory.PathIcons;
 import qupath.lib.gui.viewer.QuPathViewer;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.PixelCalibration;
+import qupath.lib.objects.classes.PathClass;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -141,6 +144,8 @@ public class ContextHelpViewer {
 
 	private BooleanProperty largeNonPyramidalImage = new SimpleBooleanProperty(false);
 
+	private BooleanProperty classificationAndDefaultObjectColorsSimilar = new SimpleBooleanProperty(false);
+
 	private ContextHelpViewer(QuPathGUI qupath) {
 		this.qupath = qupath;
 		this.imageDataProperty.addListener(this::imageDataChanged);
@@ -188,6 +193,31 @@ public class ContextHelpViewer {
 			currentPixelSize.set(imageData.getServer().getPixelCalibration());
 			currentImageType.set(imageData.getImageType());
 		}
+	}
+
+	private void updateSimilarClassificationColors() {
+		var pathClasses = qupath.getAvailablePathClasses();
+		var defaultColor = PathPrefs.colorDefaultObjectsProperty();
+		for (var pathClass : pathClasses) {
+			if (similarColors(pathClass.getColor(), defaultColor.get())) {
+				classificationAndDefaultObjectColorsSimilar.set(true);
+				return;
+			}
+		}
+		classificationAndDefaultObjectColorsSimilar.set(false);
+	}
+
+	private static boolean similarColors(Integer rgba1, Integer rgba2) {
+		if (rgba1 == null || rgba2 == null)
+			return false;
+		double tol = 10.0;
+		if (Math.abs(ColorTools.red(rgba1) - ColorTools.red(rgba2)) > tol)
+			return false;
+		if (Math.abs(ColorTools.green(rgba1) - ColorTools.green(rgba2)) > tol)
+			return false;
+		if (Math.abs(ColorTools.blue(rgba1) - ColorTools.blue(rgba2)) > tol)
+			return false;
+		return true;
 	}
 
 	private void updateLargeNonPyramidalProperty() {
@@ -249,7 +279,8 @@ public class ContextHelpViewer {
 				createOpacityZeroEntry(),
 				createGammaNotDefault(),
 				createInvertedColors(),
-				createNoChannelsVisible()
+				createNoChannelsVisible(),
+				createColorsTooSimilar()
 				);
 	}
 
@@ -609,6 +640,15 @@ public class ContextHelpViewer {
 		entry.visibleProperty().bind(qupath.imageDataProperty().isNotNull().and(Bindings.createBooleanBinding(
 				() -> emptyChannels == null || emptyChannels.getValue() == null ? false : emptyChannels.getValue(), emptyChannels
 		)));
+		return entry;
+	}
+
+	private HelpListEntry createColorsTooSimilar() {
+		var entry = HelpListEntry.createWarning(
+				"ContextHelp.warning.colorsSimilar");
+		qupath.getAvailablePathClasses().addListener((Change<? extends PathClass> c) -> updateSimilarClassificationColors());
+		PathPrefs.colorDefaultObjectsProperty().addListener((v, o, n) -> updateSimilarClassificationColors());
+		entry.visibleProperty().bind(classificationAndDefaultObjectColorsSimilar);
 		return entry;
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
@@ -138,8 +138,12 @@ class PathClassPane {
 		// Intercept space presses because we handle them elsewhere
 		listClasses.addEventFilter(KeyEvent.KEY_PRESSED, this::filterKeyPresses);
 		listClasses.setOnMouseClicked(e -> {
-			if (!e.isPopupTrigger() && e.getClickCount() == 2)
-				promptToEditSelectedClass();
+			if (!e.isPopupTrigger() && e.getClickCount() == 2) {
+				if (promptToEditSelectedClass()) {
+					// This fires a change event to notify any listeners
+					availablePathClasses.setAll(availablePathClasses.stream().toList());
+				}
+			}
 		});
 
 		ContextMenu menuClasses = createClassesMenu();

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -18,6 +18,8 @@ ContextHelp.warning.invertedBackground = Image is being shown with inverted back
                             Change this option in the brightness/contrast dialog.
 ContextHelp.warning.noChannels = No channels are selected!\n\
                                  Use the 'Brightness/Contrast' command to select channels.
+ContextHelp.warning.colorsSimilar = At least one classification color is similar to the default object color.\n\
+                                 It will be hard to see whether objects are classified.
 ContextHelp.warning.unseenErrors = There are errors reported in the log that have not yet been seen.\n\
                             Please check the log for details.
 ContextHelp.warning.pixelSizeMissing = Pixel size information is not set.\n\


### PR DESCRIPTION
Show a warning with the Context Help if a classification is added that has a similar color to the default object color