### PR TITLE
Update to Java 21

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,14 +14,14 @@
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
     - name: Validate Gradle wrapper
       uses: gradle/wrapper-validation-action@v1
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: build -P toolchain=17
+        arguments: build -P toolchain=21

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -13,14 +13,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
-         arguments: publish -P toolchain=17 -P release=true
+         arguments: publish -P toolchain=21 -P release=true
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASS: ${{ secrets.MAVEN_PASS }}

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -13,14 +13,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish snapshot
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
-         arguments: publish -P toolchain=17
+         arguments: publish -P toolchain=21
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASS: ${{ secrets.MAVEN_PASS }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This is a *work in progress* for the next major release.
 
+*QuPath v0.6.0 requires Java 21 or later*
+
 ### Enhancements
 * Read and write OME-Zarr images (https://github.com/qupath/qupath/pull/1474)
 * Improved display of annotation names (https://github.com/qupath/qupath/pull/1532)

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,7 +9,6 @@
  * <p>
  *     gradlew.bat clean jpackage
  * <p>
- * NOTE: This build requires OpenJDK 17+ (since it contains jpackage).
  * Gradle's toolchain options are used to overcome this: if you run gradlew with a different JDK,
  * gradle will use a different JDK for building QuPath itself (downloading it if necessary).
  */

--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -80,8 +80,8 @@ import qupath.lib.scripting.languages.ScriptLanguage;
 @Command(name = "QuPath", subcommands = {HelpCommand.class, ScriptCommand.class, GenerateCompletion.class},
 	footer = {"",
 			"Copyright(c) The Queen's University Belfast (2014-2016)",
-			"Copyright(c) QuPath developers (2017-2022)",
-			"Copyright(c) The University of Edinburgh (2018-2022)"
+			"Copyright(c) QuPath developers (2017-2024)",
+			"Copyright(c) The University of Edinburgh (2018-2024)"
 			}, mixinStandardHelpOptions = true, versionProvider = QuPath.VersionProvider.class)
 public class QuPath {
 	


### PR DESCRIPTION
We already default to using Java 21, but we were still building artifacts with Java 17. This meant we couldn't actually use any features from after Java 17.

Things we can now use (roughly in order of relevance):
- Sequenced collections - https://openjdk.org/jeps/431
- Code snippets in Javadocs - https://openjdk.org/jeps/431
- Pattern matching for switch - https://openjdk.org/jeps/441
- Virtual threads - https://openjdk.org/jeps/444
- Record patterns - https://openjdk.org/jeps/440

Note that this may require updates in any extensions that declare v0.6.0 dependencies, to ensure they also use Java 21 (and have a suitably recent Gradle wrapper).