### PR TITLE
Reinstate mergedJavadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,36 @@ plugins {
 // We don't want to generate javadocs for the root project
 javadoc.enabled = false
 
+// See https://discuss.gradle.org/t/best-approach-gradle-multi-module-project-generate-just-one-global-javadoc/18657
+tasks.register('mergedJavadocs', Javadoc) {
+    dependsOn subprojects.tasks.collect { it.withType(Javadoc) }
+    description 'Generate merged javadocs for all projects'
+    group 'Documentation'
+
+    destinationDir = layout.buildDirectory.dir("docs-merged/javadoc").get().getAsFile()
+    title = "QuPath $gradle.ext.qupathVersion"
+
+    // See https://docs.gradle.org/current/javadoc/org/gradle/external/javadoc/StandardJavadocDocletOptions.html
+    options.author(true)
+    options.addStringOption('Xdoclint:none', '-quiet')
+
+    options.encoding = 'UTF-8'
+
+    options.links "https://docs.oracle.com/en/java/javase/${libs.versions.jdk.get()}/docs/api/"
+    // Need to use the major version only with javafx
+    options.links "https://openjfx.io/javadoc/${libs.versions.javafx.get().split('\\.')[0]}/"
+    options.links "https://javadoc.io/doc/org.bytedeco/javacpp/${libs.versions.javacpp.get()}/"
+    options.links "https://javadoc.io/doc/org.bytedeco/opencv/${libs.versions.opencv.get()}/"
+    options.links "https://javadoc.io/doc/com.google.code.gson/gson/${libs.versions.gson.get()}/"
+    options.links "https://javadoc.io/doc/org.locationtech.jts/jts-core/${libs.versions.jts.get()}/"
+    options.links "https://javadoc.io/doc/net.imagej/ij/${libs.versions.imagej.get()}/"
+    options.links "https://javadoc.scijava.org/Bio-Formats/"
+    options.links "https://javadoc.io/doc/ai.djl/api/${libs.versions.deepJavaLibrary.get()}/"
+
+    // Don't fail on error, because this happened too often due to a javadoc link being temporarily down
+    failOnError = false
+}
+
 /*
  * Get version catalog
  */

--- a/buildSrc/src/main/groovy/qupath.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.java-conventions.gradle
@@ -106,6 +106,13 @@ tasks.withType(Javadoc).each { javadocTask ->
     javadocTask.options.links "https://javadoc.io/doc/net.imagej/ij/${libs.versions.imagej.get()}/"
     javadocTask.options.links "https://javadoc.scijava.org/Bio-Formats/"
     javadocTask.options.links "https://javadoc.io/doc/ai.djl/api/${libs.versions.deepJavaLibrary.get()}/"
+
+    rootProject.tasks.withType(Javadoc) { rootTask ->
+        rootTask.source += javadocTask.source
+        rootTask.classpath += javadocTask.classpath
+        rootTask.excludes += javadocTask.excludes
+        rootTask.includes += javadocTask.includes
+    }
 }
 
 /*

--- a/qupath-core/src/main/java/qupath/lib/io/PathIO.java
+++ b/qupath-core/src/main/java/qupath/lib/io/PathIO.java
@@ -580,8 +580,7 @@ public class PathIO {
 	
 	/**
 	 * Read and initialize an {@link ImageData} from a data file.
-	 * @param <T> the generic parameter, usually BufferedImage
-	 * 
+	 *
 	 * @param path path to data file
 	 * @param server an ImageServer to use rather than any that might be stored within the serialized data.
 	 *              Should be null to use the serialized path to build a new server.

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -650,7 +650,7 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 	 * The {@code PathClass} object is used as the internal representation of the object's classification,
 	 * encapsulating both the different string components of the classification and the color used for display.
 	 * <p>
-	 * For convenience, {@link #getClassification()} and {@link }{@link #getClassifications()} provide a simpler way to interact with
+	 * For convenience, {@link #getClassification()} and {@link #getClassifications()} provide a simpler way to interact with
 	 * classifications as one or more strings.
 	 * @return
 	 * @see #setPathClass(PathClass)
@@ -667,7 +667,7 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 	 * <p>
 	 * If the classification is null, the object is considered to be unclassified.
 	 * <p>
-	 * For convenience, {@link #setClassification(String)} ()} and {@link }{@link #setClassifications(Collection)} ()}
+	 * For convenience, {@link #setClassification(String)} and {@link #setClassifications(Collection)}
 	 * provide alternative ways to set classifications using strings - but this does not allow for setting the color,
 	 * and internally a {@code PathClass} object will still be used.
 	 * @param pathClass

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
@@ -1201,7 +1201,7 @@ public final class PathObjectHierarchy implements Serializable {
 
 	/**
 	 * Get a subdivision containing detections.
-	 * This does <i>not<</i> include sub-classes such as 'cell' or 'tile'.
+	 * This does <i>not</i> include sub-classes such as 'cell' or 'tile'.
 	 * <p>
 	 * This is an <i>experimental method</i> added in v0.6.0, subject to change.
 	 * @param plane


### PR DESCRIPTION
Removed `mergedJavadocs` gradle task with https://github.com/qupath/qupath/pull/1513 but it turns out that we do need it for a while longer.

It is used to generate the javadocs that are hosted online, and as part of the `jpackage` GitHub workflow.