### PR TITLE
Fix out-of-bounds cell detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This is a *work in progress* for the next major release.
 * Search distance when selecting points in the viewer is too low (https://github.com/qupath/qupath/issues/1552)
 * `ImageOps.Core.replace()` does not work as expected (https://github.com/qupath/qupath/issues/1564)
 * QuPath doesn't always use the specified file extension when exporting snapshots (https://github.com/qupath/qupath/issues/1567)
+* Out-of-bounds tiles can result in detected cells being in the wrong place (https://github.com/qupath/qupath/issues/1606)
 
 ### API changes
 * New `Map<String, String> getMetadata()` method added to `PathObject`, `Project` and `ProjectImageEntry` (https://github.com/qupath/qupath/pull/1587)

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
@@ -213,7 +213,8 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 				ImageServer<BufferedImage> server = imageData.getServer();
 				lastServerPath = imageData.getServerPath();
 				double downsample = ServerTools.getDownsampleFactor(server, getPreferredPixelSizeMicrons(imageData, params));
-				pathImage = IJTools.convertToImagePlus(server, RegionRequest.createInstance(server.getPath(), downsample, pathROI));
+				var request = RegionRequest.createInstance(server.getPath(), downsample, pathROI);
+				pathImage = IJTools.convertToImagePlus(server, request);
 //				pathImage = IJTools.createPathImage(server, pathROI, ServerTools.getDownsampleFactor(server, getPreferredPixelSizeMicrons(imageData, params), false));
 				logger.trace("Cell detection with downsample: {}", pathImage.getDownsampleFactor());
 				this.pathROI = pathROI;


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/1606

Note that this makes the change at a higher level than cell detection, so potentially impacts (fixes?) other commands.

Note also that it can potentially change how tiling operates, by adjusting the parent ROI temporarily. In other words, large regions may be tiled with a different origin - and so have boundaries in a different place.

However it is planned for a v0.x release, and most ROIs shouldn't be outside the image, so any reproducibility impact is expected to be minimal.