### PR TITLE
Reorder cell measurement names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ This is a *work in progress* for the next major release.
 * `PathObject` and `PathObjectHierarchy` have also been revised, with deprecated methods removed
   * New `PathObject.getClassification()` and `PathObject.setClassification(String)` methods 
     to simplify working with classifications in scripts (https://github.com/qupath/qupath/pull/1593)
+* `ObjectMeasurements` names cell intensity measurements in the order `Compartment: Channel: Measurement`
+  * This is a change from `Channel: Compartment: Measurement` to make it easier to find measurements in the list
+  * *This will affect the use of the QuPath StarDist extension*
 
 ### Dependency updates
 * Bio-Formats 7.3.1

--- a/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
+++ b/qupath-core/src/main/java/qupath/lib/images/writers/TileExporter.java
@@ -54,7 +54,6 @@ import qupath.lib.images.servers.LabeledImageServer;
 import qupath.lib.images.servers.ImageServerMetadata.ChannelType;
 import qupath.lib.images.servers.TransformedServerBuilder;
 import qupath.lib.io.GsonTools;
-import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.classes.PathClass;


### PR DESCRIPTION
Use the `Compartment: Channel: Measurement` with `ObjectMeasurements`. This is to group measurements by compartment, which seems more intuitive and easier to work with than grouping by channel.