### PR TITLE
Remove ImageServer.finalize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ This is a *work in progress* for the next major release.
 * `ObjectMeasurements` names cell intensity measurements in the order `Compartment: Channel: Measurement`
   * This is a change from `Channel: Compartment: Measurement` to make it easier to find measurements in the list
   * *This will affect the use of the QuPath StarDist extension*
+* `ImageServer.finalize()` is no longer overridden to call `close()` in case the caller forgets
+  * `finalize()` is deprecated for removal; any class that relied on this should consider using `Cleaner`
 
 ### Dependency updates
 * Bio-Formats 7.3.1

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageDataServer.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageDataServer.java
@@ -41,6 +41,6 @@ public interface ImageDataServer<T> extends ImageServer<T> {
 	 * Get the {@link ImageData} wrapped by the {@link ImageDataServer}.
 	 * @return
 	 */
-	public ImageData<T> getImageData();
+	ImageData<T> getImageData();
 	
 }

--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractImageServer.java
@@ -141,7 +141,7 @@ public abstract class AbstractImageServer<T> implements ImageServer<T> {
 	
 	@Override
 	public void close() throws Exception {
-		logger.trace("Server " + this + " being closed now...");		
+		logger.trace("Server {} is being closed now", this);
 	}
 	
 	@Override
@@ -170,22 +170,6 @@ public abstract class AbstractImageServer<T> implements ImageServer<T> {
 	@Override
 	public PixelType getPixelType() {
 		return getMetadata().getPixelType();
-	}
-	
-	
-	/**
-	 * Attempt to close the server.  While not at all a good idea to rely on this, it may help clean up after some forgotten servers.
-	 */
-	@Override
-	protected void finalize() throws Throwable {
-		// Ensure we close...
-		try{
-			close();
-		} catch(Throwable t){
-			throw t;
-		} finally{
-			super.finalize();
-		}
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/images/servers/LabeledImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/LabeledImageServer.java
@@ -843,9 +843,6 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 	}
 
 	@Override
-	public void close() {}
-
-	@Override
 	public String getServerType() {
 		return "Labelled image";
 	}

--- a/qupath-core/src/main/java/qupath/lib/images/servers/RotatedImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/RotatedImageServer.java
@@ -42,7 +42,7 @@ public class RotatedImageServer extends TransformingImageServer<BufferedImage> {
 	/**
 	 * Enum for rotations in increments of 90 degrees.
 	 */
-	public static enum Rotation{
+	public enum Rotation{
 		
 		/**
 		 * No rotation.

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -1331,7 +1331,8 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			}
 			
 			
-			cleanables.add(cleaner.register(this, new ReaderCleaner(Integer.toString(cleanables.size()+1), imageReader)));
+			cleanables.add(cleaner.register(this,
+					new ReaderCleaner(Integer.toString(cleanables.size()+1), imageReader)));
 			
 			return imageReader;
 		}
@@ -1542,6 +1543,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		
 		@Override
 		public void close() throws Exception {
+			logger.debug("Closing ReaderManager");
 			isClosed = true;
 			if (task != null && !task.isDone())
 				task.cancel(true);
@@ -1549,19 +1551,14 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 				try {
 					c.clean();
 				} catch (Exception e) {
-					logger.error("Exception during cleanup: " + e.getLocalizedMessage());
-					logger.debug(e.getLocalizedMessage(), e);
+					logger.error("Exception during cleanup: {}", e.getMessage(), e);
 				}
 			}
-			// Allow the queue to be garbage collected - clearing could result in a queue.poll()
-			// lingering far too long
-//			queue.clear();
 		}
+
 		
-		
-		
-		private static Cleaner cleaner = Cleaner.create();
-		private List<Cleanable> cleanables = new ArrayList<>();
+		private static final Cleaner cleaner = Cleaner.create();
+		private final List<Cleanable> cleanables = new ArrayList<>();
 
 
 		/**
@@ -1677,8 +1674,8 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		 */
 		static class ReaderCleaner implements Runnable {
 
-			private String name;
-			private IFormatReader reader;
+			private final String name;
+			private final IFormatReader reader;
 
 			ReaderCleaner(String name, IFormatReader reader) {
 				this.name = name;
@@ -1687,11 +1684,11 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 
 			@Override
 			public void run() {
-				logger.debug("Cleaner " + name + " called for " + reader + " (" + reader.getCurrentFile() + ")");
+                logger.debug("Cleaner {} called for {} ({})", name, reader, reader.getCurrentFile());
 				try {
 					this.reader.close(false);
 				} catch (IOException e) {
-					logger.warn("Error when calling cleaner for " + name, e);
+                    logger.warn("Error when calling cleaner for {}", name, e);
 				}
 			}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/images/servers/PathHierarchyImageServer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/images/servers/PathHierarchyImageServer.java
@@ -176,10 +176,6 @@ public class PathHierarchyImageServer extends AbstractTileableImageServer implem
 			return false;
 	}
 
-
-	@Override
-	public void close() {}
-
 	@Override
 	public String getServerType() {
 		return "Overlay";


### PR DESCRIPTION
This gets rid of the warnings about deprecation during startup.

Only the Bio-Formats and OpenSlide servers relied upon this as a backup in case `ImageServer.close()`, and both now use `Cleaner`.

Note that this should be more reliable anyway, since servers that wrapped other servers don't reliably call `close()` on the servers that they wrap. They arguably should, but if multiple servers wrap the same core server then there's a chance it is closed even while still in use... so it's safer to rely on the `Cleaner` (unfortunately).

One way to test this is to run a script such as 
```groovy
int n = 10
for (int i = 0; i < n; i++) {
    def server = getProjectEntry().getServerBuilder().build()
    println server
}
```
for a project with an OpenSlide or Bio-Formats image open, and check the log for evidence that `Cleaner` was used (at debug level).