### PR TITLE
New OverlapFixer class

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
@@ -194,13 +194,17 @@ public class PixelProcessor<S, T, U> {
         }
         List<Runnable> mergeTasks = new ArrayList<>();
         for (var entry : tempObjects.entrySet()) {
+            // Get the original parent object
             var pathObject = entry.getKey();
+            // Get all new objects detected from the tile
             var proxyList = entry.getValue().stream()
                     .flatMap(proxy -> proxy.getChildObjects().stream())
                     .toList();
             if (merger != null) {
+                // Use the merger if we have one
                 mergeTasks.add(() -> mergeAndAddObjects(merger, pathObject, proxyList));
             } else {
+                // Just add the new objects if we have no merger
                 pathObject.clearChildObjects();
                 pathObject.addChildObjects(proxyList);
                 pathObject.setLocked(true);

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2023-2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/OverlapFixer.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/OverlapFixer.java
@@ -1,0 +1,300 @@
+package qupath.lib.objects.utils;
+
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
+import org.locationtech.jts.index.quadtree.Quadtree;
+import qupath.lib.objects.DefaultPathObjectComparator;
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.PathObjectTools;
+import qupath.lib.roi.RoiTools;
+import qupath.lib.roi.interfaces.ROI;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class OverlapFixer {
+
+    public enum Strategy {
+        KEEP_OVERLAPS,
+        DROP_OVERLAPS,
+        CLIP_OVERLAPS
+    }
+
+    private enum ComparatorType {
+        AREA,
+        SOLIDITY
+    }
+
+    /**
+     * Comparator to choose which object to keep unchanged when two or more overlap.
+     * Objects returned first are kept unchanged, objects returned later are dropped or clipped.
+     */
+    private final Supplier<Comparator<PathObject>> comparatorSupplier;
+
+    /**
+     * Minimum area for objects to be retained.
+     */
+    private final double minArea;
+
+    private final Strategy strategy;
+
+    private OverlapFixer(Strategy strategy, double minArea, Supplier<Comparator<PathObject>> comparatorSupplier) {
+        this.strategy = strategy;
+        this.minArea = minArea;
+        this.comparatorSupplier = comparatorSupplier;
+    }
+
+
+
+    public List<PathObject> fix(Collection<? extends PathObject> pathObjects) {
+        var index = new Quadtree();
+
+        // Sort objects in *reverse* order using the comparator.
+        // This is because removals from the end of the list are faster than the start.
+        // We don't use a queue because then we can't insert objects in the middle,
+        // and we don't use a priority queue because it doesn't have great performance.
+        var comparator = comparatorSupplier.get();
+        var reversedComparator = comparator.reversed();
+        List<PathObject> list = pathObjects.parallelStream()
+                .filter(p -> p.hasROI() && p.getROI().getArea() >= minArea)
+                .sorted(reversedComparator)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        // Nothing else to do if we're keeping overlaps
+        if (strategy == Strategy.KEEP_OVERLAPS) {
+            return list;
+        }
+
+        // Precompute envelopes - it's better to do it in parallel since it requests geometries,
+        // which can sometimes be expensive to compute
+        GeometryCache cache = new GeometryCache();
+        pathObjects.parallelStream().forEach(cache::add);
+
+        // Build the spatial index
+        for (var pathObject : pathObjects) {
+            index.insert(cache.getEnvelope(pathObject), pathObject);
+        }
+
+        // Query the index to find overlapping objects
+        // We are iterating in order of the objects we want to keep
+        List<PathObject> output = new ArrayList<>();
+        while (!list.isEmpty()) {
+            PathObject pathObject = list.removeLast();
+            var envelope = cache.getEnvelope(pathObject);
+            // Query returns *potentially* overlapping objects (including the current object),
+            // but we can proceed quickly if there are no others
+            List<PathObject> overlapping = index.query(envelope);
+            if (!overlapping.contains(pathObject)) {
+                // Object has already been removed - skip
+                continue;
+            }
+            // Keep this object
+            output.add(pathObject);
+            if (overlapping.size() > 1) {
+                // Perform stricter overlap check
+                var geom = cache.getGeometry(pathObject);
+                if (overlapping.size() > 2) {
+                    var prepared = PreparedGeometryFactory.prepare(geom);
+                    overlapping = overlapping.stream()
+                            .filter(p -> p != pathObject)
+                            .filter(p -> prepared.overlaps(cache.getGeometry(p)) || geom.equalsExact(cache.getGeometry(p)))
+                            .sorted(comparator)
+                            .toList();
+                } else {
+                    overlapping = overlapping.stream()
+                            .filter(p -> p != pathObject)
+                            .filter(p -> geom.overlaps(cache.getGeometry(p)) || geom.equalsExact(cache.getGeometry(p)))
+                            .sorted(comparator)
+                            .toList();
+                }
+            }
+            if (overlapping.isEmpty()) {
+                // No overlaps - continue
+                continue;
+            }
+            // Drop all overlapping objects
+            // We only need to remove them from the index (to avoid the cost of removing them from the list)
+            for (var overlap : overlapping) {
+                index.remove(cache.getEnvelope(overlap), overlap);
+            }
+            if (strategy == Strategy.CLIP_OVERLAPS) {
+                // Clip overlapping objects, inserting them back into the list if they are big enough
+                List<ROI> previousROIs = new ArrayList<>();
+                previousROIs.add(pathObject.getROI());
+                for (var overlap : overlapping) {
+                    // Subtract the union from the current object
+                    ROI roiCurrent = overlap.getROI();
+                    roiCurrent = RoiTools.subtract(roiCurrent, previousROIs);
+                    ROI roiNucleus = PathObjectTools.getNucleusROI(overlap);
+                    if (roiNucleus != null) {
+                        roiNucleus = RoiTools.subtract(roiNucleus, previousROIs);
+                    }
+                    // Retain the ROI if it is big enough
+                    if (!roiCurrent.isEmpty() && roiCurrent.isArea() && roiCurrent.getArea() >= minArea) {
+                        var clippedObject = PathObjectTools.createLike(pathObject, roiCurrent, roiNucleus);
+                        output.add(clippedObject);
+                        index.insert(cache.getEnvelope(clippedObject), clippedObject);
+                        previousROIs.add(roiCurrent);
+                        // Insert into the list, while ensuring it remains sorted
+                        int ind = Collections.binarySearch(list, clippedObject, reversedComparator);
+                        if (ind >= 0) {
+                            list.add(ind, clippedObject);
+                        } else {
+                            list.add(-ind - 1, clippedObject);
+                        }
+                    }
+                }
+            }
+        }
+        return output;
+    }
+
+    /**
+     * A cache of normalized geometries and envelopes.
+     * This can be useful for a short time to avoid unnecessary recomputation.
+     */
+    private static class GeometryCache {
+
+        private final Map<ROI, Geometry> geometryMap = new ConcurrentHashMap<>();
+        private final Map<ROI, Envelope> envelopMap = new ConcurrentHashMap<>();
+
+        private void add(PathObject pathObject) {
+            var roi = pathObject.getROI();
+            var geom = roi.getGeometry().norm();
+            geometryMap.put(roi, geom);
+            envelopMap.put(roi, getEnvelope(pathObject));
+        }
+
+        private Geometry getGeometry(PathObject pathObject) {
+            return getGeometry(pathObject.getROI());
+        }
+
+        private Geometry getGeometry(ROI roi) {
+            return geometryMap.computeIfAbsent(roi, r -> r.getGeometry().norm());
+        }
+
+        private Envelope getEnvelope(PathObject pathObject) {
+            return getEnvelope(pathObject.getROI());
+        }
+
+        private Envelope getEnvelope(ROI roi) {
+            return envelopMap.computeIfAbsent(roi, r -> getGeometry(r).getEnvelopeInternal());
+        }
+
+    }
+
+
+    /**
+     * Create a new builder for the OverlapFixer.
+     * @return
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Supplier<Comparator<PathObject>> comparator = () -> Comparators.createAreaFirstComparator();
+
+        private double minArea = Double.NEGATIVE_INFINITY;
+
+        private Strategy strategy = Strategy.CLIP_OVERLAPS;
+
+        private Builder() {}
+
+        public Builder setComparator(Comparator<PathObject> comparator) {
+            this.comparator = () -> comparator;
+            return this;
+        }
+
+        public Builder setMinArea(double minArea) {
+            this.minArea = minArea;
+            return this;
+        }
+
+        public Builder sortBySolidity() {
+            this.comparator = () -> Comparators.createSolidityFirstComparator();
+            return this;
+        }
+
+        public Builder sortByArea() {
+            this.comparator = () -> Comparators.createAreaFirstComparator();
+            return this;
+        }
+
+        public Builder setStrategy(Strategy strategy) {
+            this.strategy = strategy;
+            return this;
+        }
+
+        public Builder clipOverlaps() {
+            this.strategy = Strategy.CLIP_OVERLAPS;
+            return this;
+        }
+
+        public Builder dropOverlaps() {
+            this.strategy = Strategy.DROP_OVERLAPS;
+            return this;
+        }
+
+        public OverlapFixer build() {
+            return new OverlapFixer(strategy, minArea, comparator);
+        }
+
+    }
+
+
+
+    private static class Comparators {
+
+        private static Comparator<PathObject> createAreaFirstComparator() {
+            var c = new Comparators();
+            return c.compareByArea()
+                    .thenComparing(c.compareByLength())
+                    .thenComparing(c.compareByPoints())
+                    .thenComparing(DefaultPathObjectComparator.getInstance());
+        }
+
+        private static Comparator<PathObject> createSolidityFirstComparator() {
+            var c = new Comparators();
+            return c.compareBySolidity()
+                    .thenComparing(c.compareByArea())
+                    .thenComparing(c.compareByLength())
+                    .thenComparing(c.compareByPoints())
+                    .thenComparing(DefaultPathObjectComparator.getInstance());
+        }
+
+        private Map<ROI, Double> solidityMap = new ConcurrentHashMap<>();
+        private Map<ROI, Double> areaMap = new ConcurrentHashMap<>();
+        private Map<ROI, Double> lengthMap = new ConcurrentHashMap<>();
+        private Map<ROI, Integer> pointsMap = new ConcurrentHashMap<>();
+
+        // We use negative values as a cheap way to sort in descending order
+
+        private Comparator<PathObject> compareBySolidity() {
+            return Comparator.comparingDouble(p -> -solidityMap.computeIfAbsent(p.getROI(), ROI::getSolidity));
+        }
+
+        private Comparator<PathObject> compareByArea() {
+            return Comparator.comparingDouble(p -> -areaMap.computeIfAbsent(p.getROI(), ROI::getArea));
+        }
+
+        private Comparator<PathObject> compareByLength() {
+            return Comparator.comparingDouble(p -> -lengthMap.computeIfAbsent(p.getROI(), ROI::getArea));
+        }
+
+        private Comparator<PathObject> compareByPoints() {
+            return Comparator.comparingInt(p -> -pointsMap.computeIfAbsent(p.getROI(), ROI::getNumPoints));
+        }
+
+    }
+
+}

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/OverlapFixer.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/OverlapFixer.java
@@ -84,6 +84,18 @@ public class OverlapFixer {
     }
 
     /**
+     * Fix overlaps in an array of PathObjects, by the criteria specified in the builder.
+     * This method is thread-safe.
+     * @param pathObjects the input objects
+     * @return the output objects. This may be the same as the input objects, or contain fewer objects -
+     *         possibly with new (clipped) ROIs - but no object will be added or have its properties changed.
+     */
+    public List<PathObject> fix(PathObject... pathObjects) {
+        return fix(List.of(pathObjects));
+    }
+
+
+    /**
      * Fix overlaps in a collection of PathObjects, by the criteria specified in the builder.
      * This method is thread-safe.
      * @param pathObjects the input objects

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -897,15 +897,20 @@ public class GeometryTools {
 	     * 
 	     * @param roi
 	     * @return
+		 * @implNote since v0.6.0 this returns a normalized geometry.
 	     */
 	    public Geometry roiToGeometry(ROI roi) {
+			Geometry geom = null;
 	    	if (roi.isPoint())
-	    		return pointsToGeometry(roi);
+				geom = pointsToGeometry(roi);
 	    	if (roi.isArea())
-	    		return areaToGeometry(roi);
+				geom = areaToGeometry(roi);
 	    	if (roi.isLine())
-	    		return lineToGeometry(roi);
-	    	throw new UnsupportedOperationException("Unknown ROI " + roi + " - cannot convert to a Geometry!");
+				geom = lineToGeometry(roi);
+			if (geom == null)
+		    	throw new UnsupportedOperationException("Unknown ROI " + roi + " - cannot convert to a Geometry!");
+			else
+				return geom.norm();
 	    }
 	    
 	    private Geometry lineToGeometry(ROI roi) {

--- a/qupath-core/src/test/java/qupath/lib/objects/utils/TestOverlapFixer.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/utils/TestOverlapFixer.java
@@ -1,0 +1,104 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2024 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.objects.utils;
+
+import org.junit.jupiter.api.Test;
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.PathObjects;
+import qupath.lib.regions.ImagePlane;
+import qupath.lib.roi.ROIs;
+import qupath.lib.roi.interfaces.ROI;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestOverlapFixer {
+
+    @Test
+    public void test_keepFragments() {
+        var large = createRectangle(0, 0, 100, 100);
+        var thin = createRectangle(-10, 45, 120, 10);
+
+        var fixer = OverlapFixer.builder()
+                .keepFragments()
+                .build();
+        assertEquals(2, fixer.fix(large, thin).size());
+    }
+
+    @Test
+    public void test_discardFragments() {
+        var large = createRectangle(0, 0, 100, 100);
+        var thin = createRectangle(-10, 45, 120, 10);
+
+        var fixer = OverlapFixer.builder()
+                .discardFragments()
+                .build();
+        assertEquals(1, fixer.fix(large, thin).size());
+    }
+
+    @Test
+    public void test_dropOverlaps() {
+        var large = createRectangle(0, 0, 100, 100);
+        var small = createRectangle(40, 0, 80, 100);
+
+        var fixer = OverlapFixer.builder()
+                .dropOverlaps()
+                .build();
+        assertEquals(Collections.singletonList(large), fixer.fix(large, small));
+    }
+
+    @Test
+    public void test_clipOverlaps() {
+        var large = createRectangle(0, 0, 100, 100);
+        var small = createRectangle(40, 0, 80, 100);
+
+        var fixer = OverlapFixer.builder()
+                .clipOverlaps()
+                .build();
+        assertEquals(2, fixer.fix(large, small).size());
+        assertEquals(120 * 100, sumAreas(fixer.fix(large, small)));
+    }
+
+    @Test
+    public void test_disconnected() {
+        var large = createRectangle(0, 0, 100, 100);
+        var small = createRectangle(140, 120, 80, 100);
+
+        var fixer = OverlapFixer.builder()
+                .clipOverlaps()
+                .build();
+        var set = Set.of(large, small);
+        assertEquals(set, Set.copyOf(fixer.fix(large, small)));
+    }
+
+    private static double sumAreas(Collection<? extends PathObject> pathObjects) {
+        return pathObjects.stream().map(PathObject::getROI).mapToDouble(ROI::getArea).sum();
+    }
+
+    private static PathObject createRectangle(double x, double y, double width, double height) {
+        return PathObjects.createDetectionObject(ROIs.createRectangleROI(x, y, width, height, ImagePlane.getDefaultPlane()));
+    }
+
+}


### PR DESCRIPTION
This exists alongside `ObjectMerger` to provide more post-processing that is relevant when resolving the processing tiles.

`OverlapFixer` prioritizes objects according to a `Comparator` (e.g. to prefer larger areas), then can do two main things when objects overlap:
* Drop the lower priority objects
* Clip the lower priority objects

The aim of this class is to do those tasks flexibly and efficiently.