### PR TITLE
Better handle symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This is a *work in progress* for the next major release.
     * If you use this command, the calculated connections are displayed instead of the default neighbor connections for compatibility.
       However, this support will be removed in a future version.
 * More viewer options are persistent (e.g. show/hide the overview thumbnail, location text, or scalebar)
+* Better support for symbolic links (https://github.com/qupath/qupath/issues/1586)
 
 ### Bugs fixed
 * Tile export to .ome.tif can convert to 8-bit unnecessarily (https://github.com/qupath/qupath/issues/1494)

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -317,7 +317,8 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 		try {
 			var path = GeneralTools.toPath(uri);
 			if (path != null) {
-				filePathOrUrl = path.toString();
+				// Use toRealPath to resolve any symbolic links
+				filePathOrUrl = path.toRealPath().toString();
 			}
 		} catch (Exception e) {
 			logger.error(e.getLocalizedMessage(), e);

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -139,8 +139,9 @@ public class OpenslideImageServer extends AbstractTileableImageServer {
 		Path filePath = GeneralTools.toPath(uri);
 		String name;
 		// OpenSlide conventionally expects a file path, but some builds might accept a URI
-		if (Files.exists(filePath)) {
-			osr = OpenSlideLoader.openImage(filePath.toAbsolutePath().toString());
+		if (filePath != null && Files.exists(filePath)) {
+			// We need to use the real path to resolve symlinks
+			osr = OpenSlideLoader.openImage(filePath.toRealPath().toString());
 			name = filePath.getFileName().toString();
 		} else {
 			osr = OpenSlideLoader.openImage(uri.toString());

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
@@ -81,7 +81,7 @@ public class OpenslideServerBuilder implements ImageServerBuilder<BufferedImage>
 			return 0;
 		
 		try {
-			File file = Paths.get(uri).toFile();
+			File file = Paths.get(uri).toFile().getCanonicalFile();
 			String vendor = OpenSlideLoader.detectVendor(file.toString());
 			if (vendor == null)
 				return 0;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -314,13 +314,14 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 			logger.warn("No files given!");
 			return;
 		}
-		
+
 		// Check if we have only jar or css files
 		int nJars = 0;
 		int nCss = 0;
 		int nJson = 0;
 		for (File file : list) {
-			var ext = GeneralTools.getExtension(file).orElse("").toLowerCase();
+			// Use the canonical file in case we have a symlink
+			var ext = GeneralTools.getExtension(file.getCanonicalFile()).orElse("").toLowerCase();
 			if (ext.equals(".jar"))
 				nJars++;
 			else if (ext.equals(".css"))
@@ -378,7 +379,7 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 		// This helps us determine whether or not a zip file contains an image or objects, for example
 		Set<String> allUnzippedExtensions = list.stream().flatMap(f -> {
 			try {
-				return PathIO.unzippedExtensions(f.toPath()).stream();
+				return PathIO.unzippedExtensions(f.getCanonicalFile().toPath()).stream();
 			} catch (IOException e) {
 				logger.debug(e.getLocalizedMessage(), e);
 				return Arrays.stream(new String[0]);
@@ -386,9 +387,10 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 		}).collect(Collectors.toSet());
 		
 		// Extract the first (and possibly only) file
-		File file = list.get(0);
-		
-		String fileName = file.getName().toLowerCase();
+		File file = list.getFirst();
+
+		// Get the name of the file using the canonical file, in case we have a symlink
+		String fileName = file.getCanonicalFile().getName().toLowerCase();
 
 		// Check if this is a hierarchy file
 		if (singleFile && (fileName.endsWith(PathPrefs.getSerializationExtension()))) {


### PR DESCRIPTION
Proposed fix for https://github.com/qupath/qupath/issues/1586

@alanocallaghan @Rylern please test this and let me know what you think, I don't use symlinks much...

Ideal tests should involve a range of file types, including images and .qpdata, via drag & drop and opened in other ways.

In particular, the original report related to an image that involves multiple files (.vsi). I don't know of good .vsi examples are public, but .ndpis is similar-ish: https://downloads.openmicroscopy.org/images/Hamamatsu-NDPI/manuel/

Then you have 3 .ndpi files that *could* be opened independently, but if you open the .ndpis then the other files should act as different channels. The trouble for me is that it won't work on an Apple Silicon Mac due to Bio-Formats - it needs an Intel build.