### PR TITLE
Introduce ObjectProcessor interface

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
@@ -94,7 +94,7 @@ public class PixelProcessor<S, T, U> {
                           OutputHandler<S, T, U> outputHandler,
                           Processor<S, T, U> processor,
                           Tiler tiler,
-                           ObjectProcessor objectProcessor,
+                          ObjectProcessor objectProcessor,
                           Padding padding,
                           DownsampleCalculator downsampleCalculator) {
         Objects.requireNonNull(imageSupplier, "Image supplier cannot be null");

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectProcessor.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectProcessor.java
@@ -24,7 +24,7 @@ public interface ObjectProcessor {
      * @param after the processor to apply next
      * @return a processor that applies this processor first, and then the given processor
      */
-    default ObjectProcessor then(ObjectProcessor after) {
+    default ObjectProcessor andThen(ObjectProcessor after) {
         return (input) -> after.process(process(input));
     }
 

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectProcessor.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectProcessor.java
@@ -1,0 +1,31 @@
+package qupath.lib.objects.utils;
+
+import qupath.lib.objects.PathObject;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Minimal interface for processing one or more objects.
+ * <p>
+ * This is intended for tasks such as merging, splitting, filtering, etc.
+ */
+public interface ObjectProcessor {
+
+    /**
+     * Process a collection of objects and return the result.
+     * @param input the input objects
+     * @return the output objects; this should always be a new collection (even if it contains the same objects)
+     */
+    List<PathObject> process(Collection<? extends PathObject> input);
+
+    /**
+     * Create a new ObjectProcessor that applies (at least) two processors sequentially.
+     * @param after the processor to apply next
+     * @return a processor that applies this processor first, and then the given processor
+     */
+    default ObjectProcessor then(ObjectProcessor after) {
+        return (input) -> after.process(process(input));
+    }
+
+}

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/OverlapFixer.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/OverlapFixer.java
@@ -46,7 +46,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class OverlapFixer {
+public class OverlapFixer implements ObjectProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(OverlapFixer.class);
 
@@ -83,17 +83,6 @@ public class OverlapFixer {
         this.keepFragments = keepFragments;
     }
 
-    /**
-     * Fix overlaps in an array of PathObjects, by the criteria specified in the builder.
-     * This method is thread-safe.
-     * @param pathObjects the input objects
-     * @return the output objects. This may be the same as the input objects, or contain fewer objects -
-     *         possibly with new (clipped) ROIs - but no object will be added or have its properties changed.
-     */
-    public List<PathObject> fix(PathObject... pathObjects) {
-        return fix(List.of(pathObjects));
-    }
-
 
     /**
      * Fix overlaps in a collection of PathObjects, by the criteria specified in the builder.
@@ -102,7 +91,7 @@ public class OverlapFixer {
      * @return the output objects. This may be the same as the input objects, or contain fewer objects -
      *         possibly with new (clipped) ROIs - but no object will be added or have its properties changed.
      */
-    public List<PathObject> fix(Collection<? extends PathObject> pathObjects) {
+    public List<PathObject> process(Collection<? extends PathObject> pathObjects) {
 
         int nInput = pathObjects.size();
 

--- a/qupath-core/src/main/java/qupath/lib/objects/utils/Tiler.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/Tiler.java
@@ -37,6 +37,7 @@ import qupath.lib.roi.interfaces.ROI;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -212,7 +213,7 @@ public class Tiler {
         var preparedParent = PreparedGeometryFactory.prepare(parent);
         return tiles.parallelStream()
                 .map(createTileFilter(preparedParent, cropToParent, filterByCentroid))
-                .filter(g -> g != null)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 

--- a/qupath-core/src/main/java/qupath/lib/plugins/AbstractTaskRunner.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/AbstractTaskRunner.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -151,7 +151,7 @@ public abstract class AbstractTaskRunner implements TaskRunner {
 				pendingTasks.remove(future);
 			}
 			if (monitor != null)
-				monitor.pluginCompleted("Tasks completed!");
+				monitor.pluginCompleted("");
 		} catch (InterruptedException e) {
 			logger.error("Plugin interrupted: {}", e.getMessage(), e);
 			monitor.pluginCompleted("Completed with error " + e.getMessage());

--- a/qupath-core/src/test/java/qupath/lib/objects/utils/TestOverlapFixer.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/utils/TestOverlapFixer.java
@@ -30,6 +30,7 @@ import qupath.lib.roi.interfaces.ROI;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +45,7 @@ public class TestOverlapFixer {
         var fixer = OverlapFixer.builder()
                 .keepFragments()
                 .build();
-        assertEquals(2, fixer.fix(large, thin).size());
+        assertEquals(2, fixer.process(List.of(large, thin)).size());
     }
 
     @Test
@@ -66,7 +67,7 @@ public class TestOverlapFixer {
         var fixer = OverlapFixer.builder()
                 .dropOverlaps()
                 .build();
-        assertEquals(Collections.singletonList(large), fixer.fix(large, small));
+        assertEquals(Collections.singletonList(large), fixer.process(List.of(large, small)));
     }
 
     @Test
@@ -77,8 +78,8 @@ public class TestOverlapFixer {
         var fixer = OverlapFixer.builder()
                 .clipOverlaps()
                 .build();
-        assertEquals(2, fixer.fix(large, small).size());
-        assertEquals(120 * 100, sumAreas(fixer.fix(large, small)));
+        assertEquals(2, fixer.process(List.of(large, small)).size());
+        assertEquals(120 * 100, sumAreas(fixer.process(List.of(large, small))));
     }
 
     @Test
@@ -90,7 +91,7 @@ public class TestOverlapFixer {
                 .clipOverlaps()
                 .build();
         var set = Set.of(large, small);
-        assertEquals(set, Set.copyOf(fixer.fix(large, small)));
+        assertEquals(set, Set.copyOf(fixer.process(List.of(large, small))));
     }
 
     private static double sumAreas(Collection<? extends PathObject> pathObjects) {

--- a/qupath-core/src/test/java/qupath/lib/objects/utils/TestOverlapFixer.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/utils/TestOverlapFixer.java
@@ -56,7 +56,7 @@ public class TestOverlapFixer {
         var fixer = OverlapFixer.builder()
                 .discardFragments()
                 .build();
-        assertEquals(1, fixer.fix(large, thin).size());
+        assertEquals(1, fixer.process(List.of(large, thin)).size());
     }
 
     @Test

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ScriptMenuLoader.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ScriptMenuLoader.java
@@ -154,7 +154,7 @@ class ScriptMenuLoader {
 				else
 					menu.getItems().setAll(miOpenDirectory, miCreateScript, new SeparatorMenuItem());
 				Path path = Paths.get(scriptDir);
-				if (path != null && path.getFileName() != null) {
+				if (path.getFileName() != null) {
 					addMenuItemsForPath(menu, path);
 				}
 			} else if (miSetPath != null)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/TaskRunnerFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/TaskRunnerFX.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -23,7 +23,6 @@
 
 package qupath.lib.gui;
 
-import java.awt.image.BufferedImage;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
@@ -47,7 +46,6 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.util.Duration;
 import qupath.fx.utils.GridPaneUtils;
-import qupath.lib.images.ImageData;
 import qupath.lib.plugins.CommandLineTaskRunner;
 import qupath.lib.plugins.PathTask;
 import qupath.lib.plugins.AbstractTaskRunner;
@@ -308,7 +306,7 @@ public class TaskRunnerFX extends AbstractTaskRunner {
 			}
 			long endTime = System.currentTimeMillis();
 			logger.info(String.format("Processing complete in %.2f seconds", (endTime - startTimeMS)/1000.));
-			if (message != null && message.trim().length() > 0)
+			if (message != null && !message.trim().isEmpty())
 				logger.info(message);
 		}
 		


### PR DESCRIPTION
This enable `ObjectMerger` and `OverlapFixer` to implement the same interface, and means they can easily be applied sequentially.

Then the `PixelProcessor` class was updated to support an `ObjectProcessor` to handle detections made across tiles, rather than an `ObjectMerger` - since that gives more flexibility in dealing with the output.