### PR TITLE
Change detection line thickness when upsampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,18 @@ This is a *work in progress* for the next major release.
   * New icon & other drawing icons change to indicate when they are active in selection mode
   * Selection mode works with line ROIs, selecting any intersecting objects
   * Temporarily active 'Selection mode' by pressing the `S` key while interacting with a viewer
+* More viewer options are persistent (e.g. show/hide the overview thumbnail, location text, or scalebar)
+* Better support for symbolic links (https://github.com/qupath/qupath/issues/1586)
+
+### Experimental features
+These features are included for testing and feedback.
+They may change or be removed in future versions.
+* 'Dynamic detection line thickness (experimental)' preference (https://github.com/qupath/qupath/pull/1623)
+  * Experimental preference to adjust how detections are displayed when zoomed in
 * New toolbar button to show/hide 'neighbors' in the viewer (https://github.com/qupath/qupath/pull/1597)
-  * *Experimental* new code to help with querying neighbors
   * Note that the *Delaunay cluster features 2D* command is now deprecated - see https://github.com/qupath/qupath/issues/1590 for details
     * If you use this command, the calculated connections are displayed instead of the default neighbor connections for compatibility.
       However, this support will be removed in a future version.
-* More viewer options are persistent (e.g. show/hide the overview thumbnail, location text, or scalebar)
-* Better support for symbolic links (https://github.com/qupath/qupath/issues/1586)
 
 ### Bugs fixed
 * Tile export to .ome.tif can convert to 8-bit unnecessarily (https://github.com/qupath/qupath/issues/1494)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -495,6 +495,9 @@ public class PreferencePane {
 		@DoublePref("Prefs.Objects.detectionLineThickness")
 		public final DoubleProperty detectonStrokeThickness = PathPrefs.detectionStrokeThicknessProperty();
 
+		@BooleanPref("Prefs.Objects.newDetectionRendering")
+		public final BooleanProperty newDetectionRendering = PathPrefs.newDetectionRenderingProperty();
+
 		@BooleanPref("Prefs.Objects.useSelectedColor")
 		public final BooleanProperty useSelectedColor = PathPrefs.useSelectedColorProperty();
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -1712,6 +1712,18 @@ public class PathPrefs {
     public static DoubleProperty annotationStrokeThicknessProperty() {
     	return strokeThickThickness;
     }
+
+	private static BooleanProperty newDetectionRendering = new SimpleBooleanProperty(false);
+
+	/**
+	 * Flag to enable the new rendering strategy for detections.
+	 * This can be used to temporarily turn on/off the rendering, to help refine the behavior.
+	 * @return
+	 * @since v0.6.0
+	 */
+	public static BooleanProperty newDetectionRenderingProperty() {
+		return newDetectionRendering;
+	}
     
     private static final BooleanProperty usePixelSnapping = createPersistentPreference("usePixelSnapping", true);
     

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -367,7 +367,7 @@ public class PathObjectPainter {
 
 
 	private static Stroke calculateStroke(PathObject pathObject, double downsample, boolean isSelected) {
-		if (pathObject.isDetection()) {
+		if (pathObject.isDetection() && downsample > 1) {
 			// Detections inside detections get half the line width
 			if (pathObject.getParent() instanceof PathDetectionObject)
 				return getCachedStroke(PathPrefs.detectionStrokeThicknessProperty().get() / 2.0);
@@ -409,7 +409,7 @@ public class PathObjectPainter {
 				return ((Number)obj).doubleValue();
 			}
 		} catch (Exception e) {
-			logger.warn("Unable to parse double from " + obj);
+			logger.warn("Unable to parse double from {}", obj);
 		}		
 		return null;
 	}
@@ -1181,7 +1181,7 @@ public class PathObjectPainter {
 
 		float alpha = (float)(1f - downsampleFactor / 5);
 		alpha = Math.min(alpha, 0.4f);
-		double thickness = PathPrefs.detectionStrokeThicknessProperty().get();
+		double thickness = PathPrefs.detectionStrokeThicknessProperty().get() * Math.min(1, downsampleFactor);
 		if (alpha < .1f || thickness / downsampleFactor <= 0.25)
 			return;
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -366,8 +366,13 @@ public class PathObjectPainter {
 	}
 
 
+	private static boolean useDetectionStrokeWidth(double downsample) {
+		return downsample >= 1 || !PathPrefs.newDetectionRenderingProperty().get();
+	}
+
+
 	private static Stroke calculateStroke(PathObject pathObject, double downsample, boolean isSelected) {
-		if (pathObject.isDetection() && downsample > 1) {
+		if (pathObject.isDetection() && useDetectionStrokeWidth(downsample)) {
 			// Detections inside detections get half the line width
 			if (pathObject.getParent() instanceof PathDetectionObject)
 				return getCachedStroke(PathPrefs.detectionStrokeThicknessProperty().get() / 2.0);
@@ -1080,6 +1085,34 @@ public class PathObjectPainter {
 	}
 
 	/**
+	 * Return the stroke thickness to use for drawing connection lines between objects.
+	 * @param downsample
+	 * @return
+	 */
+	private static double getConnectionStrokeThickness(double downsample) {
+		double thickness = PathPrefs.detectionStrokeThicknessProperty().get();
+		// Don't try to draw connections if the line is too thin
+		if (thickness / downsample <= 0.25)
+			return 0;
+		// Check if we're using the 'standard' stroke width, or the experimental new rendering
+		if (useDetectionStrokeWidth(downsample))
+			return thickness;
+		else
+			return thickness * Math.min(1, downsample);
+	}
+
+	/**
+	 * Adjust the opacity of connection lines according to the downsample (since rendering a huge number
+	 * is slow, and makes the image look cluttered).
+	 * @param downsample
+	 * @return
+	 */
+	private static float getConnectionAlpha(double downsample) {
+		float alpha = (float)(1f - downsample / 5);
+		return Math.min(alpha, 0.4f);
+	}
+
+	/**
 	 * Paint connections between objects (e.g. from Delaunay triangulation).
 	 * 
 	 * @param connections
@@ -1097,10 +1130,9 @@ public class PathObjectPainter {
 
 		LogTools.warnOnce(logger, "Legacy 'Delaunay cluster features 2D' connections are being shown in the viewer - this command is deprecated, and support will be removed in a future version");
 
-		float alpha = (float)(1f - downsampleFactor / 5);
-		alpha = Math.min(alpha, 0.4f);
-		double thickness = PathPrefs.detectionStrokeThicknessProperty().get();
-		if (alpha < .1f || thickness / downsampleFactor <= 0.25)
+		float alpha = getConnectionAlpha(downsampleFactor);
+		double thickness = getConnectionStrokeThickness(downsampleFactor);
+		if (alpha < .1f || thickness <= 0.0)
 			return;
 
 		g2d = (Graphics2D)g2d.create();
@@ -1179,10 +1211,9 @@ public class PathObjectPainter {
 		if (hierarchy == null || subdivision.size() <= 1)
 			return;
 
-		float alpha = (float)(1f - downsampleFactor / 5);
-		alpha = Math.min(alpha, 0.4f);
-		double thickness = PathPrefs.detectionStrokeThicknessProperty().get() * Math.min(1, downsampleFactor);
-		if (alpha < .1f || thickness / downsampleFactor <= 0.25)
+		float alpha = getConnectionAlpha(downsampleFactor);
+		double thickness = getConnectionStrokeThickness(downsampleFactor);
+		if (alpha < .1f || thickness <= 0.0)
 			return;
 
 		g2d = (Graphics2D)g2d.create();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -443,42 +443,11 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 			context.strokeRect(0, 0, canvas.getWidth(), canvas.getHeight());
 		}
 		
-		
-		
-//		// Basic code for including the TMA core name
-//		if (getHierarchy().getTMAGrid() != null) {
-//			Point2D pSource = new Point2D.Double();
-//			Point2D pDest = new Point2D.Double();
-//			context.setTextAlign(TextAlignment.CENTER);
-//			context.setTextBaseline(VPos.CENTER);
-//			for (TMACoreObject core : getHierarchy().getTMAGrid().getTMACoreList()) {
-//				if (core.getName() == null)
-//					continue;
-//				double x = core.getROI().getBoundsX() + core.getROI().getBoundsWidth()/2;
-//				double y = core.getROI().getBoundsY() + core.getROI().getBoundsHeight()/2;
-//				pSource.setLocation(x, y);
-//				transform.transform(pSource, pDest);
-//				context.setFill(getSuggestedOverlayColorFX());
-//				context.setStroke(javafx.scene.paint.Color.WHITE);
-//				double xf = pDest.getX();
-//				double yf = pDest.getY();
-//				context.fillText(core.getName(), xf, yf, core.getROI().getBoundsWidth()/getDownsampleFactor()*0.5);
-//			}
-//		}
-		
-		
-//		if (getServer() == null) {
-//			context.setStroke(javafx.scene.paint.Color.GREENYELLOW);
-//			context.setLineWidth(borderLineWidth);
-//			context.strokeRect(0, 0, canvas.getWidth(), canvas.getHeight());
-//		}
-		
 		long time = System.currentTimeMillis();
 		logger.trace("Time since last repaint: {} ms", (time - lastPaint));
 		lastPaint = System.currentTimeMillis();
 		
 		imageDataChanging.set(false);
-//		repaintRequested = false;
 	}
 	
 	/**
@@ -768,7 +737,8 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 		
 		// We need a simple repaint for color changes & simple (thick) line changes
 		manager.attachListener(PathPrefs.annotationStrokeThicknessProperty(), repainter);
-		
+		manager.attachListener(PathPrefs.newDetectionRenderingProperty(), repainter);
+
 		gammaProperty.set(PathPrefs.viewerGammaProperty().get());
 		gammaProperty.bind(PathPrefs.viewerGammaProperty());
 		manager.attachListener(gammaProperty, repainterEntire);

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -822,6 +822,8 @@ Prefs.Objects.annotationLineThickness = Annotation line thickness
 Prefs.Objects.annotationLineThickness.description = Thickness (in display pixels) for annotation/TMA core object outlines (default = 2)
 Prefs.Objects.detectionLineThickness = Detection line thickness
 Prefs.Objects.detectionLineThickness.description = Thickness (in image pixels) for detection object outlines (default = 2)
+Prefs.Objects.newDetectionRendering = Dynamic detection line thickness (experimental)
+Prefs.Objects.newDetectionRendering.description = Experimental feature to render detection objects with a stroke thickness that scales with the zoom level
 Prefs.Objects.useSelectedColor = Use selected color
 Prefs.Objects.useSelectedColor.description = Highlight selected objects by recoloring them; otherwise, a slightly thicker line thickness will be used
 Prefs.Objects.selectedColor = Selected object color


### PR DESCRIPTION
Possibly controversial, possibly very welcome...

Usually, the annotation line thickness remains constant at all zoom levels - whereas the detection line thickness increases and decreases when zooming in and out.

This is partly to avoid having thick detection lines when zoomed out, and partly for performance reasons: we cache detections rendered at different resolutions.

*However*, detections *are* painted 'live' (like annotations) when zooming in beyond full resolution.

I find this can be annoying at times, because the default detection line thickness of 2 can be too much - and obscures details. I need to toggle detections on and off to see the pixels that overlap with the border, or else go to the preferences to reduce the line for some images... then go back to increase the line for the next images.

So this PR causes detections to be painted more like annotations when upsampling. The result is that lines narrow to become subpixel when zooming in, and that it is possible to more accurately judge where the detection boundary really lies.

Screenshots below, but they aren't the best examples - and it's better to play around with the behavior using different images to form an opinion as to whether this is better, worse, or pretty neutral.

## Previous

![older-rendering](https://github.com/user-attachments/assets/4e637414-6e6a-46c3-9044-bb51db67fa6d)

## With this PR

![new-rendering](https://github.com/user-attachments/assets/0fd890bc-76d2-4aff-885b-5d25580d0114)
