### PR TITLE
Support remote ome-zarr

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -1198,9 +1198,12 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			}
 			
 			IFormatReader imageReader;
-			if (new File(id).isDirectory()) {
+			if (new File(id).isDirectory() || id.toLowerCase().endsWith(".zarr")) {
 				// Using new ImageReader() on a directory won't work
 				imageReader = new ZarrReader();
+				if (id.startsWith("https") && imageReader.getMetadataOptions() instanceof DynamicMetadataOptions zarrOptions) {
+					zarrOptions.set("omezarr.alt_store", id);
+				}
 			} else {
 				if (classList != null) {
 					imageReader = new ImageReader(classList);


### PR DESCRIPTION
First steps to handle remote OME-Zarr.

See https://forum.image.sc/t/qupath-0-6-0rc1-unable-to-read-remote-ome-zarr-by-url/101605 for details.

This currently 'works' for https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr but is too slow to be very usable.