### PR TITLE
Zarr writer and ConvertCommand improvements

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
@@ -23,11 +23,14 @@ package qupath.lib.images.writers.ome;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.DoubleStream;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -179,6 +182,18 @@ public class ConvertCommand implements Runnable, Subcommand {
 		if (inputFile.equals(outputFile)) {
 			logger.error("Input and output files are the same!");
 			System.exit(-1);
+		}
+
+		try {
+			if (overwrite && outputFile.exists()) {
+				if (outputFile.isDirectory()) {
+					FileUtils.deleteDirectory(outputFile);
+				} else {
+					Files.delete(outputFile.toPath());
+				}
+			}
+		} catch (IOException e) {
+			logger.error("Error while deleting existing image", e);
 		}
 		
 		String[] args;

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEXMLCreator.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEXMLCreator.java
@@ -1,0 +1,169 @@
+package qupath.lib.images.writers.ome.zarr;
+
+import ome.units.UNITS;
+import ome.units.quantity.Length;
+import ome.units.quantity.Time;
+import ome.xml.model.Channel;
+import ome.xml.model.Image;
+import ome.xml.model.OME;
+import ome.xml.model.Pixels;
+import ome.xml.model.enums.DimensionOrder;
+import ome.xml.model.enums.PixelType;
+import ome.xml.model.primitives.Color;
+import ome.xml.model.primitives.PositiveInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import qupath.lib.common.ColorTools;
+import qupath.lib.images.servers.ImageChannel;
+import qupath.lib.images.servers.ImageServerMetadata;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/**
+ * Create the content of an OME XML file as described by the
+ * <a href="http://www.openmicroscopy.org/Schemas/OME/2016-06/">Open Microscopy Environment OME Schema</a>.
+ */
+class OMEXMLCreator {
+
+    private static final Logger logger = LoggerFactory.getLogger(OMEXMLCreator.class);
+    private static final String NAMESPACE = "http://www.openmicroscopy.org/Schemas/OME/2016-06";
+
+    private OMEXMLCreator() {
+        throw new RuntimeException("This class is not instantiable.");
+    }
+
+    /**
+     * Create the content of an OME XML file that corresponds to the June 2016 Open Microscopy Environment OME Schema
+     * applied to the provided metadata.
+     *
+     * @param metadata the metadata of the image
+     * @return a text representing the provided metadata according the June 2016 Open Microscopy Environment OME Schema,
+     * or an empty optional if the creation failed
+     */
+    public static Optional<String> create(ImageServerMetadata metadata) {
+        OME ome = new OME();
+        ome.addImage(createImage(metadata));
+
+        try {
+            Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            Element root = ome.asXMLElement(document);
+            root.setAttribute("xmlns", NAMESPACE);
+            document.appendChild(root);
+
+            try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+                TransformerFactory.newInstance().newTransformer().transform(
+                        new DOMSource(document),
+                        new StreamResult(new OutputStreamWriter(os, StandardCharsets.UTF_8))
+                );
+                return Optional.ofNullable(os.toString());
+            }
+        } catch (Exception e) {
+            logger.error("Error while creating OME XML content", e);
+            return Optional.empty();
+        }
+    }
+
+    private static Image createImage(ImageServerMetadata metadata) {
+        Image image = new Image();
+
+        image.setID("Image:0");
+        image.setPixels(createPixels(metadata));
+
+        return image;
+    }
+
+    private static Pixels createPixels(ImageServerMetadata metadata) {
+        Pixels pixels = new Pixels();
+
+        pixels.setID("Pixels:0");
+
+        pixels.setSizeX(new PositiveInteger(metadata.getWidth()));
+        pixels.setSizeY(new PositiveInteger(metadata.getHeight()));
+        pixels.setSizeZ(new PositiveInteger(metadata.getSizeZ()));
+        pixels.setSizeC(new PositiveInteger(metadata.getSizeC()));
+        pixels.setSizeT(new PositiveInteger(metadata.getSizeT()));
+
+        pixels.setDimensionOrder(DimensionOrder.XYZCT);
+
+        pixels.setType(switch (metadata.getPixelType()) {
+            case UINT8 -> PixelType.UINT8;
+            case INT8 -> PixelType.INT8;
+            case UINT16 -> PixelType.UINT16;
+            case INT16 -> PixelType.INT16;
+            case UINT32 -> PixelType.UINT32;
+            case INT32 -> PixelType.INT32;
+            case FLOAT32 -> PixelType.FLOAT;
+            case FLOAT64 -> PixelType.DOUBLE;
+        });
+
+        if (!Double.isNaN(metadata.getPixelCalibration().getPixelWidthMicrons())) {
+            pixels.setPhysicalSizeX(new Length(
+                    metadata.getPixelCalibration().getPixelWidthMicrons(),
+                    UNITS.MICROMETRE
+            ));
+        }
+        if (!Double.isNaN(metadata.getPixelCalibration().getPixelHeightMicrons())) {
+            pixels.setPhysicalSizeY(new Length(
+                    metadata.getPixelCalibration().getPixelHeightMicrons(),
+                    UNITS.MICROMETRE
+            ));
+        }
+        if (!Double.isNaN(metadata.getPixelCalibration().getZSpacingMicrons())) {
+            pixels.setPhysicalSizeZ(new Length(
+                    metadata.getPixelCalibration().getZSpacingMicrons(),
+                    UNITS.MICROMETRE
+            ));
+        }
+        if (metadata.getSizeT() > 1 && !Double.isNaN(metadata.getTimepoint(0)) && !Double.isNaN(metadata.getTimepoint(1))) {
+            pixels.setTimeIncrement(new Time(
+                    Math.abs(metadata.getTimepoint(1) - metadata.getTimepoint(0)),
+                    switch (metadata.getTimeUnit()) {
+                        case NANOSECONDS -> UNITS.NANOSECOND;
+                        case MICROSECONDS -> UNITS.MICROSECOND;
+                        case MILLISECONDS -> UNITS.MILLISECOND;
+                        case SECONDS -> UNITS.SECOND;
+                        case MINUTES -> UNITS.MINUTE;
+                        case HOURS -> UNITS.HOUR;
+                        case DAYS -> UNITS.DAY;
+                    }
+            ));
+        }
+
+        for (ImageChannel channel: metadata.getChannels()) {
+            pixels.addChannel(createChannel(metadata, channel));
+        }
+
+        return pixels;
+    }
+
+    private static Channel createChannel(ImageServerMetadata metadata, ImageChannel imageChannel) {
+        Channel channel = new Channel();
+
+        channel.setID("Channel:" + metadata.getChannels().indexOf(imageChannel));
+
+        channel.setColor(new Color(packRGBA(
+                ColorTools.red(imageChannel.getColor()),
+                ColorTools.green(imageChannel.getColor()),
+                ColorTools.blue(imageChannel.getColor())
+        )));
+        channel.setName(imageChannel.getName());
+
+        return channel;
+    }
+
+    private static int packRGBA(int r, int g, int b) {
+        return ((r & 0xff)<<24) +
+                ((g & 0xff)<<16) +
+                ((b & 0xff)<<8) +
+                (1 & 0xff);
+    }
+}

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrAttributesCreator.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrAttributesCreator.java
@@ -96,7 +96,8 @@ class OMEZarrAttributesCreator {
                                 "defaultZ", 0,
                                 "model", "color"
                         )
-                )
+                ),
+                "bioformats2raw.layout" , 3
         );
     }
 

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrAttributesCreator.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrAttributesCreator.java
@@ -1,15 +1,13 @@
 package qupath.lib.images.writers.ome.zarr;
 
 import qupath.lib.common.ColorTools;
-import qupath.lib.images.servers.ImageChannel;
+import qupath.lib.images.servers.ImageServerMetadata;
 import qupath.lib.images.servers.PixelCalibration;
-import qupath.lib.images.servers.PixelType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 /**
@@ -19,16 +17,7 @@ import java.util.stream.IntStream;
 class OMEZarrAttributesCreator {
 
     private static final String VERSION = "0.4";
-    private final String imageName;
-    private final int numberOfZSlices;
-    private final int numberOfTimePoints;
-    private final int numberOfChannels;
-    private final PixelCalibration pixelCalibration;
-    private final TimeUnit timeUnit;
-    private final double[] downsamples;
-    private final List<ImageChannel> channels;
-    private final boolean isRGB;
-    private final PixelType pixelType;
+    private final ImageServerMetadata metadata;
     private enum Dimension {
         X,
         Y,
@@ -40,39 +29,10 @@ class OMEZarrAttributesCreator {
     /**
      * Create an instance of the attributes' creator.
      *
-     * @param imageName  the name of the image
-     * @param numberOfZSlices  the number of z-stacks
-     * @param numberOfTimePoints  the number of time points
-     * @param numberOfChannels  the number of channels
-     * @param pixelCalibration  the pixel calibration
-     * @param timeUnit  the unit of the time dimension of the image
-     * @param downsamples  the downsamples of the image
-     * @param channels  the channels of the image
-     * @param isRGB  whether the image stores pixel values with the RGB format
-     * @param pixelType  the type of the pixel values of the image
+     * @param metadata  the metadata of the image
      */
-    public OMEZarrAttributesCreator(
-            String imageName,
-            int numberOfZSlices,
-            int numberOfTimePoints,
-            int numberOfChannels,
-            PixelCalibration pixelCalibration,
-            TimeUnit timeUnit,
-            double[] downsamples,
-            List<ImageChannel> channels,
-            boolean isRGB,
-            PixelType pixelType
-    ) {
-        this.imageName = imageName;
-        this.numberOfZSlices = numberOfZSlices;
-        this.numberOfTimePoints = numberOfTimePoints;
-        this.numberOfChannels = numberOfChannels;
-        this.pixelCalibration = pixelCalibration;
-        this.timeUnit = timeUnit;
-        this.downsamples = downsamples;
-        this.channels = channels;
-        this.isRGB = isRGB;
-        this.pixelType = pixelType;
+    public OMEZarrAttributesCreator(ImageServerMetadata metadata) {
+        this.metadata = metadata;
     }
 
     /**
@@ -84,11 +44,11 @@ class OMEZarrAttributesCreator {
                 "multiscales", List.of(Map.of(
                         "axes", getAxes(),
                         "datasets", getDatasets(),
-                        "name", imageName,
+                        "name", metadata.getName(),
                         "version", VERSION
                 )),
                 "omero", Map.of(
-                        "name", imageName,
+                        "name", metadata.getName(),
                         "version", VERSION,
                         "channels", getChannels(),
                         "rdefs", Map.of(
@@ -107,13 +67,13 @@ class OMEZarrAttributesCreator {
      */
     public Map<String, Object> getLevelAttributes() {
         List<String> arrayDimensions = new ArrayList<>();
-        if (numberOfTimePoints > 1) {
+        if (metadata.getSizeT() > 1) {
             arrayDimensions.add("t");
         }
-        if (numberOfChannels > 1) {
+        if (metadata.getSizeC() > 1) {
             arrayDimensions.add("c");
         }
-        if (numberOfZSlices > 1) {
+        if (metadata.getSizeZ() > 1) {
             arrayDimensions.add("z");
         }
         arrayDimensions.add("y");
@@ -125,13 +85,13 @@ class OMEZarrAttributesCreator {
     private List<Map<String, Object>> getAxes() {
         List<Map<String, Object>> axes = new ArrayList<>();
 
-        if (numberOfTimePoints > 1) {
+        if (metadata.getSizeT() > 1) {
             axes.add(getAxis(Dimension.T));
         }
-        if (numberOfChannels > 1) {
+        if (metadata.getSizeC() > 1) {
             axes.add(getAxis(Dimension.C));
         }
-        if (numberOfZSlices > 1) {
+        if (metadata.getSizeZ() > 1) {
             axes.add(getAxis(Dimension.Z));
         }
         axes.add(getAxis(Dimension.Y));
@@ -141,16 +101,16 @@ class OMEZarrAttributesCreator {
     }
 
     private List<Map<String, Object>> getDatasets() {
-        return IntStream.range(0, downsamples.length)
+        return IntStream.range(0, metadata.getPreferredDownsamplesArray().length)
                 .mapToObj(level -> Map.of(
                         "path", "s" + level,
-                        "coordinateTransformations", List.of(getCoordinateTransformation((float) downsamples[level]))
+                        "coordinateTransformations", List.of(getCoordinateTransformation((float) metadata.getPreferredDownsamplesArray()[level]))
                 ))
                 .toList();
     }
 
     private List<Map<String, Object>> getChannels() {
-        Object maxValue = isRGB ? Integer.MAX_VALUE : switch (pixelType) {
+        Object maxValue = metadata.isRGB() ? Integer.MAX_VALUE : switch (metadata.getPixelType()) {
             case UINT8, INT8 -> Byte.MAX_VALUE;
             case UINT16, INT16 -> Short.MAX_VALUE;
             case UINT32, INT32 -> Integer.MAX_VALUE;
@@ -158,7 +118,7 @@ class OMEZarrAttributesCreator {
             case FLOAT64 -> Double.MAX_VALUE;
         };
 
-        return channels.stream()
+        return metadata.getChannels().stream()
                 .map(channel -> Map.of(
                         "active", true,
                         "coefficient", 1d,
@@ -198,11 +158,11 @@ class OMEZarrAttributesCreator {
 
         switch (dimension) {
             case X, Y, Z -> {
-                if (pixelCalibration.getPixelWidthUnit().equals(PixelCalibration.MICROMETER)) {
+                if (metadata.getPixelCalibration().getPixelWidthUnit().equals(PixelCalibration.MICROMETER)) {
                     axis.put("unit", "micrometer");
                 }
             }
-            case T -> axis.put("unit", switch (timeUnit) {
+            case T -> axis.put("unit", switch (metadata.getTimeUnit()) {
                 case NANOSECONDS -> "nanosecond";
                 case MICROSECONDS -> "microsecond";
                 case MILLISECONDS -> "millisecond";
@@ -218,21 +178,21 @@ class OMEZarrAttributesCreator {
 
     private Map<String, Object> getCoordinateTransformation(float downsample) {
         List<Float> scales = new ArrayList<>();
-        if (numberOfTimePoints > 1) {
-            if (!Double.isNaN(pixelCalibration.getTimepoint(0)) && !Double.isNaN(pixelCalibration.getTimepoint(1))) {
-                scales.add((float) (pixelCalibration.getTimepoint(1) - pixelCalibration.getTimepoint(0)));
+        if (metadata.getSizeT() > 1) {
+            if (!Double.isNaN(metadata.getPixelCalibration().getTimepoint(0)) && !Double.isNaN(metadata.getPixelCalibration().getTimepoint(1))) {
+                scales.add((float) (metadata.getPixelCalibration().getTimepoint(1) - metadata.getPixelCalibration().getTimepoint(0)));
             } else {
                 scales.add(1F);
             }
         }
-        if (numberOfChannels > 1) {
+        if (metadata.getSizeC() > 1) {
             scales.add(1F);
         }
-        if (numberOfZSlices > 1) {
-            scales.add(pixelCalibration.getZSpacing().floatValue());
+        if (metadata.getSizeZ() > 1) {
+            scales.add(metadata.getPixelCalibration().getZSpacing().floatValue());
         }
-        scales.add(pixelCalibration.getPixelHeight().floatValue() * downsample);
-        scales.add(pixelCalibration.getPixelWidth().floatValue() * downsample);
+        scales.add(metadata.getPixelCalibration().getPixelHeight().floatValue() * downsample);
+        scales.add(metadata.getPixelCalibration().getPixelWidth().floatValue() * downsample);
 
         return Map.of(
                 "type", "scale",

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriter.java
@@ -19,6 +19,9 @@ import qupath.lib.regions.ImageRegion;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -89,12 +92,16 @@ public class OMEZarrWriter implements AutoCloseable {
                 server.isRGB(),
                 server.getPixelType()
         );
+
+        ZarrGroup root = ZarrGroup.create(
+                builder.path,
+                attributes.getGroupAttributes()
+        );
+
+        createOmeSubGroup(root, builder.path);
         levelArrays = createLevelArrays(
                 server,
-                ZarrGroup.create(
-                        builder.path,
-                        attributes.getGroupAttributes()
-                ),
+                root,
                 attributes.getLevelAttributes(),
                 builder.compressor
         );
@@ -377,6 +384,13 @@ public class OMEZarrWriter implements AutoCloseable {
                         Math.max(tileSize, imageSize / maxNumberOfChunks) :
                         tileSize
         );
+    }
+
+    private static void createOmeSubGroup(ZarrGroup root, String imagePath) throws IOException {
+        String name = "OME";
+        root.createSubGroup(name);
+
+        Path omeroMetadataPath = Files.createFile(Paths.get(imagePath, name, "METADATA.ome.xml"));
     }
 
     private static Map<Integer, ZarrArray> createLevelArrays(

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriter.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
  * <p>
  *     Create an OME-Zarr file writer as described by version 0.4 of the specifications of the
  *     <a href="https://ngff.openmicroscopy.org/0.4/index.html">Next-generation file formats (NGFF)</a>.
+ *     The transitional "bioformats2raw.layout" and "omero" metadata are also considered.
  * </p>
  * <p>
  *     Use a {@link Builder} to create an instance of this class.

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/TestConvertCommand.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/TestConvertCommand.java
@@ -1,5 +1,6 @@
 package qupath.lib.images.writers.ome;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
@@ -29,6 +30,7 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import org.apache.commons.io.FileUtils;
 
 public class TestConvertCommand {
 
@@ -40,7 +42,7 @@ public class TestConvertCommand {
 
         @BeforeAll
         static void createInputImage() throws Exception {
-            deleteDir(new File(inputImagePath));
+            deleteImage(inputImagePath);
 
             try (
                     ImageServer<BufferedImage> sampleServer = new SampleImageServer();
@@ -48,6 +50,11 @@ public class TestConvertCommand {
             ) {
                 writer.writeImage();
             }
+        }
+
+        @AfterAll
+        static void deleteInputImage() throws IOException {
+            deleteImage(inputImagePath);
         }
 
         @Test
@@ -64,6 +71,8 @@ public class TestConvertCommand {
                 imageWidth = server.getWidth();
             }
             Assertions.assertEquals(expectedWidth, imageWidth);
+
+            deleteImage(outputImagePath);
         }
 
         @Test
@@ -80,6 +89,8 @@ public class TestConvertCommand {
                 imageWidth = server.getWidth();
             }
             Assertions.assertEquals(expectedWidth, imageWidth);
+
+            deleteImage(outputImagePath);
         }
 
         @Test
@@ -96,6 +107,8 @@ public class TestConvertCommand {
                 zSlices = server.nZSlices();
             }
             Assertions.assertEquals(expectedZSlices, zSlices);
+
+            deleteImage(outputImagePath);
         }
 
         @Test
@@ -112,6 +125,8 @@ public class TestConvertCommand {
                 zSlices = server.nZSlices();
             }
             Assertions.assertEquals(expectedZSlices, zSlices);
+
+            deleteImage(outputImagePath);
         }
 
         @Test
@@ -128,6 +143,8 @@ public class TestConvertCommand {
                 zSlices = server.nZSlices();
             }
             Assertions.assertEquals(expectedZSlices, zSlices);
+
+            deleteImage(outputImagePath);
         }
 
         @Test
@@ -144,6 +161,8 @@ public class TestConvertCommand {
                 timepoints = server.nTimepoints();
             }
             Assertions.assertEquals(expectedTimepoints, timepoints);
+
+            deleteImage(outputImagePath);
         }
 
         @Test
@@ -160,6 +179,8 @@ public class TestConvertCommand {
                 timepoints = server.nTimepoints();
             }
             Assertions.assertEquals(expectedTimepoints, timepoints);
+
+            deleteImage(outputImagePath);
         }
 
         @Test
@@ -176,6 +197,8 @@ public class TestConvertCommand {
                 timepoints = server.nTimepoints();
             }
             Assertions.assertEquals(expectedTimepoints, timepoints);
+
+            deleteImage(outputImagePath);
         }
 
         @Test
@@ -192,6 +215,8 @@ public class TestConvertCommand {
                 width = server.getWidth();
             }
             Assertions.assertEquals(expectedWidth, width);
+
+            deleteImage(outputImagePath);
         }
 
         @Test
@@ -209,6 +234,8 @@ public class TestConvertCommand {
                 width = server.getWidth();
             }
             Assertions.assertEquals(expectedWidth, width);
+
+            deleteImage(outputImagePath);
         }
 
         @Test
@@ -221,6 +248,20 @@ public class TestConvertCommand {
             int exitCode = cmd.execute(inputImagePath, outputImagePath, "--overwrite");
 
             Assertions.assertEquals(0, exitCode);
+
+            deleteImage(outputImagePath);
+        }
+
+        private static void deleteImage(String imagePath) throws IOException {
+            File image = new File(imagePath);
+
+            if (image.exists()) {
+                if (image.isDirectory()) {
+                    FileUtils.deleteDirectory(image);
+                } else {
+                    Files.delete(image.toPath());
+                }
+            }
         }
     }
 
@@ -335,21 +376,5 @@ public class TestConvertCommand {
         private static double getPixel(int x, int y, int channel, int z, int t) {
             return z + t + channel + ((double) x / IMAGE_WIDTH + (double) y / IMAGE_HEIGHT) / 2;
         }
-    }
-
-    private static boolean deleteDir(File dir) {
-        if (dir.isDirectory()) {
-            String[] children = dir.list();
-
-            if (children != null) {
-                for (String child : children) {
-                    boolean success = deleteDir(new File(dir, child));
-                    if (!success) {
-                        return false;
-                    }
-                }
-            }
-        }
-        return dir.delete();
     }
 }

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/TestConvertCommand.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/TestConvertCommand.java
@@ -42,7 +42,7 @@ public class TestConvertCommand {
 
         @BeforeAll
         static void createInputImage() throws Exception {
-            deleteImage(inputImagePath);
+            deleteFileOrDirectory(inputImagePath);
 
             try (
                     ImageServer<BufferedImage> sampleServer = new SampleImageServer();
@@ -54,7 +54,7 @@ public class TestConvertCommand {
 
         @AfterAll
         static void deleteInputImage() throws IOException {
-            deleteImage(inputImagePath);
+            deleteFileOrDirectory(inputImagePath);
         }
 
         @Test
@@ -72,7 +72,7 @@ public class TestConvertCommand {
             }
             Assertions.assertEquals(expectedWidth, imageWidth);
 
-            deleteImage(outputImagePath);
+            deleteFileOrDirectory(outputImagePath);
         }
 
         @Test
@@ -90,7 +90,7 @@ public class TestConvertCommand {
             }
             Assertions.assertEquals(expectedWidth, imageWidth);
 
-            deleteImage(outputImagePath);
+            deleteFileOrDirectory(outputImagePath);
         }
 
         @Test
@@ -108,7 +108,7 @@ public class TestConvertCommand {
             }
             Assertions.assertEquals(expectedZSlices, zSlices);
 
-            deleteImage(outputImagePath);
+            deleteFileOrDirectory(outputImagePath);
         }
 
         @Test
@@ -126,7 +126,7 @@ public class TestConvertCommand {
             }
             Assertions.assertEquals(expectedZSlices, zSlices);
 
-            deleteImage(outputImagePath);
+            deleteFileOrDirectory(outputImagePath);
         }
 
         @Test
@@ -144,7 +144,7 @@ public class TestConvertCommand {
             }
             Assertions.assertEquals(expectedZSlices, zSlices);
 
-            deleteImage(outputImagePath);
+            deleteFileOrDirectory(outputImagePath);
         }
 
         @Test
@@ -162,7 +162,7 @@ public class TestConvertCommand {
             }
             Assertions.assertEquals(expectedTimepoints, timepoints);
 
-            deleteImage(outputImagePath);
+            deleteFileOrDirectory(outputImagePath);
         }
 
         @Test
@@ -180,7 +180,7 @@ public class TestConvertCommand {
             }
             Assertions.assertEquals(expectedTimepoints, timepoints);
 
-            deleteImage(outputImagePath);
+            deleteFileOrDirectory(outputImagePath);
         }
 
         @Test
@@ -198,7 +198,7 @@ public class TestConvertCommand {
             }
             Assertions.assertEquals(expectedTimepoints, timepoints);
 
-            deleteImage(outputImagePath);
+            deleteFileOrDirectory(outputImagePath);
         }
 
         @Test
@@ -216,7 +216,7 @@ public class TestConvertCommand {
             }
             Assertions.assertEquals(expectedWidth, width);
 
-            deleteImage(outputImagePath);
+            deleteFileOrDirectory(outputImagePath);
         }
 
         @Test
@@ -235,7 +235,7 @@ public class TestConvertCommand {
             }
             Assertions.assertEquals(expectedWidth, width);
 
-            deleteImage(outputImagePath);
+            deleteFileOrDirectory(outputImagePath);
         }
 
         @Test
@@ -249,10 +249,10 @@ public class TestConvertCommand {
 
             Assertions.assertEquals(0, exitCode);
 
-            deleteImage(outputImagePath);
+            deleteFileOrDirectory(outputImagePath);
         }
 
-        private static void deleteImage(String imagePath) throws IOException {
+        private static void deleteFileOrDirectory(String imagePath) throws IOException {
             File image = new File(imagePath);
 
             if (image.exists()) {

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEXMLCreator.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEXMLCreator.java
@@ -1,0 +1,285 @@
+package qupath.lib.images.writers.ome.zarr;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+import qupath.lib.common.ColorTools;
+import qupath.lib.images.servers.ImageChannel;
+import qupath.lib.images.servers.ImageServerMetadata;
+import qupath.lib.images.servers.PixelType;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class TestOMEXMLCreator {
+
+    private static final ImageServerMetadata sampleMetadata = new ImageServerMetadata.Builder()
+            .width(23)
+            .height(45)
+            .rgb(false)
+            .pixelType(PixelType.FLOAT32)
+            .levelsFromDownsamples(1, 4)
+            .sizeZ(4)
+            .sizeT(6)
+            .pixelSizeMicrons(2.4, 9.7)
+            .zSpacingMicrons(6.5)
+            .timepoints(TimeUnit.MICROSECONDS, 0, 2)
+            .channels(List.of(
+                    ImageChannel.getInstance("c1", ColorTools.GREEN),
+                    ImageChannel.getInstance("c2", ColorTools.BLUE),
+                    ImageChannel.getInstance("c3", ColorTools.CYAN),
+                    ImageChannel.getInstance("c4", ColorTools.RED)
+            ))
+            .name("some name")
+            .build();
+
+    @Test
+    void Check_Namespace() throws ParserConfigurationException, IOException, SAXException {
+        String expectedNamespace = "http://www.openmicroscopy.org/Schemas/OME/2016-06";
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Assertions.assertEquals(
+                expectedNamespace,
+                getRootOfXMLText(xmlContent).getAttribute("xmlns")
+        );
+    }
+
+    @Test
+    void Check_Image_Element_Exists() throws IOException, ParserConfigurationException, SAXException {
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Assertions.assertEquals(
+                1,
+                getRootOfXMLText(xmlContent).getElementsByTagName("Image").getLength()
+        );
+    }
+
+    @Test
+    void Check_Pixels_Element_Exists() throws IOException, ParserConfigurationException, SAXException {
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Assertions.assertEquals(
+                1,
+                imageElement.getElementsByTagName("Pixels").getLength()
+        );
+    }
+
+    @Test
+    void Check_Width() throws IOException, ParserConfigurationException, SAXException {
+        String expectedWidth = String.valueOf(sampleMetadata.getWidth());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedWidth, pixelsElement.getAttribute("SizeX"));
+    }
+
+    @Test
+    void Check_Height() throws IOException, ParserConfigurationException, SAXException {
+        String expectedWidth = String.valueOf(sampleMetadata.getHeight());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedWidth, pixelsElement.getAttribute("SizeY"));
+    }
+
+    @Test
+    void Check_Number_Of_Z_Stacks() throws IOException, ParserConfigurationException, SAXException {
+        String expectedWidth = String.valueOf(sampleMetadata.getSizeZ());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedWidth, pixelsElement.getAttribute("SizeZ"));
+    }
+
+    @Test
+    void Check_Number_Of_Channels() throws IOException, ParserConfigurationException, SAXException {
+        String expectedWidth = String.valueOf(sampleMetadata.getSizeC());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedWidth, pixelsElement.getAttribute("SizeC"));
+    }
+
+    @Test
+    void Check_Number_Of_Timepoints() throws IOException, ParserConfigurationException, SAXException {
+        String expectedWidth = String.valueOf(sampleMetadata.getSizeT());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedWidth, pixelsElement.getAttribute("SizeT"));
+    }
+
+    @Test
+    void Check_Pixel_Type() throws IOException, ParserConfigurationException, SAXException {
+        String expectedPixelType = "float";
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedPixelType, pixelsElement.getAttribute("Type"));
+    }
+
+    @Test
+    void Check_Pixel_Width_Value() throws IOException, ParserConfigurationException, SAXException {
+        String expectedValue = String.valueOf(sampleMetadata.getPixelCalibration().getPixelWidthMicrons());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedValue, pixelsElement.getAttribute("PhysicalSizeX"));
+    }
+
+    @Test
+    void Check_Pixel_Width_Unit() throws IOException, ParserConfigurationException, SAXException {
+        String expectedUnit = String.valueOf(sampleMetadata.getPixelCalibration().getPixelHeightUnit());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedUnit, pixelsElement.getAttribute("PhysicalSizeXUnit"));
+    }
+
+    @Test
+    void Check_Pixel_Height_Value() throws IOException, ParserConfigurationException, SAXException {
+        String expectedValue = String.valueOf(sampleMetadata.getPixelCalibration().getPixelHeightMicrons());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedValue, pixelsElement.getAttribute("PhysicalSizeY"));
+    }
+
+    @Test
+    void Check_Pixel_Height_Unit() throws IOException, ParserConfigurationException, SAXException {
+        String expectedUnit = String.valueOf(sampleMetadata.getPixelCalibration().getPixelHeightUnit());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedUnit, pixelsElement.getAttribute("PhysicalSizeYUnit"));
+    }
+
+    @Test
+    void Check_Pixel_Z_Spacing_Value() throws IOException, ParserConfigurationException, SAXException {
+        String expectedValue = String.valueOf(sampleMetadata.getPixelCalibration().getZSpacingMicrons());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedValue, pixelsElement.getAttribute("PhysicalSizeZ"));
+    }
+
+    @Test
+    void Check_Pixel_Z_Spacing_Unit() throws IOException, ParserConfigurationException, SAXException {
+        String expectedUnit = String.valueOf(sampleMetadata.getPixelCalibration().getZSpacingUnit());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedUnit, pixelsElement.getAttribute("PhysicalSizeZUnit"));
+    }
+
+    @Test
+    void Check_Pixel_T_Spacing_Value() throws IOException, ParserConfigurationException, SAXException {
+        String expectedValue = String.valueOf(
+                sampleMetadata.getPixelCalibration().getTimepoint(1) - sampleMetadata.getPixelCalibration().getTimepoint(0)
+        );
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedValue, pixelsElement.getAttribute("TimeIncrement"));
+    }
+
+    @Test
+    void Check_Pixel_T_Spacing_Unit() throws IOException, ParserConfigurationException, SAXException {
+        String expectedUnit = "µs";
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(expectedUnit, pixelsElement.getAttribute("TimeIncrementUnit"));
+    }
+
+    @Test
+    void Check_Channels_Element_Exist() throws IOException, ParserConfigurationException, SAXException {
+        int expectedNumberOfChannels = sampleMetadata.getSizeC();
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Assertions.assertEquals(
+                expectedNumberOfChannels,
+                pixelsElement.getElementsByTagName("Channel").getLength()
+        );
+    }
+
+    @Test
+    void Check_Channel_Name() throws IOException, ParserConfigurationException, SAXException {
+        int channelIndex = 2;
+        String expectedName = sampleMetadata.getChannel(channelIndex).getName();
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element channelElement = (Element) pixelsElement.getChildNodes().item(channelIndex);
+        Assertions.assertEquals(expectedName, channelElement.getAttribute("Name"));
+    }
+
+    @Test
+    void Check_Channel_Color() throws IOException, ParserConfigurationException, SAXException {
+        int channelIndex = 3;
+        int expectedColorRGB = sampleMetadata.getChannel(channelIndex).getColor();
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element channelElement = (Element) pixelsElement.getChildNodes().item(channelIndex);
+        int colorRGBA = Integer.parseInt(channelElement.getAttribute("Color"));
+        int colorRGB = ColorTools.packRGB(
+                (colorRGBA >> 24) & 0xff,
+                (colorRGBA >> 16) & 0xff,
+                (colorRGBA >> 8) & 0xff
+        );
+        Assertions.assertEquals(expectedColorRGB, colorRGB);
+    }
+
+    private Element getRootOfXMLText(String xmlText) throws IOException, ParserConfigurationException, SAXException {
+        Document document;
+        try (ByteArrayInputStream input = new ByteArrayInputStream(xmlText.getBytes(StandardCharsets.UTF_8))) {
+            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(input);
+        }
+        return document.getDocumentElement();
+    }
+}

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEXMLCreator.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEXMLCreator.java
@@ -38,6 +38,7 @@ public class TestOMEXMLCreator {
                     ImageChannel.getInstance("c4", ColorTools.RED)
             ))
             .name("some name")
+            .magnification(4.8)
             .build();
 
     @Test
@@ -50,6 +51,38 @@ public class TestOMEXMLCreator {
                 expectedNamespace,
                 getRootOfXMLText(xmlContent).getAttribute("xmlns")
         );
+    }
+
+    @Test
+    void Check_Instrument_Element_Exists() throws IOException, ParserConfigurationException, SAXException {
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Assertions.assertEquals(
+                1,
+                getRootOfXMLText(xmlContent).getElementsByTagName("Instrument").getLength()
+        );
+    }
+
+    @Test
+    void Check_Objective_Element_Exists() throws IOException, ParserConfigurationException, SAXException {
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element instrumentElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Instrument").item(0);
+        Assertions.assertEquals(
+                1,
+                instrumentElement.getElementsByTagName("Objective").getLength()
+        );
+    }
+
+    @Test
+    void Check_Magnification() throws IOException, ParserConfigurationException, SAXException {
+        String expectedMagnification = String.valueOf(sampleMetadata.getMagnification());
+
+        String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
+
+        Element instrumentElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Instrument").item(0);
+        Element objectiveElement = (Element) instrumentElement.getElementsByTagName("Objective").item(0);
+        Assertions.assertEquals(expectedMagnification, objectiveElement.getAttribute("NominalMagnification"));
     }
 
     @Test
@@ -66,7 +99,7 @@ public class TestOMEXMLCreator {
     void Check_Pixels_Element_Exists() throws IOException, ParserConfigurationException, SAXException {
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
         Assertions.assertEquals(
                 1,
                 imageElement.getElementsByTagName("Pixels").getLength()
@@ -79,8 +112,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedWidth, pixelsElement.getAttribute("SizeX"));
     }
 
@@ -90,8 +123,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedWidth, pixelsElement.getAttribute("SizeY"));
     }
 
@@ -101,8 +134,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedWidth, pixelsElement.getAttribute("SizeZ"));
     }
 
@@ -112,8 +145,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedWidth, pixelsElement.getAttribute("SizeC"));
     }
 
@@ -123,8 +156,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedWidth, pixelsElement.getAttribute("SizeT"));
     }
 
@@ -134,8 +167,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedPixelType, pixelsElement.getAttribute("Type"));
     }
 
@@ -145,8 +178,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedValue, pixelsElement.getAttribute("PhysicalSizeX"));
     }
 
@@ -156,8 +189,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedUnit, pixelsElement.getAttribute("PhysicalSizeXUnit"));
     }
 
@@ -167,8 +200,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedValue, pixelsElement.getAttribute("PhysicalSizeY"));
     }
 
@@ -178,8 +211,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedUnit, pixelsElement.getAttribute("PhysicalSizeYUnit"));
     }
 
@@ -189,8 +222,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedValue, pixelsElement.getAttribute("PhysicalSizeZ"));
     }
 
@@ -200,8 +233,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedUnit, pixelsElement.getAttribute("PhysicalSizeZUnit"));
     }
 
@@ -213,8 +246,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedValue, pixelsElement.getAttribute("TimeIncrement"));
     }
 
@@ -224,8 +257,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(expectedUnit, pixelsElement.getAttribute("TimeIncrementUnit"));
     }
 
@@ -235,8 +268,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Assertions.assertEquals(
                 expectedNumberOfChannels,
                 pixelsElement.getElementsByTagName("Channel").getLength()
@@ -250,8 +283,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Element channelElement = (Element) pixelsElement.getChildNodes().item(channelIndex);
         Assertions.assertEquals(expectedName, channelElement.getAttribute("Name"));
     }
@@ -263,8 +296,8 @@ public class TestOMEXMLCreator {
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 
-        Element imageElement = (Element) getRootOfXMLText(xmlContent).getFirstChild();
-        Element pixelsElement = (Element) imageElement.getFirstChild();
+        Element imageElement = (Element) getRootOfXMLText(xmlContent).getElementsByTagName("Image").item(0);
+        Element pixelsElement = (Element) imageElement.getElementsByTagName("Pixels").item(0);
         Element channelElement = (Element) pixelsElement.getChildNodes().item(channelIndex);
         int colorRGBA = Integer.parseInt(channelElement.getAttribute("Color"));
         int colorRGB = ColorTools.packRGB(

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrAttributesCreator.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrAttributesCreator.java
@@ -1,0 +1,886 @@
+package qupath.lib.images.writers.ome.zarr;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import qupath.lib.common.ColorTools;
+import qupath.lib.images.servers.ImageChannel;
+import qupath.lib.images.servers.ImageServerMetadata;
+import qupath.lib.images.servers.PixelType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class TestOMEZarrAttributesCreator {
+
+    private static final ImageServerMetadata sampleMetadata = new ImageServerMetadata.Builder()
+            .width(23)
+            .height(45)
+            .rgb(false)
+            .pixelType(PixelType.FLOAT32)
+            .levelsFromDownsamples(1, 4)
+            .sizeZ(4)
+            .sizeT(6)
+            .pixelSizeMicrons(2.4, 9.7)
+            .zSpacingMicrons(6.5)
+            .timepoints(TimeUnit.MICROSECONDS, 0, 2)
+            .channels(List.of(
+                    ImageChannel.getInstance("c1", ColorTools.GREEN),
+                    ImageChannel.getInstance("c2", ColorTools.BLUE),
+                    ImageChannel.getInstance("c3", ColorTools.CYAN),
+                    ImageChannel.getInstance("c4", ColorTools.RED)
+            ))
+            .name("some name")
+            .build();
+
+    @Test
+    void Check_Group_Attribute_Has_Multiscales_Array() {
+        String label = "multiscales";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonElement multiscalesElement = root.get(label);
+        Assertions.assertTrue(multiscalesElement.isJsonArray());
+    }
+    
+    @Test
+    void Check_Multiscale_Array_Has_Axes_Array() {
+        String label = "axes";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonElement axesElement = multiscale.get(0).getAsJsonObject().get(label);
+        Assertions.assertTrue(axesElement.isJsonArray());
+    }
+
+    @Test
+    void Check_Multiscale_Array_Time_Axe_Unit() {
+        String expectedUnit = "microsecond";
+        int axeIndex = 0;
+        String label = "unit";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String unit = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedUnit, unit);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Time_Axe_Name() {
+        String expectedName = "t";
+        int axeIndex = 0;
+        String label = "name";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String name = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedName, name);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Time_Axe_Type() {
+        String expectedType = "time";
+        int axeIndex = 0;
+        String label = "type";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String type = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedType, type);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Channel_Axe_Name() {
+        String expectedName = "c";
+        int axeIndex = 1;
+        String label = "name";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String name = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedName, name);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Channel_Axe_Type() {
+        String expectedType = "channel";
+        int axeIndex = 1;
+        String label = "type";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String type = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedType, type);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Z_Axe_Unit() {
+        String expectedUnit = "micrometer";
+        int axeIndex = 2;
+        String label = "unit";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String unit = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedUnit, unit);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Z_Axe_Name() {
+        String expectedName = "z";
+        int axeIndex = 2;
+        String label = "name";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String name = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedName, name);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Z_Axe_Type() {
+        String expectedType = "space";
+        int axeIndex = 2;
+        String label = "type";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String type = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedType, type);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Y_Axe_Unit() {
+        String expectedUnit = "micrometer";
+        int axeIndex = 3;
+        String label = "unit";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String unit = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedUnit, unit);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Y_Axe_Name() {
+        String expectedName = "y";
+        int axeIndex = 3;
+        String label = "name";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String name = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedName, name);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Y_Axe_Type() {
+        String expectedType = "space";
+        int axeIndex = 3;
+        String label = "type";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String type = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedType, type);
+    }
+
+    @Test
+    void Check_Multiscale_Array_X_Axe_Unit() {
+        String expectedUnit = "micrometer";
+        int axeIndex = 4;
+        String label = "unit";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String unit = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedUnit, unit);
+    }
+
+    @Test
+    void Check_Multiscale_Array_X_Axe_Name() {
+        String expectedName = "x";
+        int axeIndex = 4;
+        String label = "name";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String name = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedName, name);
+    }
+
+    @Test
+    void Check_Multiscale_Array_X_Axe_Type() {
+        String expectedType = "space";
+        int axeIndex = 4;
+        String label = "type";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray axes = multiscale.get(0).getAsJsonObject().get("axes").getAsJsonArray();
+        String type = axes.get(axeIndex).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedType, type);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Has_Datasets_Array() {
+        String label = "datasets";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonElement datasetsElement = multiscale.get(0).getAsJsonObject().get(label);
+        Assertions.assertTrue(datasetsElement.isJsonArray());
+    }
+
+    @Test
+    void Check_Multiscale_Array_Number_Of_Datasets() {
+        int expectedNumberOfDatasets = sampleMetadata.nLevels();
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        int numberOfDatasets = datasetsElement.size();
+        Assertions.assertEquals(expectedNumberOfDatasets, numberOfDatasets);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Full_Image_Datasets_Has_Path() {
+        String label = "path";
+        int level = 0;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        Assertions.assertTrue(levelDatasetsElement.has(label));
+    }
+
+    @Test
+    void Check_Multiscale_Array_Full_Image_Datasets_Path() {
+        String label = "path";
+        int level = 0;
+        String expectedPath = "s0";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        String path = levelDatasetsElement.get(label).getAsString();
+        Assertions.assertEquals(expectedPath, path);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Full_Image_Datasets_Has_Coordinate_Transformations_Json_Array() {
+        String label = "coordinateTransformations";
+        int level = 0;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        Assertions.assertTrue(levelDatasetsElement.get(label).isJsonArray());
+    }
+
+    @Test
+    void Check_Multiscale_Array_Full_Image_Datasets_Coordinate_Transformations_Has_Type() {
+        String label = "type";
+        int level = 0;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        Assertions.assertTrue(coordinateTransformationsElement.get(0).getAsJsonObject().has(label));
+    }
+
+    @Test
+    void Check_Multiscale_Array_Full_Image_Datasets_Coordinate_Transformations_Type() {
+        String label = "type";
+        int level = 0;
+        String expectedType = "scale";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        String type = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedType, type);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Full_Image_Datasets_Coordinate_Transformations_Has_Scale() {
+        String label = "scale";
+        int level = 0;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        Assertions.assertTrue(coordinateTransformationsElement.get(0).getAsJsonObject().has(label));
+    }
+
+    @Test
+    void Check_Multiscale_Array_Full_Image_Datasets_Coordinate_Transformations_Time_Scale() {
+        String label = "scale";
+        int level = 0;
+        int scaleIndex = 0;
+        float expectedScale = 2;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        float scale = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsJsonArray().get(scaleIndex).getAsFloat();
+        Assertions.assertEquals(expectedScale, scale);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Full_Image_Datasets_Coordinate_Transformations_Channel_Scale() {
+        String label = "scale";
+        int level = 0;
+        int scaleIndex = 1;
+        float expectedScale = 1;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        float scale = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsJsonArray().get(scaleIndex).getAsFloat();
+        Assertions.assertEquals(expectedScale, scale);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Full_Image_Datasets_Coordinate_Transformations_Z_Scale() {
+        String label = "scale";
+        int level = 0;
+        int scaleIndex = 2;
+        float expectedScale = sampleMetadata.getPixelCalibration().getZSpacing().floatValue();
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        float scale = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsJsonArray().get(scaleIndex).getAsFloat();
+        Assertions.assertEquals(expectedScale, scale);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Full_Image_Datasets_Coordinate_Transformations_Y_Scale() {
+        String label = "scale";
+        int level = 0;
+        int scaleIndex = 3;
+        float expectedScale = sampleMetadata.getPixelCalibration().getPixelHeight().floatValue() * (float) sampleMetadata.getDownsampleForLevel(level);
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        float scale = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsJsonArray().get(scaleIndex).getAsFloat();
+        Assertions.assertEquals(expectedScale, scale);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Full_Image_Datasets_Coordinate_Transformations_X_Scale() {
+        String label = "scale";
+        int level = 0;
+        int scaleIndex = 4;
+        float expectedScale = sampleMetadata.getPixelCalibration().getPixelWidth().floatValue() * (float) sampleMetadata.getDownsampleForLevel(level);
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        float scale = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsJsonArray().get(scaleIndex).getAsFloat();
+        Assertions.assertEquals(expectedScale, scale);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Lower_Resolution_Image_Datasets_Has_Path() {
+        String label = "path";
+        int level = 1;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        Assertions.assertTrue(levelDatasetsElement.has(label));
+    }
+
+    @Test
+    void Check_Multiscale_Array_Lower_Resolution_Image_Datasets_Path() {
+        String label = "path";
+        int level = 1;
+        String expectedPath = "s1";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        String path = levelDatasetsElement.get(label).getAsString();
+        Assertions.assertEquals(expectedPath, path);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Lower_Resolution_Image_Datasets_Has_Coordinate_Transformations_Json_Array() {
+        String label = "coordinateTransformations";
+        int level = 1;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        Assertions.assertTrue(levelDatasetsElement.get(label).isJsonArray());
+    }
+
+    @Test
+    void Check_Multiscale_Array_Lower_Resolution_Image_Datasets_Coordinate_Transformations_Has_Type() {
+        String label = "type";
+        int level = 1;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        Assertions.assertTrue(coordinateTransformationsElement.get(0).getAsJsonObject().has(label));
+    }
+
+    @Test
+    void Check_Multiscale_Array_Lower_Resolution_Image_Datasets_Coordinate_Transformations_Type() {
+        String label = "type";
+        int level = 1;
+        String expectedType = "scale";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        String type = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedType, type);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Lower_Resolution_Image_Datasets_Coordinate_Transformations_Has_Scale() {
+        String label = "scale";
+        int level = 1;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        Assertions.assertTrue(coordinateTransformationsElement.get(0).getAsJsonObject().has(label));
+    }
+
+    @Test
+    void Check_Multiscale_Array_Lower_Resolution_Image_Datasets_Coordinate_Transformations_Time_Scale() {
+        String label = "scale";
+        int level = 1;
+        int scaleIndex = 0;
+        float expectedScale = 2;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        float scale = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsJsonArray().get(scaleIndex).getAsFloat();
+        Assertions.assertEquals(expectedScale, scale);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Lower_Resolution_Image_Datasets_Coordinate_Transformations_Channel_Scale() {
+        String label = "scale";
+        int level = 1;
+        int scaleIndex = 1;
+        float expectedScale = 1;
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        float scale = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsJsonArray().get(scaleIndex).getAsFloat();
+        Assertions.assertEquals(expectedScale, scale);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Lower_Resolution_Image_Datasets_Coordinate_Transformations_Z_Scale() {
+        String label = "scale";
+        int level = 1;
+        int scaleIndex = 2;
+        float expectedScale = sampleMetadata.getPixelCalibration().getZSpacing().floatValue();
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        float scale = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsJsonArray().get(scaleIndex).getAsFloat();
+        Assertions.assertEquals(expectedScale, scale);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Lower_Resolution_Image_Datasets_Coordinate_Transformations_Y_Scale() {
+        String label = "scale";
+        int level = 1;
+        int scaleIndex = 3;
+        float expectedScale = sampleMetadata.getPixelCalibration().getPixelHeight().floatValue() * (float) sampleMetadata.getDownsampleForLevel(level);
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        float scale = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsJsonArray().get(scaleIndex).getAsFloat();
+        Assertions.assertEquals(expectedScale, scale);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Lower_Resolution_Image_Datasets_Coordinate_Transformations_X_Scale() {
+        String label = "scale";
+        int level = 1;
+        int scaleIndex = 4;
+        float expectedScale = sampleMetadata.getPixelCalibration().getPixelWidth().floatValue() * (float) sampleMetadata.getDownsampleForLevel(level);
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        JsonArray datasetsElement = multiscale.get(0).getAsJsonObject().get("datasets").getAsJsonArray();
+        JsonObject levelDatasetsElement = datasetsElement.get(level).getAsJsonObject();
+        JsonArray coordinateTransformationsElement = levelDatasetsElement.get("coordinateTransformations").getAsJsonArray();
+        float scale = coordinateTransformationsElement.get(0).getAsJsonObject().get(label).getAsJsonArray().get(scaleIndex).getAsFloat();
+        Assertions.assertEquals(expectedScale, scale);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Has_Name() {
+        String label = "name";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        Assertions.assertTrue(multiscale.get(0).getAsJsonObject().has(label));
+    }
+
+    @Test
+    void Check_Multiscale_Array_Name() {
+        String label = "name";
+        String expectedName = sampleMetadata.getName();
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        String name = multiscale.get(0).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedName, name);
+    }
+
+    @Test
+    void Check_Multiscale_Array_Has_Version() {
+        String label = "version";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        Assertions.assertTrue(multiscale.get(0).getAsJsonObject().has(label));
+    }
+
+    @Test
+    void Check_Multiscale_Array_Version() {
+        String label = "version";
+        String expectedVersion = "0.4";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonArray multiscale = root.getAsJsonArray("multiscales");
+        String version = multiscale.get(0).getAsJsonObject().get(label).getAsString();
+        Assertions.assertEquals(expectedVersion, version);
+    }
+
+    @Test
+    void Check_Group_Attribute_Has_Omero_Object() {
+        String label = "omero";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonElement omeroElement = root.get(label);
+        Assertions.assertTrue(omeroElement.isJsonObject());
+    }
+
+    @Test
+    void Check_Omero_Object_Has_Name() {
+        String label = "name";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonObject omeroElement = root.get("omero").getAsJsonObject();
+        Assertions.assertTrue(omeroElement.has(label));
+    }
+
+    @Test
+    void Check_Omero_Object_Name() {
+        String label = "name";
+        String expectedName = sampleMetadata.getName();
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonObject omeroElement = root.get("omero").getAsJsonObject();
+        String name = omeroElement.get(label).getAsString();
+        Assertions.assertEquals(expectedName, name);
+    }
+
+    @Test
+    void Check_Omero_Object_Has_Version() {
+        String label = "version";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonObject omeroElement = root.get("omero").getAsJsonObject();
+        Assertions.assertTrue(omeroElement.has(label));
+    }
+
+    @Test
+    void Check_Omero_Object_Version() {
+        String label = "version";
+        String expectedVersion = "0.4";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonObject omeroElement = root.get("omero").getAsJsonObject();
+        String name = omeroElement.get(label).getAsString();
+        Assertions.assertEquals(expectedVersion, name);
+    }
+
+    @Test
+    void Check_Omero_Object_Has_Channels_Array() {
+        String label = "channels";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonObject omeroElement = root.get("omero").getAsJsonObject();
+        JsonElement channelsElement = omeroElement.get(label);
+        Assertions.assertTrue(channelsElement.isJsonArray());
+    }
+
+    @Test
+    void Check_Omero_Object_Channels_Has_Label() {
+        int channelIndex = 2;
+        String label = "label";
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonObject omeroElement = root.get("omero").getAsJsonObject();
+        JsonArray channelsElement = omeroElement.get("channels").getAsJsonArray();
+        Assertions.assertTrue(channelsElement.get(channelIndex).getAsJsonObject().has(label));
+    }
+
+    @Test
+    void Check_Omero_Object_Channels_Label() {
+        int channelIndex = 2;
+        String expectedLabel = sampleMetadata.getChannel(channelIndex).getName();
+
+        Map<String, Object> groupAttributes = new OMEZarrAttributesCreator(sampleMetadata).getGroupAttributes();
+
+        JsonObject root = new Gson().toJsonTree(groupAttributes).getAsJsonObject();
+        JsonObject omeroElement = root.get("omero").getAsJsonObject();
+        JsonArray channelsElement = omeroElement.get("channels").getAsJsonArray();
+        String label = channelsElement.get(channelIndex).getAsJsonObject().get("label").getAsString();
+        Assertions.assertEquals(expectedLabel, label);
+    }
+
+    @Test
+    void Check_Level_Attributes_Has_Array_Dimensions() {
+        String label = "_ARRAY_DIMENSIONS";
+
+        Map<String, Object> levelAttributes = new OMEZarrAttributesCreator(sampleMetadata).getLevelAttributes();
+
+        JsonObject root = new Gson().toJsonTree(levelAttributes).getAsJsonObject();
+        JsonElement arrayDimensionsElement = root.get(label);
+        Assertions.assertTrue(arrayDimensionsElement.isJsonArray());
+    }
+
+    @Test
+    void Check_Level_Attributes_Array_T_Dimension() {
+        String label = "_ARRAY_DIMENSIONS";
+        int dimensionIndex = 0;
+        String expectedDimension = "t";
+
+        Map<String, Object> levelAttributes = new OMEZarrAttributesCreator(sampleMetadata).getLevelAttributes();
+
+        JsonObject root = new Gson().toJsonTree(levelAttributes).getAsJsonObject();
+        JsonArray arrayDimensionsElement = root.get(label).getAsJsonArray();
+        String dimension = arrayDimensionsElement.get(dimensionIndex).getAsString();
+        Assertions.assertEquals(expectedDimension, dimension);
+    }
+
+    @Test
+    void Check_Level_Attributes_Array_C_Dimension() {
+        String label = "_ARRAY_DIMENSIONS";
+        int dimensionIndex = 1;
+        String expectedDimension = "c";
+
+        Map<String, Object> levelAttributes = new OMEZarrAttributesCreator(sampleMetadata).getLevelAttributes();
+
+        JsonObject root = new Gson().toJsonTree(levelAttributes).getAsJsonObject();
+        JsonArray arrayDimensionsElement = root.get(label).getAsJsonArray();
+        String dimension = arrayDimensionsElement.get(dimensionIndex).getAsString();
+        Assertions.assertEquals(expectedDimension, dimension);
+    }
+
+    @Test
+    void Check_Level_Attributes_Array_Z_Dimension() {
+        String label = "_ARRAY_DIMENSIONS";
+        int dimensionIndex = 2;
+        String expectedDimension = "z";
+
+        Map<String, Object> levelAttributes = new OMEZarrAttributesCreator(sampleMetadata).getLevelAttributes();
+
+        JsonObject root = new Gson().toJsonTree(levelAttributes).getAsJsonObject();
+        JsonArray arrayDimensionsElement = root.get(label).getAsJsonArray();
+        String dimension = arrayDimensionsElement.get(dimensionIndex).getAsString();
+        Assertions.assertEquals(expectedDimension, dimension);
+    }
+
+    @Test
+    void Check_Level_Attributes_Array_Y_Dimension() {
+        String label = "_ARRAY_DIMENSIONS";
+        int dimensionIndex = 3;
+        String expectedDimension = "y";
+
+        Map<String, Object> levelAttributes = new OMEZarrAttributesCreator(sampleMetadata).getLevelAttributes();
+
+        JsonObject root = new Gson().toJsonTree(levelAttributes).getAsJsonObject();
+        JsonArray arrayDimensionsElement = root.get(label).getAsJsonArray();
+        String dimension = arrayDimensionsElement.get(dimensionIndex).getAsString();
+        Assertions.assertEquals(expectedDimension, dimension);
+    }
+
+    @Test
+    void Check_Level_Attributes_Array_X_Dimension() {
+        String label = "_ARRAY_DIMENSIONS";
+        int dimensionIndex = 4;
+        String expectedDimension = "x";
+
+        Map<String, Object> levelAttributes = new OMEZarrAttributesCreator(sampleMetadata).getLevelAttributes();
+
+        JsonObject root = new Gson().toJsonTree(levelAttributes).getAsJsonObject();
+        JsonArray arrayDimensionsElement = root.get(label).getAsJsonArray();
+        String dimension = arrayDimensionsElement.get(dimensionIndex).getAsString();
+        Assertions.assertEquals(expectedDimension, dimension);
+    }
+}

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrWriter.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrWriter.java
@@ -62,6 +62,22 @@ public class TestOMEZarrWriter {
     }
 
     @Test
+    void Check_OME_XML_File_Exists() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath).build()) {
+            writer.writeImage();
+        }
+
+        Assertions.assertTrue(Files.exists(Paths.get(outputImagePath, "OME", "METADATA.ome.xml")));
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
     void Check_Full_Image_Pixels() throws Exception {
         Path path = Files.createTempDirectory(UUID.randomUUID().toString());
         String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrWriter.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrWriter.java
@@ -1,0 +1,542 @@
+package qupath.lib.images.writers.ome.zarr;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import qupath.lib.color.ColorModelFactory;
+import qupath.lib.images.servers.AbstractImageServer;
+import qupath.lib.images.servers.ImageChannel;
+import qupath.lib.images.servers.ImageServer;
+import qupath.lib.images.servers.ImageServerBuilder;
+import qupath.lib.images.servers.ImageServerMetadata;
+import qupath.lib.images.servers.ImageServerProvider;
+import qupath.lib.images.servers.PixelType;
+import qupath.lib.regions.ImageRegion;
+import qupath.lib.regions.RegionRequest;
+
+import java.awt.image.BandedSampleModel;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferDouble;
+import java.awt.image.WritableRaster;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+public class TestOMEZarrWriter {
+
+    @Test
+    void Check_Error_When_Extension_Incorrect() throws Exception {
+        String extension = ".wrong.extension";
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image" + extension).toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        );
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_Full_Image_Pixels() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        int level = 0;
+        int z = 2;
+        int t = 1;
+        BufferedImage expectedImage = sampleImageServer.readRegion(
+                sampleImageServer.getDownsampleForResolution(level),
+                0,
+                0,
+                sampleImageServer.getWidth(),
+                sampleImageServer.getHeight(),
+                z,
+                t
+        );
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath).build()) {
+            writer.writeImage();
+        }
+
+        BufferedImage image;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            image = server.readRegion(
+                    server.getDownsampleForResolution(level),
+                    0,
+                    0,
+                    server.getWidth(),
+                    server.getHeight(),
+                    z,
+                    t
+            );
+        }
+        assertDoubleBufferedImagesEqual(expectedImage, image);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_Downsampled_Image_Pixels() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        int level = 1;
+        int z = 2;
+        int t = 1;
+        BufferedImage expectedImage = sampleImageServer.readRegion(
+                sampleImageServer.getDownsampleForResolution(level),
+                0,
+                0,
+                sampleImageServer.getWidth(),
+                sampleImageServer.getHeight(),
+                z,
+                t
+        );
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath).build()) {
+            writer.writeImage();
+        }
+
+        BufferedImage image;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            image = server.readRegion(
+                    server.getDownsampleForResolution(level),
+                    0,
+                    0,
+                    server.getWidth(),
+                    server.getHeight(),
+                    z,
+                    t
+            );
+        }
+        assertDoubleBufferedImagesEqual(expectedImage, image);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_Downsamples_When_Not_Specified() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        double[] expectedDownsamples = sampleImageServer.getPreferredDownsamples();
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                .setDownsamples()
+                .build()
+        ) {
+            writer.writeImage();
+        }
+
+        double[] downsamples;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            downsamples = server.getPreferredDownsamples();
+        }
+        Assertions.assertArrayEquals(expectedDownsamples, downsamples);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_Downsamples_When_Specified() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        double[] expectedDownsamples = new double[] {1, 2, 4};
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                .setDownsamples(expectedDownsamples)
+                .build()
+        ) {
+            writer.writeImage();
+        }
+
+        double[] downsamples;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            downsamples = server.getPreferredDownsamples();
+        }
+        Assertions.assertArrayEquals(expectedDownsamples, downsamples);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_Default_Tile_Width() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        int expectedTileWidth = sampleImageServer.getMetadata().getPreferredTileWidth();
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                .setTileWidth(-1)
+                .build()
+        ) {
+            writer.writeImage();
+        }
+
+        int tileWidth;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            tileWidth = server.getMetadata().getPreferredTileWidth();
+        }
+        Assertions.assertEquals(expectedTileWidth, tileWidth);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_Custom_Tile_Width() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        int expectedTileWidth = 64;
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                .setTileWidth(expectedTileWidth)
+                .build()
+        ) {
+            writer.writeImage();
+        }
+
+        int tileWidth;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            tileWidth = server.getMetadata().getPreferredTileWidth();
+        }
+        Assertions.assertEquals(expectedTileWidth, tileWidth);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_Default_Tile_Height() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        int expectedTileHeight = sampleImageServer.getMetadata().getPreferredTileHeight();
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                .setTileHeight(-1)
+                .build()
+        ) {
+            writer.writeImage();
+        }
+
+        int tileHeight;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            tileHeight = server.getMetadata().getPreferredTileHeight();
+        }
+        Assertions.assertEquals(expectedTileHeight, tileHeight);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_Custom_Tile_Height() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        int expectedTileHeight = 64;
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                .setTileHeight(expectedTileHeight)
+                .build()
+        ) {
+            writer.writeImage();
+        }
+
+        int tileHeight;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            tileHeight = server.getMetadata().getPreferredTileHeight();
+        }
+        Assertions.assertEquals(expectedTileHeight, tileHeight);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_Bounding_Box() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        int z = 2;
+        int t = 1;
+        ImageRegion boundingBox = ImageRegion.createInstance(5, 5, 20, 25, z, t);
+        BufferedImage expectedImage = sampleImageServer.readRegion(RegionRequest.createInstance(sampleImageServer.getPath(), 1, boundingBox));
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                .setBoundingBox(boundingBox)
+                .build()
+        ) {
+            writer.writeImage();
+        }
+
+        BufferedImage image;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            image = server.readRegion(1, 0, 0, server.getWidth(), server.getHeight(), z, t);
+        }
+        assertDoubleBufferedImagesEqual(expectedImage, image);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_Z_Sliced_Image_Number_Of_Z_Stacks() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        int zStart = 1;
+        int zEnd = 3;
+        int expectedNumberOfZStacks = zEnd - zStart;
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                .setZSlices(zStart, zEnd)
+                .build()
+        ) {
+            writer.writeImage();
+        }
+
+        int numberOfZStacks;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            numberOfZStacks = server.nZSlices();
+        }
+        Assertions.assertEquals(expectedNumberOfZStacks, numberOfZStacks);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_Z_Sliced_Image_Pixels() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        int zStart = 1;
+        int zEnd = 3;
+        int z = 1;
+        int t = 1;
+        BufferedImage expectedImage = sampleImageServer.readRegion(RegionRequest.createInstance(
+                sampleImageServer.getPath(),
+                1,
+                0,
+                0,
+                sampleImageServer.getWidth(),
+                sampleImageServer.getHeight(),
+                z,
+                t
+        ));
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                .setZSlices(zStart, zEnd)
+                .build()
+        ) {
+            writer.writeImage();
+        }
+
+        BufferedImage image;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            image = server.readRegion(1, 0, 0, server.getWidth(), server.getHeight(), z - zStart, t);
+        }
+        assertDoubleBufferedImagesEqual(expectedImage, image);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_T_Sliced_Image_Number_Of_Timepoints() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        int tStart = 1;
+        int tEnd = 2;
+        int expectedNumberOfTimepoints = tEnd - tStart;
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                .setTimepoints(tStart, tEnd)
+                .build()
+        ) {
+            writer.writeImage();
+        }
+
+        int numberOfTimepoints;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            numberOfTimepoints = server.nTimepoints();
+        }
+        Assertions.assertEquals(expectedNumberOfTimepoints, numberOfTimepoints);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
+    void Check_T_Sliced_Image_Pixels() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        SampleImageServer sampleImageServer = new SampleImageServer();
+        int tStart = 1;
+        int tEnd = 2;
+        int z = 1;
+        int t = 1;
+        BufferedImage expectedImage = sampleImageServer.readRegion(RegionRequest.createInstance(
+                sampleImageServer.getPath(),
+                1,
+                0,
+                0,
+                sampleImageServer.getWidth(),
+                sampleImageServer.getHeight(),
+                z,
+                t
+        ));
+
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                .setTimepoints(tStart, tEnd)
+                .build()
+        ) {
+            writer.writeImage();
+        }
+
+        BufferedImage image;
+        try (ImageServer<BufferedImage> server = ImageServerProvider.buildServer(outputImagePath, BufferedImage.class)) {
+            image = server.readRegion(1, 0, 0, server.getWidth(), server.getHeight(), z, t - tStart);
+        }
+        assertDoubleBufferedImagesEqual(expectedImage, image);
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    private static class SampleImageServer extends AbstractImageServer<BufferedImage> {
+
+        private static final int IMAGE_WIDTH = 64;
+        private static final int IMAGE_HEIGHT = 64;
+
+        public SampleImageServer() {
+            super(BufferedImage.class);
+        }
+
+        @Override
+        protected ImageServerBuilder.ServerBuilder<BufferedImage> createServerBuilder() {
+            return null;
+        }
+
+        @Override
+        protected String createID() {
+            return getClass().getName();
+        }
+
+        @Override
+        public Collection<URI> getURIs() {
+            return List.of();
+        }
+
+        @Override
+        public String getServerType() {
+            return "Sample server";
+        }
+
+        @Override
+        public ImageServerMetadata getOriginalMetadata() {
+            return new ImageServerMetadata.Builder()
+                    .width(IMAGE_WIDTH)
+                    .height(IMAGE_HEIGHT)
+                    .sizeZ(3)
+                    .sizeT(2)
+                    .pixelType(PixelType.FLOAT64)
+                    .preferredTileSize(32, 32)
+                    .channels(List.of(
+                            ImageChannel.getInstance("c1", 1),
+                            ImageChannel.getInstance("c2", 2),
+                            ImageChannel.getInstance("c3", 3),
+                            ImageChannel.getInstance("c4", 4),
+                            ImageChannel.getInstance("c5", 5)
+                    ))
+                    .name("name")
+                    .levelsFromDownsamples(1, 2)
+                    .build();
+        }
+
+        @Override
+        public BufferedImage readRegion(RegionRequest request) {
+            DataBuffer dataBuffer = createDataBuffer(request);
+
+            return new BufferedImage(
+                    ColorModelFactory.createColorModel(getMetadata().getPixelType(), getMetadata().getChannels()),
+                    WritableRaster.createWritableRaster(
+                            new BandedSampleModel(
+                                    dataBuffer.getDataType(),
+                                    (int) (request.getWidth() / request.getDownsample()),
+                                    (int) (request.getHeight() / request.getDownsample()),
+                                    nChannels()
+                            ),
+                            dataBuffer,
+                            null
+                    ),
+                    false,
+                    null
+            );
+        }
+
+        private DataBuffer createDataBuffer(RegionRequest request) {
+            double[][] array = new double[nChannels()][];
+
+            for (int c = 0; c < array.length; c++) {
+                array[c] = getPixels(request, c);
+            }
+
+            return new DataBufferDouble(array, (int) (request.getWidth() * request.getHeight() / 8 / (request.getDownsample() * request.getDownsample())));
+        }
+
+        private double[] getPixels(RegionRequest request, int channel) {
+            int originX = (int) (request.getX() / request.getDownsample());
+            int originY = (int) (request.getY() / request.getDownsample());
+            int width = (int) (request.getWidth() / request.getDownsample());
+            int height = (int) (request.getHeight() / request.getDownsample());
+            double[] pixels = new double[width * height];
+
+            for (int y=0; y<height; y++) {
+                for (int x=0; x<width; x++) {
+                    pixels[y*width + x] = getPixel(x + originX, y + originY, channel, request.getZ(), request.getT());
+                }
+            }
+
+            return pixels;
+        }
+
+        private static double getPixel(int x, int y, int channel, int z, int t) {
+            return z + t + channel + ((double) x / IMAGE_WIDTH + (double) y / IMAGE_HEIGHT) / 2;
+        }
+    }
+
+    private void assertDoubleBufferedImagesEqual(BufferedImage expectedImage, BufferedImage actualImage) {
+        Assertions.assertEquals(expectedImage.getWidth(), actualImage.getWidth());
+        Assertions.assertEquals(expectedImage.getHeight(), actualImage.getHeight());
+
+        double[] expectedPixels = new double[expectedImage.getSampleModel().getNumBands()];
+        double[] actualPixels = new double[actualImage.getSampleModel().getNumBands()];
+        for (int x = 0; x < expectedImage.getWidth(); x++) {
+            for (int y = 0; y < expectedImage.getHeight(); y++) {
+                Assertions.assertArrayEquals(
+                        (double[]) expectedImage.getData().getDataElements(x, y, expectedPixels),
+                        (double[]) actualImage.getData().getDataElements(x, y, actualPixels)
+                );
+            }
+        }
+    }
+}

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrWriter.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrWriter.java
@@ -46,6 +46,22 @@ public class TestOMEZarrWriter {
     }
 
     @Test
+    void Check_Error_When_Path_Already_Exists() throws Exception {
+        Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+        String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
+        Files.createFile(Paths.get(outputImagePath));
+        SampleImageServer sampleImageServer = new SampleImageServer();
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        );
+
+        sampleImageServer.close();
+        FileUtils.deleteDirectory(path.toFile());
+    }
+
+    @Test
     void Check_Full_Image_Pixels() throws Exception {
         Path path = Files.createTempDirectory(UUID.randomUUID().toString());
         String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();


### PR DESCRIPTION
* Cleaned up images created by `TestConvertCommand`.
* In `ConvertCommand`, deleted existing output directories whenever `—overwrite` is specified.
* Created `image.zarr/OME/METADATA.ome.xml` in Zarr writer. This allows to save the entire QuPath metadata of images.
* Added tests for the Zarr writer.