### PR TITLE
Ensure tests use UTF-8

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEXMLCreator.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEXMLCreator.java
@@ -77,7 +77,7 @@ class OMEXMLCreator {
                         new DOMSource(document),
                         new StreamResult(new OutputStreamWriter(os, StandardCharsets.UTF_8))
                 );
-                return Optional.ofNullable(os.toString());
+                return Optional.ofNullable(os.toString(StandardCharsets.UTF_8));
             }
         } catch (Exception e) {
             logger.error("Error while creating OME XML content", e);

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEXMLCreator.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEXMLCreator.java
@@ -253,7 +253,8 @@ public class TestOMEXMLCreator {
 
     @Test
     void Check_Pixel_T_Spacing_Unit() throws IOException, ParserConfigurationException, SAXException {
-        String expectedUnit = "µs";
+        // Required only for Java 17 and earlier, on platforms where UTF-8 is not the default
+        String expectedUnit = new String("µs".getBytes(), StandardCharsets.UTF_8);
 
         String xmlContent = OMEXMLCreator.create(sampleMetadata).orElse("");
 


### PR DESCRIPTION
Tests were failing when Gradle was run using Java 17 on Windows, e.g.
```
org.opentest4j.AssertionFailedError: expected: <µm> but was: <Âµm>
	at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at app//qupath.lib.images.writers.ome.zarr.TestOMEXMLCreator.Check_Pixel_Height_Unit(TestOMEXMLCreator.java:216)
	at java.base@21.0.4/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base@21.0.4/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base@21.0.4/java.util.ArrayList.forEach(ArrayList.java:1596)
```

I'm not convinced this is the right way to address it, and it shouldn't matter in practice since QuPath now assumes Java 21 (where UTF-8 is the default), but it helps avoid exceptions for users building with Gradle launched using an earlier Java version - which should be possible.