### PR TITLE
BioFormats tile size fix

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -489,8 +489,18 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			// The first resolution is the highest, i.e. the largest image
 			width = reader.getSizeX();
 			height = reader.getSizeY();
+
+			// When opening Zarr images, reader.getOptimalTileWidth/Height() returns by default
+			// the chunk width/height of the lowest resolution image, which can be too low
+			// for the full resolution image, which makes the image slow to read (especially
+			// for remote images).
+			// A workaround to get the chunk size of the full resolution image is to set the resolution
+			// to 0 and read some bytes from the full resolution image, like below:
+			reader.setResolution(0);
+			reader.openBytes(reader.getIndex(0, 0, 0), 0, 0, 1, 1);
 			tileWidth = reader.getOptimalTileWidth();
 			tileHeight = reader.getOptimalTileHeight();
+
 			nChannels = reader.getSizeC();
 
 			// Make sure tile sizes are within range

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -491,9 +491,8 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			height = reader.getSizeY();
 
 			// When opening Zarr images, reader.getOptimalTileWidth/Height() returns by default
-			// the chunk width/height of the lowest resolution image, which can be too low
-			// for the full resolution image, which makes the image slow to read (especially
-			// for remote images).
+			// the chunk width/height of the lowest resolution image. See
+			// https://github.com/qupath/qupath/pull/1645#issue-2533834067 for why it may be a problem.
 			// A workaround to get the chunk size of the full resolution image is to set the resolution
 			// to 0 and read some bytes from the full resolution image, like below:
 			reader.setResolution(0);

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -494,9 +494,10 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			// the chunk width/height of the lowest resolution image. See
 			// https://github.com/qupath/qupath/pull/1645#issue-2533834067 for why it may be a problem.
 			// A workaround to get the chunk size of the full resolution image is to set the resolution
-			// to 0 and read some bytes from the full resolution image, like below:
-			reader.setResolution(0);
-			reader.openBytes(reader.getIndex(0, 0, 0), 0, 0, 1, 1);
+			// to 0 with the Zarr reader
+			if (reader instanceof ZarrReader zarrReader) {
+				zarrReader.setResolution(0, true);
+			}
 			tileWidth = reader.getOptimalTileWidth();
 			tileHeight = reader.getOptimalTileHeight();
 


### PR DESCRIPTION
**TLDR**: the default tile size of the BioFormatsImageServer is too low, which makes reading remote Zarr too slow. This PR fixes that.


Zarr images are slow to read. This is more visible for remote images. For example, the image https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr takes way more time to open in QuPath than when using [vizarr](https://hms-dbmi.github.io/vizarr/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr).

Zarr images are divided into chunks, where each chunk contains pixel values in a dedicated file. When using [HTTP Toolkit](https://httptoolkit.com/) when opening a remote Zarr image in QuPath, we see that the underlying BioFormats readers make several web requests to the same chunk. With the example image mentioned above, QuPath downloads each chunk around 8 times, which is useless. This means that when opening the image through QuPath, around 320 web requests are made, while there should only be around 40 requests.

The reason is because of the tile size. The tile size should correspond to the chunk size, but it's not always the case. Before this PR, the tile size corresponded to the chunk size of the lowest resolution. For example with the image above, the tile size was 164 * 128 pixels (which corresponds to the chunk size of the lowest resolution image), but the chunk size of the full resolution image is 1024 * 1024 pixels. This means that to read one chunk of the full resolution image, QuPath will make several readings, and each reading will download the entire chunk of 1024*1024 pixels, thus the same file will be downloaded several times.

Therefore, to fix the issue, we must fix the tile size. The tile size is determined from the BioFormats reader's `getOptimalTileWidth()` and `getOptimalTileHeight()` functions. By default, they return the chunk size of the lowest resolution image. I found a workaround to get the chunk size of the full resolution image: we must set the resolution to 0 (full resolution) with the Zarr reader. After that, `getOptimalTileWidth()` and `getOptimalTileHeight()` return the chunk size of the full resolution image.

This PR is only implementing this. To see that it works, you can start HTTP Toolkit, open the sample image with QuPath, and compare the number of requests with and without this PR.