### PR TITLE
Support message for TaskRunner

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/experimental/pixels/PixelProcessor.java
@@ -185,7 +185,8 @@ public class PixelProcessor<S, T, U> {
                 tasks.add(new ProcessorTask(imageData, pathObject, processor, proxy));
         }
         // Run the tasks
-        runner.runTasks(tasks);
+        String message = tasks.size() == 1 ? "Processing 1 tile" : "Processing " + tasks.size() + " tiles";
+        runner.runTasks(message, tasks);
 
         // Reassign the proxy objects to the parent
         // If merging is involved, this can be slow - so pass these as new tasks
@@ -212,7 +213,7 @@ public class PixelProcessor<S, T, U> {
             }
         }
         if (!mergeTasks.isEmpty())
-           runner.runTasks(mergeTasks);
+           runner.runTasks("Post-processing", mergeTasks);
     }
 
     /**

--- a/qupath-core/src/main/java/qupath/lib/plugins/AbstractTaskRunner.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/AbstractTaskRunner.java
@@ -83,7 +83,7 @@ public abstract class AbstractTaskRunner implements TaskRunner {
 	protected abstract SimpleProgressMonitor makeProgressMonitor();
 	
 	@Override
-	public synchronized void runTasks(Collection<? extends Runnable> tasks) {
+	public synchronized void runTasks(String message, Collection<? extends Runnable> tasks) {
 		
 		if (tasks.isEmpty())
 			return;
@@ -101,7 +101,7 @@ public abstract class AbstractTaskRunner implements TaskRunner {
 			service = new ExecutorCompletionService<>(pool);
 		
 		monitor = makeProgressMonitor();
-		monitor.startMonitoring(null, tasks.size(), true);
+		monitor.startMonitoring(message, tasks.size(), true);
 		for (Runnable task : tasks) {
 			// If a task if null, then skip it - otherwise the monitor can get stuck
 			if (task == null) {

--- a/qupath-core/src/main/java/qupath/lib/plugins/TaskRunner.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/TaskRunner.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -42,6 +42,17 @@ public interface TaskRunner {
 	 * @param tasks the tasks to run. If these are instances of {@link PathTask} then 
 	 *              an optional postprocessing may be applied after all tasks are complete.
 	 */
-	void runTasks(Collection<? extends Runnable> tasks);
+	default void runTasks(Collection<? extends Runnable> tasks) {
+		runTasks(null, tasks);
+	}
+
+	/**
+	 * Pass a collection of parallelizable tasks to run.
+	 * @param message optional message to display to the user when running tasks; may be null
+	 * @param tasks the tasks to run. If these are instances of {@link PathTask} then
+	 *              an optional postprocessing may be applied after all tasks are complete.
+	 * @since v0.6.0
+	 */
+	void runTasks(String message, Collection<? extends Runnable> tasks);
 
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/TaskRunnerFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/TaskRunnerFX.java
@@ -96,12 +96,12 @@ public class TaskRunnerFX extends AbstractTaskRunner {
 	}
 	
 	@Override
-	public synchronized void runTasks(Collection<? extends Runnable> tasks) {
+	public synchronized void runTasks(String message, Collection<? extends Runnable> tasks) {
 		var viewer = qupath == null || repaintDelayMillis <= 0 ? null : qupath.getViewer();
 		if (viewer != null)
 			viewer.setMinimumRepaintSpacingMillis(repaintDelayMillis);
 		try {
-			super.runTasks(tasks);
+			super.runTasks(message, tasks);
 		} catch (Exception e) {
 			throw(e);
 		} finally {
@@ -319,7 +319,7 @@ public class TaskRunnerFX extends AbstractTaskRunner {
 			int progressPercent = (int)Math.round((double)progressValue / maxProgress * 100.0);
 			// Update the display
 			// Don't update the label if cancel was pressed, since this is probably already giving a more informative message
-			if (!cancelPressed)
+			if (!cancelPressed && STARTING_MESSAGE.equals(progressDialog.getDialogPane().getHeaderText()))
 				progressDialog.getDialogPane().setHeaderText(RUNNING_MESSAGE);
 
 			if (lastMessage == null)


### PR DESCRIPTION
This makes it possible to have more informative messages during processing, so that the user knows what is happening along the way (e.g. 'Detecting', 'Processing', 'Measuring'). PixelProcessor updated to use this to record the number of tiles being processed.