### PR TITLE
Change channel names for RGB images

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -1400,7 +1400,7 @@ public class QP {
 	 * Set the channels for the specified ImageData.
 	 * Note that number of channels provided must match the number of channels of the current image.
 	 * <p>
-	 * Also, currently it is not possible to set channels for RGB images - attempting to do so 
+	 * Also, currently it is not possible to set channel colors for RGB images - attempting to do so
 	 * will throw an IllegalArgumentException.
 	 * 
 	 * @param imageData 
@@ -1421,10 +1421,9 @@ public class QP {
 
 		// Can't adjust channel colors for RGB images - but changing names is permitted
 		if (metadata.isRGB()) {
-			if (!Arrays.equals(
-					oldChannels.stream().mapToInt(ImageChannel::getColor).toArray(),
-					newChannels.stream().mapToInt(ImageChannel::getColor).toArray()
-					)) {
+			int[] oldColors = oldChannels.stream().mapToInt(ImageChannel::getColor).toArray();
+			int[] newColors = newChannels.stream().mapToInt(ImageChannel::getColor).toArray();
+			if (!Arrays.equals(oldColors, newColors)) {
 				throw new IllegalArgumentException("Cannot set channel colors for RGB images");
 			}
 		}

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -1410,9 +1410,6 @@ public class QP {
 	 */
 	public static void setChannels(ImageData<?> imageData, ImageChannel... channels) {
 		var metadata = imageData.getServerMetadata();
-		if (metadata.isRGB()) {
-			throw new IllegalArgumentException("Cannot set channels for RGB images");
-		}
 		List<ImageChannel> oldChannels = metadata.getChannels();
 		List<ImageChannel> newChannels = Arrays.asList(channels);
 		if (oldChannels.equals(newChannels)) {
@@ -1421,7 +1418,17 @@ public class QP {
 		}
 		if (oldChannels.size() != newChannels.size())
 			throw new IllegalArgumentException("Cannot set channels - require " + oldChannels.size() + " channels but you provided " + channels.length);
-		
+
+		// Can't adjust channel colors for RGB images - but changing names is permitted
+		if (metadata.isRGB()) {
+			if (!Arrays.equals(
+					oldChannels.stream().mapToInt(ImageChannel::getColor).toArray(),
+					newChannels.stream().mapToInt(ImageChannel::getColor).toArray()
+					)) {
+				throw new IllegalArgumentException("Cannot set channel colors for RGB images");
+			}
+		}
+
 		// Set the metadata
 		var metadata2 = new ImageServerMetadata.Builder(metadata)
 				.channels(newChannels)

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -377,13 +377,13 @@ public class ImageDisplay extends AbstractImageRenderer {
 		rgbDirectChannelInfo = new RGBDirectChannelInfo(imageData);
 		rgbNormalizedChannelInfo = new RGBNormalizedChannelInfo(imageData);
 
-		// Add simple channel separation
-		rgbBasicChannels.add(new RBGColorTransformInfo(imageData, ColorTransformMethod.Red, false));
-		rgbBasicChannels.add(new RBGColorTransformInfo(imageData, ColorTransformMethod.Green, false));
-		rgbBasicChannels.add(new RBGColorTransformInfo(imageData, ColorTransformMethod.Blue, false));
-//		rgbBasicChannels.add(new ChannelDisplayInfo.MultiChannelInfo("Red", 8, 0, 255, 0, 0));
-//		rgbBasicChannels.add(new ChannelDisplayInfo.MultiChannelInfo("Green", 8, 1, 0, 255, 0));
-//		rgbBasicChannels.add(new ChannelDisplayInfo.MultiChannelInfo("Blue", 8, 2, 0, 0, 255));
+		// Add simple channel separation (changed for v0.6.0)
+		rgbBasicChannels.add(new DirectServerChannelInfo(imageData, 0));
+		rgbBasicChannels.add(new DirectServerChannelInfo(imageData, 1));
+		rgbBasicChannels.add(new DirectServerChannelInfo(imageData, 2));
+//		rgbBasicChannels.add(new RBGColorTransformInfo(imageData, ColorTransformMethod.Red, false));
+//		rgbBasicChannels.add(new RBGColorTransformInfo(imageData, ColorTransformMethod.Green, false));
+//		rgbBasicChannels.add(new RBGColorTransformInfo(imageData, ColorTransformMethod.Blue, false));
 		rgbBasicChannels.add(new RBGColorTransformInfo(imageData, ColorTransformer.ColorTransformMethod.Hue, false));
 		rgbBasicChannels.add(new RBGColorTransformInfo(imageData, ColorTransformer.ColorTransformMethod.Saturation, false));
 		rgbBasicChannels.add(new RBGColorTransformInfo(imageData, ColorTransformer.ColorTransformMethod.RGB_mean, false));

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/RBGColorTransformInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/RBGColorTransformInfo.java
@@ -78,6 +78,18 @@ class RBGColorTransformInfo extends AbstractSingleChannelInfo {
 	
 	@Override
 	public String getName() {
+		// For RGB images, the channel names can sometimes be specified
+		var server = getImageServer();
+		if (server != null) {
+			switch (method) {
+				case Red:
+					return server.getChannel(0).getName();
+				case Green:
+					return server.getChannel(1).getName();
+				case Blue:
+					return server.getChannel(2).getName();
+			}
+		}
 		return method.toString();
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastChannelPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastChannelPane.java
@@ -720,15 +720,19 @@ public class BrightnessContrastChannelPane extends BorderPane {
             setGraphic(colorPicker);
             updateStyle();
 
-            Integer rgb = item.getColor();
+            // Check if we have an RGB image - if we do, we shouldn't allow the colors to change
+            var imageData = getImageData();
+            var isRGB = imageData != null && imageData.getServerMetadata().isRGB();
+
+            Integer channelRGB = item.getColor();
             // Can only set the color for direct, non-RGB channels
-            boolean canChangeColor = rgb != null && item instanceof DirectServerChannelInfo;
+            boolean canChangeColor = !isRGB && channelRGB != null && item instanceof DirectServerChannelInfo;
             colorPicker.setDisable(!canChangeColor);
             colorPicker.setOnShowing(null);
-            if (rgb == null) {
+            if (channelRGB == null) {
                 colorPicker.setValue(Color.TRANSPARENT);
             } else {
-                Color color = ColorToolsFX.getCachedColor(rgb);
+                Color color = ColorToolsFX.getCachedColor(channelRGB);
                 setColorQuietly(color);
                 colorPicker.setOnShowing(e -> {
                     if (customColors == null)


### PR DESCRIPTION
Proposed support changing channel names for RGB images. Changing colors is still not allowed, because a packed (A)RGB representation is used.

This aims to reduce the inconvenience of QuPath sometimes creating an RGB representation for fluorescence images where it would be desirable to use different channel names.

See https://github.com/qupath/qupath-extension-omero/issues/25