### PR TITLE
Added condition for opening zarr files

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -1208,7 +1208,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer {
 			}
 			
 			IFormatReader imageReader;
-			if (new File(id).isDirectory() || id.toLowerCase().endsWith(".zarr")) {
+			if (new File(id).isDirectory() || id.toLowerCase().endsWith(".zarr") || id.toLowerCase().endsWith(".zarr/")) {
 				// Using new ImageReader() on a directory won't work
 				imageReader = new ZarrReader();
 				if (id.startsWith("https") && imageReader.getMetadataOptions() instanceof DynamicMetadataOptions zarrOptions) {


### PR DESCRIPTION
`/path/to/image.zarr` and `/path/to/image.zarr/` are two valid URIs to open a Zarr image. However, `/path/to/image.zarr/` doesn't work. This PR fixes that.