### PR TITLE
Hide script editor on close requests

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -539,6 +539,9 @@ public class DefaultScriptEditor implements ScriptEditor {
 			if (tab == null) {
 				break;
 			}
+			// We're probably quitting QuPath - if we're prompting for changes, then we should show the tab
+			if (dialog != null && !dialog.isShowing() && tab.isModifiedProperty().get() && tab.hasScript())
+				dialog.show();
 			ret = promptToClose(tab);
 		}
 		if (ret && dialog != null) {
@@ -741,7 +744,8 @@ public class DefaultScriptEditor implements ScriptEditor {
 		});
 
 		dialog.setOnCloseRequest(e -> {
-			if (!requestClose()) {
+			if (dialog != null) {
+				dialog.hide();
 				e.consume();
 			}
 		});
@@ -1998,7 +2002,9 @@ public class DefaultScriptEditor implements ScriptEditor {
 	
 	Action createExitAction(final String name) {
 		Action action = new Action(name, e -> {
-			requestClose();
+//			requestClose();
+			if (dialog != null)
+				dialog.hide();
 			e.consume();
 		});
 		action.setAccelerator(new KeyCodeCombination(KeyCode.W, KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -2002,7 +2002,6 @@ public class DefaultScriptEditor implements ScriptEditor {
 	
 	Action createExitAction(final String name) {
 		Action action = new Action(name, e -> {
-//			requestClose();
 			if (dialog != null)
 				dialog.hide();
 			e.consume();


### PR DESCRIPTION
Potential fix for https://github.com/qupath/qupath/issues/1660

This hides the script editor when either pressing the corner button to close the window, or calling 'File > Close editor' - but does *not* close the scripts.

However, when QuPath is being quit entirely, if there are unsaved scripts then the script editor should appear again - with prompts to save.