### PR TITLE
Fix RGB tile resize bug

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -481,11 +481,19 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 				int width2 = (int)Math.max(1, Math.round((maxX - request.getMinX()) / request.getDownsample() - 1e-9));
 				int height2 = (int)Math.max(1, Math.round((maxY - request.getMinY()) / request.getDownsample() - 1e-9));
 				// Be cautious with size adjustments - only permit changing by one pixel
-				if (expectedWidth == width2+1 || expectedHeight == height2+1) {
-					logger.trace("RGB image size updated from {}x{} to {}x{} to avoid border problems",
-							expectedWidth, expectedHeight, width2, height2);
-					imgWidth = width2;
-					imgHeight = height2;
+				int adjustedWidth = expectedWidth;
+				int adjustedHeight = expectedHeight;
+				if (expectedWidth == width2+1) {
+					adjustedWidth = width2;
+				}
+				if (expectedHeight == height2+1) {
+					adjustedHeight = height2;
+				}
+				if (expectedWidth != adjustedWidth || expectedHeight != adjustedHeight) {
+					logger.debug("RGB image size updated from {}x{} to {}x{} to avoid border problems",
+							expectedWidth, expectedHeight, adjustedWidth, adjustedHeight);
+					imgWidth = adjustedWidth;
+					imgHeight = adjustedHeight;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/1665 Bug introduced around https://github.com/qupath/qupath/pull/1531

It was *supposed* to only adjust the width & height of a tile by a single pixel. In practice, it would change both the width AND height if EITHER required an adjustment of a single pixel... which could sometimes cause the other to be adjusted by far too much.