### PR TITLE
Auto-update URIs for self-contained projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ Some things may be added, some things may be removed, and some things may look d
 * Better support for symbolic links (https://github.com/qupath/qupath/issues/1586)
 * Bio-Formats preference to open remote images is now turned on by default (https://github.com/qupath/qupath/pull/1653)
   * This is needed to open remote ome.zarr images - but can be turned off in the preferences if necessary
+* Self-contained projects that contain all images inside the project directory no longer prompt the user to update URIs if moved (https://github.com/qupath/qupath/pull/1668)
+* Channel names can now be set for all fluorescence images, even if they are RGB (https://github.com/qupath/qupath/pull/1659)
+  * Note that channel colors still only be set for non-RGB images
 
 ### Experimental features
 These features are included for testing and feedback.

--- a/qupath-core/src/main/java/qupath/lib/io/UriUpdater.java
+++ b/qupath-core/src/main/java/qupath/lib/io/UriUpdater.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2021 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2021, 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -244,7 +244,7 @@ public class UriUpdater<T extends UriResource> {
 	}
 
 	/**
-	 * Identify replacements for missing URIs by relativizing URI.
+	 * Identify replacements for missing URIs by relativizing the URI.
 	 * This is generally used to make corrections whenever a project has been moved.
 	 * 
 	 * @param uriOriginal the previous path (usually for the project)
@@ -316,7 +316,9 @@ public class UriUpdater<T extends UriResource> {
 	 */
 	public Map<URI, URI> getReplacements() {
 		return Collections.unmodifiableMap(
-				replacements.entrySet().stream().filter(s -> s.getValue() != null).collect(Collectors.toMap(s -> s.getKey().getURI(), s -> s.getValue().getURI()))
+				replacements.entrySet().stream()
+						.filter(s -> s.getValue() != null)
+						.collect(Collectors.toMap(s -> s.getKey().getURI(), s -> s.getValue().getURI()))
 				);
 	}
 	
@@ -385,10 +387,10 @@ public class UriUpdater<T extends UriResource> {
 	private static int updateReplacementsRelative(Collection<SingleUriItem> items, Path pathPrevious, Path pathBase, Map<SingleUriItem, SingleUriItem> replacements) {
 
 		// We care about the directory rather than the actual file
-		if (pathBase != null && !Files.isDirectory(pathBase)) {
+		if (pathBase != null && Files.exists(pathBase) && !Files.isDirectory(pathBase)) {
 			pathBase = pathBase.getParent();
 		}
-		if (pathPrevious != null && !Files.isDirectory(pathPrevious)) {
+		if (pathPrevious != null && Files.exists(pathPrevious) && !Files.isDirectory(pathPrevious)) {
 			pathPrevious = pathPrevious.getParent();
 		}
 		boolean tryRelative = pathBase != null && pathPrevious != null && !pathBase.equals(pathPrevious);


### PR DESCRIPTION
Avoid showing the URI dialog if all missing image paths can be updated using relative links, and the links are all within the existing project directory.

This can help make projects more self-contained.