### PR TITLE
Handle color changes for RGB fluorescence images

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -1399,9 +1399,6 @@ public class QP {
 	/**
 	 * Set the channels for the specified ImageData.
 	 * Note that number of channels provided must match the number of channels of the current image.
-	 * <p>
-	 * Also, currently it is not possible to set channel colors for RGB images - attempting to do so
-	 * will throw an IllegalArgumentException.
 	 * 
 	 * @param imageData 
 	 * @param channels
@@ -1418,15 +1415,6 @@ public class QP {
 		}
 		if (oldChannels.size() != newChannels.size())
 			throw new IllegalArgumentException("Cannot set channels - require " + oldChannels.size() + " channels but you provided " + channels.length);
-
-		// Can't adjust channel colors for RGB images - but changing names is permitted
-		if (metadata.isRGB()) {
-			int[] oldColors = oldChannels.stream().mapToInt(ImageChannel::getColor).toArray();
-			int[] newColors = newChannels.stream().mapToInt(ImageChannel::getColor).toArray();
-			if (!Arrays.equals(oldColors, newColors)) {
-				throw new IllegalArgumentException("Cannot set channel colors for RGB images");
-			}
-		}
 
 		// Set the metadata
 		var metadata2 = new ImageServerMetadata.Builder(metadata)

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/RBGColorTransformInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/RBGColorTransformInfo.java
@@ -78,18 +78,6 @@ class RBGColorTransformInfo extends AbstractSingleChannelInfo {
 	
 	@Override
 	public String getName() {
-		// For RGB images, the channel names can sometimes be specified
-		var server = getImageServer();
-		if (server != null) {
-			switch (method) {
-				case Red:
-					return server.getChannel(0).getName();
-				case Green:
-					return server.getChannel(1).getName();
-				case Blue:
-					return server.getChannel(2).getName();
-			}
-		}
 		return method.toString();
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -573,8 +573,16 @@ public class BrightnessContrastCommand implements Runnable {
 			var imageDisplay = imageDisplayProperty.getValue();
 			if (imageDisplay != null) {
 				if (evt.getPropertyName().equals("serverMetadata") ||
-						((evt.getSource() instanceof ImageData<?>) && evt.getPropertyName().equals("imageType")))
+						((evt.getSource() instanceof ImageData<?>) && evt.getPropertyName().equals("imageType"))) {
+					var available = List.copyOf(imageDisplay.availableChannels());
 					imageDisplay.refreshChannelOptions();
+					// When channels change (e.g. setting RGB image to fluorescence),
+					// this is needed to trigger viewer repaint & to save the channels in the properties -
+					// otherwise we can get a black image if we save now and reload.
+					if (!available.equals(imageDisplay.availableChannels())) {
+						imageDisplay.saveChannelColorProperties();
+					}
+				}
 			}
 
 			table.updateTable();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastChannelPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastChannelPane.java
@@ -460,8 +460,6 @@ public class BrightnessContrastChannelPane extends BorderPane {
             int c = multiInfo.getChannel();
             var channel = imageData.getServerMetadata().getChannel(c);
 
-            boolean canChangeColor = !imageData.getServerMetadata().isRGB();
-
             Color color = ColorToolsFX.getCachedColor(multiInfo.getColor());
             picker.setValue(color);
 
@@ -482,10 +480,7 @@ public class BrightnessContrastChannelPane extends BorderPane {
             var labelColor = new Label("Channel color");
             labelColor.setLabelFor(picker);
             String colorTooltipText = "Choose the color for the current channel";
-            if (!canChangeColor) {
-                picker.setDisable(true);
-                colorTooltipText = "Color cannot be changed for RGB images";
-            }
+
             GridPaneUtils.setFillWidth(Boolean.TRUE, picker, tfName);
             GridPaneUtils.addGridRow(paneColor, r++, 0,
                     colorTooltipText, labelColor, picker);
@@ -726,7 +721,8 @@ public class BrightnessContrastChannelPane extends BorderPane {
 
             Integer channelRGB = item.getColor();
             // Can only set the color for direct, non-RGB channels
-            boolean canChangeColor = !isRGB && channelRGB != null && item instanceof DirectServerChannelInfo;
+//            boolean canChangeColor = !isRGB && channelRGB != null && item instanceof DirectServerChannelInfo;
+            boolean canChangeColor = channelRGB != null && item instanceof DirectServerChannelInfo;
             colorPicker.setDisable(!canChangeColor);
             colorPicker.setOnShowing(null);
             if (channelRGB == null) {


### PR DESCRIPTION
This revises the approach in https://github.com/qupath/qupath/pull/1659 in the latest attempt to fix https://github.com/qupath/qupath-extension-omero/issues/25

## Purpose

With this PR, RGB images that are set to have the type 'Fluorescence' now behave much more similarly to non-RGB images, and it is possible to set both channel names and colors.

However all the other image type options remain, e.g. Brightfield H&E. If one of these is selected, then all channel name/color customisations are ignored - and the image behaves as a regular RGB.

## Risks & assumptions
* Querying channel names & colors for an RGB `ImageServer` is no longer guaranteed to return `Red`, `Green` or `Blue`
* Custom channel names for an RGB `ImageServer` are also not guaranteed to be represented in the viewer; rather, this only occurs if the image type is `Fluorescence`
* This does *not* provide a way to convert a BGR image to RGB from the perspective of any analysis. `ImageServer.readRegion()` requests should still return the same packed int (A)RGB image as before - the main difference is how things are rendered in the viewer.
* A pixel classifier that is trained on an image with custom RGB channel names will only work on an image with the same custom channel names*


> *-Caveat: this can give unexpected results if a pixel classifier is applied to two RGB images exist in a project, and one has different channel names. Then, if the classifier is applied successfully to one image, it can *appear* to work on the second image because cached tiles are used - so the mismatched channel names are not identified.

## Example

Example using the ImageJ 'Fluorescent Cells' image, flattened to RGB.

### Image type set to 'Fluorescence', channels adjusted
![RGB-fluorescence](https://github.com/user-attachments/assets/d1118dc8-a661-4129-a0ec-9fab28550a31)

### Same image with type set to 'Other'
![RGB-Other](https://github.com/user-attachments/assets/8e44ada9-33e5-4b54-8f0b-695c5849edfb)
