### PR TITLE
Format blockquotes in webviews

### DIFF
--- a/qupath-gui-fx/src/main/resources/css/web-sans-serif-dark.css
+++ b/qupath-gui-fx/src/main/resources/css/web-sans-serif-dark.css
@@ -8,3 +8,32 @@ body {
     /* Don't display built-in search, as it fails within a WebView */
     display: none;
 }
+
+/*CSS that can be copied to different files*/
+
+blockquote {
+    background: #f9f9f909;
+    border-left: 10px solid #ccc4;
+    margin: 1.5em 10px;
+    padding: 0.25em 10px;
+}
+
+blockquote.tip {
+    background: rgba(40, 200, 40, 0.1);
+    border-left: 10px solid rgba(40, 200, 40, 0.4);
+}
+
+blockquote.info {
+    background: rgba(80,  100, 200, 0.1);
+    border-left: 10px solid rgba(80,  100, 200, 0.4);
+}
+
+blockquote.warn {
+    background: rgba(200, 40, 40, 0.1);
+    border-left: 10px solid rgba(200, 40, 40, 0.4);
+}
+
+blockquote.caution {
+    background: rgba(220, 180, 40, 0.1);
+    border-left: 10px solid rgba(220, 180, 40, 0.4);
+}

--- a/qupath-gui-fx/src/main/resources/css/web-sans-serif-light.css
+++ b/qupath-gui-fx/src/main/resources/css/web-sans-serif-light.css
@@ -8,3 +8,32 @@ body {
     /* Don't display built-in search, as it fails within a WebView */
     display: none;
 }
+
+/*CSS that can be copied to different files*/
+
+blockquote {
+    background: #f9f9f909;
+    border-left: 10px solid #ccc4;
+    margin: 1.5em 10px;
+    padding: 0.25em 10px;
+}
+
+blockquote.tip {
+    background: rgba(40, 200, 40, 0.1);
+    border-left: 10px solid rgba(40, 200, 40, 0.4);
+}
+
+blockquote.info {
+    background: rgba(80,  100, 200, 0.1);
+    border-left: 10px solid rgba(80,  100, 200, 0.4);
+}
+
+blockquote.warn {
+    background: rgba(200, 40, 40, 0.1);
+    border-left: 10px solid rgba(200, 40, 40, 0.4);
+}
+
+blockquote.caution {
+    background: rgba(220, 180, 40, 0.1);
+    border-left: 10px solid rgba(220, 180, 40, 0.4);
+}

--- a/qupath-gui-fx/src/main/resources/css/web-serif-dark.css
+++ b/qupath-gui-fx/src/main/resources/css/web-serif-dark.css
@@ -8,3 +8,32 @@ body {
     /* Don't display built-in search, as it fails within a WebView */
     display: none;
 }
+
+/*CSS that can be copied to different files*/
+
+blockquote {
+    background: #f9f9f909;
+    border-left: 10px solid #ccc4;
+    margin: 1.5em 10px;
+    padding: 0.25em 10px;
+}
+
+blockquote.tip {
+    background: rgba(40, 200, 40, 0.1);
+    border-left: 10px solid rgba(40, 200, 40, 0.4);
+}
+
+blockquote.info {
+    background: rgba(80,  100, 200, 0.1);
+    border-left: 10px solid rgba(80,  100, 200, 0.4);
+}
+
+blockquote.warn {
+    background: rgba(200, 40, 40, 0.1);
+    border-left: 10px solid rgba(200, 40, 40, 0.4);
+}
+
+blockquote.caution {
+    background: rgba(220, 180, 40, 0.1);
+    border-left: 10px solid rgba(220, 180, 40, 0.4);
+}

--- a/qupath-gui-fx/src/main/resources/css/web-serif-light.css
+++ b/qupath-gui-fx/src/main/resources/css/web-serif-light.css
@@ -8,3 +8,32 @@ body {
     /* Don't display built-in search, as it fails within a WebView */
     display: none;
 }
+
+/*CSS that can be copied to different files*/
+
+blockquote {
+    background: #f9f9f909;
+    border-left: 10px solid #ccc4;
+    margin: 1.5em 10px;
+    padding: 0.25em 10px;
+}
+
+blockquote.tip {
+    background: rgba(40, 200, 40, 0.1);
+    border-left: 10px solid rgba(40, 200, 40, 0.4);
+}
+
+blockquote.info {
+    background: rgba(80,  100, 200, 0.1);
+    border-left: 10px solid rgba(80,  100, 200, 0.4);
+}
+
+blockquote.warn {
+    background: rgba(200, 40, 40, 0.1);
+    border-left: 10px solid rgba(200, 40, 40, 0.4);
+}
+
+blockquote.caution {
+    background: rgba(220, 180, 40, 0.1);
+    border-left: 10px solid rgba(220, 180, 40, 0.4);
+}


### PR DESCRIPTION
We can only apply one CSS stylesheet to WebViews - which is used by the `WebViews` class to bind to dark mode changes.

Therefore we need to add any interesting custom formatting to those shared stylesheets.

This PR then adds some provisional support for nicer blockquote formatting, so that this is available elsewhere if needed (note that it's subject to change when someone who is better at css looks at it).