### PR TITLE
Improvements to ImageJ integration

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
@@ -461,7 +461,7 @@ public class IJTools {
 	 * @since v0.4.0
 	 */
 	public static PathObject convertToAnnotation(Roi roi, double xOrigin, double yOrigin, double downsampleFactor, ImagePlane plane) {
-		return convertToPathObject(roi, xOrigin, yOrigin, downsampleFactor, r -> PathObjects.createAnnotationObject(r), plane);
+		return convertToPathObject(roi, xOrigin, yOrigin, downsampleFactor, PathObjects::createAnnotationObject, plane);
 	}
 
 	/**
@@ -571,9 +571,14 @@ public class IJTools {
 		String name = roi.getName();
 		if (name != null && !name.isBlank()) {
 			pathObject.setName(name);
-		} else if (roi.getGroup() > 0) {
+		}
+		if (roi.getGroup() > 0) {
 			// If the group is set, use it as a classification
-			pathObject.setPathClass(PathClass.getInstance("Group " + roi.getGroup(), colorRGB));
+			int group = roi.getGroup();
+			var groupName = Roi.getGroupName(group);
+			if (groupName == null)
+				groupName = "Group " + group;
+			pathObject.setPathClass(PathClass.getInstance(groupName, colorRGB));
 		}
 		if (colorRGB != null && pathObject.getPathClass() == null) {
 			pathObject.setColor(colorRGB);

--- a/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_Overlay_to_QuPath.java
+++ b/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_Overlay_to_QuPath.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -31,7 +31,6 @@ import java.util.List;
 import qupath.imagej.tools.IJTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.images.ImageData;
-import qupath.lib.images.servers.ImageServer;
 import qupath.lib.measurements.MeasurementList;
 import qupath.lib.objects.PathObject;
 import qupath.lib.regions.ImagePlane;
@@ -93,8 +92,8 @@ public class QuPath_Send_Overlay_to_QuPath implements PlugIn {
 		if (rois.isEmpty())
 			return;
 
-		var gui = QuPathGUI.getInstance();
-		var viewer = gui == null ? null : gui.getViewer();
+		var qupath = QuPathGUI.getInstance();
+		var viewer = qupath == null ? null : qupath.getViewer();
 		var imageData = viewer == null ? null : viewer.getImageData();
 		if (imageData == null) {
 			IJ.showMessage("No image selected in QuPath!");
@@ -127,7 +126,7 @@ public class QuPath_Send_Overlay_to_QuPath implements PlugIn {
 		ImagePlane plane = currentPlane;
 		if (imp == null)
 			plane = null;
-		else if (imp != null && server.nZSlices() * server.nTimepoints() > 1) {
+		else if (server.nZSlices() * server.nTimepoints() > 1) {
 			if (imp.getNSlices() == server.nZSlices() && imp.getNFrames() == server.nTimepoints())
 				plane = null;
 		}
@@ -141,24 +140,6 @@ public class QuPath_Send_Overlay_to_QuPath implements PlugIn {
 					hierarchy.getSelectionModel().selectObjects(pathObjects);
 			});
 		}
-	}
-
-	/**
-	 * Legacy method to turn an array of ImageJ ROIs into a list of QuPath PathObjects, optionally adding measurements as well.
-	 * @param imp
-	 * @param rois
-	 * @param server
-	 * @param downsample
-	 * @param asDetection
-	 * @param includeMeasurements
-	 * @param plane
-	 * @return
-	 * @deprecated use instead {@link #createObjectsFromROIs(ImagePlus, Collection, double, boolean, boolean, ImagePlane)}
-	 */
-	@Deprecated
-	public static List<PathObject> createPathObjectsFromROIs(final ImagePlus imp, final Roi[] rois, final ImageServer<?> server, 
-			final double downsample, final boolean asDetection, final boolean includeMeasurements, final ImagePlane plane) {
-		return createObjectsFromROIs(imp, Arrays.asList(rois), downsample, asDetection, includeMeasurements, plane);
 	}
 	
 	/**

--- a/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_ROI_to_QuPath.java
+++ b/qupath-extension-processing/src/main/java/qupathj/QuPath_Send_ROI_to_QuPath.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -52,10 +52,10 @@ public class QuPath_Send_ROI_to_QuPath implements PlugIn {
 			return;
 		}
 		
-		var gui = QuPathGUI.getInstance();
-		var viewer = gui == null ? null : gui.getViewer();
+		var qupath = QuPathGUI.getInstance();
+		var viewer = qupath == null ? null : qupath.getViewer();
 		var imageData = viewer == null ? null : viewer.getImageData();
-		if (gui == null) {
+		if (imageData == null) {
 			IJ.showMessage("No active image found in QuPath!");
 			return;
 		}
@@ -74,7 +74,6 @@ public class QuPath_Send_ROI_to_QuPath implements PlugIn {
 		}
 		
 		var pathObject = IJTools.convertToAnnotation(roi, cal.xOrigin, cal.yOrigin, downsample, plane);
-//		PathObject pathObject = IJTools.convertToAnnotation(imp, server, roi, downsample, viewer.getImagePlane());
 		if (pathObject == null) {
 			IJ.error("Sorry, I couldn't convert " + roi + " to a valid QuPath object");
 			return;

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -617,8 +617,10 @@ Action.ImageJ.subcellularDetection.description = Identify subcellular structures
 
 Action.ImageJ.macroRunner = ImageJ macro runner
 Action.ImageJ.macroRunner.description = Run ImageJ macros within QuPath
-Action.ImageJ.setPluginsDirectory = Set plugins directory
-Action.ImageJ.setPluginsDirectory.description = Set the plugins directory to use with QuPath's embedded version of ImageJ.\n\nThis can be set to the plugins directory of an existing ImageJ installation, to make the plugins associated with that installation available within QuPath.
+Action.ImageJ.setImageJDirectory = Set local ImageJ directory
+Action.ImageJ.setImageJDirectory.description = Set the directory to use with QuPath's embedded version of ImageJ.\n\n\
+  When this is set, plugins from an existing ImageJ installation are made available to QuPath's embedded version of ImageJ \
+  (as long as they have no incompatible dependencies).
 
 Action.ImageJ.extractRegion = Send region to ImageJ
 Action.ImageJ.extractRegion.description = Extract the selected image region and send it to ImageJ


### PR DESCRIPTION
* Fix https://github.com/qupath/qupath/issues/1674
* Make the preferences persistent when sending a region to ImageJ]
* Add "Non-rectangles only" as an option when sending ROIs to ImageJ, since rectangles tend to correspond to the entire image region... and do more harm than good.
* Use Roi group names for classifications, where available
* Rename setting the plugins directory to 'Set local ImageJ directory' - because it's needed also for LUTs as well

> Note that setting the Roi group logs an error if the ImageJ directory isn't set, because it makes a request for the Glasbey LUT that can't be fulfilled.