### PR TITLE
Improve ImageJ UI management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Some things may be added, some things may be removed, and some things may look d
 * Self-contained projects that contain all images inside the project directory no longer prompt the user to update URIs if moved (https://github.com/qupath/qupath/pull/1668)
 * Channel names can now be set for all fluorescence images, even if they are RGB (https://github.com/qupath/qupath/pull/1659)
   * Note that channel colors still only be set for non-RGB images
+* Improved ImageJ integration (https://github.com/qupath/qupath/pull/1676 https://github.com/qupath/qupath/pull/1677)
 
 ### Experimental features
 These features are included for testing and feedback.

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/AwtMenuBarBlocker.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/AwtMenuBarBlocker.java
@@ -125,7 +125,7 @@ class AwtMenuBarBlocker implements PropertyChangeListener {
         if (menuBar == null)
             return;
         logger.debug("Adding menubar notifications {}", menuBar);
-        menuBar.removeNotify();
+        menuBar.addNotify();
     }
 
 

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/IJExtension.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/IJExtension.java
@@ -724,7 +724,7 @@ public class IJExtension implements QuPathExtension {
 	public static Image getImageJIcon(final int width, final int height) {
 		try {
 			URL url = ImageJ.class.getClassLoader().getResource("microscope.gif");
-			return new Image(url.toString(), width, height, true, true);
+			return url == null ? null : new Image(url.toString(), width, height, true, true);
 		} catch (Exception e) {
 			logger.error("Unable to load ImageJ icon!", e);
 		}	

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJQuitCommandListener.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJQuitCommandListener.java
@@ -1,0 +1,79 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2024 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.imagej.gui;
+
+import ij.CommandListener;
+import ij.IJ;
+import ij.ImagePlus;
+import ij.WindowManager;
+import ij.gui.ImageWindow;
+import javafx.application.Platform;
+import qupath.lib.gui.prefs.SystemMenuBar;
+
+import java.awt.*;
+import java.util.Set;
+
+/**
+ * We need to use a CommandListener rather than a WindowListener,
+ * because this is the only way we can intercept calls to save changes for any open images.
+ */
+class ImageJQuitCommandListener implements CommandListener {
+
+    ImageJQuitCommandListener() {}
+
+    @Override
+    public String commandExecuting(String command) {
+        if ("quit".equalsIgnoreCase(command))
+            closeWindowsQuietly();
+        return command;
+    }
+
+    /**
+     * Close all windows associated with ImageJ quietly, without prompting to save changes.
+     */
+    private void closeWindowsQuietly() {
+        var ij = IJ.getInstance();
+        if (ij == null) {
+            return;
+        }
+        ij.requestFocus();
+        var nonImageFrames = Set.of(WindowManager.getNonImageWindows());
+        for (var frame : Frame.getFrames()) {
+            if (frame instanceof ImageWindow win) {
+                var imp = win.getImagePlus();
+                if (imp != null) {
+                    imp.setIJMenuBar(false);
+                    imp.changes = false;
+                    imp.close();
+                }
+            } else if (nonImageFrames.contains(frame)) {
+                frame.setVisible(false);
+                frame.dispose();
+                WindowManager.removeWindow(frame);
+            }
+        }
+        ij.setMenuBar(null);
+        ij.setVisible(false);
+        Platform.runLater(() -> SystemMenuBar.setOverrideSystemMenuBar(false));
+    }
+
+}


### PR DESCRIPTION
- Improve quitting ImageJ properly without prompting to save changes for any open images or frames
- Hopefully fix the persistent issue with the ImageJ menubar conflicting with QuPath's on macOS