### PR TITLE
ImageJ cleanup & fix a detection display bug

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
@@ -319,7 +319,7 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 			if (splitByIntensity)
 				bpSpots = new MaximumFinder().findMaxima(fpDetection, detectionThreshold/10.0, detectionThreshold, MaximumFinder.SEGMENTED, false, false);
 			else
-				bpSpots = SimpleThresholding.thresholdAboveEquals(fpDetection, (float)detectionThreshold);
+				bpSpots = SimpleThresholding.thresholdAboveEquals(fpDetection, detectionThreshold);
 			
 			if (splitByShape) {
 				new EDM().toWatershed(bpSpots);

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
@@ -781,7 +781,7 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 				}
 				
 				// Threshold the main LoG image
-				bpLoG = SimpleThresholding.thresholdAbove(fpLoG, 0f);
+				bpLoG = SimpleThresholding.thresholdAbove(fpLoG, 0.0);
 				// Need to set the threshold very slightly above zero for ImageJ
 				// TODO: DECIDE ON USING MY WATERSHED OR IMAGEJ'S....
 				fpLoG.setRoi(roi);
@@ -868,7 +868,7 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 				FloatProcessor fpBoundaryCleanup = (FloatProcessor)fpDetection.duplicate();
 				fpBoundaryCleanup.blurGaussian(1);
 				fpBoundaryCleanup.convolve(new float[]{0, -1, 0, -1, 4, -1, 0, -1, 0}, 3, 3);
-				ByteProcessor bp2 = SimpleThresholding.thresholdAbove(fpBoundaryCleanup, 0f);
+				ByteProcessor bp2 = SimpleThresholding.thresholdAbove(fpBoundaryCleanup, 0.0);
 				bp2.copyBits(bp, 0, 0, Blitter.MIN); // Remove everything not detected in bp
 				bp.filter(ByteProcessor.MIN);
 				bp.copyBits(bp2, 0, 0, Blitter.MAX);

--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/SimpleTissueDetection2.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/tissue/SimpleTissueDetection2.java
@@ -182,9 +182,9 @@ public class SimpleTissueDetection2 extends AbstractDetectionPlugin<BufferedImag
 	
 			// Apply threshold
 			if (darkBackground)
-				bp = SimpleThresholding.thresholdAbove(bp, (float)threshold);
+				bp = SimpleThresholding.thresholdAbove(bp, threshold);
 			else
-				bp = SimpleThresholding.thresholdBelow(bp, (float)threshold);
+				bp = SimpleThresholding.thresholdBelow(bp, threshold);
 					
 			if (Thread.currentThread().isInterrupted())
 				return null;

--- a/qupath-core-processing/src/main/java/qupath/imagej/processing/SimpleThresholding.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/processing/SimpleThresholding.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -26,6 +26,7 @@ package qupath.imagej.processing;
 import java.awt.image.BufferedImage;
 import java.awt.image.Raster;
 
+import ij.gui.Roi;
 import ij.plugin.filter.ThresholdToSelection;
 import ij.process.ByteProcessor;
 import ij.process.FloatProcessor;
@@ -85,7 +86,7 @@ public class SimpleThresholding {
 	 * @param threshold
 	 * @return
 	 */
-	public static ByteProcessor thresholdBelow(ImageProcessor ip, float threshold) {
+	public static ByteProcessor thresholdBelow(ImageProcessor ip, double threshold) {
 		ByteProcessor bp =  new ByteProcessor(ip.getWidth(), ip.getHeight());
 		byte[] bpPixels = (byte[])bp.getPixels();
 		for (int i = 0; i < bpPixels.length; i++) {
@@ -96,12 +97,12 @@ public class SimpleThresholding {
 	}
 	
 	/**
-	 * Created a binary image by thresholding pixels to find where ip1 &lt;= threshold
+	 * Created a binary image by thresholding pixels to find where ip1 &leq; threshold
 	 * @param ip
 	 * @param threshold
 	 * @return
 	 */
-	public static ByteProcessor thresholdBelowEquals(ImageProcessor ip, float threshold) {
+	public static ByteProcessor thresholdBelowEquals(ImageProcessor ip, double threshold) {
 		ByteProcessor bp =  new ByteProcessor(ip.getWidth(), ip.getHeight());
 		byte[] bpPixels = (byte[])bp.getPixels();
 		for (int i = 0; i < bpPixels.length; i++) {
@@ -133,7 +134,7 @@ public class SimpleThresholding {
 	 * @param threshold
 	 * @return
 	 */
-	public static ByteProcessor thresholdAbove(ImageProcessor ip, float threshold) {
+	public static ByteProcessor thresholdAbove(ImageProcessor ip, double threshold) {
 		ByteProcessor bp =  new ByteProcessor(ip.getWidth(), ip.getHeight());
 		byte[] bpPixels = (byte[])bp.getPixels();
 		for (int i = 0; i < bpPixels.length; i++) {
@@ -143,12 +144,13 @@ public class SimpleThresholding {
 		return bp;
 	}
 	
-		/**
-		 * Created a binary image by thresholding pixels to find where ip1 &gt;= threshold
-		 * @param ip
-		 * @param threshold
-		 * @return
-		 */	public static ByteProcessor thresholdAboveEquals(ImageProcessor ip, float threshold) {
+	/**
+	 * Created a binary image by thresholding pixels to find where ip1 &gt;= threshold
+	 * @param ip
+	 * @param threshold
+	 * @return
+	 */
+	public static ByteProcessor thresholdAboveEquals(ImageProcessor ip, double threshold) {
 		ByteProcessor bp =  new ByteProcessor(ip.getWidth(), ip.getHeight());
 		byte[] bpPixels = (byte[])bp.getPixels();
 		for (int i = 0; i < bpPixels.length; i++) {
@@ -165,11 +167,11 @@ public class SimpleThresholding {
 	 * @param highThreshold
 	 * @return
 	 */
-	public static ByteProcessor thresholdBetween(ImageProcessor ip, float lowThreshold, float highThreshold) {
+	public static ByteProcessor thresholdBetween(ImageProcessor ip, double lowThreshold, double highThreshold) {
 		ByteProcessor bp =  new ByteProcessor(ip.getWidth(), ip.getHeight());
 		byte[] bpPixels = (byte[])bp.getPixels();
 		for (int i = 0; i < bpPixels.length; i++) {
-			float val = ip.getf(i);
+			double val = ip.getf(i);
 			if (val >= lowThreshold && val <= highThreshold)
 				bpPixels[i] = (byte)255;
 		}
@@ -235,23 +237,12 @@ public class SimpleThresholding {
 	 * @return
 	 */
 	public static ROI thresholdToROI(ImageProcessor ip, RegionRequest request) {
-		// Need to check we have any above-threshold pixels at all
-		int n = ip.getWidth() * ip.getHeight();
-		boolean noPixels = true;
-		double min = ip.getMinThreshold();
-		double max = ip.getMaxThreshold();
-		for (int i = 0; i < n; i++) {
-			double val = ip.getf(i);
-			if (val >= min && val <= max) {
-				noPixels = false;
-				break;
-			}
-		}
-		if (noPixels)
+		// Generate a shape, using the TileRequest if we can
+		var roiIJ = thresholdToRoiIJ(ip);
+		if (roiIJ == null)
 			return null;
 		    	
 		// Generate a shape, using the RegionRequest if we can
-		var roiIJ = new ThresholdToSelection().convert(ip);
 		if (request == null)
 			return IJTools.convertToROI(roiIJ, 0, 0, 1, ImagePlane.getDefaultPlane());
 		return IJTools.convertToROI(
@@ -261,24 +252,12 @@ public class SimpleThresholding {
 				request.getDownsample(), request.getImagePlane());
 	}
 
-	static ROI thresholdToROI(ImageProcessor ip, TileRequest request) {
-		// Need to check we have any above-threshold pixels at all
-		int n = ip.getWidth() * ip.getHeight();
-		boolean noPixels = true;
-		double min = ip.getMinThreshold();
-		double max = ip.getMaxThreshold();
-		for (int i = 0; i < n; i++) {
-			double val = ip.getf(i);
-			if (val >= min && val <= max) {
-				noPixels = false;
-				break;
-			}
-		}
-		if (noPixels)
-			return null;
-		    	
+	private static ROI thresholdToROI(ImageProcessor ip, TileRequest request) {
 		// Generate a shape, using the TileRequest if we can
-		var roiIJ = new ThresholdToSelection().convert(ip);
+		var roiIJ = thresholdToRoiIJ(ip);
+		if (roiIJ == null)
+			return null;
+
 		if (request == null)
 			return IJTools.convertToROI(roiIJ, 0, 0, 1, ImagePlane.getDefaultPlane());
 		return IJTools.convertToROI(
@@ -286,6 +265,37 @@ public class SimpleThresholding {
 				-request.getTileX(),
 				-request.getTileY(),
 				request.getDownsample(), request.getImagePlane());
+	}
+
+	/**
+	 * Create an ImageJ ROI from a thresholded image.
+	 * <p>
+	 * This makes use of {@link ThresholdToSelection}, and returns null if no Roi is found.
+	 * @param ip the image, with min and/or max thresholds already set.
+	 * @return a Roi generated by applying the threshold, or null if there are no thresholded pixels
+	 */
+	public static Roi thresholdToRoiIJ(ImageProcessor ip) {
+		if (!ip.isThreshold())
+			return null;
+
+		// Need to check we have any above-threshold pixels at all
+		int n = ip.getWidth() * ip.getHeight();
+		boolean noPixels = true;
+		double min = ip.getMinThreshold();
+		double max = ip.getMaxThreshold();
+		if (min <= max) {
+			for (int i = 0; i < n; i++) {
+				double val = ip.getf(i);
+				if (val >= min && val <= max) {
+					noPixels = false;
+					break;
+				}
+			}
+		}
+		if (noPixels)
+			return null;
+
+		return new ThresholdToSelection().convert(ip);
 	}
 	
 }

--- a/qupath-core-processing/src/main/java/qupath/imagej/processing/Watershed.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/processing/Watershed.java
@@ -48,7 +48,7 @@ public class Watershed {
 	 * @param conn8 if true, use 8-connectivity
 	 */
 	public static void watershedExpandLabels(final ImageProcessor ipLabels, final double maxDistance, final boolean conn8) {
-		var bp = SimpleThresholding.thresholdAbove(ipLabels, 0f);
+		var bp = SimpleThresholding.thresholdAbove(ipLabels, 0.0);
 		FloatProcessor fpEDM = new EDM().makeFloatEDM(bp, (byte)255, false);
 		fpEDM.multiply(-1);
 		doWatershed(fpEDM, ipLabels, -maxDistance, conn8);

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/IJExtension.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/IJExtension.java
@@ -89,6 +89,7 @@ import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.prefs.SystemMenuBar;
 import qupath.lib.gui.tools.ColorToolsFX;
 import qupath.lib.gui.tools.IconFactory.PathIcons;
+import qupath.lib.gui.tools.MenuTools;
 import qupath.lib.gui.viewer.OverlayOptions;
 import qupath.lib.gui.viewer.QuPathViewer;
 import qupath.lib.gui.viewer.DragDropImportListener.DropHandler;
@@ -632,9 +633,14 @@ public class IJExtension implements QuPathExtension {
 			MenuButton btnImageJ = new MenuButton();
 			btnImageJ.setGraphic(imageView);
 			btnImageJ.setTooltip(new Tooltip("ImageJ commands"));
-			btnImageJ.getItems().addAll(
-					ActionTools.createMenuItem(commands.actionExtractRegion),
-					ActionTools.createMenuItem(commands.actionSnapshot)
+			MenuTools.addMenuItems(
+					btnImageJ.getItems(),
+					commands.actionExtractRegion,
+					commands.actionSnapshot,
+					null,
+					commands.actionImageJDirectory,
+					null,
+					commands.actionMacroRunner
 			);
 			toolbar.getItems().add(btnImageJ);
 		} catch (Exception e) {

--- a/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/gui/ImageJMacroRunner.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import javax.swing.SwingUtilities;
 
 import org.slf4j.Logger;
@@ -141,7 +142,6 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 			if (macroText != null)
 				textArea.setText(macroText);
 			BorderPane panelMacro = new BorderPane();
-//			panelMacro.setBorder(BorderFactory.createTitledBorder("Macro"));
 			panelMacro.setCenter(textArea);
 
 
@@ -154,7 +154,7 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 			btnRun.setOnAction(e -> {
 
 					macroText = textArea.getText().trim();
-					if (macroText.length() == 0)
+					if (macroText.isEmpty())
 						return;
 
 					// TODO: Consider that we're requesting a new ImageData here (probably right, but need to check)
@@ -169,9 +169,6 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 									viewer.getImageDisplay(), pathObject, macroText);
 						});
 					} else {
-						//						DisplayHelpers.showErrorMessage(getClass().getSimpleName(), "Sorry, ImageJ macros can only be run for single selected images");
-//						logger.warn("ImageJ macro being run in current thread");
-//						runPlugin(runner, arg); // TODO: Consider running in a background thread?
 						// Run in a background thread
 						Collection<? extends PathObject> parents = getParentObjects(imageDataLocal);
 						if (parents.isEmpty()) {
@@ -241,7 +238,7 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 			else
 				pathImage = IJExtension.extractROI(server, pathObject, region, sendROI);
 		} catch (IOException e) {
-			logger.error("Unable to extract image region " + region, e);
+            logger.error("Unable to extract image region {}", region, e);
 			return;
 		}
 
@@ -252,9 +249,6 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 		else
 			argument = String.format("Region (%d, %d, %d, %d)", region.getX(), region.getY(), region.getWidth(), region.getHeight());
 
-		// Check if we have an image already - if so, we need to be more cautious so we don't accidentally use it...
-//		boolean hasImage = WindowManager.getCurrentImage() != null;
-
 		// Actually run the macro
 		final ImagePlus imp = pathImage.getImage();
 		imp.setProperty("QuPath region", argument);
@@ -263,85 +257,77 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 		
 		// TODO: Pay attention to how threading should be done... I think Swing EDT ok?
 		try {
-//			SwingUtilities.invokeAndWait(() -> {
-				boolean cancelled = false;
-				ImagePlus impResult = null;
-				try {
-					IJ.redirectErrorMessages();
-					Interpreter interpreter = new Interpreter();
-					impResult = interpreter.runBatchMacro(macroText, imp);
-					
-					// If we had an error, return
-					if (interpreter.wasError()) {
-						Thread.currentThread().interrupt();
-						return;
-					}
-					
-					// Get the resulting image, if available
-					if (impResult == null)
-						impResult = WindowManager.getCurrentImage();
-				} catch (RuntimeException e) {
-					logger.error(e.getLocalizedMessage());
-					//			DisplayHelpers.showErrorMessage("ImageJ macro error", e.getLocalizedMessage());
+			boolean cancelled = false;
+			ImagePlus impResult = null;
+			try {
+				IJ.redirectErrorMessages();
+				Interpreter interpreter = new Interpreter();
+				impResult = interpreter.runBatchMacro(macroText, imp);
+
+				// If we had an error, return
+				if (interpreter.wasError()) {
 					Thread.currentThread().interrupt();
-					cancelled = true;
-				} finally {
-					//		IJ.runMacro(macroText, argument);
-					WindowManager.setTempCurrentImage(null);
-//					IJ.run("Close all");
-				}
-				if (cancelled)
 					return;
-				
-				
-				// Get the current image when the macro has finished - which may or may not be the same as the original
+				}
+
+				// Get the resulting image, if available
 				if (impResult == null)
-					impResult = imp;
-				
-				
-				boolean changes = false;
-				if (params.getBooleanParameterValue("clearObjects") && pathObject.hasChildObjects()) {
-					pathObject.clearChildObjects();
-					changes = true;
-				}
-				if (params.getBooleanParameterValue("getROI") && impResult.getRoi() != null) {
-					Roi roi = impResult.getRoi();
-					Calibration cal = impResult.getCalibration();
-					PathObject pathObjectNew = roi == null ? null : IJTools.convertToAnnotation(roi, cal.xOrigin, cal.yOrigin, downsampleFactor, region.getImagePlane());
-					if (pathObjectNew != null) {
-						// If necessary, trim any returned annotation
-						if (pathROI != null && !(pathROI instanceof RectangleROI) && pathObjectNew.isAnnotation() && RoiTools.isShapeROI(pathROI) && RoiTools.isShapeROI(pathObjectNew.getROI())) {
-							ROI roiNew = RoiTools.combineROIs(pathROI, pathObjectNew.getROI(), CombineOp.INTERSECT);
-							((PathAnnotationObject)pathObjectNew).setROI(roiNew);
-						}
-						// Only add if we have something
-						if (pathObjectNew.getROI() instanceof LineROI || !pathObjectNew.getROI().isEmpty()) {
-							pathObject.addChildObject(pathObjectNew);
-							//			imageData.getHierarchy().addPathObject(IJHelpers.convertToPathObject(imp, imageData.getServer(), imp.getRoi(), downsampleFactor, false), true);
-							changes = true;
-						}
+					impResult = WindowManager.getCurrentImage();
+			} catch (RuntimeException e) {
+				logger.error(e.getLocalizedMessage());
+				//			DisplayHelpers.showErrorMessage("ImageJ macro error", e.getLocalizedMessage());
+				Thread.currentThread().interrupt();
+				cancelled = true;
+			} finally {
+				//		IJ.runMacro(macroText, argument);
+				WindowManager.setTempCurrentImage(null);
+//					IJ.run("Close all");
+			}
+			if (cancelled)
+				return;
+
+
+			// Get the current image when the macro has finished - which may or may not be the same as the original
+			if (impResult == null)
+				impResult = imp;
+
+
+			boolean changes = false;
+			if (params.getBooleanParameterValue("clearObjects") && pathObject.hasChildObjects()) {
+				pathObject.clearChildObjects();
+				changes = true;
+			}
+			if (params.getBooleanParameterValue("getROI") && impResult.getRoi() != null) {
+				Roi roi = impResult.getRoi();
+				Calibration cal = impResult.getCalibration();
+				PathObject pathObjectNew = roi == null ? null : IJTools.convertToAnnotation(roi, cal.xOrigin, cal.yOrigin, downsampleFactor, region.getImagePlane());
+				if (pathObjectNew != null) {
+					// If necessary, trim any returned annotation
+					if (pathROI != null && !(pathROI instanceof RectangleROI) && pathObjectNew.isAnnotation() && RoiTools.isShapeROI(pathROI) && RoiTools.isShapeROI(pathObjectNew.getROI())) {
+						ROI roiNew = RoiTools.combineROIs(pathROI, pathObjectNew.getROI(), CombineOp.INTERSECT);
+						((PathAnnotationObject)pathObjectNew).setROI(roiNew);
 					}
-				}
-				
-				boolean exportAsDetection = ((String) params.getChoiceParameterValue("getOverlayAs")).equals("Detections") ? true : false;
-				if (params.getBooleanParameterValue("getOverlay") && impResult.getOverlay() != null) {
-					var overlay = impResult.getOverlay();
-					List<PathObject> childObjects = QuPath_Send_Overlay_to_QuPath.createObjectsFromROIs(imp, Arrays.asList(overlay.toArray()), downsampleFactor, exportAsDetection, true, region.getImagePlane());
-					if (!childObjects.isEmpty()) {
-						pathObject.addChildObjects(childObjects);
+					// Only add if we have something
+					if (pathObjectNew.getROI() instanceof LineROI || !pathObjectNew.getROI().isEmpty()) {
+						pathObject.addChildObject(pathObjectNew);
 						changes = true;
 					}
-//					for (Roi roi : impResult.getOverlay().toArray()) {
-//						pathObject.addPathObject(IJTools.convertToPathObject(imp, imageData.getServer(), roi, downsampleFactor, true));
-//						changes = true;
-//					}
 				}
-				
-				if (changes) {
-					Platform.runLater(() -> imageData.getHierarchy().fireHierarchyChangedEvent(null));
+			}
+
+			boolean exportAsDetection = Objects.equals(params.getChoiceParameterValue("getOverlayAs"), "Detections");
+			if (params.getBooleanParameterValue("getOverlay") && impResult.getOverlay() != null) {
+				var overlay = impResult.getOverlay();
+				List<PathObject> childObjects = QuPath_Send_Overlay_to_QuPath.createObjectsFromROIs(imp, Arrays.asList(overlay.toArray()), downsampleFactor, exportAsDetection, true, region.getImagePlane());
+				if (!childObjects.isEmpty()) {
+					pathObject.addChildObjects(childObjects);
+					changes = true;
 				}
-				
-//			});
+			}
+
+			if (changes) {
+				Platform.runLater(() -> imageData.getHierarchy().fireHierarchyChangedEvent(null));
+			}
 		} catch (Exception e) {
 			logger.error(e.getMessage(), e);
 		}
@@ -429,13 +415,5 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 				pathObjects = new ArrayList<>(hierarchy.getSelectionModel().getSelectedObjects());
 		}
 		return pathObjects;
-		
-//		// TODO: Give option to analyse annotations, even when TMA grid is present
-//		ImageData<BufferedImage> imageData = runner.getImageData();
-//		TMAGrid tmaGrid = imageData.getHierarchy().getTMAGrid();
-//		if (tmaGrid != null && tmaGrid.nCores() > 0)
-//			return PathObjectTools.getTMACoreObjects(imageData.getHierarchy(), false);
-//		else
-//			return imageData.getHierarchy().getObjects(null, PathAnnotationObject.class);
 	}
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MenuTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MenuTools.java
@@ -73,35 +73,12 @@ public class MenuTools {
 	 * <li>{@code null} (indicating that a separator should be added)</li>
 	 * </ul>
 	 * 
-	 * @param menu
-	 * @param items
+	 * @param menu menu to which items should be added
+	 * @param items the items that should be provided (MenuItems or Actions, or null to insert a separator)
 	 * @return the provided menu, so that this method can be nested inside other calls.
 	 */
 	public static Menu addMenuItems(final Menu menu, final Object... items) {
-		// Check if the last item was a separator -
-		// we don't want two adjacent separators, since this looks a bit weird
-		boolean lastIsSeparator = menu.getItems().isEmpty() ? false : menu.getItems().get(menu.getItems().size()-1) instanceof SeparatorMenuItem;
-		
-		List<MenuItem> newItems = new ArrayList<>();
-		for (Object item : items) {
-			if (item == null) {
-				if (!lastIsSeparator)
-					newItems.add(new SeparatorMenuItem());
-				lastIsSeparator = true;
-			}
-			else if (item instanceof MenuItem) {
-				newItems.add((MenuItem)item);
-				lastIsSeparator = false;
-			}
-			else if (item instanceof Action) {
-				newItems.add(ActionTools.createMenuItem((Action)item));
-				lastIsSeparator = false;
-			} else
-				logger.warn("Could not add menu item {}", item);
-		}
-		if (!newItems.isEmpty()) {
-			menu.getItems().addAll(newItems);
-		}
+		addMenuItems(menu.getItems(), items);
 		return menu;
 	}
 	
@@ -110,14 +87,16 @@ public class MenuTools {
 	 * possible to work also with a {@link ContextMenu} in addition to a standard {@link Menu}.
 	 * 
 	 * @param menuItems existing list to which items should be added, or null if a new list should be created
-	 * @param items the items that should be provided (MenuItems or Actions)
+	 * @param items the items that should be provided (MenuItems or Actions, or null to insert a separator)
 	 * @return the list containing the adding items (same as the original if provided)
 	 */
 	public static List<MenuItem> addMenuItems(List<MenuItem> menuItems, final Object... items) {
 		if (menuItems == null)
 			menuItems = new ArrayList<>();
-		
-		boolean lastIsSeparator = menuItems.isEmpty() ? false : menuItems.get(menuItems.size()-1) instanceof SeparatorMenuItem;
+
+		// Check if the last item was a separator -
+		// we don't want two adjacent separators, since this looks a bit weird
+		boolean lastIsSeparator = !menuItems.isEmpty() && menuItems.getLast() instanceof SeparatorMenuItem;
 		
 		List<MenuItem> newItems = new ArrayList<>();
 		for (Object item : items) {
@@ -126,12 +105,12 @@ public class MenuTools {
 					newItems.add(new SeparatorMenuItem());
 				lastIsSeparator = true;
 			}
-			else if (item instanceof MenuItem) {
-				newItems.add((MenuItem)item);
+			else if (item instanceof MenuItem menuItem) {
+				newItems.add(menuItem);
 				lastIsSeparator = false;
 			}
-			else if (item instanceof Action) {
-				newItems.add(ActionTools.createMenuItem((Action)item));
+			else if (item instanceof Action action) {
+				newItems.add(ActionTools.createMenuItem(action));
 				lastIsSeparator = false;
 			} else
 				logger.warn("Could not add menu item {}", item);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
@@ -216,7 +216,7 @@ public class HierarchyOverlay extends AbstractOverlay {
 				Collections.emptyList();
 
 		// Return if nothing visible
-		if (paintableSelectedObjects.isEmpty() && paintableDetections.isEmpty() && paintableAnnotations.isEmpty())
+		if (!showDetections && paintableSelectedObjects.isEmpty() && paintableDetections.isEmpty() && paintableAnnotations.isEmpty())
 			return;
 
 		// Paint detection objects, if required


### PR DESCRIPTION
Detections could sometimes not appear in the viewer.
This was caused by an overly-enthusiastic attempted optimization, introduced in v0.6.0 pre-releases.