### PR TITLE
Improved point simplification in viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ They may change or be removed in future versions.
 * Spacebar can be locked in an 'on' position within viewers (https://github.com/qupath/qupath/issues/1610)
 * Timepoint data is rarely available (or correct) (https://github.com/qupath/qupath/issues/1628)
 * Some commands cannot be run from 'Command List' (https://github.com/qupath/qupath/issues/1647)
+* ROIs with small pieces could look very 'pointy' when viewed at low resolution (https://github.com/qupath/qupath/pull/1681)
 
 ### API changes
 * New `Map<String, String> getMetadata()` method added to `PathObject`, `Project` and `ProjectImageEntry` (https://github.com/qupath/qupath/pull/1587)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -723,12 +723,13 @@ public class PathObjectPainter {
 
 		private static Shape simplifyByDownsample(final Shape shape, final double downsample) {
 			try {
+				int pointCountThreshold = -1;
 				if (downsample > 50)
-					return ShapeSimplifier.simplifyPath(shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape), 50);
+					return ShapeSimplifier.simplifyPath(shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape), 50, pointCountThreshold);
 				if (downsample > 20)
-					return ShapeSimplifier.simplifyPath(shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape), 20);
+					return ShapeSimplifier.simplifyPath(shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape), 20, pointCountThreshold);
 				if (downsample > 10)
-					return ShapeSimplifier.simplifyPath(shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape), 10);
+					return ShapeSimplifier.simplifyPath(shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape), 10, pointCountThreshold);
 			} catch (Exception e) {
 				logger.warn("Unable to simplify path: {}", e.getLocalizedMessage());
 				logger.debug("", e);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -723,7 +723,7 @@ public class PathObjectPainter {
 
 		private static Shape simplifyByDownsample(final Shape shape, final double downsample) {
 			try {
-				int pointCountThreshold = -1;
+				int pointCountThreshold = 10;
 				if (downsample > 50)
 					return ShapeSimplifier.simplifyPath(shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape), 50, pointCountThreshold);
 				if (downsample > 20)


### PR DESCRIPTION
Improve rendering of complex ROIs with many small pieces at low resolution.

The viewer creates simplified shapes for faster rendering at low resolution by discarding vertices.
However this can result in regions corresponding to a few pieces becoming triangles... and looking incongruously 'pointy'.

This PR takes a simple approach of not simplifying any distinct polygons with few vertices - including when these are part of larger multipolygons.

## Before PR
![CMU-1 (previous)](https://github.com/user-attachments/assets/d4af75a0-756d-47dd-956f-ed0f97fc65aa)

## With PR
![CMU-1 (New)](https://github.com/user-attachments/assets/63657ad3-2e04-41e0-9d40-6b2319bf305a)
