### PR TITLE
Add assemblejavadoc to jpackage action

### DIFF
--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -47,7 +47,7 @@
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v3
       with:
-        arguments: jpackage -P git-commit=true -P package=installer mergedJavadoc createChecksums -P toolchain=21
+        arguments: assembleJavadocs jpackage -P git-commit=true -P package=installer mergedJavadoc createChecksums -P toolchain=21
 
     - name: Make Linux tar.xz
       if: matrix.name == 'Linux'

--- a/qupath-app/build.gradle
+++ b/qupath-app/build.gradle
@@ -400,7 +400,6 @@ tasks.register('jpackageFinalize') {
     // Identify outputs, which are used to create checksums
     inputs.files jpackage.outputs.files
     outputs.files(jpackage.outputs.files.asFileTree.matching {
-        // I think you can tell I'm not great with Gradle
         include {
             return it.file.parentFile.name == 'dist' &&
                     it.name.startsWith('QuPath') &&


### PR DESCRIPTION
For some reason, when running `gradlew jpackage` you get the full set of qupath javadocs, but with `gradlew jpackage -P package=installer`, you get just a small subset. However you can bodge around this by explicitly asking for all the javadocs as part of the same call; it'll still copy the directory.

Temporarily address #1652; won't consider it closed until jpackage contains all javadoc jars by default.