### PR TITLE
Preserve locked status with `PathObject.createLike`

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -1936,9 +1936,10 @@ public class PathObjectTools {
 			newObject = PathObjects.createDetectionObject(roiNew, pathObject.getPathClass());
 		} else
 			throw new IllegalArgumentException("Unsupported object type - cannot create similar object for " + pathObject);
-		// Retain name and color as well
+		// Retain name, color and locked status as well
 		newObject.setName(pathObject.getName());
 		newObject.setColor(pathObject.getColor());
+		newObject.setLocked(pathObject.isLocked());
 		return newObject;
 	}
 	


### PR DESCRIPTION
When creating an object that is 'like' another one, but has a different ROI, then ensure that the locked status is preserved along with other properties.