### PR TITLE
Specify includeFlat/Build in properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,11 @@ They may change or be removed in future versions.
 * `ImageServer.finalize()` is no longer overridden to call `close()` in case the caller forgets
   * `finalize()` is deprecated for removal; any class that relied on this should consider using `Cleaner`
 
+### Build changes
+* Use Kotlin instead of Groovy for QuPath's build scripts (https://github.com/qupath/qupath/pull/1696)
+  * Also refactor and simplify the build scripts
+  * Extension writers can use either Groovy or Kotlin - but may need to make some changes to their build scripts
+
 ### Dependency updates
 * Bio-Formats 8.0.1
 * Commonmark 0.24.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,8 +4,11 @@ pluginManagement {
     }
 }
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0" // to download if needed
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0" // to download JDK if needed
 }
+
+// Define project name
+rootProject.name = "qupath"
 
 // Define the current QuPath version
 var qupathVersion = "0.6.0-SNAPSHOT"
@@ -29,9 +32,6 @@ gradle.extra["qupath.package.git-commit"] = providers.gradleProperty("git-commit
 
 // Optionally include extra libraries/extensions
 val includeExtras = "true".equals(providers.gradleProperty("include-extras").getOrElse("false"), true)
-
-
-rootProject.name = "qupath"
 
 // Main application
 include("qupath-app")
@@ -76,4 +76,23 @@ dependencyResolutionManagement {
                 bundle("extensions", listOf())
         }
     }
+}
+
+// These lines make it possible to define directories within gradle.properties
+// to include in the build using either includeFlat or includeBuild.
+// This is useful when developing extensions, especially because gradle.properties
+// is not under version control.
+
+// Include flat directories for extensions
+findIncludes("qupath.include.flat").forEach(::includeFlat)
+
+// Include build directories
+findIncludes("qupath.include.build").forEach(::includeBuild)
+
+fun findIncludes(propName: String): List<String> {
+    return providers.gradleProperty(propName)
+        .getOrElse("")
+        .split(",", "\\\n", ";")
+        .map(String::trim)
+        .filter(String::isNotBlank)
 }


### PR DESCRIPTION
Support `includeFlat` and `includeBuild` being specified in `gradle.properties`. This makes it possible to include lines such as
```
qupath.include.flat=\
  qupath-extension-training,\
  qupath-extension-instanseg

qupath.include.build=../qupath-fxtras
```
without needing to modify `gradle.settings`.

This is useful when developing extensions because `gradle.settings` is under version control, but `gradle.properties` is not - so previously you always needed to remember not to commit any changes made to `gradle.settings` during development.