### PR TITLE
Parameterise version in gradle and GHA

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,7 +1,13 @@
 
 name: Draft a GitHub release
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The QuPath version that will be built
+        required: true
+        type: string
 
 concurrency: release-${{ github.ref }}
 permissions:
@@ -11,6 +17,8 @@ jobs:
   jpackage:
     name: Run JPackage
     uses: ./.github/workflows/jpackage.yml
+    with:
+      version: ${{ inputs.version }}
 
   release:
     needs: jpackage
@@ -20,14 +28,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get qupath version from gradle
-        shell: bash
-        run: |
-          # grep reads the version line, sed strips everything before =
-          # GITHUB_ENV means it's stored in env.QUPATH_VERSION persistently
-          # not just for the current step...                
-          echo "QUPATH_VERSION=$(grep 'qupathVersion = \".*\"' settings.gradle  | sed -e 's/.*= "\(.*\)"/\1/')" >> $GITHUB_ENV
-
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
@@ -36,19 +36,19 @@ jobs:
       - name: Wrangle files
         shell: bash
         run: |
-          mv QuPath-${{ env.QUPATH_VERSION }}.msi QuPath-v${{ env.QUPATH_VERSION }}-Windows.msi
-          mv QuPath-${{ env.QUPATH_VERSION }}.zip QuPath-v${{ env.QUPATH_VERSION }}-Windows.zip
-          mv QuPath-${{ env.QUPATH_VERSION }}-x64.pkg QuPath-v${{ env.QUPATH_VERSION }}-Mac-x64.pkg
-          mv QuPath-${{ env.QUPATH_VERSION }}-arm64.pkg QuPath-v${{ env.QUPATH_VERSION }}-Mac-arm64.pkg
+          mv QuPath-${{ inputs.version }}.msi QuPath-v${{ inputs.version }}-Windows.msi
+          mv QuPath-${{ inputs.version }}.zip QuPath-v${{ inputs.version }}-Windows.zip
+          mv QuPath-${{ inputs.version }}-x64.pkg QuPath-v${{ inputs.version }}-Mac-x64.pkg
+          mv QuPath-${{ inputs.version }}-arm64.pkg QuPath-v${{ inputs.version }}-Mac-arm64.pkg
 
       - name: Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create --draft v${{ env.QUPATH_VERSION }} -t ${{ github.sha }} --title v${{ env.QUPATH_VERSION }} \
-              QuPath-v${{ env.QUPATH_VERSION }}-Windows.msi \
-              QuPath-v${{ env.QUPATH_VERSION }}-Windows.zip \
-              QuPath-v${{ env.QUPATH_VERSION }}-Mac-x64.pkg \
-              QuPath-v${{ env.QUPATH_VERSION }}-Mac-arm64.pkg \
-              QuPath-v${{ env.QUPATH_VERSION }}-Linux.tar.xz
+          gh release create --draft v${{ inputs.version }} -t ${{ github.sha }} --title v${{ inputs.version }} \
+              QuPath-v${{ inputs.version }}-Windows.msi \
+              QuPath-v${{ inputs.version }}-Windows.zip \
+              QuPath-v${{ inputs.version }}-Mac-x64.pkg \
+              QuPath-v${{ inputs.version }}-Mac-arm64.pkg \
+              QuPath-v${{ inputs.version }}-Linux.tar.xz
 

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -4,12 +4,21 @@
  name: Build packages with jpackage
 
  on: 
-  - workflow_dispatch
-  - workflow_call
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The QuPath version that will be built
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: The QuPath version that will be built
+        required: true
+        type: string
 
  jobs:
    build:
-
     strategy:
       fail-fast: false
       matrix:
@@ -27,14 +36,6 @@
 
     - uses: actions/checkout@v4
 
-    - name: Get qupath version from gradle
-      shell: bash
-      run: |
-        # grep reads the version line, sed strips everything before =
-        # GITHUB_ENV means it's stored in ${{env.QUPATH_VERSION}} persistently
-        # not just for the current step...
-        echo "QUPATH_VERSION=$(grep 'qupathVersion = \".*\"' settings.gradle  | sed -e 's/.*= \"\(.*\)\"/\1/')" >> $GITHUB_ENV
-
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
@@ -48,30 +49,30 @@
       run: ./gradlew assembleJavadocs
 
     - name: Build with Gradle
-      run: ./gradlew jpackage -P git-commit=true -P package=installer mergedJavadoc createChecksums -P toolchain=21
+      run: ./gradlew jpackage -P git-commit=true -P package=installer -P qupathVersion=${{ inputs.version }} mergedJavadoc createChecksums -P toolchain=21
 
     - name: Make Linux tar.xz
       if: matrix.name == 'Linux'
       shell: bash
       run: |
-        tar -c -C build/dist/ QuPath | xz > build/dist/QuPath-v${{ env.QUPATH_VERSION }}-${{ matrix.name }}.tar.xz
+        tar -c -C build/dist/ QuPath | xz > build/dist/QuPath-v${{ inputs.version }}-${{ matrix.name }}.tar.xz
         rm -r build/dist/QuPath/
 
     - name: Clean windows artifact
       if: matrix.name == 'Windows'
       shell: bash
       run: |
-        rm -r build/dist/QuPath-${{ env.QUPATH_VERSION }}
+        rm -r build/dist/QuPath-${{ inputs.version }}
 
     - uses: actions/upload-artifact@v4
       with:
-        name: QuPath-v${{ env.QUPATH_VERSION }}-${{ matrix.name }}
+        name: QuPath-v${{ inputs.version }}-${{ matrix.name }}
         path: build/dist/QuPath*
         retention-days: 1
 
     - uses: actions/upload-artifact@v4
       if: matrix.name == 'Mac-arm64'
       with:
-        name: javadoc-QuPath-v${{ env.QUPATH_VERSION }}
+        name: javadoc-QuPath-v${{ inputs.version }}
         path: build/docs-merged/javadoc
         retention-days: 7

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,8 +10,9 @@ plugins {
 // Define project name
 rootProject.name = "qupath"
 
-// Define the current QuPath version
-var qupathVersion = "0.6.0-SNAPSHOT"
+// Define the current QuPath version (can be set as a gradle property too)
+var qupathVersion = findProperty("qupathVersion") ?: "0.6.0-SNAPSHOT"
+
 
 // Store version & derived app name in extra properties for build scripts to use
 gradle.extra["qupath.app.version"] = qupathVersion
@@ -66,7 +67,7 @@ dependencyResolutionManagement {
         // This can be useful to make custom QuPath builds with specific versions of extensions
         create("extraLibs") {
             library("djl", "io.github.qupath", "qupath-extension-djl").version("0.4.0-20240911.172830-2")
-            library("instanseg", "io.github.qupath", "qupath-extension-instanseg").version("0.0.1-20241020.174720-4")
+//            library("instanseg", "io.github.qupath", "qupath-extension-instanseg").version("0.0.1-20241020.174720-4")
             library("training", "io.github.qupath", "qupath-extension-training").version("0.0.1-20241022.065038-2")
             library("py4j", "io.github.qupath", "qupath-extension-py4j").version("0.1.0-20241021.201937-1")
             // Include or exclude bundled extensions


### PR DESCRIPTION
This PR adds a required field for the JPackage and github-release actions, so when drafting a new release, you're required to enter the target version. Also adds an optional way to set the version in the build script via the `qupathVersion` property.

Resolve #1707 