### PR TITLE
Improve support for extension development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ hs_err*.log
 *~.nib
 *thumbs.db
 bin/
+.kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,6 +135,14 @@ dependencies {
     includedProjects.forEach {
         implementation(it)
     }
+
+    with (gradle.extra["qupath.included.dependencies"] as List<*>) {
+        forEach {
+            if (it != null)
+                implementation(it)
+        }
+    }
+
     implementation(libs.picocli)
 
     implementation(extraLibs.bundles.extensions) {
@@ -224,7 +232,6 @@ tasks.installDist {
 tasks.startScripts {
     dependsOn("generateLicenseReport")
 }
-
 
 /**
  * Copy key files into the distribution

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,9 +6,7 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven {
-        url = uri("https://plugins.gradle.org/m2/")
-    }
+    gradlePluginPortal()
 }
 
 java {


### PR DESCRIPTION
This improves support for developing extensions that are configured using the [QuPath Gradle Plugin](https://github.com/qupath/qupath-gradle-plugin) - and generally any extension that is built separately.

## The Problem
Extensions in their own repos can be built and installed separately from QuPath... that's fine.

But to actually *develop* such extensions efficiently we need to be able to launch QuPath with the extension added as a dependency from an IDE.

Which turns out to be hard.

## Previous strategy
We used to do two things to launch QuPath from an IDE with an in-development extension:
* Make sure the extension is in a directory *beside* the `qupath` source code
* Edit `settings.gradle` to add `includeFlat("extension-name")`

This kind of worked, but had a critical flaw: the extension effectively became a subproject, and so its `settings.gradle` was never used.

Rather, the main `settings.gradle` of QuPath was applied.

*Usually* that was consistent and things worked anyway... but it breaks down if the extension does something else in its settings.

'Something else' includes running the new QuPath Gradle Plugin.

The Gradle plugin cuts down the boilerplate needed for configuring extensions considerably.
It seems to work well when building the extension on its own, but it's really brittle with `includeFlat`... including nasty plugin dependency version incompatibilities that I couldn't solve.

## New strategy
`includeBuild` is preferable to `includeFlat` because it builds the extension 'properly': i.e. as it would with a standalone build.

`includeBuild` also permits the extension can be located anywhere.

The problem is that the extension isn't added to QuPath's classpath, so doesn't actually appear when running QuPath from an IDE or gradle.

The solution to *that* is to use `includeBuild` *and* also specify the project corresponding to the extension is a dependency of QuPath. Because then dependency substitution kicks in.

But the problem there is that it's not possible to access the project of an included build, or its name... so we can't automatically figure out what dependency to add.

So we end up needing to do two things:
* Use `includeBuild("path/to/extension")` in `settings.gradle.kts`
* Use `dependencies { implementation("group:name") }` for the extension in `build.gradle.kts`

which is less elegant than one `includeFlat`, but has the virtue of working.

To make this a bit easier, `settles.gradle.kts` here can recognize two properties: `qupath.include.build` and `qupath.include.dependencies`.

If set, then there's no need to edit `settings.gradle.kts` and `build.gradle.kts` - the values of the properties are handled there anyway.

What's more, the properties can be added to `gradle.properties` - which isn't under version control.

### End solution

Ultimately, `includeFlat` no longer works for developing extensions.

Instead, create/edit `gradle.properties` to contain something like this:

```properties
qupath.include.build=path/to/qupath-extension-template
qupath.include.dependencies=io.github.qupath:qupath-extension-template
```

This means it now takes two lines to include one extension, which is annoying, but I haven't figured out a more elegant way yet.

Usefully, you can add multiple extensions with a comma-separated list.