### PR TITLE
add isSpatiallyTransformed to ImageServerMetadata

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/servers/CroppedImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/CroppedImageServer.java
@@ -36,7 +36,7 @@ import qupath.lib.regions.RegionRequest;
  * @author Pete Bankhead
  *
  */
-public class CroppedImageServer extends TransformingImageServer<BufferedImage> {
+public class CroppedImageServer extends SpatiallyTransformingImageServer<BufferedImage> {
 	
 	private ImageServerMetadata metadata;
 	
@@ -54,21 +54,22 @@ public class CroppedImageServer extends TransformingImageServer<BufferedImage> {
 		var levelBuilder = new ImageServerMetadata.ImageResolutionLevel.Builder(region.getWidth(), region.getHeight());
 		boolean fullServer = server.getWidth() == region.getWidth() && server.getHeight() == region.getHeight();
 		int i = 0;
+		ImageServerMetadata embeddedMetadata = super.getMetadata();
 		do {
-			var originalLevel = server.getMetadata().getLevel(i);
+			var originalLevel = embeddedMetadata.getLevel(i);
 			if (fullServer)
 				levelBuilder.addLevel(originalLevel);
 			else
 				levelBuilder.addLevelByDownsample(originalLevel.getDownsample());
 			i++;
 		} while (i < server.nResolutions() && 
-				region.getWidth() >= server.getMetadata().getPreferredTileWidth() && 
-				region.getHeight() >= server.getMetadata().getPreferredTileHeight());
+				region.getWidth() >= embeddedMetadata.getPreferredTileWidth() &&
+				region.getHeight() >= embeddedMetadata.getPreferredTileHeight());
 		
-		metadata = new ImageServerMetadata.Builder(server.getMetadata())
+		metadata = new ImageServerMetadata.Builder(embeddedMetadata)
 				.width(region.getWidth())
 				.height(region.getHeight())
-				.name(String.format("%s (%d, %d, %d, %d)", server.getMetadata().getName(), region.getX(), region.getY(), region.getWidth(), region.getHeight()))
+				.name(String.format("%s (%d, %d, %d, %d)", embeddedMetadata.getName(), region.getX(), region.getY(), region.getWidth(), region.getHeight()))
 				.levels(levelBuilder.build())
 				.build();
 	}

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java
@@ -196,6 +196,23 @@ public interface ImageServerBuilder<T> {
 		}
 		
 	}
+
+	abstract class AbstractSpaciallyTransformedServerBuilder<T> extends AbstractServerBuilder<T> {
+
+		AbstractSpaciallyTransformedServerBuilder(ImageServerMetadata metadata) {
+			super(metadata);
+		}
+
+		@Override
+		public Optional<ImageServerMetadata> getMetadata() {
+			return super.getMetadata()
+					.map(m ->
+							new ImageServerMetadata.Builder(m)
+									.spatiallyTransformed(true)
+									.build()
+					);
+		}
+	}
 	
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerMetadata.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerMetadata.java
@@ -121,7 +121,9 @@ public class ImageServerMetadata {
 	private int sizeT = 1;
 	
 	private ImageServerMetadata.ChannelType channelType = ImageServerMetadata.ChannelType.DEFAULT;
-	
+
+	private boolean isSpatiallyTransformed = false;
+
 	private boolean isRGB = false;
 	private PixelType pixelType = PixelType.UINT8;
 	
@@ -267,6 +269,16 @@ public class ImageServerMetadata {
 		 */
 		public Builder classificationLabels(final Map<Integer, PathClass> classificationLabels) {
 			this.metadata.classificationLabels = Collections.unmodifiableMap(new LinkedHashMap<>(classificationLabels));
+			return this;
+		}
+
+		/**
+		 * Specify that some spatial transformation is applied over the original image.
+		 * @param isSpatiallyTransformed
+		 * @return
+		 */
+		public Builder spatiallyTransformed(boolean isSpatiallyTransformed) {
+			metadata.isSpatiallyTransformed = isSpatiallyTransformed;
 			return this;
 		}
 		
@@ -477,7 +489,8 @@ public class ImageServerMetadata {
 		
 		this.sizeZ = metadata.sizeZ;
 		this.sizeT = metadata.sizeT;
-				
+		
+		this.isSpatiallyTransformed = metadata.isSpatiallyTransformed;
 		this.isRGB = metadata.isRGB;
 		this.pixelType = metadata.pixelType;
 		
@@ -578,6 +591,10 @@ public class ImageServerMetadata {
 	 */
 	public ImageResolutionLevel getLevel(int level) {
 		return levels[level];
+	}
+
+	public boolean isSpatiallyTransformed() {
+		return isSpatiallyTransformed;
 	}
 	
 	/**
@@ -847,6 +864,7 @@ public class ImageServerMetadata {
 		result = prime * result + ((channelType == null) ? 0 : channelType.hashCode());
 		result = prime * result + ((channels == null) ? 0 : channels.hashCode());
 		result = prime * result + height;
+		result = prime * result + (isSpatiallyTransformed ? 4142 : 5152);
 		result = prime * result + (isRGB ? 1231 : 1237);
 		result = prime * result + Arrays.hashCode(levels);
 		result = prime * result + ((magnification == null) ? 0 : magnification.hashCode());
@@ -881,6 +899,8 @@ public class ImageServerMetadata {
 		} else if (!channels.equals(other.channels))
 			return false;
 		if (height != other.height)
+			return false;
+		if (isSpatiallyTransformed != other.isSpatiallyTransformed)
 			return false;
 		if (isRGB != other.isRGB)
 			return false;

--- a/qupath-core/src/main/java/qupath/lib/images/servers/RotatedImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/RotatedImageServer.java
@@ -37,7 +37,7 @@ import qupath.lib.regions.RegionRequest;
  * @author Pete Bankhead
  *
  */
-public class RotatedImageServer extends TransformingImageServer<BufferedImage> {
+public class RotatedImageServer extends SpatiallyTransformingImageServer<BufferedImage> {
 	
 	/**
 	 * Enum for rotations in increments of 90 degrees.
@@ -97,16 +97,16 @@ public class RotatedImageServer extends TransformingImageServer<BufferedImage> {
 		switch (rotation) {
 		case ROTATE_270:
 		case ROTATE_90:
-			metadata = getQuarterRotatedMetadata(server.getOriginalMetadata());
+			metadata = getQuarterRotatedMetadata(super.getOriginalMetadata());
 			break;
 		case ROTATE_180:
-			metadata = new ImageServerMetadata.Builder(server.getOriginalMetadata())
+			metadata = new ImageServerMetadata.Builder(super.getOriginalMetadata())
 //						.path(getPath())
 						.build();
 			break;
 		case ROTATE_NONE:
 		default:
-			metadata = server.getOriginalMetadata().duplicate();
+			metadata = super.getOriginalMetadata().duplicate();
 		}
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/images/servers/SlicedImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/SlicedImageServer.java
@@ -12,7 +12,7 @@ import java.util.stream.Stream;
  * ImageServer that treats a particular set of z-slices and timepoints of another ImageServer
  * as a full image.
  */
-public class SlicedImageServer extends TransformingImageServer<BufferedImage> {
+public class SlicedImageServer extends SpatiallyTransformingImageServer<BufferedImage> {
 
     private final int zStart;
     private final int zEnd;
@@ -61,14 +61,15 @@ public class SlicedImageServer extends TransformingImageServer<BufferedImage> {
         checkOrder(this.tStart, this.tEnd, "timepoint");
         checkStep(this.tStep);
 
-        metadata = new ImageServerMetadata.Builder(inputServer.getMetadata())
+        ImageServerMetadata embeddedMetadata = super.getMetadata();
+        metadata = new ImageServerMetadata.Builder(embeddedMetadata)
                 .sizeZ((this.zEnd - this.zStart + this.zStep - 1) / this.zStep)
                 .sizeT((this.tEnd - this.tStart + this.tStep - 1) / this.tStep)
-                .zSpacingMicrons(inputServer.getMetadata().getZSpacingMicrons() * this.zStep)
+                .zSpacingMicrons(embeddedMetadata.getZSpacingMicrons() * this.zStep)
                 .timepoints(
-                        inputServer.getMetadata().getPixelCalibration().getTimeUnit(),
+                        embeddedMetadata.getPixelCalibration().getTimeUnit(),
                         Stream.iterate(this.tStart, t -> t < this.tEnd, t -> t + this.tStep)
-                                .mapToDouble(i -> inputServer.getMetadata().getPixelCalibration().getTimepoint(i))
+                                .mapToDouble(i -> embeddedMetadata.getPixelCalibration().getTimepoint(i))
                                 .toArray()
                 )
                 .build();

--- a/qupath-core/src/main/java/qupath/lib/images/servers/SpatiallyTransformingImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/SpatiallyTransformingImageServer.java
@@ -1,0 +1,28 @@
+package qupath.lib.images.servers;
+
+import qupath.lib.regions.RegionRequest;
+
+/**
+ * An ImageServer implementation used to apply spatial transforms to another ImageServer.
+ * <p>
+ * Subclasses may only implement the methods necessary to apply the required transform,
+ * such as {@link #readRegion(RegionRequest)} since much of the remaining functionality
+ * is left up to the {@link AbstractImageServer} and {@link TransformingImageServer}
+ * implementation.
+ *
+ * @author Carlo Castoldi
+ *
+ * @param <T>
+ */
+public abstract class SpatiallyTransformingImageServer<T> extends TransformingImageServer<T> {
+    protected SpatiallyTransformingImageServer(ImageServer server) {
+        super(server);
+    }
+
+    @Override
+    public ImageServerMetadata getOriginalMetadata() {
+        return new ImageServerMetadata.Builder(getWrappedServer().getOriginalMetadata())
+                .spatiallyTransformed(true)
+                .build();
+    }
+}

--- a/qupath-core/src/main/java/qupath/lib/images/servers/TransformingImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/TransformingImageServer.java
@@ -71,5 +71,4 @@ public abstract class TransformingImageServer<T> extends AbstractImageServer<T> 
 	public ImageServerMetadata getOriginalMetadata() {
 		return server.getOriginalMetadata();
 	}
-
 }


### PR DESCRIPTION
When working with annotations coming from different programs, the user might need flip, crop, rotate or transform them according to QuPath's transformation before importing them to a QuPath project.
Thanks to https://github.com/qupath/qupath/pull/1489 users now can do this extremely fast, without loading or reading the actual `ImageServer`, _on the assumption that no spatial transformation was applied.

With this pull request I intend to add an additional metadata to image servers in order to be able to query the server if any spatial transformation was actually applied. If not, loading the server can be skipped.