### PR TITLE
Improve includeBuild behavior

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ val qupathVersion = rootProject.version.toString()
 /**
  * Set the group
  */
-base {
+allprojects {
     group = "io.github.qupath"
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -95,6 +95,9 @@ dependencyResolutionManagement {
 // This is useful when developing extensions, especially because gradle.properties
 // is not under version control.
 
+// Make subprojects of the main build available for substitution
+includeBuild(".")
+
 // Include flat directories for extensions
 findIncludes("qupath.include.flat").forEach(::includeFlat)
 


### PR DESCRIPTION
Previously, extensions added with `includeBuild` would pull in QuPath dependencies - without using dependency substitution from the main project. This commit addresses that.