### PR TITLE
Better building, javadocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ target/
 log/
 
 # Config
-include-extra.txt
+include-extra*
+include-extra.*
 
 # IntelliJ
 .idea/

--- a/buildSrc/src/main/kotlin/qupath.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.java-conventions.gradle.kts
@@ -15,7 +15,13 @@ plugins {
 val libs = the<LibrariesForLibs>()
 
 java {
-    val version = providers.gradleProperty("toolchain").getOrElse(libs.versions.jdk.get())
+    // Query version from gradle property, system property and then catalog
+    val version = providers.gradleProperty("toolchain")
+        .getOrElse(
+            System.getProperty("toolchain",
+                libs.versions.jdk.get()
+            )
+        )
     if (version.trim() == "skip") {
         logger.info("Toolchain skipped!")
     } else {

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJProperties.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJProperties.java
@@ -33,7 +33,7 @@ public class IJProperties {
     public static final String IMAGE_TYPE = "qupath.image.type";
 
     /**
-     * Key for an {@link ImagePlus} property storing either {@code "light"}  or {@core "dark} depending upon
+     * Key for an {@link ImagePlus} property storing either {@code "light"}  or {@code "dark} depending upon
      * whether an image is known to be brightfield of fluorescence respectively.
      */
     public static final String IMAGE_BACKGROUND = "qupath.image.background";

--- a/qupath-core/src/main/java/qupath/lib/images/servers/TransformedServerBuilder.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/TransformedServerBuilder.java
@@ -299,7 +299,7 @@ public class TransformedServerBuilder {
 	 * Normalize the image using the provided normalizer.
 	 * @param normalizer
 	 * @return
-	 * @ImplNote To use this method to create an image that can be added to a project, the normalizers must be JSON-serializable
+	 * @implNote To use this method to create an image that can be added to a project, the normalizers must be JSON-serializable
 	 *           and registered under {@link ImageServers#getNormalizerFactory()}.
 	 * @since v0.6.0
 	 */

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/Charts.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/Charts.java
@@ -626,7 +626,6 @@ public class Charts {
 		
 		/**
 		 * Plot two measurements against one another for the specified objects.
-		 * @name the name of the data series (useful if multiple series will be plot, otherwise may be null)
 		 * @param pathObjects the objects to plot
 		 * @param xMeasurement the measurement to extract from each object's measurement list for the x location
 		 * @param yMeasurement the measurement to extract from each object's measurement list for the y location
@@ -646,7 +645,7 @@ public class Charts {
 		 * Plot values extracted from objects within a specified collection.
 		 * @param name 
 		 * @param <T> 
-		 * @name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
+		 * @param name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
 		 * @param collection the objects to plot
 		 * @param xFun function capable of extracting a numeric value for the x location from each object in the collection
 		 * @param yFun function capable of extracting a numeric value for the y location from each object in the collection
@@ -661,8 +660,7 @@ public class Charts {
 
 		/**
 		 * Create a scatterplot using collections of numeric values.
-		 * @param name 
-		 * @name the name of the data series (useful if multiple series will be plot, otherwise may be null)
+		 * @param name the name of the data series (useful if multiple series will be plot, otherwise may be null)
 		 * @param x
 		 * @param y
 		 * @return this builder
@@ -675,8 +673,7 @@ public class Charts {
 		
 		/**
 		 * Create a scatterplot using arrays of numeric values.
-		 * @param name 
-		 * @name the name of the data series (useful if multiple series will be plot, otherwise may be null)
+		 * @param name the name of the data series (useful if multiple series will be plot, otherwise may be null)
 		 * @param x x-values
 		 * @param y y-values
 		 * @return this builder
@@ -687,9 +684,8 @@ public class Charts {
 		
 		/**
 		 * Create a scatterplot using collections of numeric values, with an associated custom object.
-		 * @param name 
-		 * @param <T> 
-		 * @name the name of the data series (useful if multiple series will be plot, otherwise may be null)
+		 * @param <T>
+		 * @param name the name of the data series (useful if multiple series will be plot, otherwise may be null)
 		 * @param x x-values
 		 * @param y y-values
 		 * @param extra array of values to associate with each data point; should be the same length as x and y
@@ -701,9 +697,8 @@ public class Charts {
 		
 		/**
 		 * Create a scatterplot using collections of numeric values, with an associated custom object.
-		 * @param name 
-		 * @param <T> 
-		 * @name the name of the data series (useful if multiple series will be plot, otherwise may be null)
+		 * @param <T>
+		 * @param name the name of the data series (useful if multiple series will be plot, otherwise may be null)
 		 * @param x x-values
 		 * @param y y-values
 		 * @param extra list of values to associate with each data point; should be the same length as x and y
@@ -722,8 +717,7 @@ public class Charts {
 		
 		/**
 		 * Create a scatterplot from existing data plots.
-		 * @param name 
-		 * @name the name of the data series (useful if multiple series will be plot, otherwise may be null)
+		 * @param name the name of the data series (useful if multiple series will be plot, otherwise may be null)
 		 * @param data the data points to plot
 		 * @return this builder
 		 */
@@ -917,9 +911,8 @@ public class Charts {
 
 		/**
 		 * Plot values extracted from objects within a specified collection.
-		 * @param name
 		 * @param <T>
-		 * @name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
+		 * @param name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
 		 * @param collection the objects to plot
 		 * @param xFun function capable of extracting a numeric value for the x location from each object in the collection
 		 * @return this builder
@@ -943,8 +936,7 @@ public class Charts {
 
 		/**
 		 * Create a bar chart using collections of numeric values.
-		 * @param name
-		 * @name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
+		 * @param name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
 		 * @param x
 		 * @param y
 		 * @return this builder
@@ -957,8 +949,7 @@ public class Charts {
 
 		/**
 		 * Create a bar chart using a map of String values and associated numeric values.
-		 * @param name
-		 * @name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
+		 * @param name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
 		 * @param data a map of String values to associated numeric values
 		 * @return this builder
 		 */
@@ -971,8 +962,7 @@ public class Charts {
 
 		/**
 		 * Create a bar chart using arrays of String values and associated numeric values.
-		 * @param name
-		 * @name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
+		 * @param name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
 		 * @param x x-values
 		 * @param y y-values
 		 * @return this builder
@@ -983,9 +973,8 @@ public class Charts {
 
 		/**
 		 * Create a bar chart using collections String values and associated numeric values, with an associated custom object.
-		 * @param name
 		 * @param <T>
-		 * @name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
+		 * @param name the name of the data series (useful if multiple series will be plotted, otherwise may be null)
 		 * @param x x-values
 		 * @param y y-values
 		 * @param extra array of values to associate with each data point; should be the same length as x and y
@@ -997,9 +986,8 @@ public class Charts {
 
 		/**
 		 * Create a bar chart using collections of String values and associated numeric values, with an associated custom object.
-		 * @param name
 		 * @param <T>
-		 * @name the name of the data series (useful if multiple series will be plot, otherwise may be null)
+		 * @param name the name of the data series (useful if multiple series will be plot, otherwise may be null)
 		 * @param x x-values
 		 * @param y y-values
 		 * @param extra list of values to associate with each data point; should be the same length as x and y
@@ -1018,8 +1006,7 @@ public class Charts {
 
 		/**
 		 * Create a bar chart from existing data plots.
-		 * @param name
-		 * @name the name of the data series (useful if multiple series will be plot, otherwise may be null)
+		 * @param name the name of the data series (useful if multiple series will be plot, otherwise may be null)
 		 * @param data the data points to plot
 		 * @return this builder
 		 */
@@ -1066,7 +1053,6 @@ public class Charts {
 
 		/**
 		 * Plot two measurements against one another for the specified objects.
-		 * @name the name of the data series (useful if multiple series will be plot, otherwise may be null)
 		 * @param pathObjects the objects to plot
 		 * @return this builder
 		 */

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -107,9 +107,11 @@ findIncludes("qupath.include.build").forEach(::includeBuild)
 // Check for include-extras file
 gradle.extra["qupath.included.dependencies"] = emptyList<String>()
 val includeExtrasFile = findIncludeExtras()
-with (includeExtrasFile!!) {
-    if (exists())
-        handleExtensionConfig(this)
+if (includeExtrasFile != null) {
+    with (includeExtrasFile) {
+        if (exists())
+            handleExtensionConfig(this)
+    }
 }
 
 /**

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ pluginManagement {
     }
 }
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0" // to download JDK if needed
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0" // to download JDK if needed
 }
 
 // Define project name
@@ -104,11 +104,26 @@ findIncludes("qupath.include.flat").forEach(::includeFlat)
 // Include build directories
 findIncludes("qupath.include.build").forEach(::includeBuild)
 
-// Check for extensions.txt
+// Check for include-extras file
 gradle.extra["qupath.included.dependencies"] = emptyList<String>()
-with (file("include-extra.txt")) {
+val includeExtrasFile = findIncludeExtras()
+with (includeExtrasFile!!) {
     if (exists())
         handleExtensionConfig(this)
+}
+
+/**
+ * Find a file called 'include-extra' (extension doesn't matter, shortest file name is preferred)
+ */
+fun findIncludeExtras(): File? {
+   val possibleFiles = rootDir.listFiles()
+       ?.filter { f -> f.name == "include-extra" || f.name.startsWith("include-extra.")}
+       ?.sortedBy { f -> f.name.length }
+    if (possibleFiles != null) {
+        return if (possibleFiles.isEmpty()) null else possibleFiles.get(0)
+    } else {
+        return null
+    }
 }
 
 /**
@@ -126,7 +141,7 @@ fun findIncludes(propName: String): List<String> {
  * Support for specifying additional builds and dependencies to include in a text file.
  *
  * This is useful when developing extensions.
- * The file should be named 'include-extra.txt' and have the format
+ * The file should be named 'include-extra.properties' and have the format
  *
  * [includeBuild]
  * /path/to/build


### PR DESCRIPTION
Support specifying toolchain with Gradle (first) or system property (second) - rather than using a gradle properly only.

This is needed because `includeBuild` requires the extension to respect the toolchain, and it is easier to as a system property that is used everywhere, i.e. within `gradle.properties` add a line such as
```
systemProp.toolchain=23
```
and then this should propagate to any included builds that use the QuPath Gradle plugin v0.2.1 (or later, presumably).

Also allow `include-extra` to have any file extension or none (shortest name is preferred). This is to make it easier to handle in an IDE, e.g. using `include-extra.properties` means that shortcuts to comment/uncomment lines can be used - but we don't want to enforce the use of `.properties` as the extension since it isn't really a properties file (it doesn't contain key-value pairs).

Also fix some javadocs (errors emerged when trying a different toolchain).