### PR TITLE
'Deselection mode' when pressing Alt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Some things may be added, some things may be removed, and some things may look d
 * Channel names can now be set for all fluorescence images, even if they are RGB (https://github.com/qupath/qupath/pull/1659)
   * Note that channel colors still only be set for non-RGB images
 * Improved ImageJ integration (https://github.com/qupath/qupath/pull/1676 https://github.com/qupath/qupath/pull/1677)
+* 'Selection mode' now supports 'deselecting' objects by pressing the 'Alt' key (https://github.com/qupath/qupath/issues/1704)
 
 ### Experimental features
 These features are included for testing and feedback.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathROIToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathROIToolEventHandler.java
@@ -200,7 +200,7 @@ abstract class AbstractPathROIToolEventHandler extends AbstractPathToolEventHand
 		
 		// If we are in selection mode, try to get objects to select
 		if (PathPrefs.selectionModeStatus().get()) {
-			var pathClass = PathPrefs.autoSetAnnotationClassProperty().get();
+			var pathClass = e.isAltDown() ? null : PathPrefs.autoSetAnnotationClassProperty().get();
 			Collection<PathObject> toSelect;
 			if (currentROI.isArea()) {
 				toSelect = hierarchy.getAllObjectsForROI(currentROI);
@@ -224,8 +224,8 @@ abstract class AbstractPathROIToolEventHandler extends AbstractPathToolEventHand
 				var reclassified = toSelect.stream()
 						.filter(p -> p.getPathClass() != pathClass)
 						.map(p -> new Reclassifier(p, pathClass, retainIntensityClass))
-						.filter(r -> r.apply())
-						.map(r -> r.getPathObject())
+						.filter(Reclassifier::apply)
+						.map(Reclassifier::getPathObject)
 						.toList();
 				if (!reclassified.isEmpty()) {
 					hierarchy.fireObjectClassificationsChangedEvent(this, reclassified);
@@ -237,7 +237,10 @@ abstract class AbstractPathROIToolEventHandler extends AbstractPathToolEventHand
 			//					viewer.getHierarchy().fireHierarchyChangedEvent(this);
 			if (toSelect.isEmpty())
 				viewer.setSelectedObject(null);
-			else if (e.isShiftDown()) {
+			else if (e.isAltDown()) {
+				hierarchy.getSelectionModel().deselectObject(pathObject);
+				hierarchy.getSelectionModel().deselectObjects(toSelect);
+			} else if (e.isShiftDown()) {
 				hierarchy.getSelectionModel().deselectObject(pathObject);
 				hierarchy.getSelectionModel().selectObjects(toSelect);
 			} else

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
@@ -219,8 +219,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 			} else if (!PathPrefs.selectionModeStatus().get()) {
 					List<PathObject> listSelectable = ToolUtils.getSelectableObjectList(viewer, p.getX(), p.getY());
 					PathObject objectSelectable = null;
-					for (int i = 0; i < listSelectable.size(); i++) {
-						PathObject temp = listSelectable.get(i);
+					for (PathObject temp : listSelectable) {
 						if (temp.isEditable() && temp instanceof PathAnnotationObject && temp.hasROI() && temp.getROI().isArea()) { //temp.getROI() instanceof AreaROI) {
 							objectSelectable = temp;
 							break;
@@ -300,12 +299,10 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 		}
 
 		ROI currentROI = pathObject.getROI();
-		if (!(currentROI instanceof ROI))
+		if (currentROI == null)
 			return;
-		
-		ROI shapeROI = currentROI;
-		
-		PathObject pathObjectUpdated = getUpdatedObject(e, shapeROI, pathObject, -1);
+
+        PathObject pathObjectUpdated = getUpdatedObject(e, currentROI, pathObject, -1);
 
 		if (pathObject != pathObjectUpdated) {
 			viewer.setSelectedObject(pathObjectUpdated, PathPrefs.selectionModeStatus().get());
@@ -319,7 +316,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 		PenInputManager manager = QuPathPenManager.getPenManager();
 		if (manager.isEraser())
 			return true;
-		return e == null ? false : e.isAltDown();
+		return e != null && (e.isAltDown() && !PathPrefs.selectionModeStatus().get());
 	}
 	
 	
@@ -385,7 +382,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 				try {
 					shapeNew = VWSimplifier.simplify(shapeNew, 0.1);
 				} catch (Exception e2) {
-					logger.error("Error simplifying ROI: " + e2.getLocalizedMessage(), e2);
+                    logger.error("Error simplifying ROI: {}", e2.getMessage(), e2);
 				}
 			}
 			


### PR DESCRIPTION
This PR addresses https://github.com/qupath/qupath/issues/1704 by changing 'selection mode' to become 'deselection mode' when the 'Alt' key is pressed.

This is comparable to how drawing tools become 'subtraction' tools when the 'Alt' key is pressed.

Therefore there are 3 different behaviors possible when drawing a ROI with selection mode turned on:
- No keys pressed - reset any current selection, and select any objects within the ROI
- Shift key pressed - add any objects within the ROI to the current selection
- Alt key pressed - remove any objects within the ROI from the current selection

(Currently there is no visual difference in how the ROI is rendered to reflect these different behaviors, because it's not straightforward to pass the 'Shift' or 'Alt' key status to the painting code where it would be needed)