### PR TITLE
Mac x64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ They may change or be removed in future versions.
 ### Dependency updates
 * Bio-Formats 8.0.1
 * Commonmark 0.24.0
-* DeepJavaLibrary 0.30.0
+* DeepJavaLibrary 0.31.0
 * Groovy 4.0.22
 * Gson 2.11.0
 * Guava 33.3.1-jre

--- a/buildSrc/src/main/java/io/github/qupath/gradle/PlatformPlugin.java
+++ b/buildSrc/src/main/java/io/github/qupath/gradle/PlatformPlugin.java
@@ -32,7 +32,7 @@ public class PlatformPlugin implements Plugin<Project> {
      */
     public enum Platform {
         WINDOWS("windows", "win32-x86_64", "ico", "msi"),
-        MAC("macosx", "darwin-x86_64", "icns", "pkg"),
+        MAC_INTEL("macosx", "darwin-x86_64", "icns", "pkg"),
         MAC_AARCH64("macosx", "darwin-aarch64", "icns", "pkg"),
         LINUX("linux", "linux-x86_64", "png", "deb"),
         LINUX_AARCH64("linux", "linux-aarch64", "png", "deb"),
@@ -68,7 +68,7 @@ public class PlatformPlugin implements Plugin<Project> {
          * @return
          */
         public boolean isMac() {
-            return this == MAC || this == MAC_AARCH64;
+            return this == MAC_INTEL || this == MAC_AARCH64;
         }
 
         /**
@@ -115,7 +115,7 @@ public class PlatformPlugin implements Plugin<Project> {
         
         @Override
         public String toString() {
-            return getPlatformName();
+            return getPlatformName() + " (" + getClassifier() + ")";
         }
         
     }
@@ -139,7 +139,7 @@ public class PlatformPlugin implements Plugin<Project> {
         } else if (os.contains("mac")) {
             if ("aarch64".equalsIgnoreCase(System.getProperty("os.arch")))
                 return Platform.MAC_AARCH64;
-            return Platform.MAC;
+            return Platform.MAC_INTEL;
         } else
             return Platform.UNKNOWN;
     }

--- a/buildSrc/src/main/kotlin/qupath.application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.application-conventions.gradle.kts
@@ -15,7 +15,7 @@ application {
     val qupathAppName = gradle.extra["qupath.app.name"] as String
 
     applicationName = qupathAppName
-    applicationDefaultJvmArgs += listOf(gradle.extra["qupath.jvm.args"] as String)
+    applicationDefaultJvmArgs += getDefaultJvmArgs()
 
     // Necessary when using ./gradlew run to support style manager to change themes
     applicationDefaultJvmArgs += "--add-opens"
@@ -26,4 +26,13 @@ application {
     applicationDefaultJvmArgs += "--add-opens"
     applicationDefaultJvmArgs += "javafx.base/com.sun.javafx.event=ALL-UNNAMED"
 
+}
+
+fun getDefaultJvmArgs(): List<String> {
+    val args = gradle.extra.properties.getOrDefault("qupath.jvm.args", null)
+    return when {
+        (args is String) -> listOf(args)
+        (args is List<*>) -> args.filterIsInstance<String>()
+        else -> emptyList()
+    }
 }

--- a/buildSrc/src/main/kotlin/qupath.djl-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.djl-conventions.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 val libs = the<LibrariesForLibs>()
-val djlVersion = libs.versions.deepJavaLibrary.get()
+var djlVersion = libs.versions.deepJavaLibrary.get()
 
 /**
  * Parse an engine string to determine which DJL engines we need
@@ -24,13 +24,13 @@ fun getDjlEngines(engineString: String): List<String> {
 		"none" -> listOf()
 		else -> engineString
 			.split(",")
-			.map({e -> e.lowercase().trim()})
-			.filter({e -> e.isNotBlank()})
+			.map { e -> e.lowercase().trim() }
+			.filter { e -> e.isNotBlank() }
 	}
 }
 
 /**
- * Parse an zoo string to determine which DJL Model Zoos we need
+ * Parse a zoo string to determine which DJL Model Zoos we need
  */
 fun getDjlZoos(zooString: String, engines: List<String>): List<String> {
 	return when (zooString.trim().lowercase()) {

--- a/buildSrc/src/main/kotlin/qupath.jpackage-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.jpackage-conventions.gradle.kts
@@ -63,7 +63,7 @@ runtime {
 
     val params = JPackageParams(
         getDistOutputDir(),
-        project.file("jpackage/${platform}"))
+        project.file("jpackage/${platform.platformName}"))
 
 
     for (installer in params.installerTypes) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ commonsMath3    = "3.6.1"
 commonsText     = "1.10.0"
 controlsFX      = "11.1.2"
 
-deepJavaLibrary = "0.30.0"
+deepJavaLibrary = "0.29.0!!"
 
 groovy          = "4.0.22"
 gson            = "2.11.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ commonsMath3    = "3.6.1"
 commonsText     = "1.10.0"
 controlsFX      = "11.1.2"
 
-deepJavaLibrary = "0.29.0!!"
+deepJavaLibrary = "0.31.0"
 
 groovy          = "4.0.22"
 gson            = "2.11.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,7 +23,9 @@ gradle.extra["qupath.app.version"] = qupathVersion
 gradle.extra["qupath.app.name"] = "QuPath"
 
 // Default is to use 50% of available RAM
-gradle.extra["qupath.jvm.args"] = providers.gradleProperty("qupath.jvm.args").getOrElse("-XX:MaxRAMPercentage=50")
+gradle.extra["qupath.jvm.args"] = listOf(
+    providers.gradleProperty("qupath.jvm.args")
+        .getOrElse("-XX:MaxRAMPercentage=50"))
 
 // By default, create an image with jpackage (not an installer, which is slower)
 gradle.extra["qupath.package"] = providers.gradleProperty("package").getOrElse("image")
@@ -59,16 +61,16 @@ include("qupath-extension-bioformats")
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            val javafxOverride = System.getProperties().getOrDefault("javafx-version", null)
+            val javafxOverride = System.getProperties().getOrDefault("javafx.version", null)
             if (javafxOverride is String) {
                 println("Overriding JavaFX version to request $javafxOverride")
                 version("javafx", javafxOverride)
             }
 
-            if (Os.isFamily(Os.FAMILY_MAC) && Os.isArch("x86_64")) {
-                val compatibleVersion = "0.28.0!!"
-                logger.warn("Setting DeepJavaLibrary version to $compatibleVersion for compatibility with Mac x64.")
-                version("deepJavaLibrary", compatibleVersion)
+            val djlOverride = System.getProperties().getOrDefault("djl.version", null)
+            if (djlOverride is String) {
+                println("Overriding DeepJavaLibrary version to request $djlOverride")
+                version("deepJavaLibrary", djlOverride)
             }
 
             // Add QuPath jars to the version catalog

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 pluginManagement {
     plugins {
         kotlin("jvm") version "2.0.21"
@@ -61,6 +63,12 @@ dependencyResolutionManagement {
             if (javafxOverride is String) {
                 println("Overriding JavaFX version to request $javafxOverride")
                 version("javafx", javafxOverride)
+            }
+
+            if (Os.isFamily(Os.FAMILY_MAC) && Os.isArch("x86_64")) {
+                val compatibleVersion = "0.28.0!!"
+                logger.warn("Setting DeepJavaLibrary version to $compatibleVersion for compatibility with Mac x64.")
+                version("deepJavaLibrary", compatibleVersion)
             }
 
             // Add QuPath jars to the version catalog


### PR DESCRIPTION
Possible strategy for https://github.com/qupath/qupath/issues/1733

PyTorch has dropped support for Intel Macs, and so too has DJL since v0.30.0. 

Downgrading to DJL v0.29.0 works, but only if we also launch with a system property that requests PyTorch 2.2.2 (rather than the default choice of v2.3.1).

This PR therefore sets the DJL version to be v0.29.0, and sets the system property *only* when building on an Intel Mac.

Advantages:
* It makes it possible to run InstanSeg (slowly) for users of Intel Macs. It also helps a significant proportion of Apple Silicon users; for as long as Bio-Formats doesn't fully support Apple Silicon (e.g. https://github.com/ome/bioformats/issues/3858) there people with some slide scanners (e.g. Zeiss Axionscan) that are forced to resort to the Intel builds.

Problems with this:
* There is no GPU support, so inference is *slow*
* There is no possibility to upgrade beyond this; we can't use more recent DJL releases without dropping support for Intel Macs, or causing them to use a different version from other platforms.
* Because the DJL version affects all engines, it also locks us to a specific TensorFlow version. This is a reason we can't use v0.28.0 or earlier, because then we've had no support for TensorFlow on Apple Silicon.

Because it seems certain that we'll need to upgrade to new DJL releases before long, I've also added support for a system property to specify a different DJL when building, e.g.

```
gradlew run -Ddjl.version=0.24.0\!\!
```
The `\!\!` is optional, but helps force through the choice in case another dependency might request a different version.

We can't commit to supporting this, but it means that if we end up having to 'break' Intel Mac support in the next release then we can suggest a temporary workaround to create a custom build for someone who needs it... and who really wants PyTorch, at the expense of TensorFlow.