### PR TITLE
Don't use parallel stream to find neighbors

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -33,7 +33,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ForkJoinPool;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
@@ -33,6 +33,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -836,10 +837,12 @@ public class DelaunayTools {
 		private synchronized NeighborMap calculateAllNeighbors() {
 			
 			logger.debug("Calculating all neighbors for {} objects", size());
-			
+
+			// Sort the edges; note that we shouldn't use a parallel stream here, because this can cause
+			// get stuck if the common fork join pool is already in use & awaiting the results of this calculation
 			@SuppressWarnings("unchecked")
 			var edges = (List<QuadEdge>)subdivision.getEdges()
-					.parallelStream()
+					.stream()
 					.sorted(Comparator.comparingDouble(QuadEdge::getLength))
 					.toList();
 


### PR DESCRIPTION
This was causing QuPath to freeze when a script queries the Subdivision in multiple threads using a parallel stream. Basically, all threads in the common pool seemed to be stuck waiting on this to complete... and if it required the common pool for sorting, it never did.