### PR TITLE
Add tooltips to summary measurements

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassificationMeasurementManager.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassificationMeasurementManager.java
@@ -706,15 +706,10 @@ public class PixelClassificationMeasurementManager {
 	 * @return
 	 */
 	public static double getProbabilityThreshold(WritableRaster raster) {
-		switch (raster.getTransferType()) {
-			case DataBuffer.TYPE_SHORT:
-			case DataBuffer.TYPE_USHORT:
-			case DataBuffer.TYPE_INT:
-			case DataBuffer.TYPE_BYTE: return 127.5;
-			case DataBuffer.TYPE_FLOAT:
-			case DataBuffer.TYPE_DOUBLE:
-			default: return 0.5;
-		}
+        return switch (raster.getTransferType()) {
+            case DataBuffer.TYPE_SHORT, DataBuffer.TYPE_USHORT, DataBuffer.TYPE_INT, DataBuffer.TYPE_BYTE -> 127.5;
+            default -> 0.5;
+        };
 	}
 
 	private synchronized MeasurementList updateMeasurements(Map<Integer, PathClass> classificationLabels, long[] counts, double pixelArea, String pixelAreaUnits) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/AbstractNumericMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/AbstractNumericMeasurementBuilder.java
@@ -1,0 +1,42 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.common.GeneralTools;
+import qupath.lib.objects.PathObject;
+
+abstract class AbstractNumericMeasurementBuilder implements MeasurementBuilder<Number> {
+
+    public double computeValue(final PathObject pathObject) {
+        // TODO: Flip this around!  Create binding from value, not value from binding...
+        try {
+            var val = createMeasurement(pathObject).getValue();
+            if (val == null)
+                return Double.NaN;
+            else
+                return val.doubleValue();
+        } catch (NullPointerException e) {
+            return Double.NaN;
+        }
+    }
+
+    public String getStringValue(final PathObject pathObject, final int decimalPlaces) {
+        double val = computeValue(pathObject);
+        if (Double.isNaN(val))
+            return "NaN";
+        if (decimalPlaces == 0)
+            return Integer.toString((int) (val + 0.5));
+        int dp = decimalPlaces;
+        // Format in some sensible way
+        if (decimalPlaces < 0) {
+            if (val > 1000)
+                dp = 1;
+            else if (val > 10)
+                dp = 2;
+            else if (val > 1)
+                dp = 3;
+            else
+                dp = 4;
+        }
+        return GeneralTools.formatNumber(val, dp);
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/AbstractStringMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/AbstractStringMeasurementBuilder.java
@@ -1,0 +1,21 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import javafx.beans.binding.StringBinding;
+import qupath.lib.objects.PathObject;
+
+abstract class AbstractStringMeasurementBuilder implements MeasurementBuilder<String> {
+
+    protected abstract String getMeasurementValue(final PathObject pathObject);
+
+    @Override
+    public Binding<String> createMeasurement(final PathObject pathObject) {
+        return new StringBinding() {
+            @Override
+            protected String computeValue() {
+                return getMeasurementValue(pathObject);
+            }
+        };
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/AreaMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/AreaMeasurementBuilder.java
@@ -1,0 +1,42 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import javafx.beans.binding.DoubleBinding;
+import qupath.lib.common.GeneralTools;
+import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathObject;
+import qupath.lib.roi.interfaces.ROI;
+
+class AreaMeasurementBuilder extends ROIMeasurementBuilder {
+
+    AreaMeasurementBuilder(final ImageData<?> imageData) {
+        super(imageData);
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Area of the selected object's ROI";
+    }
+
+    @Override
+    public String getName() {
+        return hasPixelSizeMicrons() ? "Area " + GeneralTools.micrometerSymbol() + "^2" : "Area px^2";
+    }
+
+    @Override
+    public Binding<Number> createMeasurement(final PathObject pathObject) {
+        return new DoubleBinding() {
+            @Override
+            protected double computeValue() {
+                ROI roi = pathObject.getROI();
+                if (roi == null || !roi.isArea())
+                    return Double.NaN;
+                if (hasPixelSizeMicrons())
+                    return roi.getScaledArea(pixelWidthMicrons(), pixelHeightMicrons());
+                return roi.getArea();
+            }
+
+        };
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/DerivedMeasurementManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/DerivedMeasurementManager.java
@@ -1,0 +1,659 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.DoubleBinding;
+import javafx.beans.binding.IntegerBinding;
+import javafx.beans.value.ObservableDoubleValue;
+import qupath.lib.gui.prefs.PathPrefs;
+import qupath.lib.images.ImageData;
+import qupath.lib.images.servers.PixelCalibration;
+import qupath.lib.objects.PathDetectionObject;
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.PathObjectTools;
+import qupath.lib.objects.TMACoreObject;
+import qupath.lib.objects.classes.PathClass;
+import qupath.lib.objects.classes.PathClassTools;
+import qupath.lib.regions.ImagePlane;
+import qupath.lib.roi.ROIs;
+import qupath.lib.roi.interfaces.ROI;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class to handle dynamic measurements that are based on counts of classified objects.
+ * This includes calculations of positive percentage and H-score.
+ */
+class DerivedMeasurementManager {
+
+    private final ImageData<?> imageData;
+
+    private boolean valid = false;
+
+    private final List<MeasurementBuilder<?>> builders = new ArrayList<>();
+
+    // Map to store cached counts, will be reset when the hierarchy changes (in any way)
+    private final Map<PathObject, DetectionPathClassCounts> map = new WeakHashMap<>();
+
+    private final boolean containsAnnotations;
+
+    DerivedMeasurementManager(final ImageData<?> imageData, final boolean containsAnnotations) {
+        this.imageData = imageData;
+        this.containsAnnotations = containsAnnotations;
+        updateAvailableMeasurements();
+    }
+
+    void clearMap() {
+        map.clear();
+    }
+
+    void updateAvailableMeasurements() {
+        map.clear();
+        builders.clear();
+        if (imageData == null || imageData.getHierarchy() == null)
+            return;
+
+        Set<PathClass> pathClasses = PathObjectTools.getRepresentedPathClasses(imageData.getHierarchy(), PathDetectionObject.class);
+
+        pathClasses.remove(null);
+        pathClasses.remove(PathClass.NULL_CLASS);
+
+        Set<PathClass> parentIntensityClasses = new LinkedHashSet<>();
+        Set<PathClass> parentPositiveNegativeClasses = new LinkedHashSet<>();
+        for (PathClass pathClass : pathClasses) {
+            if (PathClassTools.isGradedIntensityClass(pathClass)) {
+                parentIntensityClasses.add(pathClass.getParentClass());
+                parentPositiveNegativeClasses.add(pathClass.getParentClass());
+            } else if (PathClassTools.isPositiveClass(pathClass) || PathClassTools.isNegativeClass(pathClass))
+                parentPositiveNegativeClasses.add(pathClass.getParentClass());
+        }
+
+        // Store intensity parent classes, if required
+        if (!parentPositiveNegativeClasses.isEmpty()) {
+            List<PathClass> pathClassList = new ArrayList<>(parentPositiveNegativeClasses);
+            pathClassList.remove(null);
+            pathClassList.remove(PathClass.NULL_CLASS);
+            Collections.sort(pathClassList);
+            for (PathClass pathClass : pathClassList) {
+                builders.add(new ClassCountMeasurementBuilder(pathClass, true));
+            }
+        }
+
+        // We can compute counts for any PathClass that is represented
+        List<PathClass> pathClassList = new ArrayList<>(pathClasses);
+        Collections.sort(pathClassList);
+        for (PathClass pathClass : pathClassList) {
+            builders.add(new ClassCountMeasurementBuilder(pathClass, false));
+        }
+
+        // We can compute positive percentages if we have anything in ParentPositiveNegativeClasses
+        for (PathClass pathClass : parentPositiveNegativeClasses) {
+            builders.add(new PositivePercentageMeasurementBuilder(pathClass));
+        }
+        if (parentPositiveNegativeClasses.size() > 1)
+            builders.add(new PositivePercentageMeasurementBuilder(parentPositiveNegativeClasses.toArray(new PathClass[0])));
+
+        // We can compute H-scores and Allred scores if we have anything in ParentIntensityClasses
+        for (PathClass pathClass : parentIntensityClasses) {
+            builders.add(new HScoreMeasurementBuilder(pathClass));
+            builders.add(new AllredProportionMeasurementBuilder(pathClass));
+            builders.add(new AllredIntensityMeasurementBuilder(pathClass));
+            builders.add(new AllredMeasurementBuilder(pathClass));
+        }
+        if (parentIntensityClasses.size() > 1) {
+            PathClass[] parentIntensityClassesArray = parentIntensityClasses.toArray(PathClass[]::new);
+            builders.add(new HScoreMeasurementBuilder(parentIntensityClassesArray));
+            builders.add(new AllredProportionMeasurementBuilder(parentIntensityClassesArray));
+            builders.add(new AllredIntensityMeasurementBuilder(parentIntensityClassesArray));
+            builders.add(new AllredMeasurementBuilder(parentIntensityClassesArray));
+        }
+
+        // Add density measurements
+        // These are only added if we have a (non-derived) positive class
+        // Additionally, these are only non-NaN if we have an annotation, or a TMA core containing a single annotation
+        if (containsAnnotations) {
+            for (PathClass pathClass : pathClassList) {
+                if (PathClassTools.isPositiveClass(pathClass) && pathClass.getBaseClass() == pathClass) {
+                    builders.add(new ClassDensityMeasurementBuilder(pathClass));
+                }
+            }
+        }
+
+        valid = true;
+    }
+
+    List<MeasurementBuilder<?>> getMeasurementBuilders() {
+        if (!valid)
+            updateAvailableMeasurements();
+        return builders;
+    }
+
+
+    class ClassCountMeasurement extends IntegerBinding {
+
+        private PathObject pathObject;
+        private PathClass pathClass;
+        private boolean baseClassification;
+
+        public ClassCountMeasurement(final PathObject pathObject, final PathClass pathClass, final boolean baseClassification) {
+            this.pathObject = pathObject;
+            this.pathClass = pathClass;
+            this.baseClassification = baseClassification;
+        }
+
+        @Override
+        protected int computeValue() {
+            DetectionPathClassCounts counts = map.get(pathObject);
+            if (counts == null) {
+                counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
+                map.put(pathObject, counts);
+            }
+            if (baseClassification)
+                return counts.getCountForAncestor(pathClass);
+            else
+                return counts.getDirectCount(pathClass);
+        }
+
+    }
+
+
+    class ClassDensityMeasurementPerMM extends DoubleBinding {
+
+        private PathObject pathObject;
+        private PathClass pathClass;
+
+        public ClassDensityMeasurementPerMM(final PathObject pathObject, final PathClass pathClass) {
+            this.pathObject = pathObject;
+            this.pathClass = pathClass;
+        }
+
+        @Override
+        protected double computeValue() {
+            // If we have a TMA core, look for a single annotation inside
+            // If we don't have that, we can't return counts since it's ambiguous where the
+            // area should be coming from
+            PathObject pathObjectTemp = pathObject;
+            if (pathObject instanceof TMACoreObject) {
+                var children = pathObject.getChildObjectsAsArray();
+                if (children.length != 1)
+                    return Double.NaN;
+                pathObjectTemp = children[0];
+            }
+            // We need an annotation to get a meaningful area
+            if (pathObjectTemp == null || !(pathObjectTemp.isAnnotation() || pathObjectTemp.isRootObject()))
+                return Double.NaN;
+
+            DetectionPathClassCounts counts = map.get(pathObjectTemp);
+            if (counts == null) {
+                counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObjectTemp);
+                map.put(pathObject, counts);
+            }
+            int n = counts.getCountForAncestor(pathClass);
+            ROI roi = pathObjectTemp.getROI();
+            // For the root, we can measure density only for 2D images of a single time-point
+            var serverMetadata = imageData.getServerMetadata();
+            if (pathObjectTemp.isRootObject() && serverMetadata.getSizeZ() == 1 && serverMetadata.getSizeT() == 1)
+                roi = ROIs.createRectangleROI(0, 0, serverMetadata.getWidth(), serverMetadata.getHeight(), ImagePlane.getDefaultPlane());
+
+            if (roi != null && roi.isArea()) {
+                double pixelWidth = 1;
+                double pixelHeight = 1;
+                PixelCalibration cal = serverMetadata == null ? null : serverMetadata.getPixelCalibration();
+                if (cal != null && cal.hasPixelSizeMicrons()) {
+                    pixelWidth = cal.getPixelWidthMicrons() / 1000;
+                    pixelHeight = cal.getPixelHeightMicrons() / 1000;
+                }
+                return n / roi.getScaledArea(pixelWidth, pixelHeight);
+            }
+            return Double.NaN;
+        }
+
+    }
+
+
+    class HScore extends DoubleBinding {
+
+        private PathObject pathObject;
+        private PathClass[] pathClasses;
+
+        public HScore(final PathObject pathObject, final PathClass... pathClasses) {
+            this.pathObject = pathObject;
+            this.pathClasses = pathClasses;
+        }
+
+        @Override
+        protected double computeValue() {
+            DetectionPathClassCounts counts = map.get(pathObject);
+            if (counts == null) {
+                counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
+                map.put(pathObject, counts);
+            }
+            return counts.getHScore(pathClasses);
+        }
+
+    }
+
+
+    class AllredIntensityScore extends DoubleBinding {
+
+        private PathObject pathObject;
+        private PathClass[] pathClasses;
+        private ObservableDoubleValue minPositivePercentage;
+
+        public AllredIntensityScore(final PathObject pathObject, final ObservableDoubleValue minPositivePercentage, final PathClass... pathClasses) {
+            this.pathObject = pathObject;
+            this.pathClasses = pathClasses;
+            this.minPositivePercentage = minPositivePercentage;
+        }
+
+        @Override
+        protected double computeValue() {
+            DetectionPathClassCounts counts = map.get(pathObject);
+            if (counts == null) {
+                counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
+                map.put(pathObject, counts);
+            }
+            return counts.getAllredIntensity(minPositivePercentage.doubleValue() / 100, pathClasses);
+        }
+
+    }
+
+
+    class AllredProportionScore extends DoubleBinding {
+
+        private PathObject pathObject;
+        private PathClass[] pathClasses;
+        private ObservableDoubleValue minPositivePercentage;
+
+        public AllredProportionScore(final PathObject pathObject, final ObservableDoubleValue minPositivePercentage, final PathClass... pathClasses) {
+            this.pathObject = pathObject;
+            this.pathClasses = pathClasses;
+            this.minPositivePercentage = minPositivePercentage;
+        }
+
+        @Override
+        protected double computeValue() {
+            DetectionPathClassCounts counts = map.get(pathObject);
+            if (counts == null) {
+                counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
+                map.put(pathObject, counts);
+            }
+            return counts.getAllredProportion(minPositivePercentage.doubleValue() / 100, pathClasses);
+        }
+
+    }
+
+    class AllredScore extends DoubleBinding {
+
+        private PathObject pathObject;
+        private PathClass[] pathClasses;
+        private ObservableDoubleValue minPositivePercentage;
+
+        public AllredScore(final PathObject pathObject, final ObservableDoubleValue minPositivePercentage, final PathClass... pathClasses) {
+            this.pathObject = pathObject;
+            this.pathClasses = pathClasses;
+            this.minPositivePercentage = minPositivePercentage;
+        }
+
+        @Override
+        protected double computeValue() {
+            DetectionPathClassCounts counts = map.get(pathObject);
+            if (counts == null) {
+                counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
+                map.put(pathObject, counts);
+            }
+            return counts.getAllredScore(minPositivePercentage.doubleValue() / 100, pathClasses);
+        }
+
+    }
+
+
+    class PositivePercentage extends DoubleBinding {
+
+        private PathObject pathObject;
+        private PathClass[] pathClasses;
+
+        public PositivePercentage(final PathObject pathObject, final PathClass... pathClasses) {
+            this.pathObject = pathObject;
+            this.pathClasses = pathClasses;
+        }
+
+        @Override
+        protected double computeValue() {
+            DetectionPathClassCounts counts = map.get(pathObject);
+            if (counts == null) {
+                counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
+                map.put(pathObject, counts);
+            }
+            return counts.getPositivePercentage(pathClasses);
+        }
+
+    }
+
+
+    class ClassCountMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+        private PathClass pathClass;
+        private boolean baseClassification;
+
+        /**
+         * Count objects with specific classifications.
+         *
+         * @param pathClass
+         * @param baseClassification if {@code true}, also count objects with classifications derived from the specified classification,
+         *                           if {@code false} count objects with <i>only</i> the exact classification given.
+         */
+        ClassCountMeasurementBuilder(final PathClass pathClass, final boolean baseClassification) {
+            this.pathClass = pathClass;
+            this.baseClassification = baseClassification;
+        }
+
+        @Override
+        public String getHelpText() {
+            if (baseClassification) {
+                if (pathClass == null || pathClass == PathClass.NULL_CLASS)
+                    return "Number of detection objects with no base classification";
+                else
+                    return "Number of detection objects with the base classification '" + pathClass + "' (including all sub-classifications)";
+            } else {
+                if (pathClass == null || pathClass == PathClass.NULL_CLASS)
+                    return "Number of detection objects with no classification";
+                else
+                    return "Number of detection objects with the exact classification '" + pathClass + "'";
+            }
+        }
+
+        @Override
+        public String getName() {
+            if (baseClassification)
+                return "Num " + pathClass.toString() + " (base)";
+            else
+                return "Num " + pathClass.toString();
+        }
+
+        @Override
+        public Binding<Number> createMeasurement(final PathObject pathObject) {
+            return new ClassCountMeasurement(pathObject, pathClass, baseClassification);
+        }
+
+        @Override
+        public String toString() {
+            return getName();
+        }
+
+    }
+
+
+    class ClassDensityMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+        private PathClass pathClass;
+
+        ClassDensityMeasurementBuilder(final PathClass pathClass) {
+            this.pathClass = pathClass;
+        }
+
+        @Override
+        public String getHelpText() {
+            return "Density of detections with classification '" + pathClass + "' inside the selected objects";
+        }
+
+        @Override
+        public String getName() {
+            if (imageData != null && imageData.getServerMetadata().getPixelCalibration().hasPixelSizeMicrons())
+                return String.format("Num %s per mm^2", pathClass.toString());
+//					return String.format("Num %s per %s^2", pathClass.toString(), GeneralTools.micrometerSymbol());
+            else
+                return String.format("Num %s per px^2", pathClass.toString());
+        }
+
+        @Override
+        public Binding<Number> createMeasurement(final PathObject pathObject) {
+            // Only return density measurements for annotations
+            if (pathObject.isAnnotation() || (pathObject.isTMACore() && pathObject.nChildObjects() == 1))
+                return new ClassDensityMeasurementPerMM(pathObject, pathClass);
+            return Bindings.createDoubleBinding(() -> Double.NaN);
+        }
+
+        @Override
+        public String toString() {
+            return getName();
+        }
+
+    }
+
+
+    class PositivePercentageMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+        private PathClass[] parentClasses;
+
+        PositivePercentageMeasurementBuilder(final PathClass... parentClasses) {
+            this.parentClasses = parentClasses;
+        }
+
+        @Override
+        public String getHelpText() {
+            var pcString = getParentClassificationsString(parentClasses);
+            if (pcString.isEmpty()) {
+                return "Number of detection classified as 'Positive' / ('Positive' + 'Negative') * 100%";
+            } else {
+                return "Number of detection classified as '" + pcString + ": Positive' / ('"
+                        + pcString + ": Positive' + '" + pcString + ": Negative') * 100%";
+            }
+        }
+
+        @Override
+        public String getName() {
+            return getNameForClasses("Positive %", parentClasses);
+        }
+
+        @Override
+        public Binding<Number> createMeasurement(final PathObject pathObject) {
+            return new PositivePercentage(pathObject, parentClasses);
+        }
+
+    }
+
+    /**
+     * Get a string representation that can be used to refer to zero or more parent (base) classifications.
+     * <ul>
+     * <li>If no classifications are provided, or only the null classification, then an empty string is returned.</li>
+     * <li>If one non-null classification is provided, its {@code toString()} representation is returned.</li>
+     * <li>Otherwise, a string representing the multiple classifications is returned, e.g. {@code "(Tumor|Stroma|Other)"}.</li>*
+     * </ul>
+     *
+     * @param pathClasses
+     * @return
+     */
+    private static String getParentClassificationsString(PathClass... pathClasses) {
+        if (pathClasses.length == 0)
+            return "";
+        if (pathClasses.length == 1 && (pathClasses[0] == null || pathClasses[0] == PathClass.NULL_CLASS))
+            return "";
+        if (pathClasses.length == 1) {
+            return pathClasses[0].toString();
+        } else {
+            return "(" + Arrays.stream(pathClasses)
+                    .map(p -> p == null ? "<Unclassified>" : p.toString())
+                    .collect(Collectors.joining("|")) + ")";
+        }
+    }
+
+    /**
+     * Get a suitable name for a measurement that reflects the parent PathClasses used in its calculation, e.g.
+     * to get the positive % measurement name for both tumor & stroma classes, the input would be
+     * getNameForClasses("Positive %", tumorClass, stromaClass);
+     * and the output would be "Stroma + Tumor: Positive %"
+     *
+     * @param measurementName
+     * @param parentClasses
+     * @return
+     */
+    static String getNameForClasses(final String measurementName, final PathClass... parentClasses) {
+        if (parentClasses == null || parentClasses.length == 0)
+            return measurementName;
+        if (parentClasses.length == 1) {
+            PathClass parent = parentClasses[0];
+            if (parent == null)
+                return measurementName;
+            else
+                return parent.getBaseClass().toString() + ": " + measurementName;
+        }
+        String[] names = new String[parentClasses.length];
+        for (int i = 0; i < names.length; i++) {
+            PathClass parent = parentClasses[i];
+            names[i] = parent == null ? "" : parent.getName();
+        }
+        Arrays.sort(names);
+        return String.join(" + ", names) + ": " + measurementName;
+    }
+
+
+    class HScoreMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+        private PathClass[] pathClasses;
+
+        HScoreMeasurementBuilder(final PathClass... pathClasses) {
+            this.pathClasses = pathClasses;
+        }
+
+        @Override
+        public String getHelpText() {
+            var pcString = getParentClassificationsString(pathClasses);
+            if (pcString.isEmpty()) {
+                return "H-score calculated from Negative, 1+, 2+ and 3+ classified detections (range 0-300)";
+            } else {
+                return "H-score calculated from " + pcString + ": Negative, 1+, 2+ and 3+ classified detections (range 0-300)";
+            }
+        }
+
+        @Override
+        public String getName() {
+            return getNameForClasses("H-score", pathClasses);
+        }
+
+        @Override
+        public Binding<Number> createMeasurement(final PathObject pathObject) {
+            return new HScore(pathObject, pathClasses);
+        }
+
+    }
+
+
+    class AllredIntensityMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+        private PathClass[] pathClasses;
+
+        AllredIntensityMeasurementBuilder(final PathClass... pathClasses) {
+            this.pathClasses = pathClasses;
+        }
+
+        @Override
+        public String getHelpText() {
+            var pcString = getParentClassificationsString(pathClasses);
+            double minPercentage = PathPrefs.allredMinPercentagePositiveProperty().get();
+            String minRequires = minPercentage == 0 ? "" : "\nSet to 0 if less than " + minPercentage + "% cells positive";
+            if (pcString.isEmpty()) {
+                return "Allred intensity score calculated from Negative, 1+, 2+ and 3+ classified detections (range 0-3)" + minRequires;
+            } else {
+                return "Allred intensity score calculated from " + pcString + ": Negative, 1+, 2+ and 3+ classified detections (range 0-3)" + minRequires;
+            }
+        }
+
+        @Override
+        public String getName() {
+            double minPercentage = PathPrefs.allredMinPercentagePositiveProperty().get();
+            String name;
+            if (minPercentage > 0)
+                name = String.format("Allred intensity (min %.1f%%)", minPercentage);
+            else
+                name = "Allred intensity";
+            return getNameForClasses(name, pathClasses);
+        }
+
+        @Override
+        public Binding<Number> createMeasurement(final PathObject pathObject) {
+            return new AllredIntensityScore(pathObject, PathPrefs.allredMinPercentagePositiveProperty(), pathClasses);
+        }
+
+    }
+
+    class AllredProportionMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+        private PathClass[] pathClasses;
+
+        AllredProportionMeasurementBuilder(final PathClass... pathClasses) {
+            this.pathClasses = pathClasses;
+        }
+
+        @Override
+        public String getHelpText() {
+            var pcString = getParentClassificationsString(pathClasses);
+            double minPercentage = PathPrefs.allredMinPercentagePositiveProperty().get();
+            String minRequires = minPercentage == 0 ? "" : "\nSet to 0 if less than " + minPercentage + "% cells positive";
+            if (pcString.isEmpty()) {
+                return "Allred proportion score calculated from Negative, 1+, 2+ and 3+ classified detections (range 0-5)" + minRequires;
+            } else {
+                return "Allred proportion score calculated from " + pcString + ": Negative, 1+, 2+ and 3+ classified detections (range 0-5)" + minRequires;
+            }
+        }
+
+
+        @Override
+        public String getName() {
+            double minPercentage = PathPrefs.allredMinPercentagePositiveProperty().get();
+            String name;
+            if (minPercentage > 0)
+                name = String.format("Allred proportion (min %.1f%%)", minPercentage);
+            else
+                name = "Allred proportion";
+            return getNameForClasses(name, pathClasses);
+        }
+
+        @Override
+        public Binding<Number> createMeasurement(final PathObject pathObject) {
+            return new AllredProportionScore(pathObject, PathPrefs.allredMinPercentagePositiveProperty(), pathClasses);
+        }
+
+    }
+
+    class AllredMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+        private PathClass[] pathClasses;
+
+        AllredMeasurementBuilder(final PathClass... pathClasses) {
+            this.pathClasses = pathClasses;
+        }
+
+        @Override
+        public String getHelpText() {
+            return "Sum of Allred proportion and intensity scores (range 0-8)";
+        }
+
+        @Override
+        public String getName() {
+            double minPercentage = PathPrefs.allredMinPercentagePositiveProperty().get();
+            String name;
+            if (minPercentage > 0)
+                name = String.format("Allred score (min %.1f%%)", minPercentage);
+            else
+                name = "Allred score";
+            return getNameForClasses(name, pathClasses);
+        }
+
+        @Override
+        public Binding<Number> createMeasurement(final PathObject pathObject) {
+            return new AllredScore(pathObject, PathPrefs.allredMinPercentagePositiveProperty(), pathClasses);
+        }
+
+    }
+
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/DetectionPathClassCounts.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/DetectionPathClassCounts.java
@@ -1,0 +1,170 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.classes.PathClass;
+import qupath.lib.objects.classes.PathClassTools;
+import qupath.lib.objects.hierarchy.PathObjectHierarchy;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * Cache to store the number of descendant detection objects with a particular PathClass.
+ * <p>
+ * (The parent is included in any count if it's a detection object... but it's expected not to be.
+ * Rather, this is intended for counting the descendants of annotations or TMA cores.)
+ */
+class DetectionPathClassCounts {
+
+    private Map<PathClass, Integer> counts = new HashMap<>();
+
+    /**
+     * Create a structure to count detections inside a specified parent.
+     *
+     * @param hierarchy
+     * @param parentObject the parent object.
+     */
+    DetectionPathClassCounts(final PathObjectHierarchy hierarchy, final PathObject parentObject) {
+//			for (PathObject child : PathObjectTools.getFlattenedObjectList(parentObject, null, true)) {
+        Collection<PathObject> pathObjects;
+        if (parentObject.isRootObject())
+            pathObjects = hierarchy.getDetectionObjects();
+        else
+            pathObjects = hierarchy.getAllDetectionsForROI(parentObject.getROI());
+
+        for (PathObject child : pathObjects) {
+            if (child == parentObject || !child.isDetection())
+                continue;
+            PathClass pathClass = child.getPathClass();
+//				if (pathClass == null)
+//					continue;
+            Integer count = counts.get(pathClass);
+            if (count == null)
+                counts.put(pathClass, Integer.valueOf(1));
+            else
+                counts.put(pathClass, Integer.valueOf(count.intValue() + 1));
+        }
+    }
+
+    public int getDirectCount(final PathClass pathClass) {
+        return counts.getOrDefault(pathClass, Integer.valueOf(0));
+    }
+
+    public int getCountForAncestor(final Predicate<PathClass> predicate, final PathClass ancestor) {
+        int count = 0;
+        for (Map.Entry<PathClass, Integer> entry : counts.entrySet()) {
+            if (ancestor == null) {
+                if (predicate.test(entry.getKey()) && entry.getKey().getParentClass() == null)
+                    count += entry.getValue();
+            } else if (ancestor.isAncestorOf(entry.getKey()) && predicate.test(entry.getKey()))
+                count += entry.getValue();
+        }
+        return count;
+    }
+
+    public int getCountForAncestor(final Predicate<PathClass> predicate, final PathClass... ancestors) {
+        int count = 0;
+        for (PathClass ancestor : ancestors)
+            count += getCountForAncestor(predicate, ancestor);
+        return count;
+    }
+
+    public int getCountForAncestor(final PathClass... ancestors) {
+        return getCountForAncestor(pathClass -> true, ancestors);
+    }
+
+    public int getOnePlus(final PathClass... ancestors) {
+        return getCountForAncestor(pathClass -> PathClassTools.isOnePlus(pathClass), ancestors);
+    }
+
+    public int getTwoPlus(final PathClass... ancestors) {
+        return getCountForAncestor(pathClass -> PathClassTools.isTwoPlus(pathClass), ancestors);
+    }
+
+    public int getThreePlus(final PathClass... ancestors) {
+        return getCountForAncestor(pathClass -> PathClassTools.isThreePlus(pathClass), ancestors);
+    }
+
+    public int getNegative(final PathClass... ancestors) {
+        return getCountForAncestor(pathClass -> PathClassTools.isNegativeClass(pathClass), ancestors);
+    }
+
+    public int getPositive(final PathClass... ancestors) {
+        return getCountForAncestor(pathClass -> PathClassTools.isPositiveOrGradedIntensityClass(pathClass), ancestors);
+    }
+
+    public double getHScore(final PathClass... ancestors) {
+        double plus1 = 0;
+        double plus2 = 0;
+        double plus3 = 0;
+        double negative = 0;
+        for (PathClass ancestor : ancestors) {
+            plus1 += getOnePlus(ancestor);
+            plus2 += getTwoPlus(ancestor);
+            plus3 += getThreePlus(ancestor);
+            negative += getNegative(ancestor);
+        }
+        return (plus1 * 1 + plus2 * 2 + plus3 * 3) / (plus1 + plus2 + plus3 + negative) * 100;
+    }
+
+    public int getAllredIntensity(final double minProportion, final PathClass... ancestors) {
+        int proportionScore = getAllredProportion(minProportion, ancestors);
+        int intensityScore = 0;
+        if (proportionScore > 0) {
+            int nPositive = getPositive(ancestors);
+            double meanIntensity = (getOnePlus(ancestors) + getTwoPlus(ancestors) * 2. + getThreePlus(ancestors) * 3.) / nPositive;
+            if (meanIntensity > 7. / 3.)
+                intensityScore = 3;
+            else if (meanIntensity > 5. / 3.)
+                intensityScore = 2;
+            else
+                intensityScore = 1;
+        }
+        return intensityScore;
+    }
+
+    public int getAllredProportion(final double minProportion, final PathClass... ancestors) {
+        // Compute Allred score
+        double proportion = getPositivePercentage(ancestors) / 100.0;
+        if (proportion < minProportion)
+            return 0;
+        int proportionScore;
+        if (proportion >= 2. / 3.)
+            proportionScore = 5;
+        else if (proportion >= 1. / 3.)
+            proportionScore = 4;
+        else if (proportion >= 0.1)
+            proportionScore = 3;
+        else if (proportion >= 0.01)
+            proportionScore = 2;
+        else if (proportion > 0) // 'Strict' Allred scores accepts anything above 0 as positive... but minProportion may already have kicked in
+            proportionScore = 1;
+        else
+            proportionScore = 0;
+        return proportionScore;
+    }
+
+    public int getAllredScore(final double minProportion, final PathClass... ancestors) {
+        return getAllredIntensity(minProportion, ancestors) + getAllredProportion(minProportion, ancestors);
+    }
+
+    /**
+     * Get the percentage of positive detections, considering only descendants of one or more
+     * specified classes.
+     *
+     * @param ancestors
+     * @return
+     */
+    public double getPositivePercentage(final PathClass... ancestors) {
+        double positive = 0;
+        double negative = 0;
+        for (PathClass ancestor : ancestors) {
+            positive += getPositive(ancestor);
+            negative += getNegative(ancestor);
+        }
+        return positive / (positive + negative) * 100;
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ImageNameMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ImageNameMeasurementBuilder.java
@@ -1,0 +1,39 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.PathObjectTools;
+
+/**
+ * Get the displayed name of the parent of this object.
+ */
+class ImageNameMeasurementBuilder extends AbstractStringMeasurementBuilder {
+
+    private ImageData<?> imageData;
+
+    ImageNameMeasurementBuilder(final ImageData<?> imageData) {
+        this.imageData = imageData;
+    }
+
+    @Override
+    public String getName() {
+        return "Image";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Name for the current image";
+    }
+
+    @Override
+    public String getMeasurementValue(PathObject pathObject) {
+        if (imageData == null)
+            return null;
+        var hierarchy = imageData.getHierarchy();
+        if (PathObjectTools.hierarchyContainsObject(hierarchy, pathObject)) {
+            return imageData.getServerMetadata().getName();
+        }
+        return null;
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/LineLengthMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/LineLengthMeasurementBuilder.java
@@ -1,0 +1,42 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import javafx.beans.binding.DoubleBinding;
+import qupath.lib.common.GeneralTools;
+import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathObject;
+import qupath.lib.roi.interfaces.ROI;
+
+class LineLengthMeasurementBuilder extends ROIMeasurementBuilder {
+
+    LineLengthMeasurementBuilder(final ImageData<?> imageData) {
+        super(imageData);
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Length of the selected object's line ROI";
+    }
+
+    @Override
+    public String getName() {
+        return hasPixelSizeMicrons() ? "Length " + GeneralTools.micrometerSymbol() : "Length px";
+    }
+
+    @Override
+    public Binding<Number> createMeasurement(final PathObject pathObject) {
+        return new DoubleBinding() {
+            @Override
+            protected double computeValue() {
+                ROI roi = pathObject.getROI();
+                if (roi == null || !roi.isLine())
+                    return Double.NaN;
+                if (hasPixelSizeMicrons())
+                    return roi.getScaledLength(pixelWidthMicrons(), pixelHeightMicrons());
+                return roi.getLength();
+            }
+
+        };
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/MeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/MeasurementBuilder.java
@@ -1,0 +1,32 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import qupath.lib.objects.PathObject;
+
+/**
+ * Interface that can generate a 'lazy' measurement for a {@link PathObject}.
+ * @param <T>
+ */
+interface MeasurementBuilder<T> {
+
+    /**
+     * The name of the measurement.
+     * @return the name of the measurement
+     */
+    String getName();
+
+    /**
+     * Create a binding that represents a lazily-computed measurement for the provided objects.
+     * @param pathObject the object that should be measured
+     * @return a binding that can return the measurement value
+     */
+    Binding<T> createMeasurement(final PathObject pathObject);
+
+    /**
+     * Optional help text that explained the measurement.
+     * This may be displayed in a tooltip.
+     * @return the help text, or null if no help text is available
+     */
+    String getHelpText();
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/MissingTMACoreMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/MissingTMACoreMeasurementBuilder.java
@@ -1,0 +1,25 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.TMACoreObject;
+
+class MissingTMACoreMeasurementBuilder extends AbstractStringMeasurementBuilder {
+
+    @Override
+    public String getName() {
+        return "Missing core";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "True if the selected object is a TMA core marked as 'missing', False if it is not missing";
+    }
+
+    @Override
+    protected String getMeasurementValue(PathObject pathObject) {
+        if (pathObject instanceof TMACoreObject)
+            return ((TMACoreObject) pathObject).isMissing() ? "True" : "False";
+        return null;
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/NumPointsMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/NumPointsMeasurementBuilder.java
@@ -1,0 +1,34 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import javafx.beans.binding.DoubleBinding;
+import qupath.lib.objects.PathObject;
+import qupath.lib.roi.interfaces.ROI;
+
+class NumPointsMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+    @Override
+    public String getName() {
+        return "Num points";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "The number of points in a (multi)point ROI";
+    }
+
+    @Override
+    public Binding<Number> createMeasurement(final PathObject pathObject) {
+        return new DoubleBinding() {
+            @Override
+            protected double computeValue() {
+                ROI roi = pathObject.getROI();
+                if (roi == null || !roi.isPoint())
+                    return Double.NaN;
+                return roi.getNumPoints();
+            }
+
+        };
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObjectIdMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObjectIdMeasurementBuilder.java
@@ -1,0 +1,31 @@
+package qupath.lib.gui.measure;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.lib.objects.PathObject;
+
+class ObjectIdMeasurementBuilder extends AbstractStringMeasurementBuilder {
+
+    private static final Logger logger = LoggerFactory.getLogger(ObjectIdMeasurementBuilder.class);
+
+    @Override
+    public String getName() {
+        return ObservableMeasurementTableData.NAME_OBJECT_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Universal Unique Identifier for the selected object";
+    }
+
+    @Override
+    protected String getMeasurementValue(PathObject pathObject) {
+        var id = pathObject.getID(); // Shouldn't be null!
+        if (id == null) {
+            logger.warn("ID null for {}", pathObject);
+            return null;
+        }
+        return id.toString();
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObjectNameMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObjectNameMeasurementBuilder.java
@@ -1,0 +1,26 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.objects.PathObject;
+
+class ObjectNameMeasurementBuilder extends AbstractStringMeasurementBuilder {
+
+    @Override
+    public String getName() {
+        return "Name";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Name of the object (may be empty)";
+    }
+
+    @Override
+    protected String getMeasurementValue(PathObject pathObject) {
+        if (pathObject == null)
+            return null;
+        // v0.5.0 change - previously used pathObject.getDisplayedName(),
+        // but this frequently led to confusion for people writing scripts
+        return pathObject.getName();
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObjectTypeCountMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObjectTypeCountMeasurementBuilder.java
@@ -1,0 +1,69 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import javafx.beans.binding.IntegerBinding;
+import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.PathObjectTools;
+import qupath.lib.objects.hierarchy.PathObjectHierarchy;
+
+import java.util.Collection;
+
+class ObjectTypeCountMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+    private final ImageData<?> imageData;
+    private final Class<? extends PathObject> cls;
+
+    public ObjectTypeCountMeasurementBuilder(ImageData<?> imageData, Class<? extends PathObject> cls) {
+        this.imageData = imageData;
+        this.cls = cls;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Number of objects with type '" + PathObjectTools.getSuitableName(cls, false) + "'";
+    }
+
+    @Override
+    public String getName() {
+        return "Num " + PathObjectTools.getSuitableName(cls, true);
+    }
+
+    @Override
+    public Binding<Number> createMeasurement(final PathObject pathObject) {
+        return new ObjectTypeCountMeasurement(imageData.getHierarchy(), pathObject, cls);
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+
+    static class ObjectTypeCountMeasurement extends IntegerBinding {
+
+        private final PathObjectHierarchy hierarchy;
+        private final Class<? extends PathObject> cls;
+        private final PathObject pathObject;
+
+        ObjectTypeCountMeasurement(final PathObjectHierarchy hierarchy, final PathObject pathObject,
+                                   final Class<? extends PathObject> cls) {
+            this.hierarchy = hierarchy;
+            this.pathObject = pathObject;
+            this.cls = cls;
+        }
+
+        @Override
+        protected int computeValue() {
+            Collection<PathObject> pathObjects;
+            if (pathObject.isRootObject()) {
+                pathObjects = hierarchy.getObjects(null, cls);
+            } else {
+                pathObjects = hierarchy.getObjectsForROI(cls, pathObject.getROI());
+            }
+            pathObjects.remove(pathObject);
+            return pathObjects.size();
+        }
+
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObjectTypeMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObjectTypeMeasurementBuilder.java
@@ -1,0 +1,28 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.PathObjectTools;
+
+class ObjectTypeMeasurementBuilder extends AbstractStringMeasurementBuilder {
+
+    @Override
+    public String getName() {
+        return "Object type";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "The object type (e.g. annotation, detection, cell, tile, TMA core)";
+    }
+
+    @Override
+    protected String getMeasurementValue(PathObject pathObject) {
+        if (pathObject == null)
+            return null;
+        else if (pathObject.isRootObject())
+            return pathObject.getDisplayedName();
+        else
+            return PathObjectTools.getSuitableName(pathObject.getClass(), false);
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -25,55 +25,36 @@ package qupath.lib.gui.measure;
 
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
-import java.util.WeakHashMap;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javafx.application.Platform;
 import javafx.beans.binding.Binding;
-import javafx.beans.binding.Bindings;
 import javafx.beans.binding.DoubleBinding;
-import javafx.beans.binding.IntegerBinding;
-import javafx.beans.binding.ObjectBinding;
-import javafx.beans.binding.StringBinding;
 import javafx.beans.property.ReadOnlyListWrapper;
-import javafx.beans.value.ObservableDoubleValue;
-import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import qupath.lib.common.GeneralTools;
-import qupath.lib.gui.measure.ObservableMeasurementTableData.ROICentroidMeasurementBuilder.CentroidType;
+import qupath.lib.gui.measure.ROICentroidMeasurementBuilder.CentroidType;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerMetadata;
-import qupath.lib.images.servers.PixelCalibration;
-import qupath.lib.interfaces.MinimalMetadataStore;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathDetectionObject;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.TMACoreObject;
-import qupath.lib.objects.classes.PathClass;
-import qupath.lib.objects.classes.PathClassTools;
-import qupath.lib.objects.hierarchy.PathObjectHierarchy;
-import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.PolygonROI;
-import qupath.lib.roi.ROIs;
 import qupath.lib.roi.interfaces.ROI;
 import qupath.opencv.ml.pixel.PixelClassificationMeasurementManager;
 
@@ -119,10 +100,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		// Cannot force this to run in application thread as this can result in unexpected behavior if called from a different thread
 		if (!Platform.isFxApplicationThread())
 			logger.debug("Image data is being set by thread {}", Thread.currentThread());
-//		if (Platform.isFxApplicationThread())
 		updateMeasurementList();
-//		else
-//			Platform.runLater(() -> updateMeasurementList());
 	}
 	
 	
@@ -168,8 +146,6 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	 */
 	public synchronized void updateMeasurementList() {
 		
-//		PathPrefs.setAllredMinPercentagePositive(0);
-		
 		builderMap.clear();
 		
 		// Add the image name
@@ -179,7 +155,6 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		// Check if we have any annotations / TMA cores
 		boolean containsDetections = false;
 		boolean containsAnnotations = false;
-//		boolean containsParentAnnotations = false;
 		boolean containsTMACores = false;
 		boolean containsRoot = false;
 		boolean containsMultiZ = false;
@@ -189,8 +164,6 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		for (PathObject temp : pathObjectListCopy) {
 			containsROIs = containsROIs || temp.hasROI();
 			if (temp instanceof PathAnnotationObject) {
-//				if (temp.hasChildren())
-//					containsParentAnnotations = true;
 				containsAnnotations = true;
 			} else if (temp instanceof TMACoreObject) {
 				containsTMACores = true;
@@ -216,7 +189,6 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		builderMap.put("Object type", new ObjectTypeMeasurementBuilder());
 
 		// Include the object displayed name
-//		if (containsDetections || containsAnnotations || containsTMACores)
 		builderMap.put("Name", new ObjectNameMeasurementBuilder());
 
 		// Include the class
@@ -241,10 +213,6 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		
 		// Add centroids
 		if (containsAnnotations || containsDetections || containsTMACores) {
-//			ROICentroidMeasurementBuilder builder = new ROICentroidMeasurementBuilder(imageData, CentroidType.X);
-//			builderMap.put("Centroid X", builder);
-//			builder = new ROICentroidMeasurementBuilder(imageData, CentroidType.Y);
-//			builderMap.put("Centroid Y", builder);
 			ROICentroidMeasurementBuilder builder = new ROICentroidMeasurementBuilder(imageData, CentroidType.X);
 			builderMap.put(builder.getName(), builder);
 			builder = new ROICentroidMeasurementBuilder(imageData, CentroidType.Y);
@@ -262,8 +230,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		}
 
 		// If we have metadata, store it
-		Set<String> metadataNames = new LinkedHashSet<>();
-		metadataNames.addAll(builderMap.keySet());
+        Set<String> metadataNames = new LinkedHashSet<>(builderMap.keySet());
 		for (PathObject pathObject : pathObjectListCopy) {
 			// Don't show metadata keys that start with "_"
 			pathObject.getMetadata()
@@ -278,20 +245,14 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 				builderMap.put(name, new StringMetadataMeasurementBuilder(name));
 		}
 		
-		
 		// Get all the 'built-in' feature measurements, stored in the measurement list
 		Collection<String> features = PathObjectTools.getAvailableFeatures(pathObjectListCopy);
 		
 		// Add derived measurements if we don't have only detections
 		if (containsAnnotations || containsTMACores || containsRoot) {
-//		if (containsParentAnnotations || containsTMACores) {
-			// Omit annotations, mostly because it's can be very slow to compute
-//			var builderAnnotations = new ObjectTypeCountMeasurementBuilder(PathAnnotationObject.class);
-//			builderMap.put(builderAnnotations.getName(), builderAnnotations);
-//			features.add(builderAnnotations.getName());
 			
 			if (detectionsAnywhere) {
-				var builder = new ObjectTypeCountMeasurementBuilder(PathDetectionObject.class);
+				var builder = new ObjectTypeCountMeasurementBuilder(imageData, PathDetectionObject.class);
 				builderMap.put(builder.getName(), builder);
 				features.add(builder.getName());
 			}
@@ -347,24 +308,13 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 				builderMap.put(builder.getName(), builder);
 				features.add(builder.getName());
 			}
-//			if (anyPolygons) {
-//				MeasurementBuilder<?> builder = new MaxDiameterMeasurementBuilder(imageData);
-//				builderMap.put(builder.getName(), builder);
-//				features.add(builder.getName());
-//				
-//				builder = new MinDiameterMeasurementBuilder(imageData);
-//				builderMap.put(builder.getName(), builder);
-//				features.add(builder.getName());
-
-//			}
 		}
 		
 		if (containsAnnotations || containsTMACores || containsRoot) {
 			var pixelClassifier = getPixelLayer(imageData);
-			if (pixelClassifier instanceof ImageServer<?>) {
-				ImageServer<BufferedImage> server = (ImageServer<BufferedImage>)pixelClassifier;
-				if (server.getMetadata().getChannelType() == ImageServerMetadata.ChannelType.CLASSIFICATION || server.getMetadata().getChannelType() == ImageServerMetadata.ChannelType.PROBABILITY) {
-					var pixelManager = new PixelClassificationMeasurementManager(server);
+			if (pixelClassifier != null) {
+				if (pixelClassifier.getMetadata().getChannelType() == ImageServerMetadata.ChannelType.CLASSIFICATION || pixelClassifier.getMetadata().getChannelType() == ImageServerMetadata.ChannelType.PROBABILITY) {
+					var pixelManager = new PixelClassificationMeasurementManager(pixelClassifier);
 					for (String name : pixelManager.getMeasurementNames()) {
 //						String nameLive = name + " (live)";
 						String nameLive = "(Live) " + name;
@@ -374,8 +324,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 				}
 			}
 		}
-		
-		
+
 		// Update all the lists, if necessary
 		boolean changes = false;
 		if (metadataNames.size() != metadataList.size() || !metadataNames.containsAll(metadataList)) {
@@ -407,7 +356,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	public void refreshEntries() {
 		// Clear the cached map to force updates
 		if (manager != null)
-			manager.map.clear();
+			manager.clearMap();
 	}
 	
 	/**
@@ -425,8 +374,8 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 		MeasurementBuilder<?> builder = builderMap.get(column);
 		if (builder == null)
 			return new ObservableMeasurement(pathObject, column);
-		else if (builder instanceof NumericMeasurementBuilder)
-			return ((NumericMeasurementBuilder)builder).createMeasurement(pathObject);
+		else if (builder instanceof AbstractNumericMeasurementBuilder numericMeasurementBuilder)
+			return numericMeasurementBuilder.createMeasurement(pathObject);
 		else
 			throw new IllegalArgumentException(column + " does not represent a numeric measurement!");
 	}
@@ -445,8 +394,8 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	@Deprecated
 	public Binding<String> createStringMeasurement(final PathObject pathObject, final String column) {
 		MeasurementBuilder<?> builder = builderMap.get(column);
-		if (builder instanceof StringMeasurementBuilder)
-			return ((StringMeasurementBuilder)builder).createMeasurement(pathObject);
+		if (builder instanceof AbstractStringMeasurementBuilder stringMeasurementBuilder)
+			return stringMeasurementBuilder.createMeasurement(pathObject);
 		else
 			throw new IllegalArgumentException(column + " does not represent a String measurement!");
 	}
@@ -457,7 +406,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	 * @return true if the measurement returns a String (only), false otherwise
 	 */
 	public boolean isStringMeasurement(final String name) {
-		return builderMap.get(name) instanceof StringMeasurementBuilder;
+		return builderMap.get(name) instanceof AbstractStringMeasurementBuilder;
 	}
 	
 	/**
@@ -497,8 +446,8 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 				return Double.NaN;
 			
 			MeasurementBuilder<?> builder = builderMap.get(column);
-			if (builder instanceof NumericMeasurementBuilder)
-				return ((NumericMeasurementBuilder)builder).createMeasurement(pathObject).getValue().doubleValue();
+			if (builder instanceof AbstractNumericMeasurementBuilder)
+				return ((AbstractNumericMeasurementBuilder)builder).createMeasurement(pathObject).getValue().doubleValue();
 			else
 				return Double.NaN;
 		}
@@ -518,1465 +467,6 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	public ObservableList<PathObject> getBackingListEntries() {
 		return list;
 	}
-	
-	static ObservableValue<Number> createObservableMeasurement(final PathObject pathObject, final String name) {
-		return new ObservableMeasurement(pathObject, name);
-	}
-	
-	static ObservableValue<Number> createObservableClassProbability(final PathObject pathObject, final String name) {
-		return new ObservableClassProbability(pathObject);
-	}
-	
-	
-	static class ObservableMeasurement extends DoubleBinding {
-		
-		private PathObject pathObject;
-		private String name;
-		
-		public ObservableMeasurement(final PathObject pathObject, final String name) {
-			this.pathObject = pathObject;
-			this.name = name;
-		}
-
-		@Override
-		protected double computeValue() {
-			return pathObject.getMeasurementList().get(name);
-		}
-		
-	}
-	
-	static class ObservableClassProbability extends DoubleBinding {
-		
-		private PathObject pathObject;
-		
-		public ObservableClassProbability(final PathObject pathObject) {
-			this.pathObject = pathObject;
-		}
-
-		@Override
-		protected double computeValue() {
-			return pathObject.getClassProbability();
-		}
-		
-	}
-	
-	class ObjectTypeCountMeasurement extends IntegerBinding {
-		
-		private Class<? extends PathObject> cls;
-		private PathObject pathObject;
-		
-		public ObjectTypeCountMeasurement(final PathObject pathObject, final Class<? extends PathObject> cls) {
-			this.pathObject = pathObject;
-			this.cls = cls;
-		}
-		
-		@Override
-		protected int computeValue() {
-			Collection<PathObject> pathObjects;
-			if (pathObject.isRootObject()) {
-				pathObjects = imageData.getHierarchy().getObjects(null, cls);
-			} else {
-				pathObjects = imageData.getHierarchy().getObjectsForROI(cls, pathObject.getROI());
-			}
-			pathObjects.remove(pathObject);
-			return pathObjects.size();
-//			return PathObjectTools.countChildren(pathObject, cls, true);
-		}
-		
-	}
-	
-	
-	class ObjectTypeCountMeasurementBuilder extends NumericMeasurementBuilder {
-		
-		private Class<? extends PathObject> cls;
-		
-		public ObjectTypeCountMeasurementBuilder(final Class<? extends PathObject> cls) {
-			this.cls = cls;
-		}
-		
-		@Override
-		public String getName() {
-			return "Num " + PathObjectTools.getSuitableName(cls, true);
-		}
-		
-		@Override
-		public Binding<Number> createMeasurement(final PathObject pathObject) {
-			return new ObjectTypeCountMeasurement(pathObject, cls);
-		}
-		
-		@Override
-		public String toString() {
-			return getName();
-		}
-		
-	}
-	
-	
-	
-	static class DerivedMeasurementManager {
-		
-		private ImageData<?> imageData;
-		
-		private boolean valid = false;
-//		private Set<PathClass> parentIntensityClasses = new LinkedHashSet<>();
-//		private Set<PathClass> parentPositiveNegativeClasses = new LinkedHashSet<>();
-		
-		private List<MeasurementBuilder<?>> builders = new ArrayList<>();
-		
-		// Map to store cached counts, will be reset when the hierarchy changes (in any way)
-		private Map<PathObject, DetectionPathClassCounts> map = new WeakHashMap<>();
-		
-		private boolean containsAnnotations;
-		
-		DerivedMeasurementManager(final ImageData<?> imageData, final boolean containsAnnotations) {
-			this.imageData = imageData;
-			this.containsAnnotations = containsAnnotations;
-			updateAvailableMeasurements();
-		}
-		
-		void updateAvailableMeasurements() {
-//			parentIntensityClasses.clear();
-//			parentPositiveNegativeClasses.clear();
-			map.clear();
-			builders.clear();
-			if (imageData == null || imageData.getHierarchy() == null)
-				return;
-			
-			Set<PathClass> pathClasses = PathObjectTools.getRepresentedPathClasses(imageData.getHierarchy(), PathDetectionObject.class);
-
-//			// Ensure that any base classes are present
-//			Set<PathClass> basePathClasses = new LinkedHashSet<>();
-//			for (PathClass pathClass : pathClasses.toArray(new PathClass[0])) {
-//				basePathClasses.add(pathClass.getBaseClass());
-//			}
-//			pathClasses.addAll(basePathClasses);
-
-			pathClasses.remove(null);
-			pathClasses.remove(PathClass.NULL_CLASS);
-
-			Set<PathClass> parentIntensityClasses = new LinkedHashSet<>();
-			Set<PathClass> parentPositiveNegativeClasses = new LinkedHashSet<>();
-			for (PathClass pathClass : pathClasses) {
-				if (PathClassTools.isGradedIntensityClass(pathClass)) {
-					parentIntensityClasses.add(pathClass.getParentClass());
-					parentPositiveNegativeClasses.add(pathClass.getParentClass());
-				}
-				else if (PathClassTools.isPositiveClass(pathClass) || PathClassTools.isNegativeClass(pathClass))
-					parentPositiveNegativeClasses.add(pathClass.getParentClass());
-			}
-			
-			// Store intensity parent classes, if required
-			if (!parentPositiveNegativeClasses.isEmpty()) {
-				List<PathClass> pathClassList = new ArrayList<>(parentPositiveNegativeClasses);
-				pathClassList.remove(null);
-				pathClassList.remove(PathClass.NULL_CLASS);
-				Collections.sort(pathClassList);
-				for (PathClass pathClass : pathClassList) {
-					builders.add(new ClassCountMeasurementBuilder(pathClass, true));
-				}				
-			}
-//			// Store the base classifications, if different
-//			for (PathClass pathClass : basePathClasses) {
-//				builders.add(new ClassCountMeasurementBuilder(pathClass, true));
-//			}
-			
-			// We can compute counts for any PathClass that is represented
-			List<PathClass> pathClassList = new ArrayList<>(pathClasses);
-			Collections.sort(pathClassList);
-			for (PathClass pathClass : pathClassList) {
-				builders.add(new ClassCountMeasurementBuilder(pathClass, false));
-			}
-
-			// We can compute positive percentages if we have anything in ParentPositiveNegativeClasses
-			for (PathClass pathClass : parentPositiveNegativeClasses) {
-				builders.add(new PositivePercentageMeasurementBuilder(pathClass));
-			}
-			if (parentPositiveNegativeClasses.size() > 1)
-				builders.add(new PositivePercentageMeasurementBuilder(parentPositiveNegativeClasses.toArray(new PathClass[0])));
-
-			// We can compute H-scores and Allred scores if we have anything in ParentIntensityClasses
-			for (PathClass pathClass : parentIntensityClasses) {
-				builders.add(new HScoreMeasurementBuilder(pathClass));
-				builders.add(new AllredProportionMeasurementBuilder(pathClass));
-				builders.add(new AllredIntensityMeasurementBuilder(pathClass));
-				builders.add(new AllredMeasurementBuilder(pathClass));
-			}
-			if (parentIntensityClasses.size() > 1) {
-				PathClass[] parentIntensityClassesArray = parentIntensityClasses.toArray(PathClass[]::new);
-				builders.add(new HScoreMeasurementBuilder(parentIntensityClassesArray));
-				builders.add(new AllredProportionMeasurementBuilder(parentIntensityClassesArray));
-				builders.add(new AllredIntensityMeasurementBuilder(parentIntensityClassesArray));
-				builders.add(new AllredMeasurementBuilder(parentIntensityClassesArray));
-			}
-			
-			// Add density measurements
-			// These are only added if we have a (non-derived) positive class
-			// Additionally, these are only non-NaN if we have an annotation, or a TMA core containing a single annotation
-			if (containsAnnotations) {
-				for (PathClass pathClass : pathClassList) {
-					if (PathClassTools.isPositiveClass(pathClass) && pathClass.getBaseClass() == pathClass)
-	//				if (!(PathClassFactory.isDefaultIntensityClass(pathClass) || PathClassFactory.isNegativeClass(pathClass)))
-						builders.add(new ClassDensityMeasurementBuilder(pathClass));
-				}
-			}
-
-			valid = true;
-		}
-		
-		private List<MeasurementBuilder<?>> getMeasurementBuilders() {
-			if (!valid)
-				updateAvailableMeasurements();
-			return builders;
-		}
-
-		
-		
-		class ClassCountMeasurement extends IntegerBinding {
-			
-			private PathObject pathObject;
-			private PathClass pathClass;
-			private boolean baseClassification;
-			
-			public ClassCountMeasurement(final PathObject pathObject, final PathClass pathClass, final boolean baseClassification) {
-				this.pathObject = pathObject;
-				this.pathClass = pathClass;
-				this.baseClassification = baseClassification;
-			}
-
-			@Override
-			protected int computeValue() {
-				DetectionPathClassCounts counts = map.get(pathObject);
-				if (counts == null) {
-					counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
-					map.put(pathObject, counts);
-				}
-				if (baseClassification)
-					return counts.getCountForAncestor(pathClass);
-				else
-					return counts.getDirectCount(pathClass);
-			}
-			
-		}
-		
-		
-		class ClassDensityMeasurementPerMM extends DoubleBinding {
-			
-			private PathObject pathObject;
-			private PathClass pathClass;
-			
-			public ClassDensityMeasurementPerMM(final PathObject pathObject, final PathClass pathClass) {
-				this.pathObject = pathObject;
-				this.pathClass = pathClass;
-			}
-
-			@Override
-			protected double computeValue() {
-				// If we have a TMA core, look for a single annotation inside
-				// If we don't have that, we can't return counts since it's ambiguous where the 
-				// area should be coming from
-				PathObject pathObjectTemp = pathObject;
-				if (pathObject instanceof TMACoreObject) {
-					var children = pathObject.getChildObjectsAsArray();
-					if (children.length != 1)
-						return Double.NaN;
-					pathObjectTemp = children[0];
-				}
-				// We need an annotation to get a meaningful area
-				if (pathObjectTemp == null || !(pathObjectTemp.isAnnotation() || pathObjectTemp.isRootObject()))
-					return Double.NaN;
-				
-				DetectionPathClassCounts counts = map.get(pathObjectTemp);
-				if (counts == null) {
-					counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObjectTemp);
-					map.put(pathObject, counts);
-				}
-				int n = counts.getCountForAncestor(pathClass);
-				ROI roi = pathObjectTemp.getROI();
-				// For the root, we can measure density only for 2D images of a single time-point
-				var serverMetadata = imageData.getServerMetadata();
-				if (pathObjectTemp.isRootObject() && serverMetadata.getSizeZ() == 1 && serverMetadata.getSizeT() == 1)
-					roi = ROIs.createRectangleROI(0, 0, serverMetadata.getWidth(), serverMetadata.getHeight(), ImagePlane.getDefaultPlane());
-				
-				if (roi != null && roi.isArea()) {
-					double pixelWidth = 1;
-					double pixelHeight = 1;
-					PixelCalibration cal = serverMetadata == null ? null : serverMetadata.getPixelCalibration();
-					if (cal != null && cal.hasPixelSizeMicrons()) {
-						pixelWidth = cal.getPixelWidthMicrons() / 1000;
-						pixelHeight = cal.getPixelHeightMicrons() / 1000;
-					}
-					return n / roi.getScaledArea(pixelWidth, pixelHeight);
-				}
-				return Double.NaN;
-			}
-			
-		}
-		
-		
-		class HScore extends DoubleBinding {
-			
-			private PathObject pathObject;
-			private PathClass[] pathClasses;
-			
-			public HScore(final PathObject pathObject, final PathClass... pathClasses) {
-				this.pathObject = pathObject;
-				this.pathClasses = pathClasses;
-			}
-
-			@Override
-			protected double computeValue() {
-				DetectionPathClassCounts counts = map.get(pathObject);
-				if (counts == null) {
-					counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
-					map.put(pathObject, counts);
-				}
-				return counts.getHScore(pathClasses);
-			}
-			
-		}
-		
-		
-		class AllredIntensityScore extends DoubleBinding {
-			
-			private PathObject pathObject;
-			private PathClass[] pathClasses;
-			private ObservableDoubleValue minPositivePercentage;
-			
-			public AllredIntensityScore(final PathObject pathObject, final ObservableDoubleValue minPositivePercentage, final PathClass... pathClasses) {
-				this.pathObject = pathObject;
-				this.pathClasses = pathClasses;
-				this.minPositivePercentage = minPositivePercentage;
-			}
-
-			@Override
-			protected double computeValue() {
-				DetectionPathClassCounts counts = map.get(pathObject);
-				if (counts == null) {
-					counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
-					map.put(pathObject, counts);
-				}
-				return counts.getAllredIntensity(minPositivePercentage.doubleValue() / 100, pathClasses);
-			}
-			
-		}
-		
-		
-		class AllredProportionScore extends DoubleBinding {
-			
-			private PathObject pathObject;
-			private PathClass[] pathClasses;
-			private ObservableDoubleValue minPositivePercentage;
-			
-			public AllredProportionScore(final PathObject pathObject, final ObservableDoubleValue minPositivePercentage, final PathClass... pathClasses) {
-				this.pathObject = pathObject;
-				this.pathClasses = pathClasses;
-				this.minPositivePercentage = minPositivePercentage;
-			}
-
-			@Override
-			protected double computeValue() {
-				DetectionPathClassCounts counts = map.get(pathObject);
-				if (counts == null) {
-					counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
-					map.put(pathObject, counts);
-				}
-				return counts.getAllredProportion(minPositivePercentage.doubleValue() / 100, pathClasses);
-			}
-			
-		}
-		
-		class AllredScore extends DoubleBinding {
-			
-			private PathObject pathObject;
-			private PathClass[] pathClasses;
-			private ObservableDoubleValue minPositivePercentage;
-			
-			public AllredScore(final PathObject pathObject, final ObservableDoubleValue minPositivePercentage, final PathClass... pathClasses) {
-				this.pathObject = pathObject;
-				this.pathClasses = pathClasses;
-				this.minPositivePercentage = minPositivePercentage;
-			}
-
-			@Override
-			protected double computeValue() {
-				DetectionPathClassCounts counts = map.get(pathObject);
-				if (counts == null) {
-					counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
-					map.put(pathObject, counts);
-				}
-				return counts.getAllredScore(minPositivePercentage.doubleValue() / 100, pathClasses);
-			}
-			
-		}
-		
-		
-		class PositivePercentage extends DoubleBinding {
-			
-			private PathObject pathObject;
-			private PathClass[] pathClasses;
-			
-			public PositivePercentage(final PathObject pathObject, final PathClass... pathClasses) {
-				this.pathObject = pathObject;
-				this.pathClasses = pathClasses;
-			}
-
-			@Override
-			protected double computeValue() {
-				DetectionPathClassCounts counts = map.get(pathObject);
-				if (counts == null) {
-					counts = new DetectionPathClassCounts(imageData.getHierarchy(), pathObject);
-					map.put(pathObject, counts);
-				}
-				return counts.getPositivePercentage(pathClasses);
-			}
-			
-		}
-		
-		
-		class ClassCountMeasurementBuilder extends NumericMeasurementBuilder {
-			
-			private PathClass pathClass;
-			private boolean baseClassification;
-			
-			/**
-			 * Count objects with specific classifications.
-			 * 
-			 * @param pathClass
-			 * @param baseClassification if {@code true}, also count objects with classifications derived from the specified classification, 
-			 * if {@code false} count objects with <i>only</i> the exact classification given.
-			 */
-			ClassCountMeasurementBuilder(final PathClass pathClass, final boolean baseClassification) {
-				this.pathClass = pathClass;
-				this.baseClassification = baseClassification;
-			}
-
-			@Override
-			public String getHelpText() {
-				if (baseClassification) {
-					if (pathClass == null || pathClass == PathClass.NULL_CLASS)
-						return "Number of detection objects with no BASE classification";
-					else
-						return "Number of detection objects with the BASE classification '" + pathClass + "' (including all sub-classifications)";
-				} else {
-					if (pathClass == null || pathClass == PathClass.NULL_CLASS)
-						return "Number of detection objects with no classification";
-					else
-						return "Number of detection objects with the exact classification '" + pathClass + "'";
-				}
-			}
-			
-			@Override
-			public String getName() {
-				if (baseClassification)
-					return "Num " + pathClass.toString() + " (base)";
-				else
-					return "Num " + pathClass.toString();
-			}
-			
-			@Override
-			public Binding<Number> createMeasurement(final PathObject pathObject) {
-				return new ClassCountMeasurement(pathObject, pathClass, baseClassification);
-			}
-			
-			@Override
-			public String toString() {
-				return getName();
-			}
-			
-		}
-		
-		
-		class ClassDensityMeasurementBuilder extends NumericMeasurementBuilder {
-			
-			private PathClass pathClass;
-			
-			ClassDensityMeasurementBuilder(final PathClass pathClass) {
-				this.pathClass = pathClass;
-			}
-			
-			@Override
-			public String getName() {
-				if (imageData != null && imageData.getServerMetadata().getPixelCalibration().hasPixelSizeMicrons())
-					return String.format("Num %s per mm^2", pathClass.toString());
-//					return String.format("Num %s per %s^2", pathClass.toString(), GeneralTools.micrometerSymbol());
-				else
-					return String.format("Num %s per px^2", pathClass.toString());
-			}
-			
-			@Override
-			public Binding<Number> createMeasurement(final PathObject pathObject) {
-				// Only return density measurements for annotations
-				if (pathObject.isAnnotation() || (pathObject.isTMACore() && pathObject.nChildObjects() == 1))
-					return new ClassDensityMeasurementPerMM(pathObject, pathClass);
-				return Bindings.createDoubleBinding(() -> Double.NaN);
-			}
-			
-			@Override
-			public String toString() {
-				return getName();
-			}
-			
-		}
-		
-		
-		class PositivePercentageMeasurementBuilder extends NumericMeasurementBuilder {
-			
-			private PathClass[] parentClasses;
-			
-			PositivePercentageMeasurementBuilder(final PathClass... parentClasses) {
-				this.parentClasses = parentClasses;
-			}
-
-			@Override
-			public String getHelpText() {
-				if (parentClasses.length == 0 || parentClasses[0] == null || parentClasses[0] == PathClass.NULL_CLASS) {
-					return "Number of detection classified as 'Positive' / ('Positive' + 'Negative') * 100%";
-				} else {
-					String pc;
-					if (parentClasses.length == 1) {
-						pc = parentClasses[0].toString();
-					} else {
-						pc = "(" + Arrays.stream(parentClasses)
-								.map(p -> p == null ? "<Unclassified>" : p.toString())
-								.collect(Collectors.joining("|")) + ")";
-					}
-					return "Number of detection classified as '" + pc + ": Positive' / ('"
-							+ pc + ": Positive' + '" + pc + ": Negative') * 100%";
-				}
-			}
-			
-			@Override
-			public String getName() {
-				return getNameForClasses("Positive %", parentClasses);
-			}
-			
-			@Override
-			public Binding<Number> createMeasurement(final PathObject pathObject) {
-				return new PositivePercentage(pathObject, parentClasses);
-			}
-			
-		}
-		
-		
-		/**
-		 * Get a suitable name for a measurement that reflects the parent PathClasses used in its calculation, e.g.
-		 * to get the positive % measurement name for both tumor & stroma classes, the input would be
-		 *   getNameForClasses("Positive %", tumorClass, stromaClass);
-		 * and the output would be "Stroma + Tumor: Positive %"
-		 * 
-		 * @param measurementName
-		 * @param parentClasses
-		 * @return
-		 */
-		static String getNameForClasses(final String measurementName, final PathClass...parentClasses) {
-			if (parentClasses == null || parentClasses.length == 0)
-				return measurementName;
-			if (parentClasses.length == 1) {
-				PathClass parent = parentClasses[0];
-				if (parent == null)
-					return measurementName;
-				else
-					return parent.getBaseClass().toString() + ": " + measurementName;
-			}
-			String[] names = new String[parentClasses.length];
-			for (int i = 0; i < names.length; i++) {
-				PathClass parent = parentClasses[i];
-				names[i] = parent == null ? "" : parent.getName();
-			}
-			Arrays.sort(names);
-			return String.join(" + ", names) + ": " + measurementName;
-		}
-		
-		
-		
-		class HScoreMeasurementBuilder extends NumericMeasurementBuilder {
-			
-			private PathClass[] pathClasses;
-			
-			HScoreMeasurementBuilder(final PathClass... pathClasses) {
-				this.pathClasses = pathClasses;
-			}
-			
-			@Override
-			public String getName() {
-				return getNameForClasses("H-score", pathClasses);
-			}
-			
-			@Override
-			public Binding<Number> createMeasurement(final PathObject pathObject) {
-				return new HScore(pathObject, pathClasses);
-			}
-			
-		}
-		
-		
-		class AllredIntensityMeasurementBuilder extends NumericMeasurementBuilder {
-			
-			private PathClass[] pathClasses;
-			
-			AllredIntensityMeasurementBuilder(final PathClass... pathClasses) {
-				this.pathClasses = pathClasses;
-			}
-			
-			@Override
-			public String getName() {
-				double minPercentage = PathPrefs.allredMinPercentagePositiveProperty().get();
-				String name;
-				if (minPercentage > 0)
-					name = String.format("Allred intensity (min %.1f%%)", minPercentage);
-				else
-					name = "Allred intensity";
-				return getNameForClasses(name, pathClasses);
-			}
-			
-			@Override
-			public Binding<Number> createMeasurement(final PathObject pathObject) {
-				return new AllredIntensityScore(pathObject, PathPrefs.allredMinPercentagePositiveProperty(), pathClasses);
-			}
-			
-		}
-		
-		class AllredProportionMeasurementBuilder extends NumericMeasurementBuilder {
-			
-			private PathClass[] pathClasses;
-			
-			AllredProportionMeasurementBuilder(final PathClass... pathClasses) {
-				this.pathClasses = pathClasses;
-			}
-			
-			@Override
-			public String getName() {
-				double minPercentage = PathPrefs.allredMinPercentagePositiveProperty().get();
-				String name;
-				if (minPercentage > 0)
-					name = String.format("Allred proportion (min %.1f%%)", minPercentage);
-				else
-					name = "Allred proportion";
-				return getNameForClasses(name, pathClasses);
-			}
-			
-			@Override
-			public Binding<Number> createMeasurement(final PathObject pathObject) {
-				return new AllredProportionScore(pathObject, PathPrefs.allredMinPercentagePositiveProperty(), pathClasses);
-			}
-			
-		}
-		
-		class AllredMeasurementBuilder extends NumericMeasurementBuilder {
-			
-			private PathClass[] pathClasses;
-			
-			AllredMeasurementBuilder(final PathClass... pathClasses) {
-				this.pathClasses = pathClasses;
-			}
-			
-			@Override
-			public String getName() {
-				double minPercentage = PathPrefs.allredMinPercentagePositiveProperty().get();
-				String name;
-				if (minPercentage > 0)
-					name = String.format("Allred score (min %.1f%%)", minPercentage);
-				else
-					name = "Allred score";
-				return getNameForClasses(name, pathClasses);
-			}
-			
-			@Override
-			public Binding<Number> createMeasurement(final PathObject pathObject) {
-				return new AllredScore(pathObject, PathPrefs.allredMinPercentagePositiveProperty(), pathClasses);
-			}
-			
-		}
-		
-		
-	}
-	
-	
-	interface MeasurementBuilder<T> {
-		
-		String getName();
-		
-		Binding<T> createMeasurement(final PathObject pathObject);
-
-		String getHelpText();
-
-	}
-	
-	
-	
-	abstract static class StringMeasurementBuilder implements MeasurementBuilder<String> {
-		
-		protected abstract String getMeasurementValue(final PathObject pathObject);
-		
-		@Override
-		public Binding<String> createMeasurement(final PathObject pathObject) {
-			return new StringBinding() {
-				@Override
-				protected String computeValue() {
-					return getMeasurementValue(pathObject);
-				}
-			};
-		}
-		
-	}
-	
-	
-	static class ObjectIdMeasurementBuilder extends StringMeasurementBuilder {
-		
-		@Override
-		public String getName() {
-			return NAME_OBJECT_ID;
-		}
-
-		@Override
-		protected String getMeasurementValue(PathObject pathObject) {
-			var id = pathObject.getID(); // Shouldn't be null!
-			if (id == null) {
-				logger.warn("ID null for {}", pathObject);
-				return null;
-			}
-			return id.toString();
-		}
-		
-	}
-	
-	
-	static class ObjectNameMeasurementBuilder extends StringMeasurementBuilder {
-
-		@Override
-		public String getName() {
-			return "Name";
-		}
-
-		@Override
-		public String getHelpText() {
-			return "Name of the object (may be empty)";
-		}
-
-		@Override
-		protected String getMeasurementValue(PathObject pathObject) {
-			if (pathObject == null)
-				return null;
-			// v0.5.0 change - previously used pathObject.getDisplayedName(),
-			// but this frequently led to confusion for people writing scripts
-			String name = pathObject.getName();
-			return name;
-		}
-		
-	}
-
-	static class ObjectTypeMeasurementBuilder extends StringMeasurementBuilder {
-
-		@Override
-		public String getName() {
-			return "Object type";
-		}
-
-		@Override
-		protected String getMeasurementValue(PathObject pathObject) {
-			if (pathObject == null)
-				return null;
-			else if (pathObject.isRootObject())
-				return pathObject.getDisplayedName();
-			else
-				return PathObjectTools.getSuitableName(pathObject.getClass(), false);
-		}
-
-	}
-	
-	
-	static class PathClassMeasurementBuilder extends StringMeasurementBuilder {
-
-		@Override
-		public String getName() {
-			return "Classification";
-		}
-
-		@Override
-		protected String getMeasurementValue(PathObject pathObject) {
-			return pathObject.getPathClass() == null ? null : pathObject.getPathClass().toString();
-		}
-		
-	}
-	
-	
-	static class ROINameMeasurementBuilder extends StringMeasurementBuilder {
-
-		@Override
-		public String getName() {
-			return "ROI";
-		}
-
-		@Override
-		protected String getMeasurementValue(PathObject pathObject) {
-			return pathObject.hasROI() ? pathObject.getROI().getRoiName() : null;
-		}
-		
-	}
-	
-	
-	static class ROICentroidMeasurementBuilder extends RoiMeasurementBuilder {
-		
-		enum CentroidType {X, Y};
-		private CentroidType type;
-
-		ROICentroidMeasurementBuilder(ImageData<?> imageData, final CentroidType type) {
-			super(imageData);
-			this.type = type;
-		}
-
-		@Override
-		public String getName() {
-			return String.format("Centroid %s %s", type, hasPixelSizeMicrons() ? GeneralTools.micrometerSymbol() : "px");
-		}
-
-		public double getCentroid(ROI roi) {
-			if (roi == null || type == null)
-				return Double.NaN;
-			if (hasPixelSizeMicrons()) {
-				return type == CentroidType.X
-						? roi.getCentroidX() * pixelWidthMicrons()
-						: roi.getCentroidY() * pixelHeightMicrons();
-			} else {
-				return type == CentroidType.X
-						? roi.getCentroidX()
-						: roi.getCentroidY();
-			}
-		}
-
-		@Override
-		public Binding<Number> createMeasurement(PathObject pathObject) {
-			return new DoubleBinding() {
-				@Override
-				protected double computeValue() {
-					return getCentroid(pathObject.getROI());
-				}
-				
-			};
-		}
-		
-	}
-	
-	
-	static class MissingTMACoreMeasurementBuilder extends StringMeasurementBuilder {
-
-		@Override
-		public String getName() {
-			return "Missing core";
-		}
-
-		@Override
-		protected String getMeasurementValue(PathObject pathObject) {
-			if (pathObject instanceof TMACoreObject)
-				return ((TMACoreObject)pathObject).isMissing() ? "True" : "False";
-			return null;
-		}
-		
-	}
-	
-	
-	
-	static class StringMetadataMeasurementBuilder extends StringMeasurementBuilder {
-		
-		private String name;
-		
-		StringMetadataMeasurementBuilder(final String name) {
-			this.name = name;
-		}
-
-		@Override
-		public String getName() {
-			return name;
-		}
-
-		@Override
-		public String getMeasurementValue(PathObject pathObject) {
-			if (pathObject != null) {
-				return pathObject.getMetadata().getOrDefault(name, null);
-			}
-			return null;
-		}
-		
-	}
-	
-	/**
-	 * Get the displayed name of the first TMACoreObject that is an ancestor of the supplied object.
-	 */
-	static class TMACoreNameMeasurementBuilder extends StringMeasurementBuilder {
-		
-		@Override
-		public String getName() {
-			return "TMA Core";
-		}
-		
-		private TMACoreObject getAncestorTMACore(PathObject pathObject) {
-			if (pathObject == null)
-				return null;
-			if (pathObject instanceof TMACoreObject)
-				return (TMACoreObject)pathObject;
-			return getAncestorTMACore(pathObject.getParent());
-		}
-
-		@Override
-		public String getMeasurementValue(PathObject pathObject) {
-			TMACoreObject core = getAncestorTMACore(pathObject);
-			if (core == null)
-				return null;
-			return core.getDisplayedName();
-		}
-		
-	}
-	
-	
-	/**
-	 * Get the displayed name of the parent of this object.
-	 */
-	static class ImageNameMeasurementBuilder extends StringMeasurementBuilder {
-		
-		private ImageData<?> imageData;
-		
-		ImageNameMeasurementBuilder(final ImageData<?> imageData) {
-			this.imageData = imageData;
-		}
-		
-		@Override
-		public String getName() {
-			return "Image";
-		}
-
-		@Override
-		public String getHelpText() {
-			return "Name for the current image";
-		}
-		
-		@Override
-		public String getMeasurementValue(PathObject pathObject) {
-			if (imageData == null)
-				return null;
-			var hierarchy = imageData.getHierarchy();
-			if (PathObjectTools.hierarchyContainsObject(hierarchy, pathObject)) {
-				return imageData.getServerMetadata().getName();
-			}
-			return null;
-		}
-		
-	}
-	
-	
-	/**
-	 * Get the displayed name of the parent of this object.
-	 */
-	static class ParentNameMeasurementBuilder extends StringMeasurementBuilder {
-		
-		@Override
-		public String getName() {
-			return "Parent";
-		}
-
-		@Override
-		public String getHelpText() {
-			return "Displayed name the parent of the selected object in the object hierarchy";
-		}
-		
-		@Override
-		public String getMeasurementValue(PathObject pathObject) {
-			PathObject parent = pathObject == null ? null : pathObject.getParent();
-			if (parent == null)
-				return null;
-			return parent.getDisplayedName();
-		}
-		
-	}
-	
-	
-	
-	abstract static class NumericMeasurementBuilder implements MeasurementBuilder<Number> {
-		
-		public double computeValue(final PathObject pathObject) {
-			// TODO: Flip this around!  Create binding from value, not value from binding...
-			try {
-				var val = createMeasurement(pathObject).getValue();
-				if (val == null)
-					return Double.NaN;
-				else
-					return val.doubleValue();
-			} catch (NullPointerException e) {
-				return Double.NaN;
-			}
-		}
-		
-		public String getStringValue(final PathObject pathObject, final int decimalPlaces) {
-			double val = computeValue(pathObject);
-			if (Double.isNaN(val))
-				return "NaN";
-			if (decimalPlaces == 0)
-				return Integer.toString((int)(val + 0.5));
-			int dp = decimalPlaces;
-			// Format in some sensible way
-			if (decimalPlaces < 0) {
-				if (val > 1000)
-					dp = 1;
-				else if (val > 10)
-					dp = 2;
-				else if (val > 1)
-					dp = 3;
-				else
-					dp = 4;
-			}
-			return GeneralTools.formatNumber(val, dp);
-		}
-		
-	}
-	
-	
-	
-	
-	abstract static class RoiMeasurementBuilder extends NumericMeasurementBuilder {
-		
-		private ImageData<?> imageData;
-		
-		RoiMeasurementBuilder(final ImageData<?> imageData) {
-			this.imageData = imageData;
-		}
-		
-		boolean hasPixelSizeMicrons() {
-			return imageData != null && imageData.getServerMetadata().getPixelCalibration().hasPixelSizeMicrons();
-		}
-
-		double pixelWidthMicrons() {
-			if (hasPixelSizeMicrons())
-				return imageData.getServerMetadata().getPixelCalibration().getPixelWidthMicrons();
-			return Double.NaN;
-		}
-
-		double pixelHeightMicrons() {
-			if (hasPixelSizeMicrons())
-				return imageData.getServerMetadata().getPixelCalibration().getPixelHeightMicrons();
-			return Double.NaN;
-		}
-		
-	}
-	
-	
-	static class ZSliceMeasurementBuilder extends NumericMeasurementBuilder {
-		
-		@Override
-		public String getName() {
-			return "Z-slice";
-		}
-
-		@Override
-		public String getHelpText() {
-			return "Index of z-slice (0-based)";
-		}
-		
-		@Override
-		public Binding<Number> createMeasurement(final PathObject pathObject) {
-			return new ObjectBinding<>() {
-
-                @Override
-                protected Number computeValue() {
-                    ROI roi = pathObject.getROI();
-                    if (roi == null)
-                        return null;
-                    return roi.getZ();
-                }
-            };
-		}
-		
-	}
-	
-	static class TimepointMeasurementBuilder extends NumericMeasurementBuilder {
-		
-		@Override
-		public String getName() {
-			return "Timepoint";
-		}
-
-		@Override
-		public String getHelpText() {
-			return "Index of timepoint (0-based)";
-		}
-		
-		@Override
-		public Binding<Number> createMeasurement(final PathObject pathObject) {
-			return new ObjectBinding<>() {
-
-                @Override
-                protected Number computeValue() {
-                    ROI roi = pathObject.getROI();
-                    if (roi == null)
-                        return null;
-                    return roi.getT();
-                }
-            };
-		}
-		
-	}
-	
-	
-	static class AreaMeasurementBuilder extends RoiMeasurementBuilder {
-		
-		AreaMeasurementBuilder(final ImageData<?> imageData) {
-			super(imageData);
-		}
-		
-		@Override
-		public String getName() {
-			return hasPixelSizeMicrons() ? "Area " + GeneralTools.micrometerSymbol() + "^2" : "Area px^2";
-		}
-		
-		@Override
-		public Binding<Number> createMeasurement(final PathObject pathObject) {
-			return new DoubleBinding() {
-				@Override
-				protected double computeValue() {
-					ROI roi = pathObject.getROI();
-					if (roi == null || !roi.isArea())
-						return Double.NaN;
-					if (hasPixelSizeMicrons())
-						return roi.getScaledArea(pixelWidthMicrons(), pixelHeightMicrons());
-					return roi.getArea();
-				}
-				
-			};
-		}
-		
-	}
-	
-	
-	static class PerimeterMeasurementBuilder extends RoiMeasurementBuilder {
-		
-		PerimeterMeasurementBuilder(final ImageData<?> imageData) {
-			super(imageData);
-		}
-		
-		@Override
-		public String getName() {
-			return hasPixelSizeMicrons() ? "Perimeter " + GeneralTools.micrometerSymbol() : "Perimeter px";
-		}
-		
-		@Override
-		public Binding<Number> createMeasurement(final PathObject pathObject) {
-			return new DoubleBinding() {
-				@Override
-				protected double computeValue() {
-					ROI roi = pathObject.getROI();
-					if (roi == null || !roi.isArea())
-						return Double.NaN;
-					if (hasPixelSizeMicrons())
-						return roi.getScaledLength(pixelWidthMicrons(), pixelHeightMicrons());
-					return roi.getLength();
-				}
-				
-			};
-		}
-		
-	}
-	
-	
-//	static class MaxDiameterMeasurementBuilder extends RoiMeasurementBuilder {
-//		
-//		MaxDiameterMeasurementBuilder(final ImageData<?> imageData) {
-//			super(imageData);
-//		}
-//		
-//		@Override
-//		public String getName() {
-//			return hasPixelSizeMicrons() ? "Max diameter " + GeneralTools.micrometerSymbol() : "Max diameter px";
-//		}
-//		
-//		@Override
-//		public Binding<Number> createMeasurement(final PathObject pathObject) {
-//			return new DoubleBinding() {
-//				@Override
-//				protected double computeValue() {
-//					ROI roi = pathObject.getROI();
-//					if (hasPixelSizeMicrons())
-//						return roi.getMaxDiameter();
-//					else
-//						return roi.getScaledMaxDiameter(pixelWidthMicrons(), pixelHeightMicrons());
-//				}
-//				
-//			};
-//		}
-//		
-//	}
-//	
-//	
-//	static class MinDiameterMeasurementBuilder extends RoiMeasurementBuilder {
-//		
-//		MinDiameterMeasurementBuilder(final ImageData<?> imageData) {
-//			super(imageData);
-//		}
-//		
-//		@Override
-//		public String getName() {
-//			return hasPixelSizeMicrons() ? "Min diameter " + GeneralTools.micrometerSymbol() : "Min diameter px";
-//		}
-//		
-//		@Override
-//		public Binding<Number> createMeasurement(final PathObject pathObject) {
-//			return new DoubleBinding() {
-//				@Override
-//				protected double computeValue() {
-//					ROI roi = pathObject.getROI();
-//					if (hasPixelSizeMicrons())
-//						return roi.getMinDiameter();
-//					else
-//						return roi.getScaledMinDiameter(pixelWidthMicrons(), pixelHeightMicrons());
-//				}
-//				
-//			};
-//		}
-//		
-//	}
-	
-	
-	static class LineLengthMeasurementBuilder extends RoiMeasurementBuilder {
-		
-		LineLengthMeasurementBuilder(final ImageData<?> imageData) {
-			super(imageData);
-		}
-		
-		@Override
-		public String getName() {
-			return hasPixelSizeMicrons() ? "Length " + GeneralTools.micrometerSymbol() : "Length px";
-		}
-		
-		@Override
-		public Binding<Number> createMeasurement(final PathObject pathObject) {
-			return new DoubleBinding() {
-				@Override
-				protected double computeValue() {
-					ROI roi = pathObject.getROI();
-					if (roi == null || !roi.isLine())
-						return Double.NaN;
-					if (hasPixelSizeMicrons())
-						return roi.getScaledLength(pixelWidthMicrons(), pixelHeightMicrons());
-					return roi.getLength();
-				}
-				
-			};
-		}
-		
-	}
-	
-	
-	static class NumPointsMeasurementBuilder extends NumericMeasurementBuilder {
-		
-		@Override
-		public String getName() {
-			return "Num points";
-		}
-		
-		@Override
-		public Binding<Number> createMeasurement(final PathObject pathObject) {
-			return new DoubleBinding() {
-				@Override
-				protected double computeValue() {
-					ROI roi = pathObject.getROI();
-					if (roi == null || !roi.isPoint())
-						return Double.NaN;
-					return roi.getNumPoints();
-				}
-				
-			};
-		}
-		
-	}
-	
-	
-	
-	
-	
-	/**
-	 * Cache to store the number of descendant detection objects with a particular PathClass.
-	 * <p>
-	 * (The parent is included in any count if it's a detection object... but it's expected not to be.
-	 * Rather, this is intended for counting the descendants of annotations or TMA cores.)
-	 *
-	 */
-	static class DetectionPathClassCounts {
-		
-		private Map<PathClass, Integer> counts = new HashMap<>();
-		
-		/**
-		 * Create a structure to count detections inside a specified parent.
-		 * @param hierarchy 
-		 * 
-		 * @param parentObject the parent object.
-		 */
-		DetectionPathClassCounts(final PathObjectHierarchy hierarchy, final PathObject parentObject) {
-//			for (PathObject child : PathObjectTools.getFlattenedObjectList(parentObject, null, true)) {
-			Collection<PathObject> pathObjects;
-			if (parentObject.isRootObject())
-				pathObjects = hierarchy.getDetectionObjects();
-			else
-				pathObjects = hierarchy.getAllDetectionsForROI(parentObject.getROI());
-			
-			for (PathObject child : pathObjects) {
-				if (child == parentObject || !child.isDetection())
-					continue;
-				PathClass pathClass = child.getPathClass();
-//				if (pathClass == null)
-//					continue;
-				Integer count = counts.get(pathClass);
-				if (count == null)
-					counts.put(pathClass, Integer.valueOf(1));
-				else
-					counts.put(pathClass, Integer.valueOf(count.intValue() + 1));
-			}
-		}
-		
-		public int getDirectCount(final PathClass pathClass) {
-			return counts.getOrDefault(pathClass, Integer.valueOf(0));
-		}
-		
-		public int getCountForAncestor(final Predicate<PathClass> predicate, final PathClass ancestor) {
-			int count = 0;
-			for (Entry<PathClass, Integer> entry : counts.entrySet()) {
-				if (ancestor == null) {
-					if (predicate.test(entry.getKey()) && entry.getKey().getParentClass() == null)
-						count += entry.getValue();
-				} else if (ancestor.isAncestorOf(entry.getKey()) && predicate.test(entry.getKey()))
-					count += entry.getValue();
-			}
-			return count;
-		}
-		
-		public int getCountForAncestor(final Predicate<PathClass> predicate, final PathClass... ancestors) {
-			int count = 0;
-			for (PathClass ancestor : ancestors)
-				count += getCountForAncestor(predicate, ancestor);
-			return count;
-		}
-		
-		public int getCountForAncestor(final PathClass... ancestors) {
-			return getCountForAncestor(pathClass -> true, ancestors);
-		}
-		
-		public int getOnePlus(final PathClass... ancestors) {
-			return getCountForAncestor(pathClass -> PathClassTools.isOnePlus(pathClass), ancestors);
-		}
-		
-		public int getTwoPlus(final PathClass... ancestors) {
-			return getCountForAncestor(pathClass -> PathClassTools.isTwoPlus(pathClass), ancestors);
-		}
-
-		public int getThreePlus(final PathClass... ancestors) {
-			return getCountForAncestor(pathClass -> PathClassTools.isThreePlus(pathClass), ancestors);
-		}
-
-		public int getNegative(final PathClass... ancestors) {
-			return getCountForAncestor(pathClass -> PathClassTools.isNegativeClass(pathClass), ancestors);
-		}
-
-		public int getPositive(final PathClass... ancestors) {
-			return getCountForAncestor(pathClass -> PathClassTools.isPositiveOrGradedIntensityClass(pathClass), ancestors);
-		}
-		
-		public double getHScore(final PathClass... ancestors) {
-			double plus1 = 0;
-			double plus2 = 0;
-			double plus3 = 0;
-			double negative = 0;
-			for (PathClass ancestor : ancestors) {
-				plus1 += getOnePlus(ancestor);
-				plus2 += getTwoPlus(ancestor);
-				plus3 += getThreePlus(ancestor);
-				negative += getNegative(ancestor);
-			}
-			return (plus1 * 1 + plus2 * 2 + plus3 * 3) / (plus1 + plus2 + plus3 + negative) * 100;
-		}
-		
-		public int getAllredIntensity(final double minProportion, final PathClass... ancestors) {
-			int proportionScore = getAllredProportion(minProportion, ancestors);
-			int intensityScore = 0;
-			if (proportionScore > 0) {
-				int nPositive = getPositive(ancestors);
-				double meanIntensity = (getOnePlus(ancestors) + getTwoPlus(ancestors)*2. + getThreePlus(ancestors)*3.) / nPositive;
-				if (meanIntensity > 7./3.)
-					intensityScore = 3;
-				else if (meanIntensity > 5./3.)
-					intensityScore = 2;
-				else
-					intensityScore = 1;
-			}			
-			return intensityScore;
-		}
-		
-		public int getAllredProportion(final double minProportion, final PathClass... ancestors) {
-			// Compute Allred score
-			double proportion = getPositivePercentage(ancestors)/100.0;
-			if (proportion < minProportion)
-				return 0;
-			int proportionScore;
-			if (proportion >= 2./3.)
-				proportionScore = 5;
-			else if (proportion >= 1./3.)
-				proportionScore = 4;
-			else if (proportion >= 0.1)
-				proportionScore = 3;
-			else if (proportion >= 0.01)
-				proportionScore = 2;
-			else if (proportion > 0) // 'Strict' Allred scores accepts anything above 0 as positive... but minProportion may already have kicked in
-					proportionScore = 1;
-			else
-				proportionScore = 0;
-			return proportionScore;
-		}
-		
-		public int getAllredScore(final double minProportion, final PathClass... ancestors) {
-			return getAllredIntensity(minProportion, ancestors) + getAllredProportion(minProportion, ancestors);
-		}
-		
-		/**
-		 * Get the percentage of positive detections, considering only descendants of one or more
-		 * specified classes.
-		 * 
-		 * @param ancestors
-		 * @return
-		 */
-		public double getPositivePercentage(final PathClass... ancestors) {
-			double positive = 0;
-			double negative = 0;
-			for (PathClass ancestor : ancestors) {
-				positive += getPositive(ancestor);
-				negative += getNegative(ancestor);
-			}
-			return positive / (positive + negative) * 100;
-		}
-
-	}
-
-	
-	
-	static class PixelClassifierMeasurementBuilder extends NumericMeasurementBuilder {
-		
-		private PixelClassificationMeasurementManager manager;
-		private String name;
-		
-		PixelClassifierMeasurementBuilder(PixelClassificationMeasurementManager manager, String name) {
-			this.manager = manager;
-			this.name = name;
-		}
-
-		@Override
-		public String getName() {
-			return name;
-		}
-
-		@Override
-		public Binding<Number> createMeasurement(PathObject pathObject) {
-			// Return only measurements that can be generated rapidly from cached tiles
-			return Bindings.createObjectBinding(() -> manager.getMeasurementValue(pathObject, name, true));
-		}
-		
-	}
-
-
-
 
 	@Override
 	public List<String> getAllNames() {
@@ -2004,11 +494,11 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	@Override
 	public String getStringValue(PathObject pathObject, String column, int decimalPlaces) {
 		MeasurementBuilder<?> builder = builderMap.get(column);
-		if (builder instanceof StringMeasurementBuilder) {
-			return ((StringMeasurementBuilder)builder).getMeasurementValue(pathObject);
+		if (builder instanceof AbstractStringMeasurementBuilder stringMeasurementBuilder) {
+			return stringMeasurementBuilder.getMeasurementValue(pathObject);
 		}
-		else if (builder instanceof NumericMeasurementBuilder)
-			return ((NumericMeasurementBuilder)builder).getStringValue(pathObject, decimalPlaces);
+		else if (builder instanceof AbstractNumericMeasurementBuilder numericMeasurementBuilder)
+			return numericMeasurementBuilder.getStringValue(pathObject, decimalPlaces);
 		
 		if (pathObject == null) {
 			logger.warn("Requested measurement {} for null object! Returned empty String.", column);
@@ -2026,7 +516,24 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	 */
 	public ReadOnlyListWrapper<String> getMetadataNames() {
 		return new ReadOnlyListWrapper<>(metadataList);
-	}	
-	
-	
+	}
+
+
+	static class ObservableMeasurement extends DoubleBinding {
+
+		private PathObject pathObject;
+		private String measurementName;
+
+		public ObservableMeasurement(final PathObject pathObject, final String measurementName) {
+			this.pathObject = pathObject;
+			this.measurementName = measurementName;
+		}
+
+		@Override
+		protected double computeValue() {
+			return pathObject.getMeasurementList().get(measurementName);
+		}
+
+	}
+
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ParentNameMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ParentNameMeasurementBuilder.java
@@ -1,0 +1,28 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.objects.PathObject;
+
+/**
+ * Get the displayed name of the parent of this object.
+ */
+class ParentNameMeasurementBuilder extends AbstractStringMeasurementBuilder {
+
+    @Override
+    public String getName() {
+        return "Parent";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Displayed name the parent of the selected object in the object hierarchy";
+    }
+
+    @Override
+    public String getMeasurementValue(PathObject pathObject) {
+        PathObject parent = pathObject == null ? null : pathObject.getParent();
+        if (parent == null)
+            return null;
+        return parent.getDisplayedName();
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/PathClassMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/PathClassMeasurementBuilder.java
@@ -1,0 +1,22 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.objects.PathObject;
+
+class PathClassMeasurementBuilder extends AbstractStringMeasurementBuilder {
+
+    @Override
+    public String getName() {
+        return "Classification";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "The classification of the selected object";
+    }
+
+    @Override
+    protected String getMeasurementValue(PathObject pathObject) {
+        return pathObject.getPathClass() == null ? null : pathObject.getPathClass().toString();
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/PathTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/PathTableData.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -48,7 +48,7 @@ public interface PathTableData<T> {
 	 * 
 	 * @return
 	 */
-	public List<String> getAllNames();
+	List<String> getAllNames();
 
 	/**
 	 * Get a string representation of the value.
@@ -59,7 +59,7 @@ public interface PathTableData<T> {
 	 * @param name
 	 * @return
 	 */
-	public String getStringValue(final T item, final String name);
+	String getStringValue(final T item, final String name);
 
 	/**
 	 * Get a string value, converting to a fixed number of decimal places if the column is numeric.
@@ -69,13 +69,13 @@ public interface PathTableData<T> {
 	 * @param decimalPlaces
 	 * @return
 	 */
-	public String getStringValue(final T item, final String name, final int decimalPlaces);
+	String getStringValue(final T item, final String name, final int decimalPlaces);
 
 	/**
 	 * Get the names of all numeric measurements.
 	 * @return
 	 */
-	public List<String> getMeasurementNames();
+	List<String> getMeasurementNames();
 
 	/**
 	 * Get the numeric value from an object for the specific measurement.
@@ -83,7 +83,7 @@ public interface PathTableData<T> {
 	 * @param column
 	 * @return
 	 */
-	public double getNumericValue(final T pathObject, final String column);
+	double getNumericValue(final T pathObject, final String column);
 
 	/**
 	 * Get all double values for all items.
@@ -91,14 +91,14 @@ public interface PathTableData<T> {
 	 * @param column
 	 * @return
 	 */
-	public double[] getDoubleValues(final String column);
+	double[] getDoubleValues(final String column);
 	
 	/**
 	 * Get internal list of the items used to provide measurements.
 	 * 
 	 * @return
 	 */
-	public List<T> getItems();
+	List<T> getItems();
 
 	
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/PerimeterMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/PerimeterMeasurementBuilder.java
@@ -1,0 +1,42 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import javafx.beans.binding.DoubleBinding;
+import qupath.lib.common.GeneralTools;
+import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathObject;
+import qupath.lib.roi.interfaces.ROI;
+
+class PerimeterMeasurementBuilder extends ROIMeasurementBuilder {
+
+    PerimeterMeasurementBuilder(final ImageData<?> imageData) {
+        super(imageData);
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Perimeter of the selected object's ROI";
+    }
+
+    @Override
+    public String getName() {
+        return hasPixelSizeMicrons() ? "Perimeter " + GeneralTools.micrometerSymbol() : "Perimeter px";
+    }
+
+    @Override
+    public Binding<Number> createMeasurement(final PathObject pathObject) {
+        return new DoubleBinding() {
+            @Override
+            protected double computeValue() {
+                ROI roi = pathObject.getROI();
+                if (roi == null || !roi.isArea())
+                    return Double.NaN;
+                if (hasPixelSizeMicrons())
+                    return roi.getScaledLength(pixelWidthMicrons(), pixelHeightMicrons());
+                return roi.getLength();
+            }
+
+        };
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/PixelClassifierMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/PixelClassifierMeasurementBuilder.java
@@ -1,0 +1,34 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import javafx.beans.binding.Bindings;
+import qupath.lib.objects.PathObject;
+import qupath.opencv.ml.pixel.PixelClassificationMeasurementManager;
+
+class PixelClassifierMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+    private PixelClassificationMeasurementManager manager;
+    private String name;
+
+    PixelClassifierMeasurementBuilder(PixelClassificationMeasurementManager manager, String name) {
+        this.manager = manager;
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "A temporary measurement made by the current pixel classifier";
+    }
+
+    @Override
+    public Binding<Number> createMeasurement(PathObject pathObject) {
+        // Return only measurements that can be generated rapidly from cached tiles
+        return Bindings.createObjectBinding(() -> manager.getMeasurementValue(pathObject, name, true));
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ROICentroidMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ROICentroidMeasurementBuilder.java
@@ -1,0 +1,56 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import javafx.beans.binding.DoubleBinding;
+import qupath.lib.common.GeneralTools;
+import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathObject;
+import qupath.lib.roi.interfaces.ROI;
+
+class ROICentroidMeasurementBuilder extends ROIMeasurementBuilder {
+
+    enum CentroidType {X, Y}
+
+    private CentroidType type;
+
+    ROICentroidMeasurementBuilder(ImageData<?> imageData, final CentroidType type) {
+        super(imageData);
+        this.type = type;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "The location of the ROI centroid";
+    }
+
+    @Override
+    public String getName() {
+        return String.format("Centroid %s %s", type, hasPixelSizeMicrons() ? GeneralTools.micrometerSymbol() : "px");
+    }
+
+    public double getCentroid(ROI roi) {
+        if (roi == null || type == null)
+            return Double.NaN;
+        if (hasPixelSizeMicrons()) {
+            return type == CentroidType.X
+                    ? roi.getCentroidX() * pixelWidthMicrons()
+                    : roi.getCentroidY() * pixelHeightMicrons();
+        } else {
+            return type == CentroidType.X
+                    ? roi.getCentroidX()
+                    : roi.getCentroidY();
+        }
+    }
+
+    @Override
+    public Binding<Number> createMeasurement(PathObject pathObject) {
+        return new DoubleBinding() {
+            @Override
+            protected double computeValue() {
+                return getCentroid(pathObject.getROI());
+            }
+
+        };
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ROIMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ROIMeasurementBuilder.java
@@ -1,0 +1,29 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.images.ImageData;
+
+abstract class ROIMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+    private ImageData<?> imageData;
+
+    ROIMeasurementBuilder(final ImageData<?> imageData) {
+        this.imageData = imageData;
+    }
+
+    boolean hasPixelSizeMicrons() {
+        return imageData != null && imageData.getServerMetadata().getPixelCalibration().hasPixelSizeMicrons();
+    }
+
+    double pixelWidthMicrons() {
+        if (hasPixelSizeMicrons())
+            return imageData.getServerMetadata().getPixelCalibration().getPixelWidthMicrons();
+        return Double.NaN;
+    }
+
+    double pixelHeightMicrons() {
+        if (hasPixelSizeMicrons())
+            return imageData.getServerMetadata().getPixelCalibration().getPixelHeightMicrons();
+        return Double.NaN;
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ROINameMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ROINameMeasurementBuilder.java
@@ -1,0 +1,22 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.objects.PathObject;
+
+class ROINameMeasurementBuilder extends AbstractStringMeasurementBuilder {
+
+    @Override
+    public String getName() {
+        return "ROI";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "The name of the region of interest (ROI) type";
+    }
+
+    @Override
+    protected String getMeasurementValue(PathObject pathObject) {
+        return pathObject.hasROI() ? pathObject.getROI().getRoiName() : null;
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/StringMetadataMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/StringMetadataMeasurementBuilder.java
@@ -1,0 +1,31 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.objects.PathObject;
+
+class StringMetadataMeasurementBuilder extends AbstractStringMeasurementBuilder {
+
+    private String name;
+
+    StringMetadataMeasurementBuilder(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "A metadata value stored within the selected object";
+    }
+
+    @Override
+    public String getMeasurementValue(PathObject pathObject) {
+        if (pathObject != null) {
+            return pathObject.getMetadata().getOrDefault(name, null);
+        }
+        return null;
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/TMACoreNameMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/TMACoreNameMeasurementBuilder.java
@@ -1,0 +1,37 @@
+package qupath.lib.gui.measure;
+
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.TMACoreObject;
+
+/**
+ * Get the displayed name of the first TMACoreObject that is an ancestor of the supplied object.
+ */
+class TMACoreNameMeasurementBuilder extends AbstractStringMeasurementBuilder {
+
+    @Override
+    public String getHelpText() {
+        return "The name of the selected tissue microarray (TMA) core";
+    }
+
+    @Override
+    public String getName() {
+        return "TMA Core";
+    }
+
+    private TMACoreObject getAncestorTMACore(PathObject pathObject) {
+        if (pathObject == null)
+            return null;
+        if (pathObject instanceof TMACoreObject)
+            return (TMACoreObject) pathObject;
+        return getAncestorTMACore(pathObject.getParent());
+    }
+
+    @Override
+    public String getMeasurementValue(PathObject pathObject) {
+        TMACoreObject core = getAncestorTMACore(pathObject);
+        if (core == null)
+            return null;
+        return core.getDisplayedName();
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/TimepointMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/TimepointMeasurementBuilder.java
@@ -1,0 +1,34 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import javafx.beans.binding.ObjectBinding;
+import qupath.lib.objects.PathObject;
+import qupath.lib.roi.interfaces.ROI;
+
+class TimepointMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+    @Override
+    public String getName() {
+        return "Timepoint";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Index of timepoint (0-based)";
+    }
+
+    @Override
+    public Binding<Number> createMeasurement(final PathObject pathObject) {
+        return new ObjectBinding<>() {
+
+            @Override
+            protected Number computeValue() {
+                ROI roi = pathObject.getROI();
+                if (roi == null)
+                    return null;
+                return roi.getT();
+            }
+        };
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ZSliceMeasurementBuilder.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ZSliceMeasurementBuilder.java
@@ -1,0 +1,34 @@
+package qupath.lib.gui.measure;
+
+import javafx.beans.binding.Binding;
+import javafx.beans.binding.ObjectBinding;
+import qupath.lib.objects.PathObject;
+import qupath.lib.roi.interfaces.ROI;
+
+class ZSliceMeasurementBuilder extends AbstractNumericMeasurementBuilder {
+
+    @Override
+    public String getName() {
+        return "Z-slice";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Index of z-slice (0-based)";
+    }
+
+    @Override
+    public Binding<Number> createMeasurement(final PathObject pathObject) {
+        return new ObjectBinding<>() {
+
+            @Override
+            protected Number computeValue() {
+                ROI roi = pathObject.getROI();
+                if (roi == null)
+                    return null;
+                return roi.getZ();
+            }
+        };
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
@@ -160,6 +160,7 @@ public class SelectedMeasurementTableView implements PathObjectSelectionListener
 		col1.setCellValueFactory(this::tableKeyColumnValueFactory);
 		TableColumn<String, String> col2 = new TableColumn<>("Value");
 		col2.setCellValueFactory(this::tableValueColumnValueFactory);
+
 		tableMeasurements.getColumns().addAll(col1, col2);
 		tableMeasurements.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
 		tableMeasurements.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
@@ -188,6 +189,17 @@ public class SelectedMeasurementTableView implements PathObjectSelectionListener
 						.then((ContextMenu) null)
 						.otherwise(menu)
 		);
+
+		var tooltip = new Tooltip();
+		row.itemProperty().addListener((v, o, n) -> {
+			String helpText = n == null ? null : tableModel.getHelpText(n);
+			if (helpText == null || helpText.isBlank())
+				row.setTooltip(null);
+			else {
+				tooltip.setText(helpText);
+				row.setTooltip(tooltip);
+			}
+		});
 
 		return row;
 	}


### PR DESCRIPTION
This aims to help demystify the measurements under the 'Annotations' and 'Hierarchy' tabs.

Along the way, `ObservableMeasurementTableData` was split up to extract its many subclasses - as a first step towards simplifying the designing and improving maintainability. 

The use of tooltips means that the *Context help* can also display the explanations.

![tooltips](https://github.com/user-attachments/assets/13f7a081-6cb7-435f-86c2-4aed42744cd9)