### PR TITLE
Update BioimageIoTools to handle 0.5 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ They may change or be removed in future versions.
   * *This will affect the use of the QuPath StarDist extension*
 * `ImageServer.finalize()` is no longer overridden to call `close()` in case the caller forgets
   * `finalize()` is deprecated for removal; any class that relied on this should consider using `Cleaner`
+* Remove `BioImageioSpec` from `QP.getCoreClasses()`
 
 ### Build changes
 * Use Kotlin instead of Groovy for QuPath's build scripts (https://github.com/qupath/qupath/pull/1696)
@@ -131,6 +132,7 @@ They may change or be removed in future versions.
 * RichTextFX 0.11.4
 * slf4j 2.0.16
 * snakeyaml 2.3
+* qupath-bioimageio-spec 0.2.0
 
 
 ## Version 0.5.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 bioformats      = "8.0.1"
-bioimageIoSpec  = "0.2.0"
+bioimageIoSpec  = "0.2.1"
 omeZarrReader   = "0.5.2"
 blosc           = "1.21.6+01"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 bioformats      = "8.0.1"
-bioimageIoSpec  = "0.2.1"
+bioimageIoSpec  = "0.2.0-SNAPSHOT"
 omeZarrReader   = "0.5.2"
 blosc           = "1.21.6+01"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 bioformats      = "8.0.1"
-bioimageIoSpec  = "0.2.0-20250204.102546-3"
+bioimageIoSpec  = "0.2.0-SNAPSHOT"
 omeZarrReader   = "0.5.2"
 blosc           = "1.21.6+01"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 bioformats      = "8.0.1"
-bioimageIoSpec  = "0.2.0-SNAPSHOT"
+bioimageIoSpec  = "0.2.0-20250131.094718-2"
 omeZarrReader   = "0.5.2"
 blosc           = "1.21.6+01"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 bioformats      = "8.0.1"
-bioimageIoSpec  = "0.2.0-20250131.094718-2"
+bioimageIoSpec  = "0.2.0-20250204.102546-3"
 omeZarrReader   = "0.5.2"
 blosc           = "1.21.6+01"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 bioformats      = "8.0.1"
-bioimageIoSpec  = "0.1.0"
+bioimageIoSpec  = "0.2.0"
 omeZarrReader   = "0.5.2"
 blosc           = "1.21.6+01"
 

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -64,7 +64,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ObjectArrays;
 
-import qupath.bioimageio.spec.BioimageIoSpec;
 import qupath.imagej.processing.IJFilters;
 import qupath.imagej.tools.IJProperties;
 import qupath.imagej.tools.IJTools;
@@ -318,7 +317,7 @@ public class QP {
 			ServerTools.class,
 			PixelClassifierTools.class,
 			
-			BioimageIoSpec.class,
+
 			BioimageIoTools.class,
 			
 			DensityMaps.class,

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/BioimageIoTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/BioimageIoTools.java
@@ -36,6 +36,7 @@ import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import qupath.bioimageio.spec.BioimageIoSpec;
 import qupath.bioimageio.spec.BioimageIoSpec.Processing.Binarize;
 import qupath.bioimageio.spec.BioimageIoSpec.BioimageIoModel;
 import qupath.bioimageio.spec.BioimageIoSpec.Processing.Clip;
@@ -59,6 +60,7 @@ import qupath.opencv.dnn.DnnModels;
 import qupath.opencv.dnn.DnnShape;
 import qupath.opencv.ops.ImageOp;
 import qupath.opencv.ops.ImageOps;
+
 
 /**
  * Helper class for working with Bioimage Model Zoo model specs, and attempting to 
@@ -155,7 +157,7 @@ public class BioimageIoTools {
 					// *Conceivably* we could support these via some as-yet-unwritten extension... but we probably don't
 					break;
 				}
-				String axes = spec.getInputs().get(0).getAxes();
+				String axes = BioimageIoSpec.getAxesString(spec.getInputs().getFirst().getAxes());
 				var inputShapeMap = spec.getInputs().stream().collect(Collectors.toMap(i -> i.getName(), i -> getShape(i)));
 				var inputShape = inputShapeMap.size() == 1 ? inputShapeMap.values().iterator().next() : null; // Need a single input, otherwise can't be used for output
 				var outputShapeMap = spec.getOutputs().stream().collect(Collectors.toMap(o -> o.getName(), o -> getShape(o, inputShape)));
@@ -240,7 +242,7 @@ public class BioimageIoTools {
 		var output = outputs.get(0);
 		
 		// Get dimensions and padding
-		var axes = input.getAxes();
+		String axes = BioimageIoSpec.getAxesString(input.getAxes());
 		int indChannels = axes.indexOf("c");
 		int indX = axes.indexOf("x");
 		int indY = axes.indexOf("y");
@@ -418,7 +420,7 @@ public class BioimageIoTools {
 			var scale = (ScaleRange)transform;
 			var mode = warnIfUnsupportedMode(transform.getName(), scale.getMode(), List.of(Processing.ProcessingMode.PER_SAMPLE));
 			assert mode == Processing.ProcessingMode.PER_SAMPLE; // TODO: Consider how to support per dataset
-			var axes = scale.getAxes();
+			String axes = BioimageIoSpec.getAxesString(scale.getAxes());
 			boolean perChannel = false;
 			if (axes != null)
 				perChannel = !axes.contains("c");
@@ -435,7 +437,7 @@ public class BioimageIoTools {
 			var zeroMeanUnitVariance = (ZeroMeanUnitVariance)transform;
 			var mode = warnIfUnsupportedMode(transform.getName(), zeroMeanUnitVariance.getMode(), List.of(Processing.ProcessingMode.PER_SAMPLE, Processing.ProcessingMode.FIXED));
 			if (mode == Processing.ProcessingMode.PER_SAMPLE) {
-				var axes = zeroMeanUnitVariance.getAxes();
+				String axes = BioimageIoSpec.getAxesString(zeroMeanUnitVariance.getAxes());
 				boolean perChannel = false;
 				if (axes != null) {
 					perChannel = !axes.contains("c");

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/BioimageIoTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/BioimageIoTools.java
@@ -55,6 +55,8 @@ import qupath.opencv.dnn.DnnShape;
 import qupath.opencv.ops.ImageOp;
 import qupath.opencv.ops.ImageOps;
 
+import static qupath.bioimageio.spec.tensor.axes.Axes.getAxesString;
+
 /**
  * Helper class for working with Bioimage Model Zoo model specs, and attempting to 
  * replicating the processing within QuPath.
@@ -150,7 +152,7 @@ public class BioimageIoTools {
 					// *Conceivably* we could support these via some as-yet-unwritten extension... but we probably don't
 					break;
 				}
-				String axes = Axis.getAxesString(spec.getInputs().getFirst().getAxes());
+				String axes = getAxesString(spec.getInputs().getFirst().getAxes());
 				var inputShapeMap = spec.getInputs().stream().collect(Collectors.toMap(i -> i.getName(), i -> getShape(i)));
 				var inputShape = inputShapeMap.size() == 1 ? inputShapeMap.values().iterator().next() : null; // Need a single input, otherwise can't be used for output
 				var outputShapeMap = spec.getOutputs().stream().collect(Collectors.toMap(o -> o.getName(), o -> getShape(o, inputShape)));
@@ -235,7 +237,7 @@ public class BioimageIoTools {
 		var output = outputs.getFirst();
 		
 		// Get dimensions and padding
-		String axes = Axis.getAxesString(input.getAxes());
+		String axes = getAxesString(input.getAxes());
 		int indChannels = axes.indexOf("c");
 		int indX = axes.indexOf("x");
 		int indY = axes.indexOf("y");
@@ -406,7 +408,7 @@ public class BioimageIoTools {
 		if (transform instanceof Processing.ScaleRange scale) {
             var mode = warnIfUnsupportedMode(transform.getName(), scale.getMode(), List.of(Processing.ProcessingMode.PER_SAMPLE));
 			assert mode == Processing.ProcessingMode.PER_SAMPLE; // TODO: Consider how to support per dataset
-			String axes = Axis.getAxesString(scale.getAxes());
+			String axes = getAxesString(scale.getAxes());
 			boolean perChannel = false;
 			if (axes != null)
 				perChannel = !axes.contains("c");
@@ -422,7 +424,7 @@ public class BioimageIoTools {
 		if (transform instanceof Processing.ZeroMeanUnitVariance zeroMeanUnitVariance) {
             var mode = warnIfUnsupportedMode(transform.getName(), zeroMeanUnitVariance.getMode(), List.of(Processing.ProcessingMode.PER_SAMPLE, Processing.ProcessingMode.FIXED));
 			if (mode == Processing.ProcessingMode.PER_SAMPLE) {
-				String axes = Axis.getAxesString(zeroMeanUnitVariance.getAxes());
+				String axes = getAxesString(zeroMeanUnitVariance.getAxes());
 				boolean perChannel = false;
 				if (axes != null) {
 					perChannel = !axes.contains("c");

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/BioimageIoTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/BioimageIoTools.java
@@ -207,7 +207,7 @@ public class BioimageIoTools {
 	 * be modified and updated according to user requirements.
 	 * @param model the model spec to initialize the parameters
 	 * @param inputOps optional additional preprocessing ops to apply, before any in the model spec are added
-	 * @return A parameters object.
+	 * @return a parameters object
 	 */
 	public static PatchClassifierParams buildPatchClassifierParams(Model model, ImageOp... inputOps) {
 		return buildPatchClassifierParams(model, -1, -1, inputOps);
@@ -221,7 +221,7 @@ public class BioimageIoTools {
 	 * @param preferredTileWidth preferred tile width, or -1 to automatically determine this; the width will be updated based on the spec
 	 * @param preferredTileHeight preferred tile height, or -1 to automatically determine this; the height will be updated based on the spec
 	 * @param inputOps optional additional preprocessing ops to apply, before any in the model spec are added
-	 * @return A parameters object.
+	 * @return a parameters object
 	 */
 	public static PatchClassifierParams buildPatchClassifierParams(Model modelSpec, int preferredTileWidth, int preferredTileHeight, ImageOp...inputOps) {
 

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
@@ -267,7 +267,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the input channels using channel names.
 		 * @param channels The input channel names.
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 * @see #inputChannels(int...)
 		 */
 		public Builder inputChannels(String... channels) {
@@ -280,7 +280,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the input channels using (zero-based) channel numbers.
 		 * @param channels The channel indices.
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 * @see #inputChannels(String...)
 		 */
 		public Builder inputChannels(int... channels) {
@@ -295,7 +295,7 @@ public class PatchClassifierParams {
 		 * An ordered collection (e.g. list) should be used, since the iteration order 
 		 * is important.
 		 * @param channels The channels.
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 */
 		public Builder inputChannels(Collection<? extends ColorTransform> channels) {
 			this.params.inputChannels = new ArrayList<>(channels);
@@ -306,7 +306,7 @@ public class PatchClassifierParams {
 		 * Define the input resolution using a pixel calibration and a scaling factor.
 		 * @param cal input calibration; if null, a default calibration will be used
 		 * @param downsample scaling factor (1.0 to use the calibration directly)
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 */
 		public Builder inputResolution(PixelCalibration cal, double downsample) {
 			if (cal == null)
@@ -317,7 +317,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the input resolution using a pixel calibration object.
 		 * @param cal The pixel calibration.
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 */
 		public Builder inputResolution(PixelCalibration cal) {
 			this.params.inputResolution = cal;
@@ -327,7 +327,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define a halo that is symmetric in x and y.
 		 * @param padding padding value, to be added both before and after rows and columns.
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 * @see #halo(Padding)
 		 */
 		public Builder halo(int padding) {
@@ -337,7 +337,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define a halo using a padding object.
 		 * @param halo The padding/halo
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 * @see #halo(int)
 		 */
 		public Builder halo(Padding halo) {
@@ -348,7 +348,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the requested square patch size.
 		 * @param patchSize width and height of the patch
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 */
 		public Builder patchSize(int patchSize) {
 			return patchSize(patchSize, patchSize);
@@ -358,7 +358,7 @@ public class PatchClassifierParams {
 		 * Define the requested patch size.
 		 * @param patchWidth requested patch width
 		 * @param patchHeight requested patch height
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 */
 		public Builder patchSize(int patchWidth, int patchHeight) {
 			this.params.patchWidth = patchWidth;
@@ -371,7 +371,7 @@ public class PatchClassifierParams {
 		 * Note that any existing preprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param preprocessingOps The preprocessing operations
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 */
 		public Builder preprocessing(ImageOp... preprocessingOps) {
 			this.params.preprocessingOps = Arrays.asList(preprocessingOps);
@@ -383,7 +383,7 @@ public class PatchClassifierParams {
 		 * Note that any existing preprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param preprocessingOps The preprocessing operations
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 */
 		public Builder preprocessing(Collection<? extends ImageOp> preprocessingOps) {
 			this.params.preprocessingOps = new ArrayList<>(preprocessingOps);
@@ -394,7 +394,7 @@ public class PatchClassifierParams {
 		 * Define the prediction image op, to be applied after preprocessing 
 		 * and before postprocessing.
 		 * @param predictionOp The prediction operations
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 * @see #prediction(DnnModel, Padding, String...)
 		 */
 		public Builder prediction(ImageOp predictionOp) {
@@ -408,7 +408,7 @@ public class PatchClassifierParams {
 		 * @param model The model
 		 * @param padding The padding
 		 * @param outputNames The output names
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 * @see #prediction(ImageOp)
 		 */
 		public Builder prediction(DnnModel model, Padding padding, String... outputNames) {
@@ -423,7 +423,7 @@ public class PatchClassifierParams {
 		 * Note that any existing postprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param postprocessingOps The postprocessing operations
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 */
 		public Builder postprocessing(ImageOp... postprocessingOps) {
 			this.params.postprocessingOps = Arrays.asList(postprocessingOps);
@@ -435,7 +435,7 @@ public class PatchClassifierParams {
 		 * Note that any existing postprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param postprocessingOps The postprocessing operations
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 */
 		public Builder postprocessing(Collection<? extends ImageOp> postprocessingOps) {
 			this.params.postprocessingOps = new ArrayList<>(postprocessingOps);
@@ -445,7 +445,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the channel type for the output.
 		 * @param channelType The channel type
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 */
 		public Builder outputChannelType(ChannelType channelType) {
 			this.params.outputChannelType = channelType;
@@ -455,7 +455,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as a map.
 		 * @param outputClasses The output classes
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 * @see #outputClassNames(Map)
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)
@@ -468,7 +468,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as an array.
 		 * @param outputClasses The output classes
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 * @see #outputClasses(Map)
 		 * @see #outputClassNames(Map)
 		 * @see #outputClassNames(String...)
@@ -484,7 +484,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as an array of classification names.
 		 * @param outputClasses The output classes
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)
 		 */
@@ -499,7 +499,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as a map with string values.
 		 * @param outputClasses A map from integer output to output class names
-		 * @return The modified builder.
+		 * @return The same builder modified
 		 * @see #outputClasses(Map)
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
@@ -97,7 +97,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get the channels to extract from the image as input to the model.
-	 * @return The input channels.
+	 * @return the input channels.
 	 */
 	public List<ColorTransform> getInputChannels() {
 		return inputChannels == null ? Collections.emptyList() : new ArrayList<>(inputChannels);
@@ -105,7 +105,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get the width of a patch, in pixels.
-	 * @return The width of a patch in pixels
+	 * @return the width of a patch in pixels
 	 */
 	public int getPatchWidth() {
 		return patchWidth;
@@ -113,7 +113,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get the height of a patch, in pixels.
-	 * @return The height of a patch in pixels
+	 * @return the height of a patch in pixels
 	 */
 	public int getPatchHeight() {
 		return patchHeight;
@@ -124,7 +124,7 @@ public class PatchClassifierParams {
 	 * This can be used to determine appropriate padding to 
 	 * avoid tile boundary artifacts. 
 	 * Can be null or empty.
-	 * @return The padding
+	 * @return the padding
 	 */
 	public Padding getHalo() {
 		return halo == null ? Padding.empty() : halo;
@@ -132,7 +132,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get the requested input resolution for the image.
-	 * @return The requested pixel calibration of the input
+	 * @return the requested pixel calibration of the input
 	 */
 	public PixelCalibration getInputResolution() {
 		return inputResolution;
@@ -140,7 +140,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get the requested output channel type.
-	 * @return The requested output type
+	 * @return the requested output type
 	 */
 	public ChannelType getOutputChannelType() {
 		return outputChannelType;
@@ -150,7 +150,7 @@ public class PatchClassifierParams {
 	 * Get the classifications for the output.
 	 * Keys to the map are generally channel numbers of the output 
 	 * (zero-based), or could be labels in a single-channel labeled image.
-	 * @return A map from ints to class names.
+	 * @return a map from ints to class names.
 	 */
 	public Map<Integer, PathClass> getOutputClasses() {
 		return new LinkedHashMap<>(outputClasses);
@@ -158,7 +158,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get any preprocessing steps that should be applied.
-	 * @return The preprocessing operations.
+	 * @return the preprocessing operations.
 	 */
 	public List<ImageOp> getPreprocessing() {
 		return preprocessingOps == null ? Collections.emptyList() : new ArrayList<>(preprocessingOps);
@@ -168,7 +168,7 @@ public class PatchClassifierParams {
 	 * Get the image op used for prediction only.
 	 * This is applied after any preprocessing steps, but before 
 	 * any postprocessing steps.
-	 * @return The prediction operation.
+	 * @return the prediction operation.
 	 */
 	public ImageOp getPredictionOp() {
 		return predictionOp;
@@ -176,7 +176,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get any postprocessing steps that should be applied after prediction.
-	 * @return The postprocessing operations.
+	 * @return the postprocessing operations.
 	 */
 	public List<ImageOp> getPostprocessing() {
 		return postprocessingOps == null ? Collections.emptyList() : new ArrayList<>(postprocessingOps);
@@ -185,8 +185,8 @@ public class PatchClassifierParams {
 	
 	/**
 	 * Build a pixel classifier using these parameters
-	 * @param params The classifier parameters.
-	 * @return A pixel classifier using the input parameters.
+	 * @param params the classifier parameters.
+	 * @return a pixel classifier using the input parameters.
 	 */
 	public static PixelClassifier buildPixelClassifier(PatchClassifierParams params) {
 
@@ -239,7 +239,7 @@ public class PatchClassifierParams {
 	 * Create a builder to generate new patch classifier params, 
 	 * initialized with the values from an existing parameter object.
 	 * @param params the existing parameters, used to initialize the builder
-	 * @return A builder using the input parameters.
+	 * @return a builder using the input parameters.
 	 */
 	public static Builder builder(PatchClassifierParams params) {
 		return new Builder(params);
@@ -266,7 +266,7 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define the input channels using channel names.
-		 * @param channels The input channel names.
+		 * @param channels the names of the channels to be used as input
 		 * @return a reference to this builder
 		 * @see #inputChannels(int...)
 		 */
@@ -279,7 +279,7 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define the input channels using (zero-based) channel numbers.
-		 * @param channels The channel indices.
+		 * @param channels the indices of the channels to be used as input
 		 * @return a reference to this builder
 		 * @see #inputChannels(String...)
 		 */
@@ -294,7 +294,7 @@ public class PatchClassifierParams {
 		 * Define the input channels from a collection of color transforms.
 		 * An ordered collection (e.g. list) should be used, since the iteration order 
 		 * is important.
-		 * @param channels The channels.
+		 * @param channels the channels to be used as input
 		 * @return a reference to this builder
 		 */
 		public Builder inputChannels(Collection<? extends ColorTransform> channels) {
@@ -316,7 +316,7 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define the input resolution using a pixel calibration object.
-		 * @param cal The pixel calibration.
+		 * @param cal the pixel calibration
 		 * @return a reference to this builder
 		 */
 		public Builder inputResolution(PixelCalibration cal) {
@@ -336,7 +336,7 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define a halo using a padding object.
-		 * @param halo The padding/halo
+		 * @param halo padding value, to be added both before and after rows and columns
 		 * @return a reference to this builder
 		 * @see #halo(int)
 		 */
@@ -370,7 +370,7 @@ public class PatchClassifierParams {
 		 * Define the preprocessing steps from an array.
 		 * Note that any existing preprocessing steps in the builder will 
 		 * be replaced by those provided here.
-		 * @param preprocessingOps The preprocessing operations
+		 * @param preprocessingOps the preprocessing operations
 		 * @return a reference to this builder
 		 */
 		public Builder preprocessing(ImageOp... preprocessingOps) {
@@ -382,7 +382,7 @@ public class PatchClassifierParams {
 		 * Define the preprocessing steps from a collection.
 		 * Note that any existing preprocessing steps in the builder will 
 		 * be replaced by those provided here.
-		 * @param preprocessingOps The preprocessing operations
+		 * @param preprocessingOps the preprocessing operations
 		 * @return a reference to this builder
 		 */
 		public Builder preprocessing(Collection<? extends ImageOp> preprocessingOps) {
@@ -393,7 +393,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the prediction image op, to be applied after preprocessing 
 		 * and before postprocessing.
-		 * @param predictionOp The prediction operations
+		 * @param predictionOp the prediction operations
 		 * @return a reference to this builder
 		 * @see #prediction(DnnModel, Padding, String...)
 		 */
@@ -405,9 +405,9 @@ public class PatchClassifierParams {
 		/**
 		 * Define the DNN to be used for prediction, to be applied after preprocessing 
 		 * and before postprocessing.
-		 * @param model The model
-		 * @param padding The padding
-		 * @param outputNames The output names
+		 * @param model the model
+		 * @param padding the padding
+		 * @param outputNames the output names
 		 * @return a reference to this builder
 		 * @see #prediction(ImageOp)
 		 */
@@ -422,7 +422,7 @@ public class PatchClassifierParams {
 		 * Define the postprocessing steps from an array.
 		 * Note that any existing postprocessing steps in the builder will 
 		 * be replaced by those provided here.
-		 * @param postprocessingOps The postprocessing operations
+		 * @param postprocessingOps the postprocessing operations
 		 * @return a reference to this builder
 		 */
 		public Builder postprocessing(ImageOp... postprocessingOps) {
@@ -434,7 +434,7 @@ public class PatchClassifierParams {
 		 * Define the postprocessing steps from a collection.
 		 * Note that any existing postprocessing steps in the builder will 
 		 * be replaced by those provided here.
-		 * @param postprocessingOps The postprocessing operations
+		 * @param postprocessingOps the postprocessing operations
 		 * @return a reference to this builder
 		 */
 		public Builder postprocessing(Collection<? extends ImageOp> postprocessingOps) {
@@ -444,7 +444,7 @@ public class PatchClassifierParams {
 
 		/**
 		 * Define the channel type for the output.
-		 * @param channelType The channel type
+		 * @param channelType the channel type (feature, probability, etc)
 		 * @return a reference to this builder
 		 */
 		public Builder outputChannelType(ChannelType channelType) {
@@ -454,7 +454,7 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define the classifications for the output as a map.
-		 * @param outputClasses The output classes
+		 * @param outputClasses the classifications to be given to output objects
 		 * @return a reference to this builder
 		 * @see #outputClassNames(Map)
 		 * @see #outputClasses(PathClass...)
@@ -467,7 +467,7 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define the classifications for the output as an array.
-		 * @param outputClasses The output classes
+		 * @param outputClasses the classifications to be given to output objects
 		 * @return a reference to this builder
 		 * @see #outputClasses(Map)
 		 * @see #outputClassNames(Map)
@@ -498,7 +498,7 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define the classifications for the output as a map with string values.
-		 * @param outputClasses A map from integer output to output class names
+		 * @param outputClasses a map from integer output to output class names
 		 * @return a reference to this builder
 		 * @see #outputClasses(Map)
 		 * @see #outputClasses(PathClass...)

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
@@ -267,7 +267,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the input channels using channel names.
 		 * @param channels The input channel names.
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 * @see #inputChannels(int...)
 		 */
 		public Builder inputChannels(String... channels) {
@@ -280,7 +280,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the input channels using (zero-based) channel numbers.
 		 * @param channels The channel indices.
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 * @see #inputChannels(String...)
 		 */
 		public Builder inputChannels(int... channels) {
@@ -295,7 +295,7 @@ public class PatchClassifierParams {
 		 * An ordered collection (e.g. list) should be used, since the iteration order 
 		 * is important.
 		 * @param channels The channels.
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 */
 		public Builder inputChannels(Collection<? extends ColorTransform> channels) {
 			this.params.inputChannels = new ArrayList<>(channels);
@@ -306,7 +306,7 @@ public class PatchClassifierParams {
 		 * Define the input resolution using a pixel calibration and a scaling factor.
 		 * @param cal input calibration; if null, a default calibration will be used
 		 * @param downsample scaling factor (1.0 to use the calibration directly)
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 */
 		public Builder inputResolution(PixelCalibration cal, double downsample) {
 			if (cal == null)
@@ -317,7 +317,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the input resolution using a pixel calibration object.
 		 * @param cal The pixel calibration.
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 */
 		public Builder inputResolution(PixelCalibration cal) {
 			this.params.inputResolution = cal;
@@ -327,7 +327,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define a halo that is symmetric in x and y.
 		 * @param padding padding value, to be added both before and after rows and columns.
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 * @see #halo(Padding)
 		 */
 		public Builder halo(int padding) {
@@ -337,7 +337,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define a halo using a padding object.
 		 * @param halo The padding/halo
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 * @see #halo(int)
 		 */
 		public Builder halo(Padding halo) {
@@ -348,7 +348,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the requested square patch size.
 		 * @param patchSize width and height of the patch
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 */
 		public Builder patchSize(int patchSize) {
 			return patchSize(patchSize, patchSize);
@@ -358,7 +358,7 @@ public class PatchClassifierParams {
 		 * Define the requested patch size.
 		 * @param patchWidth requested patch width
 		 * @param patchHeight requested patch height
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 */
 		public Builder patchSize(int patchWidth, int patchHeight) {
 			this.params.patchWidth = patchWidth;
@@ -371,7 +371,7 @@ public class PatchClassifierParams {
 		 * Note that any existing preprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param preprocessingOps The preprocessing operations
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 */
 		public Builder preprocessing(ImageOp... preprocessingOps) {
 			this.params.preprocessingOps = Arrays.asList(preprocessingOps);
@@ -383,7 +383,7 @@ public class PatchClassifierParams {
 		 * Note that any existing preprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param preprocessingOps The preprocessing operations
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 */
 		public Builder preprocessing(Collection<? extends ImageOp> preprocessingOps) {
 			this.params.preprocessingOps = new ArrayList<>(preprocessingOps);
@@ -394,7 +394,7 @@ public class PatchClassifierParams {
 		 * Define the prediction image op, to be applied after preprocessing 
 		 * and before postprocessing.
 		 * @param predictionOp The prediction operations
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 * @see #prediction(DnnModel, Padding, String...)
 		 */
 		public Builder prediction(ImageOp predictionOp) {
@@ -408,7 +408,7 @@ public class PatchClassifierParams {
 		 * @param model The model
 		 * @param padding The padding
 		 * @param outputNames The output names
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 * @see #prediction(ImageOp)
 		 */
 		public Builder prediction(DnnModel model, Padding padding, String... outputNames) {
@@ -423,7 +423,7 @@ public class PatchClassifierParams {
 		 * Note that any existing postprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param postprocessingOps The postprocessing operations
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 */
 		public Builder postprocessing(ImageOp... postprocessingOps) {
 			this.params.postprocessingOps = Arrays.asList(postprocessingOps);
@@ -435,7 +435,7 @@ public class PatchClassifierParams {
 		 * Note that any existing postprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param postprocessingOps The postprocessing operations
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 */
 		public Builder postprocessing(Collection<? extends ImageOp> postprocessingOps) {
 			this.params.postprocessingOps = new ArrayList<>(postprocessingOps);
@@ -445,7 +445,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the channel type for the output.
 		 * @param channelType The channel type
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 */
 		public Builder outputChannelType(ChannelType channelType) {
 			this.params.outputChannelType = channelType;
@@ -455,7 +455,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as a map.
 		 * @param outputClasses The output classes
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 * @see #outputClassNames(Map)
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)
@@ -468,7 +468,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as an array.
 		 * @param outputClasses The output classes
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 * @see #outputClasses(Map)
 		 * @see #outputClassNames(Map)
 		 * @see #outputClassNames(String...)
@@ -484,7 +484,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as an array of classification names.
 		 * @param outputClasses The output classes
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)
 		 */
@@ -499,7 +499,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as a map with string values.
 		 * @param outputClasses A map from integer output to output class names
-		 * @return The same builder modified
+		 * @return a reference to this builder
 		 * @see #outputClasses(Map)
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)
@@ -514,7 +514,7 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Build the patch classifier parameters.
-		 * @return A built classifier params object.
+		 * @return a built classifier params object.
 		 */
 		public PatchClassifierParams build() {
 			// Update prediction op

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
@@ -63,7 +63,7 @@ public class PatchClassifierParams {
 	
 	private static final Logger logger = LoggerFactory.getLogger(PatchClassifierParams.class);
 
-	private static int DEFAULT_PATCH_SIZE = 256;
+	private static final int DEFAULT_PATCH_SIZE = 256;
 
 	private List<ColorTransform> inputChannels;
 	
@@ -83,12 +83,11 @@ public class PatchClassifierParams {
 	private PatchClassifierParams() {}
 
 	private PatchClassifierParams(PatchClassifierParams params) {
-		this.inputChannels = params.inputChannels == null ? null : new ArrayList<>(params.inputChannels);
 		this.patchWidth =  params.patchWidth;
 		this.patchHeight = params.patchHeight;
 		this.halo = params.halo;
 		this.inputResolution = params.inputResolution;
-		this.inputChannels = new ArrayList<>(params.inputChannels);
+		this.inputChannels = params.inputChannels == null ? null : new ArrayList<>(params.inputChannels);
 		this.outputChannelType = params.outputChannelType;
 		this.preprocessingOps = params.preprocessingOps == null ? null : new ArrayList<>(params.preprocessingOps);
 		this.postprocessingOps = params.postprocessingOps == null ? null : new ArrayList<>(params.postprocessingOps);
@@ -98,7 +97,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get the channels to extract from the image as input to the model.
-	 * @return
+	 * @return The input channels.
 	 */
 	public List<ColorTransform> getInputChannels() {
 		return inputChannels == null ? Collections.emptyList() : new ArrayList<>(inputChannels);
@@ -106,7 +105,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get the width of a patch, in pixels.
-	 * @return
+	 * @return The width of a patch in pixels
 	 */
 	public int getPatchWidth() {
 		return patchWidth;
@@ -114,7 +113,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get the height of a patch, in pixels.
-	 * @return
+	 * @return The height of a patch in pixels
 	 */
 	public int getPatchHeight() {
 		return patchHeight;
@@ -125,7 +124,7 @@ public class PatchClassifierParams {
 	 * This can be used to determine appropriate padding to 
 	 * avoid tile boundary artifacts. 
 	 * Can be null or empty.
-	 * @return
+	 * @return The padding
 	 */
 	public Padding getHalo() {
 		return halo == null ? Padding.empty() : halo;
@@ -133,7 +132,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get the requested input resolution for the image.
-	 * @return
+	 * @return The requested pixel calibration of the input
 	 */
 	public PixelCalibration getInputResolution() {
 		return inputResolution;
@@ -141,7 +140,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get the requested output channel type.
-	 * @return
+	 * @return The requested output type
 	 */
 	public ChannelType getOutputChannelType() {
 		return outputChannelType;
@@ -151,7 +150,7 @@ public class PatchClassifierParams {
 	 * Get the classifications for the output.
 	 * Keys to the map are generally channel numbers of the output 
 	 * (zero-based), or could be labels in a single-channel labeled image.
-	 * @return
+	 * @return A map from ints to class names.
 	 */
 	public Map<Integer, PathClass> getOutputClasses() {
 		return new LinkedHashMap<>(outputClasses);
@@ -159,7 +158,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get any preprocessing steps that should be applied.
-	 * @return
+	 * @return The preprocessing operations.
 	 */
 	public List<ImageOp> getPreprocessing() {
 		return preprocessingOps == null ? Collections.emptyList() : new ArrayList<>(preprocessingOps);
@@ -169,7 +168,7 @@ public class PatchClassifierParams {
 	 * Get the image op used for prediction only.
 	 * This is applied after any preprocessing steps, but before 
 	 * any postprocessing steps.
-	 * @return
+	 * @return The prediction operation.
 	 */
 	public ImageOp getPredictionOp() {
 		return predictionOp;
@@ -177,7 +176,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Get any postprocessing steps that should be applied after prediction.
-	 * @return
+	 * @return The postprocessing operations.
 	 */
 	public List<ImageOp> getPostprocessing() {
 		return postprocessingOps == null ? Collections.emptyList() : new ArrayList<>(postprocessingOps);
@@ -186,8 +185,8 @@ public class PatchClassifierParams {
 	
 	/**
 	 * Build a pixel classifier using these parameters
-	 * @param params
-	 * @return
+	 * @param params The classifier parameters.
+	 * @return A pixel classifier using the input parameters.
 	 */
 	public static PixelClassifier buildPixelClassifier(PatchClassifierParams params) {
 
@@ -230,7 +229,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Create a builder to generate new patch classifier params.
-	 * @return
+	 * @return A builder.
 	 */
 	public static Builder builder() {
 		return new Builder();
@@ -240,7 +239,7 @@ public class PatchClassifierParams {
 	 * Create a builder to generate new patch classifier params, 
 	 * initialized with the values from an existing parameter object.
 	 * @param params the existing parameters, used to initialize the builder
-	 * @return
+	 * @return A builder using the input parameters.
 	 */
 	public static Builder builder(PatchClassifierParams params) {
 		return new Builder(params);
@@ -251,7 +250,7 @@ public class PatchClassifierParams {
 	 */
 	public static class Builder {
 		
-		private PatchClassifierParams params;
+		private final PatchClassifierParams params;
 		
 		private Padding dnnPadding;
 		private DnnModel dnnModel;
@@ -267,27 +266,27 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define the input channels using channel names.
-		 * @param channels
-		 * @return
+		 * @param channels The input channel names.
+		 * @return A modified builder.
 		 * @see #inputChannels(int...)
 		 */
 		public Builder inputChannels(String... channels) {
 			return inputChannels(Arrays
 						.stream(channels)
-						.map(c -> ColorTransforms.createChannelExtractor(c))
+						.map(ColorTransforms::createChannelExtractor)
 						.toList());
 		}
 		
 		/**
 		 * Define the input channels using (zero-based) channel numbers.
-		 * @param channels
-		 * @return
+		 * @param channels The channel indices.
+		 * @return A modified builder.
 		 * @see #inputChannels(String...)
 		 */
 		public Builder inputChannels(int... channels) {
 			return inputChannels(Arrays
 						.stream(channels)
-						.mapToObj(c -> ColorTransforms.createChannelExtractor(c))
+						.mapToObj(ColorTransforms::createChannelExtractor)
 						.toList());
 		}
 		
@@ -295,8 +294,8 @@ public class PatchClassifierParams {
 		 * Define the input channels from a collection of color transforms.
 		 * An ordered collection (e.g. list) should be used, since the iteration order 
 		 * is important.
-		 * @param channels
-		 * @return
+		 * @param channels The channels.
+		 * @return A modified builder.
 		 */
 		public Builder inputChannels(Collection<? extends ColorTransform> channels) {
 			this.params.inputChannels = new ArrayList<>(channels);
@@ -307,7 +306,7 @@ public class PatchClassifierParams {
 		 * Define the input resolution using a pixel calibration and a scaling factor.
 		 * @param cal input calibration; if null, a default calibration will be used
 		 * @param downsample scaling factor (1.0 to use the calibration directly)
-		 * @return
+		 * @return A modified builder.
 		 */
 		public Builder inputResolution(PixelCalibration cal, double downsample) {
 			if (cal == null)
@@ -317,8 +316,8 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define the input resolution using a pixel calibration object.
-		 * @param cal
-		 * @return
+		 * @param cal The pixel calibration.
+		 * @return A modified builder.
 		 */
 		public Builder inputResolution(PixelCalibration cal) {
 			this.params.inputResolution = cal;
@@ -328,7 +327,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define a halo that is symmetric in x and y.
 		 * @param padding padding value, to be added both before and after rows and columns.
-		 * @return
+		 * @return A modified builder.
 		 * @see #halo(Padding)
 		 */
 		public Builder halo(int padding) {
@@ -337,8 +336,8 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define a halo using a padding object.
-		 * @param halo
-		 * @return
+		 * @param halo The padding/halo
+		 * @return A modified builder.
 		 * @see #halo(int)
 		 */
 		public Builder halo(Padding halo) {
@@ -349,7 +348,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the requested square patch size.
 		 * @param patchSize width and height of the patch
-		 * @return
+		 * @return A modified builder.
 		 */
 		public Builder patchSize(int patchSize) {
 			return patchSize(patchSize, patchSize);
@@ -359,7 +358,7 @@ public class PatchClassifierParams {
 		 * Define the requested patch size.
 		 * @param patchWidth requested patch width
 		 * @param patchHeight requested patch height
-		 * @return
+		 * @return A modified builder.
 		 */
 		public Builder patchSize(int patchWidth, int patchHeight) {
 			this.params.patchWidth = patchWidth;
@@ -371,8 +370,8 @@ public class PatchClassifierParams {
 		 * Define the preprocessing steps from an array.
 		 * Note that any existing preprocessing steps in the builder will 
 		 * be replaced by those provided here.
-		 * @param preprocessingOps
-		 * @return
+		 * @param preprocessingOps The preprocessing operations
+		 * @return A modified builder.
 		 */
 		public Builder preprocessing(ImageOp... preprocessingOps) {
 			this.params.preprocessingOps = Arrays.asList(preprocessingOps);
@@ -383,8 +382,8 @@ public class PatchClassifierParams {
 		 * Define the preprocessing steps from a collection.
 		 * Note that any existing preprocessing steps in the builder will 
 		 * be replaced by those provided here.
-		 * @param preprocessingOps
-		 * @return
+		 * @param preprocessingOps The preprocessing operations
+		 * @return A modified builder.
 		 */
 		public Builder preprocessing(Collection<? extends ImageOp> preprocessingOps) {
 			this.params.preprocessingOps = new ArrayList<>(preprocessingOps);
@@ -394,8 +393,8 @@ public class PatchClassifierParams {
 		/**
 		 * Define the prediction image op, to be applied after preprocessing 
 		 * and before postprocessing.
-		 * @param predictionOp
-		 * @return
+		 * @param predictionOp The prediction operations
+		 * @return A modified builder.
 		 * @see #prediction(DnnModel, Padding, String...)
 		 */
 		public Builder prediction(ImageOp predictionOp) {
@@ -406,10 +405,10 @@ public class PatchClassifierParams {
 		/**
 		 * Define the DNN to be used for prediction, to be applied after preprocessing 
 		 * and before postprocessing.
-		 * @param model 
-		 * @param padding 
-		 * @param outputNames 
-		 * @return
+		 * @param model The model
+		 * @param padding The padding
+		 * @param outputNames The output names
+		 * @return A modified builder.
 		 * @see #prediction(ImageOp)
 		 */
 		public Builder prediction(DnnModel model, Padding padding, String... outputNames) {
@@ -423,8 +422,8 @@ public class PatchClassifierParams {
 		 * Define the postprocessing steps from an array.
 		 * Note that any existing postprocessing steps in the builder will 
 		 * be replaced by those provided here.
-		 * @param postprocessingOps
-		 * @return
+		 * @param postprocessingOps The postprocessing operations
+		 * @return A modified builder.
 		 */
 		public Builder postprocessing(ImageOp... postprocessingOps) {
 			this.params.postprocessingOps = Arrays.asList(postprocessingOps);
@@ -435,8 +434,8 @@ public class PatchClassifierParams {
 		 * Define the postprocessing steps from a collection.
 		 * Note that any existing postprocessing steps in the builder will 
 		 * be replaced by those provided here.
-		 * @param postprocessingOps
-		 * @return
+		 * @param postprocessingOps The postprocessing operations
+		 * @return A modified builder.
 		 */
 		public Builder postprocessing(Collection<? extends ImageOp> postprocessingOps) {
 			this.params.postprocessingOps = new ArrayList<>(postprocessingOps);
@@ -445,8 +444,8 @@ public class PatchClassifierParams {
 
 		/**
 		 * Define the channel type for the output.
-		 * @param channelType
-		 * @return
+		 * @param channelType The channel type
+		 * @return A modified builder.
 		 */
 		public Builder outputChannelType(ChannelType channelType) {
 			this.params.outputChannelType = channelType;
@@ -455,8 +454,8 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define the classifications for the output as a map.
-		 * @param outputClasses
-		 * @return
+		 * @param outputClasses The output classes
+		 * @return A modified builder.
 		 * @see #outputClassNames(Map)
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)
@@ -468,8 +467,8 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define the classifications for the output as an array.
-		 * @param outputClasses
-		 * @return
+		 * @param outputClasses The output classes
+		 * @return A modified builder.
 		 * @see #outputClasses(Map)
 		 * @see #outputClassNames(Map)
 		 * @see #outputClassNames(String...)
@@ -484,19 +483,19 @@ public class PatchClassifierParams {
 		
 		/**
 		 * Define the classifications for the output as an array of classification names.
-		 * @param outputClasses
-		 * @return
+		 * @param outputClasses The output classes
+		 * @return A modified builder.
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)
 		 */
 		public Builder outputClassNames(String... outputClasses) {
-			return outputClasses(Arrays.stream(outputClasses).map(c -> PathClass.fromString(c)).toArray(PathClass[]::new));
+			return outputClasses(Arrays.stream(outputClasses).map(PathClass::fromString).toArray(PathClass[]::new));
 		}
 		
 		/**
 		 * Define the classifications for the output as a map with string values.
-		 * @param outputClasses
-		 * @return
+		 * @param outputClasses A map from integer output to output class names
+		 * @return A modified builder.
 		 * @see #outputClasses(Map)
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)
@@ -504,12 +503,14 @@ public class PatchClassifierParams {
 		public Builder outputClassNames(Map<Integer, String> outputClasses) {
 			return outputClasses(
 					outputClasses.entrySet().stream()
-					.collect(Collectors.toMap(e -> e.getKey(), e -> PathClass.fromString(e.getValue()))));
+					.collect(
+							Collectors.toMap(Map.Entry::getKey, e -> PathClass.fromString(e.getValue()))
+					));
 		}
 		
 		/**
 		 * Build the patch classifier parameters.
-		 * @return
+		 * @return A built classifier params object.
 		 */
 		public PatchClassifierParams build() {
 			// Update prediction op

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
@@ -229,7 +229,7 @@ public class PatchClassifierParams {
 
 	/**
 	 * Create a builder to generate new patch classifier params.
-	 * @return A builder.
+	 * @return a new builder.
 	 */
 	public static Builder builder() {
 		return new Builder();

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
@@ -267,7 +267,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the input channels using channel names.
 		 * @param channels The input channel names.
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 * @see #inputChannels(int...)
 		 */
 		public Builder inputChannels(String... channels) {
@@ -280,7 +280,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the input channels using (zero-based) channel numbers.
 		 * @param channels The channel indices.
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 * @see #inputChannels(String...)
 		 */
 		public Builder inputChannels(int... channels) {
@@ -295,7 +295,7 @@ public class PatchClassifierParams {
 		 * An ordered collection (e.g. list) should be used, since the iteration order 
 		 * is important.
 		 * @param channels The channels.
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 */
 		public Builder inputChannels(Collection<? extends ColorTransform> channels) {
 			this.params.inputChannels = new ArrayList<>(channels);
@@ -306,7 +306,7 @@ public class PatchClassifierParams {
 		 * Define the input resolution using a pixel calibration and a scaling factor.
 		 * @param cal input calibration; if null, a default calibration will be used
 		 * @param downsample scaling factor (1.0 to use the calibration directly)
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 */
 		public Builder inputResolution(PixelCalibration cal, double downsample) {
 			if (cal == null)
@@ -317,7 +317,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the input resolution using a pixel calibration object.
 		 * @param cal The pixel calibration.
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 */
 		public Builder inputResolution(PixelCalibration cal) {
 			this.params.inputResolution = cal;
@@ -327,7 +327,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define a halo that is symmetric in x and y.
 		 * @param padding padding value, to be added both before and after rows and columns.
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 * @see #halo(Padding)
 		 */
 		public Builder halo(int padding) {
@@ -337,7 +337,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define a halo using a padding object.
 		 * @param halo The padding/halo
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 * @see #halo(int)
 		 */
 		public Builder halo(Padding halo) {
@@ -348,7 +348,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the requested square patch size.
 		 * @param patchSize width and height of the patch
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 */
 		public Builder patchSize(int patchSize) {
 			return patchSize(patchSize, patchSize);
@@ -358,7 +358,7 @@ public class PatchClassifierParams {
 		 * Define the requested patch size.
 		 * @param patchWidth requested patch width
 		 * @param patchHeight requested patch height
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 */
 		public Builder patchSize(int patchWidth, int patchHeight) {
 			this.params.patchWidth = patchWidth;
@@ -371,7 +371,7 @@ public class PatchClassifierParams {
 		 * Note that any existing preprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param preprocessingOps The preprocessing operations
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 */
 		public Builder preprocessing(ImageOp... preprocessingOps) {
 			this.params.preprocessingOps = Arrays.asList(preprocessingOps);
@@ -383,7 +383,7 @@ public class PatchClassifierParams {
 		 * Note that any existing preprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param preprocessingOps The preprocessing operations
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 */
 		public Builder preprocessing(Collection<? extends ImageOp> preprocessingOps) {
 			this.params.preprocessingOps = new ArrayList<>(preprocessingOps);
@@ -394,7 +394,7 @@ public class PatchClassifierParams {
 		 * Define the prediction image op, to be applied after preprocessing 
 		 * and before postprocessing.
 		 * @param predictionOp The prediction operations
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 * @see #prediction(DnnModel, Padding, String...)
 		 */
 		public Builder prediction(ImageOp predictionOp) {
@@ -408,7 +408,7 @@ public class PatchClassifierParams {
 		 * @param model The model
 		 * @param padding The padding
 		 * @param outputNames The output names
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 * @see #prediction(ImageOp)
 		 */
 		public Builder prediction(DnnModel model, Padding padding, String... outputNames) {
@@ -423,7 +423,7 @@ public class PatchClassifierParams {
 		 * Note that any existing postprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param postprocessingOps The postprocessing operations
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 */
 		public Builder postprocessing(ImageOp... postprocessingOps) {
 			this.params.postprocessingOps = Arrays.asList(postprocessingOps);
@@ -435,7 +435,7 @@ public class PatchClassifierParams {
 		 * Note that any existing postprocessing steps in the builder will 
 		 * be replaced by those provided here.
 		 * @param postprocessingOps The postprocessing operations
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 */
 		public Builder postprocessing(Collection<? extends ImageOp> postprocessingOps) {
 			this.params.postprocessingOps = new ArrayList<>(postprocessingOps);
@@ -445,7 +445,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the channel type for the output.
 		 * @param channelType The channel type
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 */
 		public Builder outputChannelType(ChannelType channelType) {
 			this.params.outputChannelType = channelType;
@@ -455,7 +455,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as a map.
 		 * @param outputClasses The output classes
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 * @see #outputClassNames(Map)
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)
@@ -468,7 +468,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as an array.
 		 * @param outputClasses The output classes
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 * @see #outputClasses(Map)
 		 * @see #outputClassNames(Map)
 		 * @see #outputClassNames(String...)
@@ -484,7 +484,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as an array of classification names.
 		 * @param outputClasses The output classes
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)
 		 */
@@ -499,7 +499,7 @@ public class PatchClassifierParams {
 		/**
 		 * Define the classifications for the output as a map with string values.
 		 * @param outputClasses A map from integer output to output class names
-		 * @return A modified builder.
+		 * @return The modified builder.
 		 * @see #outputClasses(Map)
 		 * @see #outputClasses(PathClass...)
 		 * @see #outputClassNames(String...)

--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/PatchClassifierParams.java
@@ -489,7 +489,11 @@ public class PatchClassifierParams {
 		 * @see #outputClassNames(String...)
 		 */
 		public Builder outputClassNames(String... outputClasses) {
-			return outputClasses(Arrays.stream(outputClasses).map(PathClass::fromString).toArray(PathClass[]::new));
+			return outputClasses(
+					Arrays.stream(outputClasses)
+							.map(PathClass::fromString)
+							.toArray(PathClass[]::new)
+			);
 		}
 		
 		/**
@@ -504,7 +508,7 @@ public class PatchClassifierParams {
 			return outputClasses(
 					outputClasses.entrySet().stream()
 					.collect(
-							Collectors.toMap(Map.Entry::getKey, e -> PathClass.fromString(e.getValue()))
+							Collectors.toMap(e -> e.getKey(), e -> PathClass.fromString(e.getValue()))
 					));
 		}
 		


### PR DESCRIPTION
See https://github.com/qupath/qupath-bioimageio-spec/pull/13 for details on the spec updates.

Also removes `BioImageioSpec` from the core classes - this is unlikely to have any major impacts, but should be mentioned in the release notes.