### PR TITLE
Improve "convert to detections" and "simplify objects" code

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -5241,7 +5241,7 @@ public class QP {
 	 * Convert the selected objects to points, based on the object centroids.
 	 * Cells are converted based on the nucleus ROI.
 	 * <br>
-	 * The original objects are not removed; see {@link QP#removeObject(PathObject pathObject)}.
+	 * The original objects are not removed; see {@link QP#removeObjects(Collection pathObjects)}.
 	 * See {@link PathObjectTools#convertToPoints(Collection, boolean)} if you want to use the cell ROI instead.
 	 * The original objects will be removed from the object hierarchy.
 	 */
@@ -5254,7 +5254,7 @@ public class QP {
 	 * Convert all detection objects to points, based on the object centroids.
 	 * Cells are converted based on the nucleus ROI.
 	 * <br>
-	 * The original objects are not removed; see {@link QP#removeObject(PathObject pathObject)}.
+	 * The original objects are not removed; see {@link QP#removeObjects(Collection pathObjects)}.
 	 * See {@link PathObjectTools#convertToPoints(Collection, boolean)} if you want to use the cell ROI instead.
 	 * The original objects will be removed from the object hierarchy.
 	 */
@@ -5266,7 +5266,7 @@ public class QP {
 	 * Convert the selected objects to points, based on the object centroids.
 	 * Cells are converted based on the nucleus ROI.
 	 * <br>
-	 * The original objects are not removed; see {@link QP#removeObject(PathObject pathObject)}.
+	 * The original objects are not removed; see {@link QP#removeObjects(Collection pathObjects)}.
 	 * See {@link PathObjectTools#convertToPoints(Collection, boolean)} if you want to use the cell ROI instead.
 	 * @param pathObjects The objects to be converted to points (these will be removed from the object hierarchy).
 	 */

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -5192,9 +5192,7 @@ public class QP {
 
 	/**
 	 * Simplify all annotations to a given threshold
-	 * <p>
-	 *     See {@link ShapeSimplifier#simplifyPolygon(PolygonROI, double)} )} for details.
-	 * </p>
+	 * @see ShapeSimplifier#simplifyPolygon(PolygonROI, double)
 	 * @param altitudeThreshold altitude value for simplification
 	 */
 	public static void simplifyAllAnnotations(double altitudeThreshold) {
@@ -5203,9 +5201,7 @@ public class QP {
 
 	/**
 	 * Simplify the currently selected annotations to a given threshold
-	 * <p>
-	 *     See {@link ShapeSimplifier#simplifyPolygon(PolygonROI, double)} )} for details.
-	 * </p>
+	 * @see ShapeSimplifier#simplifyPolygon(PolygonROI, double)
 	 * @param altitudeThreshold altitude value for simplification
 	 */
 	public static void simplifySelectedAnnotations(double altitudeThreshold) {
@@ -5218,9 +5214,7 @@ public class QP {
 
 	/**
 	 * Simplify a set of pathObjects to a given threshold.
-	 * <p>
-	 *     See {@link ShapeSimplifier#simplifyPolygon(PolygonROI, double)} )} for details.
-	 * </p>
+	 * @see ShapeSimplifier#simplifyPolygon(PolygonROI, double)
 	 * @param pathObjects the path objects
 	 * @param altitudeThreshold altitude value for simplification
 	 */
@@ -5244,8 +5238,7 @@ public class QP {
 	 * Cells are converted based on the nucleus ROI.
 	 * <br>
 	 * The original objects are not removed; see {@link QP#removeObjects(Collection pathObjects)}.
-	 * See {@link PathObjectTools#convertToPoints(Collection, boolean)} if you want to use the cell ROI instead.
-	 * The original objects will be removed from the object hierarchy.
+	 * @see PathObjectTools#convertToPoints(Collection, boolean) if you want to use the cell ROI instead.
 	 */
 	public static void convertSelectedObjectsToPoints() {
 		convertSpecifiedObjectsToPoints(getCurrentHierarchy(), getSelectedObjects());
@@ -5257,8 +5250,7 @@ public class QP {
 	 * Cells are converted based on the nucleus ROI.
 	 * <br>
 	 * The original objects are not removed; see {@link QP#removeObjects(Collection pathObjects)}.
-	 * See {@link PathObjectTools#convertToPoints(Collection, boolean)} if you want to use the cell ROI instead.
-	 * The original objects will be removed from the object hierarchy.
+	 * @see PathObjectTools#convertToPoints(Collection, boolean) if you want to use the cell ROI instead.
 	 */
 	public static void convertDetectionsToPoints() {
 		convertSpecifiedObjectsToPoints(getCurrentHierarchy(), getDetectionObjects());
@@ -5269,8 +5261,9 @@ public class QP {
 	 * Cells are converted based on the nucleus ROI.
 	 * <br>
 	 * The original objects are not removed; see {@link QP#removeObjects(Collection pathObjects)}.
-	 * See {@link PathObjectTools#convertToPoints(Collection, boolean)} if you want to use the cell ROI instead.
-	 * @param pathObjects The objects to be converted to points (these will be removed from the object hierarchy).
+	 * @see PathObjectTools#convertToPoints(Collection, boolean) if you want to use the cell ROI instead.
+	 * @param hierarchy the hierarchy that the objects are contained in
+	 * @param pathObjects the objects to be converted to points (these will be removed from the object hierarchy).
 	 */
 	public static void convertSpecifiedObjectsToPoints(PathObjectHierarchy hierarchy, Collection<? extends PathObject> pathObjects) {
 		PathObjectTools.convertToPoints(hierarchy, pathObjects, true, false);

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -5240,6 +5240,8 @@ public class QP {
 	/**
 	 * Convert the selected objects to points, based on the object centroids.
 	 * Cells are converted based on the nucleus ROI.
+	 * <br>
+	 * The original objects are not removed; see {@link QP#removeObject(PathObject pathObject)}.
 	 * See {@link PathObjectTools#convertToPoints(Collection, boolean)} if you want to use the cell ROI instead.
 	 * The original objects will be removed from the object hierarchy.
 	 */
@@ -5251,6 +5253,8 @@ public class QP {
 	/**
 	 * Convert all detection objects to points, based on the object centroids.
 	 * Cells are converted based on the nucleus ROI.
+	 * <br>
+	 * The original objects are not removed; see {@link QP#removeObject(PathObject pathObject)}.
 	 * See {@link PathObjectTools#convertToPoints(Collection, boolean)} if you want to use the cell ROI instead.
 	 * The original objects will be removed from the object hierarchy.
 	 */
@@ -5261,10 +5265,12 @@ public class QP {
 	/**
 	 * Convert the selected objects to points, based on the object centroids.
 	 * Cells are converted based on the nucleus ROI.
+	 * <br>
+	 * The original objects are not removed; see {@link QP#removeObject(PathObject pathObject)}.
 	 * See {@link PathObjectTools#convertToPoints(Collection, boolean)} if you want to use the cell ROI instead.
 	 * @param pathObjects The objects to be converted to points (these will be removed from the object hierarchy).
 	 */
 	public static void convertSpecifiedObjectsToPoints(Collection<? extends PathObject> pathObjects) {
-		PathObjectTools.convertToPoints(getCurrentHierarchy(), pathObjects, true, true);
+		PathObjectTools.convertToPoints(getCurrentHierarchy(), pathObjects, true, false);
 	}
 }

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -67,8 +67,10 @@ import qupath.lib.regions.RegionRequest;
 import qupath.lib.roi.GeometryTools;
 import qupath.lib.roi.LineROI;
 import qupath.lib.roi.PointsROI;
+import qupath.lib.roi.PolygonROI;
 import qupath.lib.roi.RoiTools;
 import qupath.lib.roi.ROIs;
+import qupath.lib.roi.ShapeSimplifier;
 import qupath.lib.roi.interfaces.ROI;
 
 /**
@@ -746,7 +748,7 @@ public class PathObjectTools {
 	 * 
 	 * @see #convertToPoints(Collection, boolean)
 	 */
-	public static void convertToPoints(PathObjectHierarchy hierarchy, Collection<PathObject> pathObjects, boolean preferNucleus, boolean deleteObjects) {
+	public static void convertToPoints(PathObjectHierarchy hierarchy, Collection<? extends PathObject> pathObjects, boolean preferNucleus, boolean deleteObjects) {
 		var points = convertToPoints(pathObjects, preferNucleus);
 		if (deleteObjects)
 			hierarchy.removeObjects(pathObjects, true);
@@ -767,7 +769,7 @@ public class PathObjectTools {
 	 * 
 	 * @see #convertToPoints(PathObjectHierarchy, Collection, boolean, boolean)
 	 */
-	public static Collection<PathObject> convertToPoints(Collection<PathObject> pathObjects, boolean preferNucleus) {
+	public static Collection<PathObject> convertToPoints(Collection<? extends PathObject> pathObjects, boolean preferNucleus) {
 		// Create Points lists for each class
 		Map<PathClass, Map<ImagePlane, List<Point2>>> pointsMap = new HashMap<>();
 		for (PathObject pathObject : pathObjects) {
@@ -2178,5 +2180,5 @@ public class PathObjectTools {
 	public static void setIntensityClassifications(final Collection<? extends PathObject> pathObjects, final String measurementName, final double... thresholds) {
 		pathObjects.stream().forEach(p -> setIntensityClassification(p, measurementName, thresholds));
 	}
-	
+
 }

--- a/qupath-core/src/main/java/qupath/lib/roi/ShapeSimplifier.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/ShapeSimplifier.java
@@ -37,7 +37,7 @@ import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.interfaces.ROI;
 
 /**
- * Helper methods for simplifying shapes, such removing polygon points while retaining the a similar overall 
+ * Helper methods for simplifying shapes, such removing polygon points while retaining a similar overall
  * shape at a coarser level.
  * <p>
  * This can help manage storage and performance requirements when working with large numbers of ROIs,

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -1724,8 +1724,16 @@ public class Commands {
 		boolean	deleteDetections = button == ButtonType.YES;
 		PathObjectTools.convertToPoints(hierarchy, pathObjects, preferNucleus, deleteDetections);
 		imageData.getHistoryWorkflow().addStep(
-				new DefaultScriptableWorkflowStep("Convert detections to points", "convertDetectionsToPoints()")
+				new DefaultScriptableWorkflowStep("Select detections", "selectDetections()")
 		);
+		imageData.getHistoryWorkflow().addStep(
+				new DefaultScriptableWorkflowStep("Convert selected objects to points", "convertSelectedObjects()")
+		);
+		if (deleteDetections) {
+			imageData.getHistoryWorkflow().addStep(
+					new DefaultScriptableWorkflowStep("Delete converted detections", "removeObjects(getSelectedObjects())")
+			);
+		}
 	}
 
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -1724,17 +1724,11 @@ public class Commands {
 		boolean	deleteDetections = button == ButtonType.YES;
 		PathObjectTools.convertToPoints(hierarchy, pathObjects, preferNucleus, deleteDetections);
 		imageData.getHistoryWorkflow().addStep(
-				new DefaultScriptableWorkflowStep("Select detections", "selectDetections()")
-		);
-		imageData.getHistoryWorkflow().addStep(
-				new DefaultScriptableWorkflowStep("Convert selected objects to points", "convertSelectedObjectsToPoints()")
+				new DefaultScriptableWorkflowStep("Convert detections to points", "convertDetectionsToPoints()")
 		);
 		if (deleteDetections) {
 			imageData.getHistoryWorkflow().addStep(
-					new DefaultScriptableWorkflowStep("Delete converted detections", "removeObjects(getSelectedObjects())")
-			);
-			imageData.getHistoryWorkflow().addStep(
-					new DefaultScriptableWorkflowStep("Deselect deleted objects", "deselectAll()")
+					new DefaultScriptableWorkflowStep("Delete detections", "removeDetections()")
 			);
 		}
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -1733,6 +1733,9 @@ public class Commands {
 			imageData.getHistoryWorkflow().addStep(
 					new DefaultScriptableWorkflowStep("Delete converted detections", "removeObjects(getSelectedObjects())")
 			);
+			imageData.getHistoryWorkflow().addStep(
+					new DefaultScriptableWorkflowStep("Deselect deleted objects", "deselectAll()")
+			);
 		}
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -1724,9 +1724,7 @@ public class Commands {
 		boolean	deleteDetections = button == ButtonType.YES;
 		PathObjectTools.convertToPoints(hierarchy, pathObjects, preferNucleus, deleteDetections);
 		imageData.getHistoryWorkflow().addStep(
-				new DefaultScriptableWorkflowStep("Convert detections to points",
-						String.format("PathObjectTools.convertToPoints(getCurrentHierarchy(), getDetectionObjects(), %b, %b)", preferNucleus, deleteDetections)
-				)
+				new DefaultScriptableWorkflowStep("Convert detections to points", "convertDetectionsToPoints()")
 		);
 	}
 
@@ -1763,22 +1761,13 @@ public class Commands {
 		}
 		
 		long startTime = System.currentTimeMillis();
-		for (var pathObject : pathObjects) {
-			ROI pathROI = pathObject.getROI();
-			if (pathROI instanceof PolygonROI) {
-				PolygonROI polygonROI = (PolygonROI)pathROI;
-				pathROI = ShapeSimplifier.simplifyPolygon(polygonROI, altitudeThreshold);
-			} else {
-				pathROI = ShapeSimplifier.simplifyShape(pathROI, altitudeThreshold);
-			}
-			((PathAnnotationObject)pathObject).setROI(pathROI);
-		}
+		QP.simplifySpecifiedAnnotations(pathObjects, altitudeThreshold);
 		long endTime = System.currentTimeMillis();
 		logger.debug("Shapes simplified in " + (endTime - startTime) + " ms");
 		hierarchy.fireObjectsChangedEvent(hierarchy, pathObjects);
 		imageData.getHistoryWorkflow().addStep(
-				new DefaultScriptableWorkflowStep("Simplify annotations",
-						String.format("simplifyAnnotations(getSelectedObjects(), %f)", altitudeThreshold)
+				new DefaultScriptableWorkflowStep("Simplify selected annotations",
+						String.format("simplifySelectedAnnotations(%f)", altitudeThreshold)
 				)
 		);
 	}
@@ -2139,7 +2128,4 @@ public class Commands {
 			Dialogs.showErrorNotification("Export error", e.getLocalizedMessage());
 		}
 	}
-
-	
-	
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -1727,7 +1727,7 @@ public class Commands {
 				new DefaultScriptableWorkflowStep("Select detections", "selectDetections()")
 		);
 		imageData.getHistoryWorkflow().addStep(
-				new DefaultScriptableWorkflowStep("Convert selected objects to points", "convertSelectedObjects()")
+				new DefaultScriptableWorkflowStep("Convert selected objects to points", "convertSelectedObjectsToPoints()")
 		);
 		if (deleteDetections) {
 			imageData.getHistoryWorkflow().addStep(

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/QPEx.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/QPEx.java
@@ -91,8 +91,6 @@ import qupath.lib.plugins.PathPlugin;
 import qupath.lib.plugins.TaskRunner;
 import qupath.lib.plugins.TaskRunnerUtils;
 import qupath.lib.regions.RegionRequest;
-import qupath.lib.roi.PolygonROI;
-import qupath.lib.roi.ShapeSimplifier;
 import qupath.lib.scripting.QP;
 
 /**
@@ -771,24 +769,6 @@ public class QPEx extends QP {
 		}
 	}
 
-	/**
-	 * Simplify a set of pathObjects to a given threshold.
-	 * <p>
-	 *     See {@link ShapeSimplifier#simplifyPolygon(PolygonROI, double)} )} for details.
-	 * </p>
-	 * @param pathObjects the path objects
-	 * @param altitudeThreshold altitude value for simplification
-	 */
-	public static void simplifyAnnotations(Collection<PathAnnotationObject> pathObjects, double altitudeThreshold) {
-		for (var po: pathObjects) {
-			var pathROI = po.getROI();
-			if (pathROI instanceof PolygonROI polygonROI) {
-				pathROI = ShapeSimplifier.simplifyPolygon(polygonROI, altitudeThreshold);
-			} else {
-				pathROI = ShapeSimplifier.simplifyShape(pathROI, altitudeThreshold);
-			}
-			po.setROI(pathROI);
-		}
-	}
+
 	
 }


### PR DESCRIPTION
- Move methods from QPEx to QP.
- Make similar to existing APIs (simplify/convert all, selected, or specified objects).
- Use nucleus by default, and handle deleting objects if requested.