### PR TITLE
More control to show/hide objects based on class (& other criteria)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Some things may be added, some things may be removed, and some things may look d
 * Read and write OME-Zarr images (https://github.com/qupath/qupath/pull/1474)
   * Use `convert-ome` to write OME-Zarr from a command line
   * Use *File → Export images... → OME-Zarr* to export images from the user interface
+* Add, remove & upgrade extensions easily with *Extensions → Manage extensions* (https://github.com/qupath/qupath/pull/1716)
+  * See also https://github.com/qupath/extension-manager
+* More control over showing/hiding objects by classification (https://github.com/qupath/qupath/pull/1752)
+* New ImageJ script runner (https://github.com/qupath/qupath/pull/1682)
+* Improved measurements - with tooltips & scatterplots (https://github.com/qupath/qupath/pull/1747 & https://github.com/qupath/qupath/pull/1544)
+* Optionally build QuPath *and* Fiji together (https://github.com/qupath/qupath/pull/1728)
 
 ### Enhancements
 (These are not yet ordered by interestingness)
@@ -53,6 +59,7 @@ Some things may be added, some things may be removed, and some things may look d
   * Note that channel colors still only be set for non-RGB images
 * Improved ImageJ integration (https://github.com/qupath/qupath/pull/1676 https://github.com/qupath/qupath/pull/1677)
 * 'Selection mode' now supports 'deselecting' objects by pressing the 'Alt' key (https://github.com/qupath/qupath/issues/1704)
+* More 'filter boxes' in the user interface to find things in long lists or tables (https://github.com/qupath/qupath/pull/1742)
 
 ### Experimental features
 These features are included for testing and feedback.

--- a/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/classes/PathClass.java
@@ -176,12 +176,12 @@ public final class PathClass implements Comparable<PathClass>, Serializable {
 	/**
 	 * Cache the set representation
 	 */
-	private transient Set<String> set;
+	private transient volatile Set<String> set;
 	
 	/**
 	 * Cache the list representation
 	 */
-	private transient List<String> list;
+	private transient volatile List<String> list;
 
 	private PathClass(UUID mySecret) {
 		if (!Objects.equals(secret, mySecret))

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
@@ -273,6 +273,7 @@ public class ContextHelpViewer {
 				createDetectionsHiddenEntry(),
 				createPixelClassificationOverlayHiddenEntry(),
 				createTMAGridHiddenEntry(),
+				createHiddenObjectsPredicate(),
 				createHiddenClassificationsEntry(),
 				createNoImageEntry(),
 				createNoProjectEntry(),
@@ -542,7 +543,14 @@ public class ContextHelpViewer {
 				qupath.getLogViewerCommand().hasUnseenErrors());
 		return entry;
 	}
-	
+
+	private HelpListEntry createHiddenObjectsPredicate() {
+		var entry = HelpListEntry.createWarning(
+				"ContextHelp.warning.hiddenObjectsPredicate");
+		entry.visibleProperty().bind(
+				qupath.getOverlayOptions().showObjectPredicateProperty().isNotNull());
+		return entry;
+	}
 	
 	private HelpListEntry createAnnotationsHiddenEntry() {
 		var entry = HelpListEntry.createInfo(

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/PathObjectGridView.java
@@ -68,6 +68,7 @@ import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.localization.QuPathResources;
 import qupath.lib.gui.measure.ObservableMeasurementTableData;
+import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.images.ImageData;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.TMACoreObject;
@@ -546,9 +547,7 @@ public class PathObjectGridView implements ChangeListener<ImageData<BufferedImag
 
 
 	private static Text createPlaceholderText(String text) {
-		var textNode = new Text(text);
-		textNode.setStyle("-fx-fill: -fx-text-base-color;");
-		return textNode;
+		return GuiTools.createPlaceholderText(text);
 	}
 	
 	class QuPathGridView extends StackPane {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SpecifyAnnotationCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SpecifyAnnotationCommand.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2023, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -34,23 +34,20 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListCell;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
-import javafx.scene.shape.Rectangle;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.common.GeneralTools;
 import qupath.fx.dialogs.Dialogs;
-import qupath.lib.gui.tools.ColorToolsFX;
 import qupath.fx.utils.GridPaneUtils;
 import qupath.lib.gui.tools.GuiTools;
+import qupath.lib.gui.tools.PathClassListCell;
 import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathObjects;
-import qupath.lib.objects.classes.PathClass;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.ROIs;
 import qupath.lib.roi.interfaces.ROI;
@@ -157,7 +154,7 @@ class SpecifyAnnotationCommand {
 				);
 		comboClassification.setMaxWidth(Double.MAX_VALUE);
 		comboClassification.setCellFactory(o -> {
-			return new ClassificationCell();
+			return new PathClassListCell();
 		});
 		//			comboClassification.cell;
 
@@ -350,26 +347,5 @@ class SpecifyAnnotationCommand {
 		return pane;
 	}
 
-
-
-	class ClassificationCell extends ListCell<PathClass> {
-
-		@Override
-		protected void updateItem(PathClass value, boolean empty) {
-			super.updateItem(value, empty);
-			int size = 10;
-			if (value == null || empty) {
-				setText(null);
-				setGraphic(null);
-			} else if (value.getName() == null) {
-				setText("None");
-				setGraphic(new Rectangle(size, size, ColorToolsFX.getCachedColor(0, 0, 0, 0)));
-			} else {
-				setText(value.getName());
-				setGraphic(new Rectangle(size, size, ColorToolsFX.getPathClassColor(value)));
-			}
-		}
-
-	}
 
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastChannelPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastChannelPane.java
@@ -81,6 +81,7 @@ import qupath.lib.display.DirectServerChannelInfo;
 import qupath.lib.display.ImageDisplay;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.tools.ColorToolsFX;
+import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageChannel;
 import qupath.lib.images.servers.ImageServer;
@@ -261,9 +262,7 @@ public class BrightnessContrastChannelPane extends BorderPane {
         var imageDisplay = imageDisplayObjectProperty.getValue();
         if (imageDisplay != null)
             channelList.setAll(imageDisplay.availableChannels());
-        var textPlaceholder = new Text("No channels available");
-        textPlaceholder.setStyle("-fx-fill: -fx-text-base-color;");
-        table.setPlaceholder(textPlaceholder);
+        table.setPlaceholder(GuiTools.createPlaceholderText("No channels available"));
         table.addEventHandler(KeyEvent.KEY_PRESSED, new ChannelTableKeypressedListener());
 
         table.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastSettingsPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastSettingsPane.java
@@ -58,6 +58,7 @@ import qupath.lib.display.ImageDisplay;
 import qupath.lib.display.settings.DisplaySettingUtils;
 import qupath.lib.display.settings.ImageDisplaySettings;
 import qupath.lib.gui.prefs.PathPrefs;
+import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.projects.ResourceManager;
 
 import java.io.IOException;
@@ -135,9 +136,7 @@ public class BrightnessContrastSettingsPane extends GridPane {
         });
         comboSettings.setCellFactory(c -> FXUtils.createCustomListCell(ImageDisplaySettings::getName));
         comboSettings.setButtonCell(new SettingListCell(settingsChanged));
-        var placeholder = new Text("No compatible settings");
-        placeholder.setStyle("-fx-fill: -fx-text-base-color;");
-        comboSettings.setPlaceholder(placeholder);
+        comboSettings.setPlaceholder(GuiTools.createPlaceholderText("No compatible settings"));
         resourceManagerProperty.addListener((v, o, n) -> refreshResources());
         var btnSave = new Button("Save");
         btnSave.setTooltip(new Tooltip("Save the current display settings in the project"));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
@@ -266,11 +266,18 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 		panelObjects.setBottom(new VBox(filter, panelButtons));
 
 		var btnProperties = new Button(null, IconFactory.createNode(FontAwesome.Glyph.PENCIL, 12));
+		btnProperties.setTooltip(new Tooltip("Set selected annotation properties"));
 		btnProperties.disableProperty().bind(Bindings.isEmpty(listAnnotations.getSelectionModel().getSelectedItems()));
 		btnProperties.setOnAction(e -> {
 			var hierarchy = qupath.getViewer().getHierarchy();
-			if (hierarchy != null)
+			if (hierarchy != null) {
+				// TODO: We lose the selection here...
 				GuiTools.promptToSetActiveAnnotationProperties(hierarchy);
+				// Try to recover the selection
+				var model = hierarchy.getSelectionModel();
+				selectedPathObjectChanged(
+						model.getSelectedObject(), model.getSelectedObject(), model.getSelectedObjects());
+			}
 		});
 
 		var titled = GuiTools.createLeftRightTitledPane("Annotation list", btnProperties);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
@@ -33,6 +33,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import javafx.geometry.Insets;
+import javafx.scene.control.TitledPane;
+import javafx.scene.layout.HBox;
+import org.controlsfx.glyphfont.FontAwesome;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +65,7 @@ import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.tools.GuiTools;
 import qupath.fx.utils.GridPaneUtils;
+import qupath.lib.gui.tools.IconFactory;
 import qupath.lib.gui.tools.PathObjectLabels;
 import qupath.lib.images.ImageData;
 import qupath.lib.objects.PathObject;
@@ -86,19 +91,19 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 
 	private static final Logger logger = LoggerFactory.getLogger(AnnotationPane.class);
 
-	private QuPathGUI qupath;
+	private final QuPathGUI qupath;
 	
 	// Need to preserve this to guard against garbage collection
 	@SuppressWarnings("unused")
-	private ObservableValue<ImageData<BufferedImage>> imageDataProperty;
+	private final ObservableValue<ImageData<BufferedImage>> imageDataProperty;
 	private ImageData<BufferedImage> imageData;
 	
-	private BooleanProperty disableUpdates = new SimpleBooleanProperty(false);
+	private final BooleanProperty disableUpdates = new SimpleBooleanProperty(false);
 	
 	private PathObjectHierarchy hierarchy;
-	private BooleanProperty hasImageData = new SimpleBooleanProperty(false);
+	private final BooleanProperty hasImageData = new SimpleBooleanProperty(false);
 	
-	private BorderPane pane = new BorderPane();
+	private final BorderPane pane = new BorderPane();
 
 	/*
 	 * Request that we only synchronize to the primary selection; otherwise synchronizing to 
@@ -106,7 +111,7 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 	 */
 	private static boolean synchronizePrimarySelectionOnly = true;
 	
-	private PathClassPane pathClassPane;
+	private final PathClassPane pathClassPane;
 	
 	/*
 	 * List displaying annotations in the current hierarchy
@@ -237,7 +242,19 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 		});
 
 		panelObjects.setBottom(panelButtons);
-		return panelObjects;
+
+		var titled = PathClassPane.createLeftRightTitledPane("Annotation list",
+				new HBox(
+//						new Button(null, IconFactory.createNode(FontAwesome.Glyph.EDIT, 12)),
+//						new Button(null, IconFactory.createNode(FontAwesome.Glyph.MINUS, 12)),
+//						new Button(null, IconFactory.createNode(FontAwesome.Glyph.CARET_RIGHT, 12))
+				));
+		titled.setContent(panelObjects);
+		panelObjects.setPadding(Insets.EMPTY);
+		titled.setCollapsible(false);
+		titled.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
+
+		return new BorderPane(titled);
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ImageDetailsPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ImageDetailsPane.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.stream.IntStream;
 
 import javafx.scene.control.TitledPane;
+import javafx.scene.text.Text;
 import org.controlsfx.control.MasterDetailPane;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -162,6 +163,7 @@ public class ImageDetailsPane implements ChangeListener<ImageData<BufferedImage>
 		imageDataProperty.addListener(this);
 
 		// Create the table
+		table.setPlaceholder(GuiTools.createPlaceholderText("No image selected"));
 		table.setMinHeight(200);
 		table.setPrefHeight(250);
 		table.setMaxHeight(Double.MAX_VALUE);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
@@ -124,18 +124,45 @@ class PathClassPane {
 		this.qupath = qupath;
 		this.availablePathClasses = qupath.getAvailablePathClasses();
 		var mainPane = createClassPane();
-		var titled = new TitledPane(null, mainPane);
-		titled.setMaxWidth(Double.MAX_VALUE);
-		titled.setMaxHeight(Double.MAX_VALUE);
-		titled.setCollapsible(false);
+		var titled = createLeftRightTitledPane("Class list", createTitleNode());
+		titled.setContent(mainPane);
 		mainPane.setPadding(Insets.EMPTY);
-		var title = createTitleNode();
-		title.minWidthProperty().bind(titled.widthProperty().subtract(20));
-		titled.setGraphic(title);
 
 		titled.setContentDisplay(ContentDisplay.RIGHT);
 		pane = new BorderPane(titled);
 	}
+
+	static TitledPane createLeftRightTitledPane(String name, Node right) {
+		var label = new Label(name);
+		label.setMaxWidth(Double.MAX_VALUE);
+		label.setMaxHeight(Double.MAX_VALUE);
+		label.setAlignment(Pos.CENTER_LEFT);
+		return createLeftRightTitledPane(label, right);
+	}
+
+	private static TitledPane createLeftRightTitledPane(Node left, Node right) {
+		var pane = new BorderPane();
+		pane.setLeft(left);
+		pane.setRight(right);
+		pane.setMaxWidth(Double.MAX_VALUE);
+		pane.setPadding(Insets.EMPTY);
+		var titled = new TitledPane();
+		titled.setGraphic(pane);
+		titled.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+		titled.setAlignment(Pos.CENTER);
+		titled.setMaxWidth(Double.MAX_VALUE);
+		titled.setMaxHeight(Double.MAX_VALUE);
+		titled.setCollapsible(false);
+		pane.paddingProperty().bind(Bindings.createObjectBinding(() -> {
+			if (titled.isCollapsible())
+				return new Insets(0, 5, 0, 25);
+			else
+				return new Insets(0, 5, 0, 5);
+		}, titled.collapsibleProperty()));
+		pane.minWidthProperty().bind(titled.widthProperty());
+		return titled;
+	}
+
 
 	private Pane createTitleNode() {
 		int iconSize = 8;
@@ -156,16 +183,15 @@ class PathClassPane {
 		btnMore.setText(null);
 		btnMore.setGraphic(IconFactory.createNode(FontAwesome.Glyph.CARET_RIGHT, 12));
 
-		var label = new  Label("Class list");
-		label.setMaxWidth(Double.MAX_VALUE);
-
 		var spacer = new Pane();
 		spacer.setPrefWidth(4.0);
 
-		var pane = new BorderPane(label);
-		pane.setRight(new HBox(spacer, btnAdd, btnRemove, btnMore));
-		pane.setMaxWidth(Double.MAX_VALUE);
-		return pane;
+		var insets = new Insets(1.0, 8, 1, 8);
+		btnAdd.setPadding(insets);
+		btnRemove.setPadding(insets);
+		btnMore.setPadding(insets);
+
+		return new HBox(spacer, btnAdd, btnRemove, btnMore);
 	}
 
 	
@@ -326,10 +352,10 @@ class PathClassPane {
 	
 	private BooleanBinding createRemoveClassDisabledBinding() {
 		return Bindings.createBooleanBinding(() -> {
-			PathClass item = listClasses.getSelectionModel().getSelectedItem();
-			return item == null || PathClass.NULL_CLASS == item;
-		},
-		listClasses.getSelectionModel().selectedItemProperty()
+					PathClass item = listClasses.getSelectionModel().getSelectedItem();
+					return item == null || PathClass.NULL_CLASS == item;
+				},
+				listClasses.getSelectionModel().selectedItemProperty()
 		);
 	}
 
@@ -517,17 +543,17 @@ class PathClassPane {
 		if (hierarchy == null)
 			return false;
 
-        List<PathClass> newClasses = hierarchy.getFlattenedObjectList(null)
-                .stream()
-                .filter(p -> !p.isRootObject())
-                .map(PathObject::getPathClass)
-                .filter(p -> p != null && p != PathClass.NULL_CLASS)
-                .map(p -> baseClassesOnly ? p.getBaseClass() : p)
+		List<PathClass> newClasses = hierarchy.getFlattenedObjectList(null)
+				.stream()
+				.filter(p -> !p.isRootObject())
+				.map(PathObject::getPathClass)
+				.filter(p -> p != null && p != PathClass.NULL_CLASS)
+				.map(p -> baseClassesOnly ? p.getBaseClass() : p)
 				.distinct()
 				.sorted()
 				.collect(Collectors.toCollection(ArrayList::new));
 
-        if (newClasses.isEmpty()) {
+		if (newClasses.isEmpty()) {
 			Dialogs.showErrorMessage("Set available classes", "No classifications found in current image!");
 			return false;
 		}
@@ -721,7 +747,7 @@ class PathClassPane {
 		private final QuPathGUI qupath;
 		private final OverlayOptions overlayOptions;
 
-        private final BorderPane pane = new BorderPane();
+		private final BorderPane pane = new BorderPane();
 		private final Label label = new Label();
 
 		private final int size = 10;
@@ -742,10 +768,10 @@ class PathClassPane {
 			label.setMaxWidth(Double.MAX_VALUE);
 			label.setMinWidth(20);
 			label.setGraphic(rectangle);
-            // Tooltip for the main label (but not the visibility part)
-            Tooltip tooltip = new Tooltip("Available classifications (right-click to add or remove).\n" +
-                    "Names ending with an Asterisk* are 'ignored' under certain circumstances - see the docs for more info.");
-            label.setTooltip(tooltip);
+			// Tooltip for the main label (but not the visibility part)
+			Tooltip tooltip = new Tooltip("Available classifications (right-click to add or remove).\n" +
+					"Names ending with an Asterisk* are 'ignored' under certain circumstances - see the docs for more info.");
+			label.setTooltip(tooltip);
 			label.setTextOverrun(OverrunStyle.ELLIPSIS);
 
 			var sp = new StackPane(label);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
@@ -28,11 +28,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javafx.collections.SetChangeListener;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
@@ -43,7 +45,6 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.OverrunStyle;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.SeparatorMenuItem;
-import javafx.scene.control.TitledPane;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseEvent;
@@ -130,6 +131,11 @@ class PathClassPane {
 
 		titled.setContentDisplay(ContentDisplay.RIGHT);
 		pane = new BorderPane(titled);
+
+		// Refresh when visibilities change
+		var options = qupath.getOverlayOptions();
+		options.hideExactClassesOnlyProperty().addListener((v, o, n) -> listClasses.refresh());
+		options.hiddenClassesProperty().addListener((SetChangeListener.Change<? extends PathClass> c) -> listClasses.refresh());
 	}
 
 
@@ -374,6 +380,9 @@ class PathClassPane {
 		MenuItem miSetVisible = new MenuItem("Show objects with selected classes");
 		miSetVisible.setOnAction(e -> setSelectedClassesVisibility(true));
 
+		CheckMenuItem miShowHideExact = new CheckMenuItem("Only hide if object class matches exactly");
+		miShowHideExact.selectedProperty().bindBidirectional(qupath.getOverlayOptions().hideExactClassesOnlyProperty());
+
 		MenuItem miSelectObjects = new MenuItem("Select objects by classification");
 		miSelectObjects.disableProperty().bind(Bindings.createBooleanBinding(
 				() -> {
@@ -400,6 +409,7 @@ class PathClassPane {
 		menu.getItems().addAll(
 				miSetVisible,
 				miSetHidden,
+				miShowHideExact,
 				new SeparatorMenuItem(),
 				miSelectObjects);
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
@@ -51,6 +51,7 @@ import javafx.scene.paint.Color;
 import org.controlsfx.control.action.Action;
 import org.controlsfx.control.action.ActionUtils;
 import org.controlsfx.glyphfont.FontAwesome;
+import org.controlsfx.glyphfont.GlyphFontRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -698,7 +699,9 @@ class PathClassPane {
 
 		private final Node iconShowing = new StackPane(IconFactory.createNode(FontAwesome.Glyph.EYE));
 		private final Node iconHidden = new StackPane(IconFactory.createNode(FontAwesome.Glyph.EYE_SLASH));
-		private final Node iconUnavailable = new StackPane(IconFactory.createNode(FontAwesome.Glyph.TIMES));
+		private final Node iconUnavailable = new StackPane(GlyphFontRegistry.font("FontAwesome")
+				.create('\uf2a8')
+				.size(QuPathGUI.TOOLBAR_ICON_SIZE));
 
 		private static final String STYLE_HIDDEN = "-fx-font-family:arial; -fx-font-style:italic;";
 		private static final String STYLE_SHOWING = "-fx-font-family:arial; -fx-font-style:normal;";

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
@@ -124,7 +124,7 @@ class PathClassPane {
 		this.qupath = qupath;
 		this.availablePathClasses = qupath.getAvailablePathClasses();
 		var mainPane = createClassPane();
-		var titled = createLeftRightTitledPane("Class list", createTitleNode());
+		var titled = GuiTools.createLeftRightTitledPane("Class list", createTitleNode());
 		titled.setContent(mainPane);
 		mainPane.setPadding(Insets.EMPTY);
 
@@ -132,36 +132,6 @@ class PathClassPane {
 		pane = new BorderPane(titled);
 	}
 
-	static TitledPane createLeftRightTitledPane(String name, Node right) {
-		var label = new Label(name);
-		label.setMaxWidth(Double.MAX_VALUE);
-		label.setMaxHeight(Double.MAX_VALUE);
-		label.setAlignment(Pos.CENTER_LEFT);
-		return createLeftRightTitledPane(label, right);
-	}
-
-	private static TitledPane createLeftRightTitledPane(Node left, Node right) {
-		var pane = new BorderPane();
-		pane.setLeft(left);
-		pane.setRight(right);
-		pane.setMaxWidth(Double.MAX_VALUE);
-		pane.setPadding(Insets.EMPTY);
-		var titled = new TitledPane();
-		titled.setGraphic(pane);
-		titled.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
-		titled.setAlignment(Pos.CENTER);
-		titled.setMaxWidth(Double.MAX_VALUE);
-		titled.setMaxHeight(Double.MAX_VALUE);
-		titled.setCollapsible(false);
-		pane.paddingProperty().bind(Bindings.createObjectBinding(() -> {
-			if (titled.isCollapsible())
-				return new Insets(0, 5, 0, 25);
-			else
-				return new Insets(0, 5, 0, 5);
-		}, titled.collapsibleProperty()));
-		pane.minWidthProperty().bind(titled.widthProperty());
-		return titled;
-	}
 
 
 	private Pane createTitleNode() {
@@ -186,12 +156,7 @@ class PathClassPane {
 		var spacer = new Pane();
 		spacer.setPrefWidth(4.0);
 
-		var insets = new Insets(1.0, 8, 1, 8);
-		btnAdd.setPadding(insets);
-		btnRemove.setPadding(insets);
-		btnMore.setPadding(insets);
-
-		return new HBox(spacer, btnAdd, btnRemove, btnMore);
+		return new HBox(btnAdd, btnRemove, btnMore);
 	}
 
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
@@ -64,6 +64,7 @@ import javafx.scene.control.TableColumn.CellDataFeatures;
 import javafx.scene.control.TableRow;
 import qupath.fx.controls.PredicateTextField;
 import qupath.lib.gui.measure.ObservableMeasurementTableData;
+import qupath.lib.gui.tools.GuiTools;
 import qupath.lib.images.ImageData;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.hierarchy.events.PathObjectHierarchyEvent;
@@ -155,9 +156,7 @@ public class SelectedMeasurementTableView implements PathObjectSelectionListener
 	private TableView<String> createMeasurementTable() {
 		TableView<String> tableMeasurements = new TableView<>();
 
-		var placeholder = new Text("No image or object selected");
-		placeholder.setStyle("-fx-fill: -fx-text-base-color;");
-		tableMeasurements.setPlaceholder(placeholder);
+		tableMeasurements.setPlaceholder(GuiTools.createPlaceholderText("No image or object selected"));
 		allKeys.setAll(tableModel.getAllNames());
 		tableMeasurements.setItems(filteredKeys);
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
@@ -41,6 +41,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Pane;
+import javafx.scene.text.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +93,7 @@ public class SelectedMeasurementTableView implements PathObjectSelectionListener
 	private BorderPane pane;
 	private TableView<String> tableMeasurements;
 	
-	private ObservableMeasurementTableData tableModel = new ObservableMeasurementTableData();
+	private final ObservableMeasurementTableData tableModel = new ObservableMeasurementTableData();
 	
 	private boolean delayedUpdate = false;
 
@@ -102,14 +103,14 @@ public class SelectedMeasurementTableView implements PathObjectSelectionListener
 	 * Property to indicate whether the table is currently visible.
 	 * If it isn't, it doesn't need to be updated.
 	 */
-	private BooleanProperty isShowing = new SimpleBooleanProperty(false);
+	private final BooleanProperty isShowing = new SimpleBooleanProperty(false);
 
-	private ObservableList<String> allKeys = FXCollections.observableArrayList();
-	private FilteredList<String> filteredKeys = new FilteredList<>(allKeys);
+	private final ObservableList<String> allKeys = FXCollections.observableArrayList();
+	private final FilteredList<String> filteredKeys = new FilteredList<>(allKeys);
 
-	private BooleanProperty useRegex = new SimpleBooleanProperty(false);
-	private BooleanProperty ignoreCase = new SimpleBooleanProperty(true);
-	private StringProperty filterText = new SimpleStringProperty("");
+	private final BooleanProperty useRegex = new SimpleBooleanProperty(false);
+	private final BooleanProperty ignoreCase = new SimpleBooleanProperty(true);
+	private final StringProperty filterText = new SimpleStringProperty("");
 
 	/**
 	 * Constructor.
@@ -153,6 +154,10 @@ public class SelectedMeasurementTableView implements PathObjectSelectionListener
 	@SuppressWarnings("unchecked")
 	private TableView<String> createMeasurementTable() {
 		TableView<String> tableMeasurements = new TableView<>();
+
+		var placeholder = new Text("No image or object selected");
+		placeholder.setStyle("-fx-fill: -fx-text-base-color;");
+		tableMeasurements.setPlaceholder(placeholder);
 		allKeys.setAll(tableModel.getAllNames());
 		tableMeasurements.setItems(filteredKeys);
 
@@ -251,7 +256,6 @@ public class SelectedMeasurementTableView implements PathObjectSelectionListener
 						return "Filter measurements by key";
 				}, useRegex)
 		);
-		filter.setSpacing(5.0);
 		var tooltip = new Tooltip("Enter text to find specific measurements by key");
 		Tooltip.install(filter, tooltip);
 		return filter;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/ColorToolsFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/ColorToolsFX.java
@@ -61,8 +61,8 @@ public class ColorToolsFX {
 	 */
 	public static final Color TRANSLUCENT_WHITE_FX = Color.rgb(255, 255, 255, 0.5);
 
-	private static Map<Integer, Color> colorMap = new HashMap<>();
-	private static Map<Integer, Color> colorMapWithAlpha = new HashMap<>();
+	private static final Map<Integer, Color> colorMap = new HashMap<>();
+	private static final Map<Integer, Color> colorMapWithAlpha = new HashMap<>();
 	
 	private static final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
     private static final Lock r = rwl.readLock();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -58,6 +58,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
 import javafx.scene.robot.Robot;
+import javafx.scene.text.Text;
 import javafx.stage.Modality;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
@@ -128,8 +129,15 @@ public class GuiTools {
 	/**
 	 * Vertical ellipsis, which can be used to indicate a 'more' button.
 	 */
-	private static String MORE_ELLIPSIS = "⋮";
-	
+	private static final String MORE_ELLIPSIS = "⋮";
+
+	/**
+	 * Style class to use with placeholder text.
+	 * This is commonly used in a list or table to indicate that no items are present.
+	 */
+	public static final String STYLE_PLACEHOLDER_TEXT = "text-placeholder";
+
+
 	/**
 	 * Create a {@link Button} with a standardized icon and tooltip text to indicate 'More', 
 	 * which triggers a {@link ContextMenu} when clicked.
@@ -176,11 +184,27 @@ public class GuiTools {
 		Dialogs.showErrorMessage(title, QuPathResources.getString("Dialogs.noProject"));
 	}
 
+	/**
+	 * Create a {@link Text} object for use as a placeholder in a list or table.
+	 * This is used to overcome the fact that the default styling does not update with the application
+	 * theme (e.g. dark mode), and {@link Text} nodes do not have a style class associated with them
+	 * by default.
+	 * @param text the text to display
+	 * @return a text object showing the requested text
+	 * @see #STYLE_PLACEHOLDER_TEXT
+	 * @since v0.6.0
+	 */
+	public static Text createPlaceholderText(String text) {
+		var textNode = new Text(text);
+		textNode.getStyleClass().add(STYLE_PLACEHOLDER_TEXT);
+		return textNode;
+	}
+
 
 	/**
 	 * Kinds of snapshot image that can be created for QuPath.
 	 */
-	public static enum SnapshotType {
+	public enum SnapshotType {
 		/**
 		 * Snapshot of the current viewer content.
 		 */

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/PathClassListCell.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/PathClassListCell.java
@@ -1,0 +1,90 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
+ * Contact: IP Management (ipmanagement@qub.ac.uk)
+ * Copyright (C) 2018 - 2023, 2025 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.tools;
+
+import javafx.scene.control.ListCell;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+import qupath.lib.objects.classes.PathClass;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * A cell for displaying {@link PathClass} objects in a list view or combo box.
+ * @since v0.6.0
+ */
+public class PathClassListCell extends ListCell<PathClass> {
+
+    private final Function<PathClass, String> stringFunction;
+    private final Rectangle rectangle = new Rectangle(10, 10);
+
+    /**
+     * Create a list cell using the specified string function.
+     * @param stringFunction function to convert a path class (or null) to a string.
+     */
+    public PathClassListCell(Function<PathClass, String> stringFunction) {
+        Objects.requireNonNull(stringFunction);
+        this.stringFunction = stringFunction;
+    }
+
+    /**
+     * Create a list cell using the default string function.
+     * @see #defaultStringFunction(PathClass)
+     */
+    public PathClassListCell() {
+        this(PathClassListCell::defaultStringFunction);
+    }
+
+    @Override
+    protected void updateItem(PathClass value, boolean empty) {
+        super.updateItem(value, empty);
+        if (value == null || empty) {
+            setText(null);
+            setGraphic(null);
+        } else {
+            if (value == PathClass.NULL_CLASS) {
+                rectangle.setFill(Color.TRANSPARENT);
+            } else {
+                rectangle.setFill(ColorToolsFX.getPathClassColor(value));
+            }
+            setText(stringFunction.apply(value));
+            setGraphic(rectangle);
+        }
+    }
+
+    /**
+     * Default function to convert a PathClass to a string.
+     * Returns {@code "None"} if the PathClass is {@code null} or {@link PathClass#NULL_CLASS},
+     * otherwise uses {@link PathClass#toString()}.
+     * @param pathClass input class
+     * @return string representation
+     */
+    public static String defaultStringFunction(PathClass pathClass) {
+        if (pathClass == null || pathClass == PathClass.NULL_CLASS)
+            return "None";
+        return pathClass.toString();
+    }
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -72,30 +72,30 @@ public class OverlayOptions {
 		CENTROIDS
 		};
 	
-	private ObjectProperty<MeasurementMapper> measurementMapper = new SimpleObjectProperty<>();
-	private BooleanProperty showAnnotations = new SimpleBooleanProperty(null, "showAnnotations", true);
-	private BooleanProperty showNames = new SimpleBooleanProperty(null, "showAnnotationNames", true);
-	private BooleanProperty showTMAGrid = new SimpleBooleanProperty(null, "showTMAGrid", true);
-	private BooleanProperty showDetections = new SimpleBooleanProperty(null, "showDetections", true);
-	private BooleanProperty showConnections = new SimpleBooleanProperty(null, "showConnections", false);
-	private BooleanProperty fillDetections = new SimpleBooleanProperty(null, "fillDetections", false);
-	private BooleanProperty fillAnnotations = new SimpleBooleanProperty(null, "fillAnnotations", false);
-	private BooleanProperty showTMACoreLabels = new SimpleBooleanProperty(null, "showTMACoreLabels", false);
-	private BooleanProperty showGrid = new SimpleBooleanProperty(null, "showGrid", false);
-	private ObjectProperty<GridLines> gridLines = new SimpleObjectProperty<>(null, "showGridLines", new GridLines());
+	private final ObjectProperty<MeasurementMapper> measurementMapper = new SimpleObjectProperty<>();
+	private final BooleanProperty showAnnotations = new SimpleBooleanProperty(null, "showAnnotations", true);
+	private final BooleanProperty showNames = new SimpleBooleanProperty(null, "showAnnotationNames", true);
+	private final BooleanProperty showTMAGrid = new SimpleBooleanProperty(null, "showTMAGrid", true);
+	private final BooleanProperty showDetections = new SimpleBooleanProperty(null, "showDetections", true);
+	private final BooleanProperty showConnections = new SimpleBooleanProperty(null, "showConnections", false);
+	private final BooleanProperty fillDetections = new SimpleBooleanProperty(null, "fillDetections", false);
+	private final BooleanProperty fillAnnotations = new SimpleBooleanProperty(null, "fillAnnotations", false);
+	private final BooleanProperty showTMACoreLabels = new SimpleBooleanProperty(null, "showTMACoreLabels", false);
+	private final BooleanProperty showGrid = new SimpleBooleanProperty(null, "showGrid", false);
+	private final ObjectProperty<GridLines> gridLines = new SimpleObjectProperty<>(null, "showGridLines", new GridLines());
 
-	private BooleanProperty showPixelClassification = new SimpleBooleanProperty(null, "showPixelClassification", true);
-	private ObjectProperty<RegionFilter> pixelClassificationFilter = new SimpleObjectProperty<>(null, "pixelClassificationFilter", RegionFilter.StandardRegionFilters.EVERYWHERE);
+	private final BooleanProperty showPixelClassification = new SimpleBooleanProperty(null, "showPixelClassification", true);
+	private final ObjectProperty<RegionFilter> pixelClassificationFilter = new SimpleObjectProperty<>(null, "pixelClassificationFilter", RegionFilter.StandardRegionFilters.EVERYWHERE);
 
-	private FloatProperty fontSize = new SimpleFloatProperty();
+	private final FloatProperty fontSize = new SimpleFloatProperty();
 
-	private ObservableSet<PathClass> hiddenClasses = FXCollections.observableSet();
+	private final ObservableSet<PathClass> hiddenClasses = FXCollections.observableSet();
 
-	private ObjectProperty<DetectionDisplayMode> cellDisplayMode = new SimpleObjectProperty<>(null, "cellDisplayMode", DetectionDisplayMode.NUCLEI_AND_BOUNDARIES);
+	private final ObjectProperty<DetectionDisplayMode> cellDisplayMode = new SimpleObjectProperty<>(null, "cellDisplayMode", DetectionDisplayMode.NUCLEI_AND_BOUNDARIES);
 
-	private FloatProperty opacity = new SimpleFloatProperty(1.0f);
+	private final FloatProperty opacity = new SimpleFloatProperty(1.0f);
 	
-	private LongProperty timestamp = new SimpleLongProperty(System.currentTimeMillis());
+	private final LongProperty timestamp = new SimpleLongProperty(System.nanoTime());
 
 	private static final OverlayOptions SHARED_INSTANCE = createSharedInstance();
 
@@ -175,7 +175,7 @@ public class OverlayOptions {
 	}
 	
 	private void updateTimestamp() {
-		this.timestamp.set(System.currentTimeMillis());
+		this.timestamp.set(System.nanoTime());
 	}
 	
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
@@ -91,6 +91,7 @@ public class OverlayOptions {
 	private final FloatProperty fontSize = new SimpleFloatProperty();
 
 	private final ObservableSet<PathClass> hiddenClasses = FXCollections.observableSet();
+	private final BooleanProperty hideExactClassesOnly = new SimpleBooleanProperty(false);
 
 	private final ObjectProperty<DetectionDisplayMode> cellDisplayMode = new SimpleObjectProperty<>(null, "cellDisplayMode", DetectionDisplayMode.NUCLEI_AND_BOUNDARIES);
 
@@ -113,7 +114,8 @@ public class OverlayOptions {
 		for (var prop : Arrays.asList(options.showNames, options.showConnections, options.fillDetections,
 				options.fillAnnotations, options.showTMACoreLabels,
 				options.showGrid, options.showAnnotations, options.showDetections,
-				options.showPixelClassification, options.showTMAGrid)) {
+				options.showPixelClassification, options.showTMAGrid,
+				options.hideExactClassesOnly)) {
 			prop.bindBidirectional(PathPrefs.createPersistentPreference("overlayOptions_" + prop.getName(), prop.get()));
 		}
 		options.cellDisplayMode.bindBidirectional(PathPrefs.createPersistentPreference("overlayOptions_cellDisplayMode", options.cellDisplayMode.get(), DetectionDisplayMode.class));
@@ -162,6 +164,8 @@ public class OverlayOptions {
 		this.fillDetections.set(options.fillDetections.get());
 		this.gridLines.set(options.gridLines.get());
 		this.hiddenClasses.addAll(options.hiddenClasses);
+		this.showObjectPredicateProperty().set(options.showObjectPredicateProperty().get());
+		this.hideExactClassesOnly.set(options.hideExactClassesOnlyProperty().get());
 		this.measurementMapper.set(options.measurementMapper.get());
 		this.opacity.set(options.opacity.get());
 		this.showAnnotations.set(options.showAnnotations.get());
@@ -545,6 +549,7 @@ public class OverlayOptions {
 	 * <p>
 	 * @return the predicate used to determine whether an object should be displayed or hidden
 	 * @see #isHidden(PathObject)
+	 * @since v0.6.0
 	 */
 	public ObjectProperty<Predicate<PathObject>> showObjectPredicateProperty() {
 		return showObjectPredicate;
@@ -552,6 +557,7 @@ public class OverlayOptions {
 
 	/**
 	 * Reset the value of {@link #showObjectPredicateProperty()}.
+	 * @since v0.6.0
 	 */
 	public void resetShowObjectPredicate() {
 		setShowObjectPredicate(null);
@@ -565,6 +571,7 @@ public class OverlayOptions {
 	 *
 	 * @param pathObjectPredicate the predicate to use, or {@code null} null if no predicate should be used
 	 * @see #isHidden(PathObject)
+	 * @since v0.6.0
 	 */
 	public void setShowObjectPredicate(Predicate<PathObject> pathObjectPredicate) {
 		showObjectPredicate.set(pathObjectPredicate);
@@ -573,6 +580,7 @@ public class OverlayOptions {
 	/**
 	 * Get the value of {@link #showObjectPredicateProperty()}.
 	 * @return the value of the predicate
+	 * @since v0.6.0
 	 */
 	public Predicate<PathObject> getShowObjectPredicate() {
 		return showObjectPredicate.get();
@@ -608,8 +616,7 @@ public class OverlayOptions {
 		if (hiddenClasses.contains(pathClass))
 			return true;
 
-		boolean hideExactClassificationsOnly = false;
-		if (hideExactClassificationsOnly)
+		if (getHideExactClassesOnly())
 			return false;
 		else
 			return isPathClassHiddenByParts(pathClass);
@@ -654,6 +661,37 @@ public class OverlayOptions {
 	 */
 	public ObservableSet<PathClass> hiddenClassesProperty() {
 		return hiddenClasses;
+	}
+
+	/**
+	 * Request that only exact matches to classes in {@link #hiddenClassesProperty()} should be hidden.
+	 * This influences the result of {@link #isPathClassHidden(PathClass)}.
+	 * <p>
+	 * If false, then any object with a classification that is a superset of a hidden classification will also be hidden.
+	 * For example, if {@code "CD3"} is hidden then {@code "CD3: CD8"} will also be hidden.
+	 * @return
+	 * @since v0.6.0
+	 */
+	public BooleanProperty hideExactClassesOnlyProperty() {
+		return hideExactClassesOnly;
+	}
+
+	/**
+	 * Get the value of {@link #hideExactClassesOnlyProperty()}.
+	 * @return
+	 * @since v0.6.0
+	 */
+	public boolean getHideExactClassesOnly() {
+		return hideExactClassesOnly.get();
+	}
+
+	/**
+	 * Set the value of {@link #hideExactClassesOnlyProperty()}.
+	 * @param value the new value
+	 * @since v0.6.0
+	 */
+	public void setHideExactClassesOnly(boolean value) {
+		hideExactClassesOnly.set(value);
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
@@ -527,7 +527,8 @@ public class OverlayOptions {
 		if (pathClass == null || pathClass == PathClass.NULL_CLASS)
 			return hiddenClasses.contains(null) || hiddenClasses.contains(PathClass.NULL_CLASS);
 		return hiddenClasses.contains(pathClass) || 
-				((PathClassTools.isPositiveOrGradedIntensityClass(pathClass) || PathClassTools.isNegativeClass(pathClass)) && pathClass.isDerivedClass() && isPathClassHidden(pathClass.getParentClass()));
+				((PathClassTools.isPositiveOrGradedIntensityClass(pathClass) || PathClassTools.isNegativeClass(pathClass)) &&
+						pathClass.isDerivedClass() && isPathClassHidden(pathClass.getParentClass()));
 	}
 
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -252,7 +252,7 @@ public class PathObjectPainter {
 
 		// Always paint selected objects, otherwise check if the object should be hidden
 		if (!isSelected) {
-			if ((overlayOptions.isPathClassHidden(pathObject.getPathClass()) && !pathObject.isTMACore())
+			if ((overlayOptions.isHidden(pathObject) && !pathObject.isTMACore())
 					|| isHiddenObjectType(pathObject, overlayOptions))
 				return false;
 		}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -914,6 +914,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 			overlayOptionsManager.attachListener(overlayOptions.measurementMapperProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.detectionDisplayModeProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.showConnectionsProperty(), repainterOverlay);
+			overlayOptionsManager.attachListener(overlayOptions.showObjectPredicateProperty(), repainterOverlay);
 
 			overlayOptionsManager.attachListener(overlayOptions.showAnnotationsProperty(), repainter);
 			overlayOptionsManager.attachListener(overlayOptions.showNamesProperty(), repainter);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -911,6 +911,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 			
 			overlayOptionsManager.attachListener(overlayOptions.fillDetectionsProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.hiddenClassesProperty(), repainterOverlay);
+			overlayOptionsManager.attachListener(overlayOptions.hideExactClassesOnlyProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.measurementMapperProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.detectionDisplayModeProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.showConnectionsProperty(), repainterOverlay);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/HierarchyOverlay.java
@@ -365,7 +365,7 @@ public class HierarchyOverlay extends AbstractOverlay {
 					}
 				}
 				
-				if (name != null && !name.isBlank() && roi != null && !overlayOptions.isPathClassHidden(namedObject.getPathClass())) {
+				if (name != null && !name.isBlank() && roi != null && !overlayOptions.isHidden(namedObject)) {
 
 					var bounds = metrics.getStringBounds(name, g2d);
 

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -187,3 +187,8 @@
   -fx-fill: -qp-script-warn-color;
   -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.25), 2, 0, 1, 1);
 }
+
+/* Title pane with small additional buttons */
+.titled-pane > .title .titled-button-pane .button {
+  -fx-padding: 1 8 1 8;
+}

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -45,6 +45,11 @@
 
 }
 
+/* Text objects used as placeholders */
+.text-placeholder {
+  -fx-fill: -fx-text-base-color;
+  -fx-opacity: 0.8;
+}
 
 /* Soften the main toolbar icons */
 .tool-bar .qupath-icon * {

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -3,6 +3,7 @@
 ContextHelp.title = Context help
 ContextHelp.defaultHelpText = Move the cursor over something to view any available help text
 ContextHelp.warning.selectionMode = Selection mode is active - this will switch drawing tools to become selection tools instead
+ContextHelp.warning.hiddenObjectsPredicate = Overlay options are set to hide objects based on a predicate
 ContextHelp.warning.annotationsHidden = Annotations are hidden
 ContextHelp.warning.detectionsHidden = Detections are hidden
 ContextHelp.warning.classificationsHidden = Objects might be hidden based on their classification.\n\


### PR DESCRIPTION
This PR cleans up the classification list and introduces icons so that it is easier to see that visibility can be toggled.

<img src="https://github.com/user-attachments/assets/1caab7b2-4309-4d82-aa94-63fc162fdc6d" width="40%">

We still need to figure out what the right behavior is when toggling...