### PR TITLE
Another attempt to improve class visibility settings

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
@@ -27,7 +27,6 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.LongBinding;
 import javafx.beans.binding.ObjectExpression;
-import javafx.beans.binding.SetBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -63,7 +62,6 @@ import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.actions.InfoMessage;
 import qupath.lib.gui.localization.QuPathResources;
 import qupath.lib.gui.prefs.PathPrefs;
-import qupath.lib.gui.tools.ColorToolsFX;
 import qupath.lib.gui.tools.IconFactory;
 import qupath.lib.gui.tools.IconFactory.PathIcons;
 import qupath.lib.gui.viewer.QuPathViewer;
@@ -573,7 +571,7 @@ public class ContextHelpViewer {
 	private HelpListEntry createHiddenClassificationsEntry() {
 		var entry = HelpListEntry.createWarning(
 				"ContextHelp.warning.classificationsHidden");
-		entry.visibleProperty().bind(Bindings.isEmpty(qupath.getOverlayOptions().hiddenClassesProperty()).not());
+		entry.visibleProperty().bind(Bindings.isEmpty(qupath.getOverlayOptions().selectedClassesProperty()).not());
 		return entry;
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
@@ -269,16 +269,16 @@ class PathClassPane {
 		@Override
 		public String toString(OverlayOptions.ClassVisibilityMode object) {
 			return switch (object) {
-				case HIDE_SELECTED -> "Select to hide";
-				case SHOW_SELECTED -> "Select to show";
+				case HIDE_SELECTED -> "Show by default";
+				case SHOW_SELECTED -> "Hide by default";
 			};
 		}
 
 		@Override
 		public OverlayOptions.ClassVisibilityMode fromString(String string) {
 			return switch (string) {
-				case "Select to hide" -> OverlayOptions.ClassVisibilityMode.HIDE_SELECTED;
-				case "Select to show" -> OverlayOptions.ClassVisibilityMode.SHOW_SELECTED;
+				case "Show by default" -> OverlayOptions.ClassVisibilityMode.HIDE_SELECTED;
+				case "Hide by default" -> OverlayOptions.ClassVisibilityMode.SHOW_SELECTED;
 				default -> null;
 			};
 		}
@@ -344,7 +344,7 @@ class PathClassPane {
 			e.consume();
 			return;
 		} else if (pasteCombo.match(e)) {
-			logger.debug("Paste not implemented for classification list!");
+			logger.debug("Paste not implemented for class list!");
 			e.consume();
 			return;
 		}
@@ -418,7 +418,7 @@ class PathClassPane {
 		MenuItem miResetClassVisibility = new MenuItem("Reset selected classes");
 		miResetClassVisibility.setOnAction(e -> resetSelectedClassVisibility());
 
-		MenuItem miRestoreClassVisibilityDefaults = new MenuItem("Restore default visibility");
+		MenuItem miRestoreClassVisibilityDefaults = new MenuItem("Restore class visibility to default settings");
 		miRestoreClassVisibilityDefaults.setOnAction(e -> restoreClassVisibilityDefaults());
 
 		menu.getItems().addAll(
@@ -582,7 +582,7 @@ class PathClassPane {
 				.collect(Collectors.toCollection(ArrayList::new));
 
 		if (newClasses.isEmpty()) {
-			Dialogs.showErrorMessage("Set available classes", "No classifications found in current image!");
+			Dialogs.showErrorMessage("Set available classes", "No classes found in current image!");
 			return false;
 		}
 		
@@ -629,7 +629,7 @@ class PathClassPane {
 				return false;
 			}
 			if (pathClasses.size() == availablePathClasses.size() && availablePathClasses.containsAll(pathClasses)) {
-				Dialogs.showInfoNotification("Import PathClasses", file.getName() + " contains same classifications - no changes to make");
+				Dialogs.showInfoNotification("Import PathClasses", file.getName() + " contains same classes - no changes to make");
 				return false;
 			}
 			availablePathClasses.setAll(pathClasses);
@@ -797,7 +797,7 @@ class PathClassPane {
 			label.setMinWidth(20);
 			label.setGraphic(rectangle);
 			// Tooltip for the main label (but not the visibility part)
-			Tooltip tooltip = new Tooltip("Available classifications (right-click to add or remove).\n" +
+			Tooltip tooltip = new Tooltip("Available classes (right-click to add or remove).\n" +
 					"Names ending with an Asterisk* are 'ignored' under certain circumstances - see the docs for more info.");
 			label.setTooltip(tooltip);
 			label.setTextOverrun(OverrunStyle.ELLIPSIS);
@@ -817,7 +817,7 @@ class PathClassPane {
 		private void configureHiddenIcon() {
 			iconHidden.opacityProperty().bind(opacityBinding);
 			if (overlayOptions != null) {
-				Tooltip.install(iconHidden, new Tooltip("Classification hidden - click to toggle visibility"));
+				Tooltip.install(iconHidden, new Tooltip("Class hidden - click to toggle visibility"));
 				iconHidden.setOnMouseClicked(this::handleToggleVisibility);
 			}
 		}
@@ -825,7 +825,7 @@ class PathClassPane {
 		private void configureShowingIcon() {
 			iconShowing.opacityProperty().bind(opacityBinding);
 			if (overlayOptions != null) {
-				Tooltip.install(iconShowing, new Tooltip("Classification showing - click to toggle visibility"));
+				Tooltip.install(iconShowing, new Tooltip("Class showing - click to toggle visibility"));
 				iconShowing.setOnMouseClicked(this::handleToggleVisibility);
 			}
 		}
@@ -863,7 +863,7 @@ class PathClassPane {
 			iconUnavailable.opacityProperty().bind(opacityBinding);
 			if (overlayOptions != null) {
 				Tooltip.install(iconUnavailable,
-						new Tooltip("Derived classification is hidden because a related classification is already hidden"));
+						new Tooltip("Derived class is hidden because a related class is already hidden"));
 				iconUnavailable.setOnMouseClicked(this::handleToggleVisibility);
 			}
 		}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
@@ -805,7 +805,7 @@ class PathClassPane {
 			label.setMaxWidth(Double.MAX_VALUE);
 			label.setMinWidth(20);
 
-			colorPicker.getStyleClass().addAll("button", "minimal-color-picker", "always-opaque");
+			colorPicker.getStyleClass().addAll( "minimal-color-picker", "always-opaque", "button");
 			colorPicker.setStyle("-fx-color-rect-width: " + colorPickerSize + "; -fx-color-rect-height: " + colorPickerSize + ";");
 			colorPicker.setOnHiding(e -> this.handleColorChange(colorPicker.getValue()));
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
@@ -51,9 +51,22 @@ import java.util.function.Predicate;
  */
 public class OverlayOptions {
 
+	/**
+	 * Visibility modes for classes.
+	 * This refers to how {@link #selectedClassesProperty()} and {@link #useExactSelectedClassesProperty()}
+	 * are interpreted.
+	 */
 	public enum ClassVisibilityMode {
-		SHOW_SELECTED,
-		HIDE_SELECTED
+		/**
+		 * Hide classes that are included in the selected class collection.
+		 * Show all other classes.
+		 */
+		HIDE_SELECTED,
+		/**
+		 * Show classes that are included in the selected class collection.
+		 * Hide all other classes.
+		 */
+		SHOW_SELECTED
 	}
 	
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -910,8 +910,8 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 		if (overlayOptions != null) {
 			
 			overlayOptionsManager.attachListener(overlayOptions.fillDetectionsProperty(), repainterOverlay);
-			overlayOptionsManager.attachListener(overlayOptions.hiddenClassesProperty(), repainterOverlay);
-			overlayOptionsManager.attachListener(overlayOptions.hideExactClassesOnlyProperty(), repainterOverlay);
+			overlayOptionsManager.attachListener(overlayOptions.selectedClassesProperty(), repainterOverlay);
+			overlayOptionsManager.attachListener(overlayOptions.selectedClassVisibilityModeProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.measurementMapperProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.detectionDisplayModeProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.showConnectionsProperty(), repainterOverlay);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -912,6 +912,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 			overlayOptionsManager.attachListener(overlayOptions.fillDetectionsProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.selectedClassesProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.selectedClassVisibilityModeProperty(), repainterOverlay);
+			overlayOptionsManager.attachListener(overlayOptions.useExactSelectedClassesProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.measurementMapperProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.detectionDisplayModeProperty(), repainterOverlay);
 			overlayOptionsManager.attachListener(overlayOptions.showConnectionsProperty(), repainterOverlay);

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -130,13 +130,17 @@
   -fx-text-alignment: center;
 }
 
-/*to prevent icons from being dark when the row is selected*/
-.list-cell .button .text {
-  -fx-fill: -fx-text-base-color;
-}
-.table-row-cell .button .text {
-  -fx-fill: -fx-text-base-color;
-}
+/* To prevent icons from being dark when the row is selected
+ * Removed because it was messing up the tooltip text color for minimal-color-picker -
+ * and updating qupath-icon to use the background color is hopefully sufficient.
+ * (Code left temporarily in case it's needed again.)
+ */
+/*.list-cell .button .text {*/
+/*  -fx-fill: -fx-text-base-color;*/
+/*}*/
+/*.table-row-cell .button .text {*/
+/*  -fx-fill: -fx-text-base-color;*/
+/*}*/
 
 .list-cell .extension-manager-list-icon {
   -fx-text-fill: -fx-text-background-color;

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -58,7 +58,7 @@
 
 /* Adapt menu icon colors */
 .qupath-icon {
-  -fx-text-fill: -fx-text-base-color;
+  -fx-text-fill: -fx-text-background-color;;
 }
 
 /* Used in command finder for help text */


### PR DESCRIPTION
Extension to https://github.com/qupath/qupath/pull/1752

Initial attempt to give the user control of not just *hiding* classes, but also *showing* them.

Previously, we could do things like say 'Hide all CD3 +ve cells'.
But we *couldn't* easily request 'Show me all CD +ve cells *only*.

This PR is pretty rough, but introduces an option to switch between selecting classes to hide or selecting classes to show.

<img width="222" alt="show-hide" src="https://github.com/user-attachments/assets/7dc8f0b7-a165-4ebb-92d1-d88ebe4250b7" />
