### PR TITLE
Fix error when starting a script from the command line

### DIFF
--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -46,14 +46,11 @@ import picocli.CommandLine.IVersionProvider;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParseResult;
-import qupath.ext.extensionmanager.core.ExtensionCatalogManager;
-import qupath.ext.extensionmanager.core.savedentities.Registry;
-import qupath.ext.extensionmanager.core.savedentities.SavedCatalog;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.common.Version;
 import qupath.lib.gui.BuildInfo;
 import qupath.lib.gui.QuPathApp;
-import qupath.lib.gui.UserDirectoryManager;
+import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.extensions.Subcommand;
 import qupath.lib.gui.images.stores.ImageRegionStoreFactory;
 import qupath.lib.gui.logging.LogManager;
@@ -351,18 +348,7 @@ class ScriptCommand implements Runnable {
 		
 	@Override
 	public void run() {
-		try (ExtensionCatalogManager extensionCatalogManager = new ExtensionCatalogManager(
-				UserDirectoryManager.getInstance().extensionsDirectoryProperty(),
-				QuPath.class.getClassLoader(),
-				String.format("v%s", BuildInfo.getInstance().getVersion().toString()),
-				new Registry(List.of(new SavedCatalog(
-						"QuPath catalog",
-						"Extensions maintained by the QuPath team",
-						URI.create("https://github.com/qupath/qupath-catalog"),
-						URI.create("https://raw.githubusercontent.com/qupath/qupath-catalog/refs/heads/main/catalog.json"),
-						false
-				)))
-		)){
+		try {
 			if (projectPath != null && !projectPath.toLowerCase().endsWith(ProjectIO.getProjectExtension()))
 				throw new IOException("Project file must end with '.qpproj'");
 			if (scriptCommand == null) {
@@ -376,8 +362,8 @@ class ScriptCommand implements Runnable {
 			createTileCache();
 
 			// Load image server builders from extensions
-			ImageServerProvider.setServiceLoader(ServiceLoader.load(ImageServerBuilder.class, extensionCatalogManager.getClassLoader()));
-			Thread.currentThread().setContextClassLoader(extensionCatalogManager.getClassLoader());
+			ImageServerProvider.setServiceLoader(ServiceLoader.load(ImageServerBuilder.class, QuPathGUI.getExtensionCatalogManager().getClassLoader()));
+			Thread.currentThread().setContextClassLoader(QuPathGUI.getExtensionCatalogManager().getClassLoader());
 			
 			// Unfortunately necessary to force initialization (including GsonTools registration of some classes)
 			QP.getCoreClasses();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -180,6 +180,18 @@ public class QuPathGUI {
 	
 	private static final Logger logger = LoggerFactory.getLogger(QuPathGUI.class);
 
+	private static final ExtensionCatalogManager extensionCatalogManager = new ExtensionCatalogManager(
+			UserDirectoryManager.getInstance().extensionsDirectoryProperty(),
+			QuPathGUI.class.getClassLoader(),
+			String.format("v%s", BuildInfo.getInstance().getVersion().toString()),
+			new Registry(List.of(new SavedCatalog(
+					"QuPath catalog",
+					"Extensions maintained by the QuPath team",
+					URI.create("https://github.com/qupath/qupath-catalog"),
+					URI.create("https://raw.githubusercontent.com/qupath/qupath-catalog/refs/heads/main/catalog.json"),
+					false
+			)))
+	);
 	private static QuPathGUI instance;
 	
 	/**
@@ -203,7 +215,6 @@ public class QuPathGUI {
 	private ViewerManager viewerManager;
 	private PathClassManager pathClassManager;
 	private UpdateManager updateManager;
-	private final ExtensionCatalogManager extensionCatalogManager;
 
 	private QuPathMainPaneManager mainPaneManager;
 	private UndoRedoManager undoRedoManager;
@@ -345,18 +356,6 @@ public class QuPathGUI {
 		// Install extensions
 		timeit.checkpoint("Adding extensions");
 		new QP(); // Ensure initialized
-		extensionCatalogManager = new ExtensionCatalogManager(
-				UserDirectoryManager.getInstance().extensionsDirectoryProperty(),
-				QuPathGUI.class.getClassLoader(),
-				String.format("v%s", BuildInfo.getInstance().getVersion().toString()),
-				new Registry(List.of(new SavedCatalog(
-						"QuPath catalog",
-						"Extensions maintained by the QuPath team",
-						URI.create("https://github.com/qupath/qupath-catalog"),
-						URI.create("https://raw.githubusercontent.com/qupath/qupath-catalog/refs/heads/main/catalog.json"),
-						false
-				)))
-		);
 		ExtensionLoader.loadFromManager(extensionCatalogManager, this);
 
                 // Add scripts menu (delayed to here, since it takes a bit longer)
@@ -1207,7 +1206,7 @@ public class QuPathGUI {
 	 * @return the {@link ExtensionCatalogManager} that manage catalogs and extensions of this
 	 * QuPath GUI
 	 */
-	public ExtensionCatalogManager getExtensionCatalogManager() {
+	public static ExtensionCatalogManager getExtensionCatalogManager() {
 		return extensionCatalogManager;
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/ScriptLanguageProvider.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/ScriptLanguageProvider.java
@@ -107,7 +107,7 @@ public class ScriptLanguageProvider {
 	
 	
 	private static ClassLoader getExtensionClassLoader() {
-		return QuPathGUI.getInstance().getExtensionCatalogManager().getClassLoader();
+		return QuPathGUI.getExtensionCatalogManager().getClassLoader();
 	}
 	
 	


### PR DESCRIPTION
Fix https://github.com/qupath/qupath/pull/1716#discussion_r1939224970 by making `ExtensionCatalogManager` a static member of `QuPathGUI`.

This is not a satisfactory solution because the `ExtensionCatalogManager` instance is created in `QuPathGUI` even when the user interface is not used. However, it was the simplest PR I could think of. A better way would have been to move `ScriptLanguageProvider` away from `qupath-gui-fx` (because it can be used without the UI) and make the methods of `ScriptLanguageProvider` not static.

