### PR TITLE
Load OpenSlide when checking image support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ They may change or be removed in future versions.
 * Create training image does not work properly for z-stacks / time series (https://github.com/qupath/qupath/issues/1701)
 * Channel colors are not stored properly when using saved display settings (https://github.com/qupath/qupath/issues/1726)
 * 'Split annotations by lines' does not work for z-stacks or time-series if line thickness > 0 (https://github.com/qupath/qupath/issues/1729)
+* QuPath ignores OpenSlide when opening some images from the command line outside a project (but they work properly in the UI) (https://github.com/qupath/qupath/issues/1758)
 
 ### API changes
 * New `Map<String, String> getMetadata()` method added to `PathObject`, `Project` and `ProjectImageEntry` (https://github.com/qupath/qupath/pull/1587)

--- a/qupath-extension-openslide/src/main/java/qupath/ext/openslide/OpenSlideExtension.java
+++ b/qupath-extension-openslide/src/main/java/qupath/ext/openslide/OpenSlideExtension.java
@@ -46,12 +46,11 @@ public class OpenSlideExtension implements QuPathExtension {
 
     private static final Logger logger = LoggerFactory.getLogger(OpenSlideExtension.class);
 
-    // TODO: Check why this fails if I use @DirectoryPref!
     @DirectoryPref("pref.openslide.path")
-    public StringProperty openslidePathProperty =
+    public static final StringProperty openslidePathProperty =
             PathPrefs.createPersistentPreference("openslide.path", "");
 
-    private ChangeListener<String> openslidePathListener = this::handleOpenSlideDirectoryChange;
+    private final ChangeListener<String> openslidePathListener = this::handleOpenSlideDirectoryChange;
 
     @Override
     public void installExtension(QuPathGUI qupath) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -109,7 +109,7 @@ public class PathPrefs {
 		return PreferenceManager.createForUserPreferences(nodeName);
 	}
 
-	private static BooleanProperty useSystemMenubar = new SimpleBooleanProperty();
+	private static final BooleanProperty useSystemMenubar = new SimpleBooleanProperty();
 
 	/**
 	 * Legacy property used to specify whether the system menubar should be used for the main QuPath stage.


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/1758

The fix is not entirely satisfying, because it does not use any custom path to an OpenSlide installation.

It *could*, but currently that would require access to `PathPrefs` - and therefore JavaFX.

As we try to avoid that from non UI-related code, the custom path is currently only used when the extension is installed through the UI.