### PR TITLE
Improved use of JTS

### DIFF
--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -66,6 +66,7 @@ import qupath.lib.images.servers.ImageServerProvider;
 import qupath.lib.images.servers.ImageServers;
 import qupath.lib.projects.Project;
 import qupath.lib.projects.ProjectIO;
+import qupath.lib.roi.GeometryTools;
 import qupath.lib.scripting.QP;
 import qupath.lib.scripting.ScriptParameters;
 import qupath.lib.scripting.languages.ExecutableLanguage;
@@ -247,11 +248,8 @@ public class QuPath {
 	 * Use -Djts.overlay=old to turn off this behavior.
 	 */
 	private static void initializeJTS() {
-		var prop = System.getProperty("jts.overlay");
-		if (prop == null) {
-			logger.debug("Setting -Djts.overlay=ng");
-			System.setProperty("jts.overlay", "ng");
-		}
+		// Ensure class is loaded, to ensure OverlayNG and RelateNG properties checked
+		GeometryTools.getDefaultFactory();
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/io/GsonTools.java
+++ b/qupath-core/src/main/java/qupath/lib/io/GsonTools.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -79,7 +79,7 @@ public class GsonTools {
 	
 	private static final Logger logger = LoggerFactory.getLogger(GsonTools.class);
 	
-	private static GsonBuilder builder = new GsonBuilder()
+	private static final GsonBuilder builder = new GsonBuilder()
 			.serializeSpecialFloatingPointValues()
 			.setStrictness(Strictness.LENIENT)
 			.registerTypeAdapterFactory(new QuPathTypeAdapterFactory())

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryROI.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2024 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -65,9 +65,9 @@ public class GeometryROI extends AbstractPathROI implements Serializable {
 	
 	private static final long serialVersionUID = 1L;
 	
-	private static Logger logger = LoggerFactory.getLogger(GeometryROI.class);
+	private static final Logger logger = LoggerFactory.getLogger(GeometryROI.class);
 	
-	private Geometry geometry;
+	private final Geometry geometry;
 	private boolean checkValid = false;
 	
 	private transient GeometryStats stats = null;
@@ -393,7 +393,7 @@ public class GeometryROI extends AbstractPathROI implements Serializable {
 		private final byte[] wkb;
 		private final int c, z, t;
 
-		private GeometryStats stats;
+		private final GeometryStats stats;
 
 		WKBSerializationProxy(final GeometryROI roi) {
 			this.wkb = new WKBWriter(2).write(roi.geometry);
@@ -406,7 +406,9 @@ public class GeometryROI extends AbstractPathROI implements Serializable {
 		}
 
 		private Object readResolve() throws ParseException {
-			var geometry = new WKBReader().read(wkb);
+			// Assume we can use the default factory, since we wrote the ROI -
+			// although if we were decreasing precision this could be problematic
+			var geometry = new WKBReader(GeometryTools.getDefaultFactory()).read(wkb);
 			GeometryROI roi = new GeometryROI(geometry, ImagePlane.getPlaneWithChannel(c, z, t));
 			roi.stats = this.stats;
 			return roi;

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.function.Function;
 import org.locationtech.jts.algorithm.locate.SimplePointInAreaLocator;
@@ -101,7 +100,7 @@ public class GeometryTools {
 	private static final Logger logger = LoggerFactory.getLogger(GeometryTools.class);
 	
 	private static final GeometryFactory DEFAULT_FACTORY = new GeometryFactory(
-			new PrecisionModel(100.0),
+			new PrecisionModel(-0.01), // Consider use of PrecisionModel.FLOATING_SINGLE
 			0,
 			PackedCoordinateSequenceFactory.FLOAT_FACTORY);
 
@@ -881,7 +880,10 @@ public class GeometryTools {
 	        	if (pixelWidth == 1 && pixelHeight == 1)
 	        		this.factory = DEFAULT_FACTORY;
 	        	else
-	        		this.factory = new GeometryFactory(new PrecisionModel(PrecisionModel.FLOATING_SINGLE), 0, PackedCoordinateSequenceFactory.FLOAT_FACTORY);
+	        		this.factory = new GeometryFactory(
+							new PrecisionModel(PrecisionModel.FLOATING_SINGLE),
+							0,
+							PackedCoordinateSequenceFactory.FLOAT_FACTORY);
 	    	} else
 	    		this.factory = factory;
 	        this.flatness = flatness;

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -98,7 +98,30 @@ import qupath.lib.roi.interfaces.ROI;
 public class GeometryTools {
 	
 	private static final Logger logger = LoggerFactory.getLogger(GeometryTools.class);
-	
+
+	static {
+		/*
+		 * Use OverlayNG with Java Topology Suite by default.
+		 * This can greatly reduce TopologyExceptions.
+		 * Use -Djts.overlay=old to turn off this behavior.
+		 */
+		var propOverlay = System.getProperty("jts.overlay");
+		if (!"old".equalsIgnoreCase(propOverlay)) {
+			logger.debug("Setting -Djts.overlay=ng");
+			System.setProperty("jts.overlay", "ng");
+		}
+
+		/*
+		 * Use RelateNG with Java Topology Suite by default.
+		 * This should be considerably faster.
+		 */
+		var propRelate = System.getProperty("jts.relate");
+		if (!"old".equalsIgnoreCase(propRelate)) {
+			logger.debug("Setting -Djts.relate=ng");
+			System.setProperty("jts.relate", "ng");
+		}
+	}
+
 	private static final GeometryFactory DEFAULT_FACTORY = new GeometryFactory(
 			new PrecisionModel(-0.01), // Consider use of PrecisionModel.FLOATING_SINGLE
 			0,

--- a/qupath-core/src/main/java/qupath/lib/roi/LineROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/LineROI.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2022, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -223,12 +223,6 @@ public class LineROI extends AbstractPathROI implements Serializable {
 				x, y, x2, y2,
 				plane);
 	}
-	
-	
-//	public Geometry getGeometry() {
-//		GeometryFactory factory = new GeometryFactory();
-//	}
-	
 	
 	@Override
 	public RoiType getRoiType() {

--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -183,7 +183,7 @@ public class RoiTools {
 			}
 			geometries.add(r.getGeometry());
 		}
-		Geometry first = geometries.remove(0);
+		Geometry first = geometries.removeFirst();
 		for (var geom : geometries)
 			first = first.intersection(geom);
 		return GeometryTools.geometryToROI(GeometryTools.homogenizeGeometryCollection(first), plane);
@@ -199,6 +199,32 @@ public class RoiTools {
 	 */
 	public static ROI intersection(ROI... rois) {
 		return intersection(Arrays.asList(rois));
+	}
+
+	/**
+	 * Create area of intersection between two area ROIs.
+	 * If the ROIs do not share the same z or t index, or are not area ROIs, 0 will be returned.
+	 * @param a first ROI
+	 * @param b second ROI
+	 * @return the area of intersection between a and b, or 0 if the ROIs do not intersect
+	 */
+	public static double intersectionArea(ROI a, ROI b) {
+		if (a.getZ() != b.getZ() || a.getT() != b.getT() || !a.isArea() || !b.isArea())
+			return 0;
+		return GeometryTools.intersectionArea(a.getGeometry(), b.getGeometry());
+	}
+
+	/**
+	 * Create intersection over union for two area ROIs.
+	 * @param a first ROI
+	 * @param b second ROI
+	 * @return the intersection over union between a and b, or 0 if the ROIs do not intersect
+	 */
+	public static double iou(ROI a, ROI b) {
+		double intersection = intersectionArea(a, b);
+		if (intersection == 0)
+			return 0;
+		return intersection / (a.getArea() + b.getArea() - intersection);
 	}
 	
 	/**

--- a/qupath-core/src/test/java/qupath/lib/roi/TestGeometryTools.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestGeometryTools.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2024 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -23,6 +23,7 @@ package qupath.lib.roi;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -381,6 +382,14 @@ public class TestGeometryTools {
 		assertNull(err);
 		assertTrue(geom.isValid());
 		assertEquals(area, geom.getArea(), eps);
+	}
+
+
+	@Test
+	public void testGeometryFactory() {
+		var factory = GeometryTools.getDefaultFactory();
+		assertFalse(factory.getPrecisionModel().isFloating());
+		assertEquals(100, factory.getPrecisionModel().getScale());
 	}
 
 }

--- a/qupath-core/src/test/java/qupath/lib/roi/TestGeometryTools.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestGeometryTools.java
@@ -301,8 +301,8 @@ public class TestGeometryTools {
 	@Disabled
 	public void randomPolygonize() {
 		Random rng = new Random(100);
-		PrecisionModel pm = new PrecisionModel(100.0);
-		GeometryFactory factory = new GeometryFactory(pm);
+		GeometryFactory factory = GeometryTools.getDefaultFactory();
+		PrecisionModel pm = factory.getPrecisionModel();
 		// Note that increasing this to 1000 will cause the test to fail.
 		int n = 100;
 		Coordinate[] coords = new Coordinate[n];
@@ -391,5 +391,57 @@ public class TestGeometryTools {
 		assertFalse(factory.getPrecisionModel().isFloating());
 		assertEquals(100, factory.getPrecisionModel().getScale());
 	}
+
+
+	@Test
+	public void testRectangleIntersectionAreaTranslated() {
+		var a = GeometryTools.createRectangle(0, 0, 200, 100);
+		var b = GeometryTools.createRectangle(100, 0, 200, 100);
+		assertEquals(100*100, GeometryTools.intersectionArea(a, b), 1e-6);
+		assertEquals(a.intersection(b).getArea(), GeometryTools.intersectionArea(a, b), 1e-6);
+	}
+
+	@Test
+	public void testRectangleIntersectionAreaEqual() {
+		var a = GeometryTools.createRectangle(0, 0, 200, 100);
+		var b = GeometryTools.createRectangle(0, 0, 200, 100);
+		assertEquals(200*100, GeometryTools.intersectionArea(a, b), 1e-6);
+		assertEquals(a.intersection(b).getArea(), GeometryTools.intersectionArea(a, b), 1e-6);
+	}
+
+	@Test
+	public void testRectangleIntersectionAreaTouching() {
+		var a = GeometryTools.createRectangle(0, 0, 200, 100);
+		var b = GeometryTools.createRectangle(200, 0, 200, 100);
+		assertEquals(0, GeometryTools.intersectionArea(a, b), 1e-6);
+		assertEquals(a.intersection(b).getArea(), GeometryTools.intersectionArea(a, b), 1e-6);
+	}
+
+
+	@Test
+	public void testEllipseIntersectionAreaTranslated() {
+		int nPoints = 100;
+		var a = GeometryTools.createEllipse(0, 0, 200, 100, nPoints);
+		var b = GeometryTools.createEllipse(100, 0, 200, 100, nPoints);
+		assertEquals(a.intersection(b).getArea(), GeometryTools.intersectionArea(a, b), 1e-6);
+	}
+
+	@Test
+	public void testEllipseIntersectionAreaEqual() {
+		int nPoints = 100;
+		var a = GeometryTools.createEllipse(0, 0, 200, 100, nPoints);
+		var b = GeometryTools.createEllipse(0, 0, 200, 100, nPoints);
+		assertEquals(a.intersection(b).getArea(), GeometryTools.intersectionArea(a, b), 1e-6);
+	}
+
+	@Test
+	public void testEllipseIntersectionAreaTouching() {
+		int nPoints = 100;
+		var a = GeometryTools.createEllipse(0, 0, 200, 100, nPoints);
+		var b = GeometryTools.createEllipse(200, 0, 200, 100, nPoints);
+		assertEquals(0, GeometryTools.intersectionArea(a, b), 1e-6);
+		assertEquals(a.intersection(b).getArea(), GeometryTools.intersectionArea(a, b), 1e-6);
+	}
+
 
 }


### PR DESCRIPTION
Work-in-progress to improve the use of JTS and working with `Geometry` objects.

* Use `RelateNG` by default (along with `OverlayNG`)
* More consistently use `GeometryFactory` and `PrecisionModel`
  * These were previously not used with objects that were deserialised from .qpdata or GeoJSON

The ultimate aim is to address https://github.com/qupath/qupath/issues/1771 but the changes currently are not related to this.