### PR TITLE
Fix saving accelerator bug

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
@@ -873,7 +873,7 @@ public class ViewerManager implements QuPathViewerListener {
 			// For temporarily setting selection mode, we want to grab any S key presses eagerly
 			if (e.getCode() == KeyCode.S && e.getEventType() == KeyEvent.KEY_PRESSED) {
 				PathPrefs.tempSelectionModeProperty().set(true);
-				e.consume();
+				// Don't consume the event! Doing so can break the 'Save' accelerators
 			}
 		});
 		viewer.getView().addEventHandler(KeyEvent.KEY_RELEASED, e -> {


### PR DESCRIPTION
Fix v0.6.0-rc1 regression whereby the Ctrl+S accelerator wouldn't work on Windows, or Mac with non-system-menubar. Might also have been broken on Linux, who can say?

Edit: Hadn't yet seen bug report, fixes https://github.com/qupath/qupath/issues/1773