### PR TITLE
Use supplier in script menu loader

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -708,14 +708,14 @@ public class QuPathGUI {
 	private void populateScriptingMenu(Menu menuScripting) {
 		Objects.requireNonNull(menuScripting);
 		ScriptEditor editor = getScriptEditor();
-		var sharedScriptMenuLoader = new ScriptMenuLoader("Shared scripts...", PathPrefs.scriptsPathProperty(), editor);
+		var sharedScriptMenuLoader = new ScriptMenuLoader("Shared scripts...", PathPrefs.scriptsPathProperty(), this::getScriptEditor);
 		
 		StringBinding projectScriptsPath = Bindings.createStringBinding(() -> {
 			var project = getProject();
 			File dir = project == null ? null : Projects.getBaseDirectory(project);
 			return dir == null ? null : new File(dir, "scripts").getAbsolutePath();
 		}, projectProperty);
-		var projectScriptMenuLoader = new ScriptMenuLoader("Project scripts...", projectScriptsPath, editor);
+		var projectScriptMenuLoader = new ScriptMenuLoader("Project scripts...", projectScriptsPath, this::getScriptEditor);
 		projectScriptMenuLoader.getMenu().visibleProperty().bind(
 				projectProperty.isNotNull().and(menuVisibilityManager.ignorePredicateProperty().not())
 				);
@@ -725,7 +725,7 @@ public class QuPathGUI {
 			Path path = scriptDirectoryProperty.get();
 			return path == null ? null : path.toString();
 		}, scriptDirectoryProperty);
-		ScriptMenuLoader userScriptMenuLoader = new ScriptMenuLoader("User scripts...", userScriptsPath, editor);
+		ScriptMenuLoader userScriptMenuLoader = new ScriptMenuLoader("User scripts...", userScriptsPath, this::getScriptEditor);
 	
 		MenuTools.addMenuItems(
 				menuScripting,

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ScriptMenuLoader.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ScriptMenuLoader.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 import javax.script.ScriptException;
 
 import org.slf4j.Logger;
@@ -66,13 +67,13 @@ class ScriptMenuLoader {
 		
 	private static final String NO_SCRIPTS_NAME = "No scripts found";
 	private MenuItem miPlaceholder = new MenuItem(NO_SCRIPTS_NAME);
+	private final Supplier<ScriptEditor> scriptEditorSupplier;
 
-	private ScriptEditor scriptEditor;
 	
-	ScriptMenuLoader(final String name, final ObservableStringValue scriptDirectory, final ScriptEditor editor) {
+	ScriptMenuLoader(final String name, final ObservableStringValue scriptDirectory, Supplier<ScriptEditor> scriptEditorSupplier) {
 		this.menu = new Menu(name);
 		this.scriptDirectory = scriptDirectory;
-		this.scriptEditor = editor;
+		this.scriptEditorSupplier = scriptEditorSupplier;
 		
 		var actionCreateScript = ActionTools.actionBuilder("New script...", e -> {
 			String dir = scriptDirectory.get();
@@ -98,6 +99,7 @@ class ScriptMenuLoader {
 					logger.error("Create script error", e1);
 				}
 			}
+			ScriptEditor scriptEditor = scriptEditorSupplier.get();
 			if (scriptEditor != null)
 				scriptEditor.showScript(scriptFile);
 			else
@@ -191,7 +193,8 @@ class ScriptMenuLoader {
 					items.add(subMenu);
 					continue;
 				}
-				
+
+				ScriptEditor scriptEditor = scriptEditorSupplier.get();
 				if (scriptEditor == null || scriptEditor.supportsFile(path.toFile())) {
 					String name = path.getFileName().toString();
 					boolean cleanName = true;


### PR DESCRIPTION
There's an issue with the script editor. Basically, if I:

* launch QuPath
* open a project
* use Automate > Project scripts... > Select something.groovy

then i get the default script editor, without syntax highlighting.

This happens because `ScriptMenuLoader` stores the `ScriptEditor` before it was set to be a `RichScriptEditor`. This PR fixes that by ensuring `ScriptMenuLoader` always gets the current `ScriptEditor`.