### PR TITLE
Much faster creation & rendering of complex ROIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Some things may be added, some things may be removed, and some things may look d
   * Use *File → Export images... → OME-Zarr* to export images from the user interface
 * Add, remove & upgrade extensions easily with *Extensions → Manage extensions* (https://github.com/qupath/qupath/pull/1716)
   * See also https://github.com/qupath/extension-manager
+* _Much_ improved performance when creating & viewing very complex annotations (https://github.com/qupath/qupath/pull/1777)
 * More control over showing/hiding objects by classification (https://github.com/qupath/qupath/pull/1752)
 * New ImageJ script runner (https://github.com/qupath/qupath/pull/1682)
 * Improved measurements - with tooltips & scatterplots (https://github.com/qupath/qupath/pull/1747, https://github.com/qupath/qupath/pull/1544, https://github.com/qupath/qupath/pull/1768)

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
@@ -715,10 +715,10 @@ public class ContourTracing {
 	 * @param envelope
 	 * @return
 	 */
-	private static List<CoordinatePair> createTracedGeometry(Raster raster, double minThresholdInclusive, double maxThresholdInclusive,
-												 int band, TileRequest request, Envelope envelope) {
+	private static List<CoordinatePair> createCoordinatePairs(Raster raster, double minThresholdInclusive, double maxThresholdInclusive,
+															  int band, TileRequest request, Envelope envelope) {
 		var image = extractBand(raster, band);
-		return createTracedGeometry(image, minThresholdInclusive, maxThresholdInclusive, request, envelope);
+		return createCoordinatePairs(image, minThresholdInclusive, maxThresholdInclusive, request, envelope);
 	}
 	
 	
@@ -734,7 +734,7 @@ public class ContourTracing {
 	 * @param envelope
 	 * @return
 	 */
-	private static List<CoordinatePair> createTracedGeometry(SimpleImage image, double minThresholdInclusive, double maxThresholdInclusive, TileRequest tile, Envelope envelope) {
+	private static List<CoordinatePair> createCoordinatePairs(SimpleImage image, double minThresholdInclusive, double maxThresholdInclusive, TileRequest tile, Envelope envelope) {
 		
 		// If we are translating but not rescaling, we can do this during tracing
 		double xOffset = 0;
@@ -745,7 +745,7 @@ public class ContourTracing {
 			xOffset = tile.getTileX() * scale;
 			yOffset = tile.getTileY() * scale;
 		}
-		return traceGeometry(image, minThresholdInclusive, maxThresholdInclusive, xOffset, yOffset, scale, envelope);
+		return traceCoordinates(image, minThresholdInclusive, maxThresholdInclusive, xOffset, yOffset, scale, envelope);
 	}
 
 	private static Geometry createGeometry(GeometryFactory factory, Collection<CoordinatePair> lines, RegionRequest request) {
@@ -824,7 +824,7 @@ public class ContourTracing {
 			yOffset = request.getY();
 		}
 
-		var lines = traceGeometry(image, minThresholdInclusive, maxThresholdInclusive, xOffset, yOffset, scale, envelope);
+		var lines = traceCoordinates(image, minThresholdInclusive, maxThresholdInclusive, xOffset, yOffset, scale, envelope);
 
 		return createGeometry(GeometryTools.getDefaultFactory(), lines);
 	}
@@ -1144,7 +1144,7 @@ public class ContourTracing {
 			}
 			for (var threshold : thresholds) {
 				int c = threshold.getChannel();
-				var geometry = ContourTracing.createTracedGeometry(image, c, c, tile, null);
+				var geometry = ContourTracing.createCoordinatePairs(image, c, c, tile, null);
 				list.add(new LabeledCoordinatePairs(geometry, c));
 			}
 		} else {
@@ -1159,11 +1159,11 @@ public class ContourTracing {
 			}
 
 			for (var threshold : thresholds) {
-				var geometry = ContourTracing.createTracedGeometry(
+				var coords = ContourTracing.createCoordinatePairs(
 						raster, threshold.getMinThreshold(), threshold.getMaxThreshold(), threshold.getChannel(), tile, envelopes.getOrDefault(threshold, null));
-				if (!geometry.isEmpty()) {
+				if (!coords.isEmpty()) {
 					// Exclude lines/points that can sometimes arise
-					list.add(new LabeledCoordinatePairs(geometry, threshold.getChannel()));
+					list.add(new LabeledCoordinatePairs(coords, threshold.getChannel()));
 				}
 			}
 		}
@@ -1269,8 +1269,8 @@ public class ContourTracing {
 	 *                 This is useful to avoid searching the entire image when only a small region is needed.
 	 * @return
 	 */
-	private static List<CoordinatePair> traceGeometry(SimpleImage image, double min, double max, double xOffset,
-													  double yOffset, double scale, Envelope envelope) {
+	private static List<CoordinatePair> traceCoordinates(SimpleImage image, double min, double max, double xOffset,
+														 double yOffset, double scale, Envelope envelope) {
 
 		var factory = GeometryTools.getDefaultFactory();
 		var pm = factory.getPrecisionModel();

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
@@ -1,0 +1,362 @@
+package qupath.lib.analysis.images;
+
+import org.locationtech.jts.dissolve.LineDissolver;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Predicate;
+
+/**
+ * Some utility functions to help with converting traced line segments (coordinate pairs) into
+ * JTS geometry objects.
+ * <p>
+ * Some of the functionality could be replicated by using JTS directly, but this class is optimized
+ * or the specific requirements of tracing raster images (where we know the coordinate pairs should
+ * represent horizontal or vertical lines).
+ */
+class ContourTracingUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(ContourTracingUtils.class);
+
+    /**
+     * Create a new collection that contains only pairs that did not have any duplicate in the input.
+     * This is different from removing duplicates: if a pair is duplicated, all instances of it are removed.
+     * @param lines
+     * @return
+     */
+    static Collection<CoordinatePair> removeDuplicatesCompletely(Collection<CoordinatePair> lines) {
+        CoordinatePair lastPair = null;
+        List<CoordinatePair> pairs = new ArrayList<>();
+        boolean duplicate = false;
+        var comparator = Comparator.comparing(CoordinatePair::getC1).thenComparing(CoordinatePair::getC2);
+        var iterator = lines.stream().sorted(comparator).iterator();
+        while (iterator.hasNext()) {
+            var line = iterator.next();
+            if (Objects.equals(lastPair, line)) {
+                duplicate = true;
+            } else {
+                if (!duplicate && lastPair != null)
+                    pairs.add(lastPair);
+                duplicate = false;
+            }
+            lastPair = line;
+        }
+        if (!duplicate)
+            pairs.add(lastPair);
+        return pairs;
+    }
+
+    // Alternative implementation: more readable, but has slightly more overhead
+//	private static Collection<CoordinatePair> removeDuplicatesCompletely(List<CoordinatePair> lines) {
+//		Set<CoordinatePair> set = HashSet.newHashSet(lines.size());
+//		Set<CoordinatePair> duplicates = HashSet.newHashSet(lines.size() / 4);
+//		for (var line : lines) {
+//			if (!set.add(line)) {
+//				duplicates.add(line);
+//			}
+//		}
+//		set.removeAll(duplicates);
+//		return List.copyOf(set);
+//	}
+
+    /**
+     * Convert a collection of pairs from contour tracing into line strings for polygonization.
+     * This is the 'default' method based on JTS.
+     * It should do the same as {@link #linesFromPairsFast(GeometryFactory, Collection, double, double, double)}...
+     * but a bit more slowly for very large geometries.
+     */
+    static Geometry linesFromPairsLegacy(GeometryFactory factory, Collection<CoordinatePair> pairs,
+                                           double xOrigin, double yOrigin, double scale) {
+        var dissolver = new LineDissolver();
+        for (var p : pairs) {
+            dissolver.add(createLineString(p, factory, xOrigin, yOrigin, scale));
+        }
+        var lineStrings = dissolver.getResult();
+        return DouglasPeuckerSimplifier.simplify(lineStrings, 0);
+    }
+
+    private static LineString createLineString(CoordinatePair pair, GeometryFactory factory, double xOrigin, double yOrigin, double scale) {
+        var pm = factory.getPrecisionModel();
+        var c1 = pair.getC1();
+        var c2 = pair.getC2();
+        double x1 = pm.makePrecise(xOrigin + c1.getX() * scale);
+        double x2 =  pm.makePrecise(xOrigin + c2.getX() * scale);
+        double y1 =  pm.makePrecise(yOrigin + c1.getY() * scale);
+        double y2 =  pm.makePrecise(yOrigin + c2.getY() * scale);
+        return factory.createLineString(new Coordinate[] {
+                new Coordinate(x1, y1), new Coordinate(x2, y2)});
+    }
+
+    /**
+     * Coordinates can only be merged in a linestring if they occur exactly twice (otherwise they must be noded).
+     * This method finds all coordinates that can't be merged, and returns them as a set.
+     * <p>
+     * Note that previous implementations used a HashMap to count occurrences, but this was found to be much slower.
+     */
+    private static Set<Coordinate> findNonMergeableCoordinates(Collection<CoordinatePair> pairList) {
+        // Extract all the coordinates
+        var allCoordinates = new ArrayList<Coordinate>(pairList.size()*2);
+        for (var p : pairList) {
+            allCoordinates.add(p.getC1());
+            allCoordinates.add(p.getC2());
+        }
+
+        // Sort the list so that we can count occurrences in a single pass
+        allCoordinates.sort(null);
+
+        // Find which that can't be merged, i.e. they don't occur exactly twice
+        var nonMergable = new HashSet<Coordinate>();
+        int count = 0;
+        Coordinate currentCoord = null;
+        for (var c : allCoordinates) {
+            if (Objects.equals(currentCoord, c)) {
+                count++;
+            } else {
+                if (count != 2 && currentCoord != null)
+                    nonMergable.add(currentCoord);
+                currentCoord = c;
+                count = 1;
+            }
+        }
+        return nonMergable;
+    }
+
+    /**
+     * Faster alternative to {@link #linesFromPairsLegacy(GeometryFactory, Collection, double, double, double)}
+     * This takes a collection of {@link CoordinatePair} which should represent <i>all</i> the lines generated by
+     * coordinate tracing (as one-pixel horizontal or vertical segments).
+     * It then builds line strings from these pairs, merging them where possible, before passing the results to
+     * a {@link org.locationtech.jts.operation.polygonize.Polygonizer} to build the final geometry.
+     */
+    static Geometry linesFromPairsFast(GeometryFactory factory, Collection<CoordinatePair> pairs,
+                                            double xOrigin, double yOrigin, double scale) {
+
+        // Sort now to avoid sorting later
+        var pairList = pairs.stream()
+                .sorted(Comparator.comparing(CoordinatePair::getC1).thenComparing(CoordinatePair::getC2))
+                .toList();
+
+        var nonMergeable = findNonMergeableCoordinates(pairs);
+
+        // Find horizontal & vertical edges, split by row and column
+        var horizontal = new TreeMap<Double, List<CoordinatePair>>();
+        var vertical = new TreeMap<Double, List<CoordinatePair>>();
+        for (var p : pairList) {
+            if (p.isHorizontal())
+                horizontal.computeIfAbsent(p.getC1().getY(), y -> new ArrayList<>()).add(p);
+            else if (p.isVertical())
+                vertical.computeIfAbsent(p.getC1().getX(), x -> new ArrayList<>()).add(p);
+        }
+
+        Collection<List<Coordinate>> lines = new ArrayList<>();
+        var mergeable = new MinimalCoordinateMap<List<Coordinate>>();
+        for (var entry : horizontal.entrySet()) {
+            var list = entry.getValue();
+            for (var ls : buildLineStrings(list, nonMergeable::contains, factory, xOrigin, yOrigin, scale)) {
+                var c1 = ls.getFirst();
+                var c2 = ls.getLast();
+                boolean isMergable = false;
+                if (!nonMergeable.contains(c1)) {
+                    if (mergeable.put(c1, ls) != null)
+                        throw new RuntimeException("Horizontal mergeable already exists");
+                    isMergable = true;
+                }
+                if (!nonMergeable.contains(c2)) {
+                    if (mergeable.put(c2, ls) != null)
+                        throw new RuntimeException("Vertical mergeable already exists");
+                    isMergable = true;
+                }
+                if (!isMergable)
+                    lines.add(ls);
+            }
+        }
+        for (var entry : vertical.entrySet()) {
+            var list = entry.getValue();
+            var queued = new ArrayDeque<>(buildLineStrings(list, nonMergeable::contains, factory, xOrigin, yOrigin, scale));
+            while (!queued.isEmpty()) {
+                var ls = queued.pop();
+                if (isClosed(ls)) {
+                    lines.add(ls);
+                    continue;
+                }
+                if (Thread.interrupted())
+                    throw new RuntimeException("Interrupted");
+                var c1 = ls.getFirst();
+                var c2 = ls.getLast();
+                boolean c1Mergable = !nonMergeable.contains(c1);
+                boolean c2Mergable = !nonMergeable.contains(c2);
+                if (c1Mergable) {
+                    var existing = mergeable.remove(c1);
+                    if (existing != null) {
+                        if (c1.equals(existing.getFirst()))
+                            mergeable.remove(existing.getLast());
+                        else
+                            mergeable.remove(existing.getFirst());
+
+                        queued.add(mergeLines(existing, ls));
+                        continue;
+                    }
+                }
+                if (c2Mergable) {
+                    var existing = mergeable.remove(c2);
+                    if (existing != null) {
+                        if (c2.equals(existing.getFirst()))
+                            mergeable.remove(existing.getLast());
+                        else
+                            mergeable.remove(existing.getFirst());
+                        queued.add(mergeLines(existing, ls));
+                        continue;
+                    }
+                }
+                if (c1Mergable || c2Mergable) {
+                    if (c1Mergable)
+                        mergeable.put(c1, ls);
+                    if (c2Mergable)
+                        mergeable.put(c2, ls);
+                } else {
+                    // Line is complete
+                    lines.add(ls);
+                }
+            }
+        }
+        if (!mergeable.isEmpty())
+            logger.warn("Remaining mergeable lines: {}", mergeable.size());
+        lines.addAll(mergeable.values());
+
+        var lineStrings = new ArrayList<LineString>();
+        for (var line : lines) {
+            lineStrings.add(factory.createLineString(line.toArray(Coordinate[]::new)));
+        }
+
+        return factory.buildGeometry(lineStrings);
+    }
+
+    private static boolean isClosed(List<Coordinate> coords) {
+        return coords.size() > 2 && coords.getFirst().equals(coords.getLast());
+    }
+
+    private static List<Coordinate> mergeLines(List<Coordinate> l1, List<Coordinate> l2) {
+        var c1Start = l1.getFirst();
+        var c1End = l1.getLast();
+        var c2Start = l2.getFirst();
+        var c2End = l2.getLast();
+
+        if (c1End.equals(c2Start)) {
+            return concat(l1, l2);
+        } else if (c1Start.equals(c2End)) {
+            return concat(l2, l1);
+        } else if (c1Start.equals(c2Start)) {
+            return concat(l1.reversed(), l2);
+        } else if (c1End.equals(c2End)) {
+            return concat(l1, l2.reversed());
+        } else {
+            return null;
+        }
+    }
+
+    private static List<Coordinate> concat(List<Coordinate> l1, List<Coordinate> l2) {
+        int n = l1.size() + l2.size() - 1;
+        var list = new ArrayList<Coordinate>(n);
+        list.addAll(l1);
+        list.addAll(l2.subList(1, l2.size()));
+        return list;
+    }
+
+
+    private static List<List<Coordinate>> buildLineStrings(List<CoordinatePair> pairs, Predicate<Coordinate> counter,
+                                                           GeometryFactory factory, double xOrigin, double yOrigin, double scale) {
+        if (pairs.isEmpty())
+            return List.of();
+
+        List<List<Coordinate>> lines = new ArrayList<>();
+        Coordinate firstCoord = pairs.getFirst().getC1();
+        Coordinate secondCoord = pairs.getFirst().getC2();
+        for (int i = 1; i < pairs.size(); i++) {
+            var p = pairs.get(i);
+            if (!secondCoord.equals(p.getC1()) || counter.test(secondCoord)) {
+                // Finish the line we were building & start a new one
+                lines.add(createLineString(firstCoord, secondCoord, factory, xOrigin, yOrigin, scale));
+                firstCoord = p.getC1();
+                secondCoord = p.getC2();
+                continue;
+            } else {
+                // Continue the line
+                secondCoord = p.getC2();
+            }
+        }
+        lines.add(createLineString(firstCoord, secondCoord, factory, xOrigin, yOrigin, scale));
+        return lines;
+    }
+
+    private static List<Coordinate> createLineString(Coordinate c1, Coordinate c2,
+                                                     GeometryFactory factory, double xOrigin, double yOrigin, double scale) {
+        if (xOrigin == 0 && yOrigin == 0 && scale == 1)
+            return List.of(c1, c2);
+        var pm = factory.getPrecisionModel();
+        double x1 = pm.makePrecise(xOrigin + c1.x * scale);
+        double x2 =  pm.makePrecise(xOrigin + c2.x * scale);
+        double y1 =  pm.makePrecise(yOrigin + c1.y * scale);
+        double y2 =  pm.makePrecise(yOrigin + c2.y * scale);
+        return List.of(new Coordinate(x1, y1), new Coordinate(x2, y2));
+    }
+
+
+    /**
+     * A minimal map-like class that can use coordinates as keys.
+     * I know this looks awkward... but it can perform much better than a single HashMap<Coordinate, T>.
+     * @param <T>
+     */
+    private static class MinimalCoordinateMap<T> {
+
+        private final Map<Double, Map<Double, T>> map = new HashMap<>();
+
+        T put(Coordinate c, T val) {
+            return map.computeIfAbsent(c.getX(), x -> new HashMap<>()).put(c.getY(), val);
+        }
+
+        T remove(Coordinate c) {
+            return map.computeIfAbsent(c.getX(), x -> new HashMap<>()).remove(c.getY());
+        }
+
+        T get(Coordinate c) {
+            return getOrDefault(c, null);
+        }
+
+        T getOrDefault(Coordinate c, T defaultValue) {
+            return map.getOrDefault(c.getX(), Collections.emptyMap()).getOrDefault(c.getY(), defaultValue);
+        }
+
+        Collection<T> values() {
+            if (isEmpty())
+                return Collections.emptyList();
+            return map.values().stream().flatMap(m -> m.values().stream()).toList();
+        }
+
+        int size() {
+            return map.values().stream().mapToInt(Map::size).sum();
+        }
+
+        boolean isEmpty() {
+            return map.values().stream().allMatch(Map::isEmpty);
+        }
+
+    }
+
+}

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/CoordinatePair.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/CoordinatePair.java
@@ -1,0 +1,71 @@
+package qupath.lib.analysis.images;
+
+import org.locationtech.jts.geom.Coordinate;
+
+import java.util.Comparator;
+import java.util.Objects;
+
+class CoordinatePair {
+
+    private static final Comparator<Coordinate> topLeftCoordinateComparator = Comparator.comparingDouble(Coordinate::getY)
+            .thenComparingDouble(Coordinate::getX);
+
+    private final Coordinate c1;
+    private final Coordinate c2;
+
+    private final int hash;
+
+    CoordinatePair(Coordinate c1, Coordinate c2) {
+        var comp = topLeftCoordinateComparator.compare(c1, c2);
+        if (comp < 0) {
+            this.c1 = c1;
+            this.c2 = c2;
+        } else if (comp > 0) {
+            this.c1 = c2;
+            this.c2 = c1;
+        } else
+            throw new IllegalArgumentException("Coordinates should not be the same!");
+        if (!isHorizontal() && !isVertical())
+            throw new IllegalArgumentException("Coordinate pairs should be horizontal or vertical!");
+        this.hash = Objects.hash(c1, c2);
+    }
+
+    boolean isHorizontal() {
+        return c1.y == c2.y && c1.x != c2.x;
+    }
+
+    boolean isVertical() {
+        return c1.x == c2.x && c1.y != c2.y;
+    }
+
+    /**
+     * This does <i>not</i> make a defensive copy; the caller should not modify the returned coordinate.
+     *
+     * @return
+     */
+    Coordinate getC1() {
+        return c1;
+    }
+
+    /**
+     * This does <i>not</i> make a defensive copy; the caller should not modify the returned coordinate.
+     *
+     * @return
+     */
+    Coordinate getC2() {
+        return c2;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        CoordinatePair that = (CoordinatePair) o;
+        return Objects.equals(c1, that.c1) && Objects.equals(c2, that.c2);
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+}

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -67,10 +67,8 @@ import qupath.lib.regions.RegionRequest;
 import qupath.lib.roi.GeometryTools;
 import qupath.lib.roi.LineROI;
 import qupath.lib.roi.PointsROI;
-import qupath.lib.roi.PolygonROI;
 import qupath.lib.roi.RoiTools;
 import qupath.lib.roi.ROIs;
-import qupath.lib.roi.ShapeSimplifier;
 import qupath.lib.roi.interfaces.ROI;
 
 /**

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -1410,7 +1410,9 @@ public class GeometryTools {
 	
 	
 	    private ShapeWriter getShapeWriter() {
-	    	return new ShapeWriter(transformer);
+	    	var writer = new ShapeWriter(transformer);
+	    	writer.setRemoveDuplicatePoints(true);
+	    	return writer;
 	    }
 	
 

--- a/qupath-core/src/main/java/qupath/lib/roi/ShapeSimplifier.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/ShapeSimplifier.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020, 2024 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2024 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -27,6 +27,8 @@ import java.awt.Shape;
 import java.awt.geom.Path2D;
 import java.awt.geom.PathIterator;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -69,15 +71,16 @@ public class ShapeSimplifier {
 		
 		// Remove duplicates first
 		removeDuplicates(points);
-		
+
 		if (points.size() <= 3)
 			return;
 		
 		int n = points.size();
 		
 		// Populate the priority queue
-		PriorityQueue<PointWithArea> queue = new PriorityQueue<>(points.size()+8);
-		
+		var queue = new MinimalPriorityQueue(points.size()+8);
+//		var queue = new PriorityQueue<PointWithArea>(points.size()+8);
+
 		Point2 pPrevious = points.getLast();
 		Point2 pCurrent = points.getFirst();
 		PointWithArea pwaPrevious = null;
@@ -104,7 +107,7 @@ public class ShapeSimplifier {
 		
 		double maxArea = 0;
 		int minSize = Math.max(n / 100, 3);
-		Set<Point2> toRemove = new HashSet<>();
+		Set<Point2> toRemove = HashSet.newHashSet(queue.size()/4);
 		while (queue.size() > minSize) {
 			PointWithArea pwa = queue.poll();
 //			logger.info("BEFORE: " + pwa + " (counter " + counter + ")");
@@ -122,23 +125,78 @@ public class ShapeSimplifier {
 			// Remove the point & update accordingly
 //			points.remove(pwa.getPoint());
 			toRemove.add(pwa.getPoint());
-			
+
 			pwaPrevious = pwa.getPrevious();
 			PointWithArea pwaNext = pwa.getNext();
+
+			queue.remove(pwaPrevious);
+			queue.remove(pwaNext);
+
 			pwaPrevious.setNext(pwaNext);
 			pwaPrevious.updateArea();
 			pwaNext.setPrevious(pwaPrevious);
 			pwaNext.updateArea();
 			
 			// Reinsert into priority queue
-			queue.remove(pwaPrevious);
-			queue.remove(pwaNext);
 			queue.add(pwaPrevious);
 			queue.add(pwaNext);
 			
 //			logger.info(pwa);
 		}
 		points.removeAll(toRemove);
+	}
+
+	/**
+	 * Alternative to Java's PriorityQueue that does just enough for what we need here.
+	 * The purpose is to overcome the slow (O(n)) removal of elements from the middle of a PriorityQueue,
+	 * which was a bottleneck when simplifying polygons with many points.
+	 */
+	private static class MinimalPriorityQueue {
+
+		private final Comparator<PointWithArea> comparator = Comparator.reverseOrder();
+		private final List<PointWithArea> list;
+		private boolean initializing = true;
+
+		private MinimalPriorityQueue(int capacity) {
+			list = new ArrayList<>(capacity);
+		}
+
+		void add(PointWithArea pwa) {
+			if (initializing)
+				list.add(pwa);
+			else
+				insert(pwa);
+		}
+
+		void remove(PointWithArea pwa) {
+			int ind = Collections.binarySearch(list, pwa, comparator);
+			if (ind < 0) {
+				throw new IllegalArgumentException("PointWithArea is not in the queue");
+			}
+			list.remove(ind);
+		}
+
+		void insert(PointWithArea pwa) {
+			int ind = Collections.binarySearch(list, pwa, comparator);
+			if (ind < 0)
+				ind = -ind - 1;
+			else if (list.get(ind) == pwa)
+				throw new IllegalArgumentException("PointWithArea is already in the queue");
+			list.add(ind, pwa);
+		}
+
+		int size() {
+			return list.size();
+		}
+
+		PointWithArea poll() {
+			if (initializing) {
+				list.sort(comparator);
+				initializing = false;
+			}
+			return list.isEmpty() ? null : list.removeLast();
+		}
+
 	}
 
 
@@ -265,7 +323,6 @@ public class ShapeSimplifier {
 	}
 
 	/**
-	 *
 	 * Create a simplified polygon (fewer coordinates) using method based on Visvalingam's Algorithm.
 	 * <p>
 	 * See references:
@@ -294,6 +351,9 @@ public class ShapeSimplifier {
 		if (roi instanceof PolygonROI polygonROI) {
 			out = ShapeSimplifier.simplifyPolygon(polygonROI, altitudeThreshold);
 		} else {
+			// TODO: Handle GeometryROI as a special case (so we don't need to go through java.awt.Shape) -
+			// 		 conversion back to Geometry can be slow.
+			//		 But need to be cautious, because we could easily make invalid geometries...
 			out = ShapeSimplifier.simplifyShape(roi, altitudeThreshold);
 		}
 		return out;
@@ -333,7 +393,12 @@ public class ShapeSimplifier {
 	}
 
 	static class PointWithArea implements Comparable<PointWithArea> {
-		
+
+		private static final Comparator<PointWithArea> comparator = Comparator.comparingDouble(PointWithArea::getArea)
+				.reversed()
+				.thenComparingDouble(PointWithArea::getX)
+				.thenComparingDouble(PointWithArea::getY);
+
 		private PointWithArea pPrevious;
 		private PointWithArea pNext;
 		private Point2 p;
@@ -386,7 +451,21 @@ public class ShapeSimplifier {
 
 		@Override
 		public int compareTo(PointWithArea p) {
-			return (area < p.area) ? -1 : (area == p.area ? 0 : 1);
+			if (area < p.area)
+				return -1;
+			else if (area > p.area)
+				return 1;
+			else if (getX() < p.getX())
+				return -1;
+			else if (getX() > p.getX())
+				return 1;
+			else if (getY() < p.getY())
+				return -1;
+			else if (getY() > p.getY())
+				return 1;
+			else
+				return 0;
+//			return comparator.compare(this, p);
 		}
 		
 		@Override

--- a/qupath-core/src/test/java/qupath/lib/analysis/images/TestContourTracing.java
+++ b/qupath-core/src/test/java/qupath/lib/analysis/images/TestContourTracing.java
@@ -59,9 +59,8 @@ public class TestContourTracing {
 	
 	private static int MAX_POINTS_FOR_VALIDITY = 50_000;
 	
-	
+	// Don't to the large random image by default... it's a bit slow
 	private static List<String> excludeNames = List.of(
-//			"binary-noise-medium.png",
 			"binary-noise-large.png"
 			);
 

--- a/qupath-core/src/test/java/qupath/lib/analysis/images/TestContourTracing.java
+++ b/qupath-core/src/test/java/qupath/lib/analysis/images/TestContourTracing.java
@@ -60,8 +60,8 @@ public class TestContourTracing {
 	private static int MAX_POINTS_FOR_VALIDITY = 50_000;
 	
 	
-	private static List<String> excludeNames = Arrays.asList(
-			"binary-noise-medium.png",
+	private static List<String> excludeNames = List.of(
+//			"binary-noise-medium.png",
 			"binary-noise-large.png"
 			);
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DownsampledShapeCache.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DownsampledShapeCache.java
@@ -1,0 +1,71 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2025 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.viewer;
+
+import qupath.lib.roi.ShapeSimplifier;
+
+import java.awt.Shape;
+import java.awt.geom.Path2D;
+
+/**
+ * Helper class for managing simplified versions of a shape for rendering shapes at lower resolutions.
+ * @since v0.6.0
+ */
+class DownsampledShapeCache {
+
+    private static final int pointCountThreshold = 10;
+
+    private final Shape shape;
+
+    private final double[] downsamples;
+    private final Shape[] downsampledShapes;
+
+    DownsampledShapeCache(Shape shape, double... downsamples) {
+        this.shape = shape;
+        this.downsamples = downsamples.clone();
+        this.downsampledShapes = new Shape[downsamples.length];
+    }
+
+    Shape getForDownsample(double downsample) {
+        Shape lastShape = shape;
+        for (int i = 0; i < downsamples.length; i++) {
+            if (downsamples[i] > downsample)
+                return lastShape;
+            var currentShape = downsampledShapes[i];
+            if (currentShape == null) {
+                // Progressively simplify the shape for downsamples
+                currentShape = computeForDownsample(lastShape, downsamples[i]);
+                downsampledShapes[i] = currentShape;
+            }
+            lastShape = currentShape;
+        }
+        return lastShape;
+    }
+
+    private static Shape computeForDownsample(Shape shape, double downsample) {
+        var path = shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape);
+        boolean discardSmall = downsample > 8.0;
+        return ShapeSimplifier.simplifyPath(path, downsample, pointCountThreshold, discardSmall ? downsample * 2 : -1);
+    }
+
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DownsampledShapeCache.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DownsampledShapeCache.java
@@ -21,10 +21,19 @@
 
 package qupath.lib.gui.viewer;
 
-import qupath.lib.roi.ShapeSimplifier;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.precision.GeometryPrecisionReducer;
+import qupath.lib.roi.GeometryTools;
+import qupath.lib.roi.interfaces.ROI;
 
 import java.awt.Shape;
-import java.awt.geom.Path2D;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Helper class for managing simplified versions of a shape for rendering shapes at lower resolutions.
@@ -34,38 +43,118 @@ class DownsampledShapeCache {
 
     private static final int pointCountThreshold = 10;
 
-    private final Shape shape;
+    private final GeometryAndShape shape;
 
-    private final double[] downsamples;
-    private final Shape[] downsampledShapes;
+    private final List<Double> downsamples = new ArrayList<>();
+    private final List<GeometryAndShape> downsampledShapes = new ArrayList<>();
 
-    DownsampledShapeCache(Shape shape, double... downsamples) {
-        this.shape = shape;
-        this.downsamples = downsamples.clone();
-        this.downsampledShapes = new Shape[downsamples.length];
+    DownsampledShapeCache(ROI roi, double... downsamples) {
+        this.shape = new GeometryAndShape(roi.getGeometry(), roi.getShape(), 1);
+        for (double downsample : downsamples) {
+            this.downsamples.add(downsample);
+            this.downsampledShapes.add(null);
+        }
     }
 
     Shape getForDownsample(double downsample) {
-        Shape lastShape = shape;
-        for (int i = 0; i < downsamples.length; i++) {
-            if (downsamples[i] > downsample)
-                return lastShape;
-            var currentShape = downsampledShapes[i];
+        GeometryAndShape lastShape = shape;
+        double lastDownsample = lastShape.getDownsample();
+        for (int i = 0; i < downsamples.size(); i++) {
+            if (downsamples.get(i) > downsample)
+                return lastShape.getShape();
+            var currentShape = downsampledShapes.get(i);
             if (currentShape == null) {
                 // Progressively simplify the shape for downsamples
-                currentShape = computeForDownsample(lastShape, downsamples[i]);
-                downsampledShapes[i] = currentShape;
+                currentShape = computeForDownsample(lastShape, downsamples.get(i));
+                downsampledShapes.set(i, currentShape);
             }
             lastShape = currentShape;
         }
-        return lastShape;
+        return lastShape.getShape();
     }
 
-    private static Shape computeForDownsample(Shape shape, double downsample) {
-        var path = shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape);
-        boolean discardSmall = downsample > 8.0;
-        return ShapeSimplifier.simplifyPath(path, downsample, pointCountThreshold, discardSmall ? downsample * 2 : -1);
+    private static GeometryAndShape computeForDownsample(GeometryAndShape shape, double downsample) {
+        var reducer = new GeometryPrecisionReducer(new PrecisionModel(-downsample));
+        reducer.setRemoveCollapsedComponents(true);
+        reducer.setPointwise(true);
+        reducer.setChangePrecisionModel(true);
+        var geometry = reducer.reduce(shape.getGeometry());
+        geometry = reducer.reduce(geometry);
+        var geoms = new ArrayList<>();
+        for (int i = 0; i < geometry.getNumGeometries(); i++) {
+            var g = geometry.getGeometryN(i);
+            if (g instanceof Polygon polygon) {
+                var env = g.getEnvelopeInternal();
+                if (env.getWidth() <= downsample || env.getHeight() <= downsample)
+                    continue;
+                var exterior = removeDuplicatePoints(polygon.getExteriorRing());
+
+                int nHoles = polygon.getNumInteriorRing();
+                var holes = new ArrayList<LinearRing>();
+                for (var h = 0; h < nHoles; h++) {
+                    var hole = polygon.getInteriorRingN(h);
+                    var hEnv = hole.getEnvelopeInternal();
+                    if (hEnv.getWidth() <= downsample || hEnv.getHeight() <= downsample)
+                        continue;
+                    holes.add(removeDuplicatePoints(hole));
+                }
+                polygon = polygon.getFactory()
+                        .createPolygon(exterior, holes.toArray(new LinearRing[0]));
+                geoms.add(polygon);
+            }
+        }
+        geometry = geometry.getFactory().buildGeometry(geoms);
+        return new GeometryAndShape(geometry, GeometryTools.geometryToShape(geometry), downsample);
     }
 
+    private static LinearRing removeDuplicatePoints(LinearRing linearRing) {
+        var coords = new ArrayList<Coordinate>();
+        Coordinate lastCoord = null;
+        for (int i = 0; i < linearRing.getNumPoints(); i++) {
+            var coord = linearRing.getCoordinateN(i);
+            if (!Objects.equals(lastCoord, coord)) {
+                coords.add(coord);
+            }
+        }
+        if (coords.size() < 3)
+            return linearRing;
+        else if (coords.size() == linearRing.getNumPoints())
+            return linearRing;
+        else
+            return linearRing.getFactory().createLinearRing(coords.toArray(new Coordinate[0]));
+    }
+
+
+    private static class GeometryAndShape {
+
+        private final Geometry geometry;
+        private final Shape shape;
+        private final double downsample;
+        private final int nPoints;
+
+        GeometryAndShape(Geometry geometry, Shape shape, double downsample) {
+            this.geometry = geometry;
+            this.shape = shape;
+            this.downsample = downsample;
+            this.nPoints = geometry.getNumPoints();
+        }
+
+        int getNumPoints() {
+            return nPoints;
+        }
+
+        double getDownsample() {
+            return downsample;
+        }
+
+        Shape getShape() {
+            return shape;
+        }
+
+        Geometry getGeometry() {
+            return geometry;
+        }
+
+    }
 
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -746,12 +746,7 @@ public class PathObjectPainter {
 			int nVertices = roi.getNumPoints();
 			if (nVertices < MIN_SIMPLIFY_VERTICES)
 				return null;
-			// TODO: Consider a better way to figure out the downsampling levels
-			if (nVertices < 100_000)
-				return new DownsampledShapeCache(roi, 4, 16, 64);
-			else {
-				return new DownsampledShapeCache(roi, 4, 8, 16, 24, 32, 48, 64, 128, 256, 512, 1024);
-			}
+			return new DownsampledShapeCache(roi);
 		}
 
     }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -85,7 +85,6 @@ import qupath.lib.roi.RoiTools;
 import qupath.lib.roi.PointsROI;
 import qupath.lib.roi.RectangleROI;
 import qupath.lib.roi.RoiEditor;
-import qupath.lib.roi.ShapeSimplifier;
 import qupath.lib.roi.interfaces.ROI;
 
 
@@ -99,16 +98,16 @@ public class PathObjectPainter {
 
 	private static final Logger logger = LoggerFactory.getLogger(PathObjectPainter.class);
 
-	private static ShapeProvider shapeProvider = new ShapeProvider();
+	private static final ShapeProvider shapeProvider = new ShapeProvider();
 
-	private static Map<Object, Double> doubleCache = new HashMap<>();
+	private static final Map<Object, Double> doubleCache = new HashMap<>();
 
-	private static Map<Number, Stroke> strokeMap = new HashMap<>();
-	private static Map<Number, Stroke> dashedStrokeMap = new HashMap<>();
+	private static final Map<Number, Stroke> strokeMap = new HashMap<>();
+	private static final Map<Number, Stroke> dashedStrokeMap = new HashMap<>();
 
-	private static ThreadLocal<Path2D> localPath2D = ThreadLocal.withInitial(Path2D.Double::new);
-	private static ThreadLocal<Rectangle2D> localRect2D = ThreadLocal.withInitial(Rectangle2D.Double::new);
-	private static ThreadLocal<Ellipse2D> localEllipse2D = ThreadLocal.withInitial(Ellipse2D.Double::new);
+	private static final ThreadLocal<Path2D> localPath2D = ThreadLocal.withInitial(Path2D.Double::new);
+	private static final ThreadLocal<Rectangle2D> localRect2D = ThreadLocal.withInitial(Rectangle2D.Double::new);
+	private static final ThreadLocal<Ellipse2D> localEllipse2D = ThreadLocal.withInitial(Ellipse2D.Double::new);
 
 	private PathObjectPainter() {}
 
@@ -692,50 +691,17 @@ public class PathObjectPainter {
 
 		static final int MIN_SIMPLIFY_VERTICES = 250;
 
-		private RectanglePool rectanglePool = new RectanglePool();
-		private EllipsePool ellipsePool = new EllipsePool();
-		private LinePool linePool = new LinePool();
+		private final RectanglePool rectanglePool = new RectanglePool();
+		private final EllipsePool ellipsePool = new EllipsePool();
+		private final LinePool linePool = new LinePool();
 
 		// TODO: Consider if it makes sense to map to PathHierarchyImageServer preferred downsamples
 		// (Only if shape simplification is often used for detection objects)
-		private Map<ROI, Shape> map50 = Collections.synchronizedMap(new WeakHashMap<>());
-		private Map<ROI, Shape> map20 = Collections.synchronizedMap(new WeakHashMap<>());
-		private Map<ROI, Shape> map10 = Collections.synchronizedMap(new WeakHashMap<>());
-		private Map<ROI, Shape> map = Collections.synchronizedMap(new WeakHashMap<>());
+		private Map<ROI, DownsampledShapeCache> shapeCache = Collections.synchronizedMap(new WeakHashMap<>());
 
 		// Note: this relies upon the fact that the ROI is immutable shapes are cached
-		private Map<Area, GriddedArea> areaMap = Collections.synchronizedMap(new WeakHashMap<>());
+		private final Map<Area, GriddedArea> areaMap = Collections.synchronizedMap(new WeakHashMap<>());
 
-		private Map<ROI, Shape> getMap(final ROI shape, final double downsample) {
-			// If we don't have many vertices, just return the main map - no need to simplify
-			int nVertices = shape.getNumPoints();
-			if (nVertices < MIN_SIMPLIFY_VERTICES || !shape.isArea())
-				return map;
-
-			if (downsample > 50)
-				return map50;
-			if (downsample > 20)
-				return map20;
-			if (downsample > 10)
-				return map10;
-			return map;
-		}
-
-		private static Shape simplifyByDownsample(final Shape shape, final double downsample) {
-			try {
-				int pointCountThreshold = 10;
-				if (downsample > 50)
-					return ShapeSimplifier.simplifyPath(shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape), 50, pointCountThreshold);
-				if (downsample > 20)
-					return ShapeSimplifier.simplifyPath(shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape), 20, pointCountThreshold);
-				if (downsample > 10)
-					return ShapeSimplifier.simplifyPath(shape instanceof Path2D ? (Path2D)shape : new Path2D.Float(shape), 10, pointCountThreshold);
-			} catch (Exception e) {
-				logger.warn("Unable to simplify path: {}", e.getLocalizedMessage());
-				logger.debug("", e);
-			}
-			return shape;
-		}
 
 		public Shape getShape(final ROI roi, final double downsample, final Rectangle clip) {
 			var shape = getShape(roi, downsample);
@@ -761,33 +727,34 @@ public class PathObjectPainter {
 				return ellipse;
 			}
 
-			if (roi instanceof LineROI) {
+			if (roi instanceof LineROI l) {
 				Line2D line = linePool.getShape();
-				LineROI l = (LineROI)roi;
-				line.setLine(l.getX1(), l.getY1(), l.getX2(), l.getY2());
+                line.setLine(l.getX1(), l.getY1(), l.getX2(), l.getY2());
 				return line;
 			}
 
-			Map<ROI, Shape> map = getMap(roi, downsample);
-			Shape shape = map.get(roi);
-			if (shape == null) {
-				shape = RoiTools.getShape(roi);
-				// Downsample if we have to
-				if (map != this.map) {
-					// JTS methods are much slower
-					//					var simplifier = new DouglasPeuckerSimplifier(roi.getGeometry());
-					//					var simplifier = new VWSimplifier(roi.getGeometry());
-					//					simplifier.setDistanceTolerance(downsample);
-					//					simplifier.setEnsureValid(false);
-					//					shape = GeometryTools.geometryToShape(simplifier.getResultGeometry());
-					shape = simplifyByDownsample(shape, downsample);
-				}
-				map.put(roi, shape);
-			}
-			return shape;
+			DownsampledShapeCache cache = shapeCache.computeIfAbsent(roi, this::createShapeCache);
+			if (cache == null)
+				return roi.getShape();
+			else
+				return cache.getForDownsample(downsample);
 		}
 
-	}
+		private DownsampledShapeCache createShapeCache(ROI roi) {
+			if (!roi.isArea())
+				return null;
+			int nVertices = roi.getNumPoints();
+			if (nVertices < MIN_SIMPLIFY_VERTICES)
+				return null;
+			// TODO: Consider a better way to figure out the downsampling levels
+			if (nVertices < 100_000)
+				return new DownsampledShapeCache(roi.getShape(), 4, 16, 64);
+			else {
+				return new DownsampledShapeCache(roi.getShape(), 4, 8, 16, 24, 32, 48, 64, 128, 256);
+			}
+		}
+
+    }
 
 	/**
 	 * Helper class for working with <i>very</i> complex Areas (e.g. over 10_000 path segments).

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -695,10 +695,6 @@ public class PathObjectPainter {
 		private final EllipsePool ellipsePool = new EllipsePool();
 		private final LinePool linePool = new LinePool();
 
-		// TODO: Consider if it makes sense to map to PathHierarchyImageServer preferred downsamples
-		// (Only if shape simplification is often used for detection objects)
-		private Map<ROI, DownsampledShapeCache> shapeCache = Collections.synchronizedMap(new WeakHashMap<>());
-
 		// Note: this relies upon the fact that the ROI is immutable shapes are cached
 		private final Map<Area, GriddedArea> areaMap = Collections.synchronizedMap(new WeakHashMap<>());
 
@@ -733,20 +729,7 @@ public class PathObjectPainter {
 				return line;
 			}
 
-			DownsampledShapeCache cache = shapeCache.computeIfAbsent(roi, this::createShapeCache);
-			if (cache == null)
-				return roi.getShape();
-			else
-				return cache.getForDownsample(downsample);
-		}
-
-		private DownsampledShapeCache createShapeCache(ROI roi) {
-			if (!roi.isArea())
-				return null;
-			int nVertices = roi.getNumPoints();
-			if (nVertices < MIN_SIMPLIFY_VERTICES)
-				return null;
-			return new DownsampledShapeCache(roi);
+			return DownsampledShapeCache.getShapeForDownsample(roi, downsample);
 		}
 
     }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -748,9 +748,9 @@ public class PathObjectPainter {
 				return null;
 			// TODO: Consider a better way to figure out the downsampling levels
 			if (nVertices < 100_000)
-				return new DownsampledShapeCache(roi.getShape(), 4, 16, 64);
+				return new DownsampledShapeCache(roi, 4, 16, 64);
 			else {
-				return new DownsampledShapeCache(roi.getShape(), 4, 8, 16, 24, 32, 48, 64, 128, 256);
+				return new DownsampledShapeCache(roi, 4, 8, 16, 24, 32, 48, 64, 128, 256, 512, 1024);
 			}
 		}
 


### PR DESCRIPTION
Major performance improvements when creating complex ROIs (e.g. from a pixel classifier) and rendering them in the viewer.

## ContourTracer improvements
Building on https://github.com/qupath/qupath/pull/1520, generating complex annotations can now be **much** faster.

For example, I applied a moderately high-resolution thresholder to `OS-2.ndpi` to generate a monster multipolygon with millions of vertices.

![image](https://github.com/user-attachments/assets/83334513-8272-4626-962c-39153bec67c1)

On the same MacBook Pro:

| Version | Time |
|---|---|
| v0.5.1 | ~494 seconds |
| v0.6.0-rc3 | ~133 seconds |
| With this PR | ~15 seconds |

The key step is to avoid creating polygons for each individual tile and unioning them at the end, because unioning is too expensive.

Instead, we trace all the lines across all the tiles and then pass them all in one big go to a `Polygonizer` at the end.

Some extra tricks and optimizations are used to speed this up, and also to reduce the number of vertices in the final result, without changing the shape.

The annotation above had about 7-8 million coordinates, while with this PR it is just under 5 million.

> This was inspired by CoverageUnion not quite working... it was very fast, but gave invalid results.

> Note that trying to generate regions at an even *higher* resolution is still unreasonably slow - so it's still not advised to apply pixel classification / thresholding to a whole slide image at full (or almost full) resolution: restricting to regions of interest can still be necessary.

## Faster rendering

Generating huge ROIs is one thing, rendering them is another.

This PR also makes this much more efficient using 2 tricks... and then a 3rd trick that renders one of the first two moot.

The tricks are:
1. Speed up `ShapeSimplifier` by replacing Java's built in `PriorityQueue` with something smaller & faster to handle removals and insertions
2. Apply shape simplification progressively & across more resolutions when zooming out in the viewer (rather than simplifying the original shape at a few downsamples only)
3. Skip `ShapeSimplifier` entirely in the viewer, and instead introduce `DownsampledShapeCache`. This uses a much simpler method of shape simplification, while also discarding very small fragments or holes.

The end result looks a bit different. I don't think it's worse, but the rendering might benefit from some tweaks in the future.

More critically, it is *far* more responsive. Previously, *rendering* the ROI might take up to a minute and it would be sluggish when zooming in & out until the simplified shapes were built. Viewing the image at a low resolution was slower than at a high resolution.

Now viewing at a low resolution should be fast, and the lag when zooming should be much less. Images with complex ROIs should also open much faster.