### PR TITLE
Event faster contour tracing (albeit only slightly this time)

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
@@ -59,6 +59,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.common.ThreadTools;
+import qupath.lib.geom.Point2;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerMetadata;
 import qupath.lib.images.servers.ImageServers;
@@ -735,7 +736,6 @@ public class ContourTracing {
 	 * @return
 	 */
 	private static List<CoordinatePair> createCoordinatePairs(SimpleImage image, double minThresholdInclusive, double maxThresholdInclusive, TileRequest tile, Envelope envelope) {
-		
 		// If we are translating but not rescaling, we can do this during tracing
 		double xOffset = 0;
 		double yOffset = 0;
@@ -1144,8 +1144,8 @@ public class ContourTracing {
 			}
 			for (var threshold : thresholds) {
 				int c = threshold.getChannel();
-				var geometry = ContourTracing.createCoordinatePairs(image, c, c, tile, null);
-				list.add(new LabeledCoordinatePairs(geometry, c));
+				var coords = ContourTracing.createCoordinatePairs(image, c, c, tile, null);
+				list.add(new LabeledCoordinatePairs(coords, c));
 			}
 		} else {
 			// Apply the provided threshold to all channels
@@ -1288,8 +1288,8 @@ public class ContourTracing {
 		}
 
 		List<CoordinatePair> lines = new ArrayList<>();
-		Coordinate lastHorizontalEdgeCoord = null;
-		Coordinate[] lastVerticalEdgeCoords = new Coordinate[xEnd-xStart+1];
+		Point2 lastHorizontalEdgeCoord = null;
+		Point2[] lastVerticalEdgeCoords = new Point2[xEnd-xStart+1];
 		for (int y = yStart; y <= yEnd; y++) {
 			for (int x = xStart; x <= xEnd; x++) {
 				boolean isOn = inRange(image, x, y, min, max);
@@ -1330,11 +1330,11 @@ public class ContourTracing {
 	}
 
 
-
-	private static Coordinate createCoordinate(PrecisionModel pm, double x, double y) {
-		return new CoordinateXY(
-				pm.makePrecise(x),
-				pm.makePrecise(y));
+	private static Point2 createCoordinate(PrecisionModel pm, double x, double y) {
+		// TODO: Could consider returning a singleton Point2 instance
+		double x2 = pm.makePrecise(x);
+		double y2 = pm.makePrecise(y);
+		return new Point2(x2, y2);
 	}
 
 

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
@@ -784,14 +784,24 @@ public class ContourTracing {
 
 		try {
 			long startTime = System.currentTimeMillis();
+			int nPairs = pairs.size();
+			if (nPairs > 10_000_000) {
+				// About 7 million pairs has been relatively fast in tests... whereas 33 million proved too much
+				logger.warn("Attempting to trace {} coordinate pairs (consider using a smaller region if this fails)",
+						nPairs);
+			} else {
+				logger.debug("Attempting to trace {} coordinate pairs", nPairs);
+			}
 			var lineStrings = ContourTracingUtils.linesFromPairsFast(factory, pairs, xOrigin, yOrigin, scale);
 			long endTime = System.currentTimeMillis();
-			logger.debug("Creating lines from pair time: {} ms", endTime - startTime);
+			logger.debug("Created {} lines from {} coordinate pairs in {} ms", lineStrings.getNumGeometries(), nPairs, endTime - startTime);
 
 			var polygonizer = new Polygonizer(true);
 			polygonizer.add(lineStrings);
 			var geometry = polygonizer.getGeometry();
 			geometry.normalize();
+
+			logger.debug("Created {} with {} coordinates", geometry.getGeometryType(), geometry.getNumPoints());
 			return geometry;
 		} catch (Throwable e) {
 			System.err.println("Error in polygonization: " + e.getMessage());

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/CoordinatePair.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/CoordinatePair.java
@@ -1,21 +1,22 @@
 package qupath.lib.analysis.images;
 
-import org.locationtech.jts.geom.Coordinate;
+import qupath.lib.geom.Point2;
 
 import java.util.Comparator;
 import java.util.Objects;
 
-class CoordinatePair {
+class CoordinatePair implements Comparable<CoordinatePair> {
 
-    private static final Comparator<Coordinate> topLeftCoordinateComparator = Comparator.comparingDouble(Coordinate::getY)
-            .thenComparingDouble(Coordinate::getX);
+    private static final Comparator<Point2> topLeftCoordinateComparator = Comparator.comparingDouble(Point2::getY)
+            .thenComparingDouble(Point2::getX);
 
-    private final Coordinate c1;
-    private final Coordinate c2;
+
+    private final Point2 c1;
+    private final Point2 c2;
 
     private final int hash;
 
-    CoordinatePair(Coordinate c1, Coordinate c2) {
+    CoordinatePair(Point2 c1, Point2 c2) {
         var comp = topLeftCoordinateComparator.compare(c1, c2);
         if (comp < 0) {
             this.c1 = c1;
@@ -31,11 +32,11 @@ class CoordinatePair {
     }
 
     boolean isHorizontal() {
-        return c1.y == c2.y && c1.x != c2.x;
+        return c1.getY() == c2.getY() && c1.getX() != c2.getX();
     }
 
     boolean isVertical() {
-        return c1.x == c2.x && c1.y != c2.y;
+        return c1.getX() == c2.getX() && c1.getY() != c2.getY();
     }
 
     /**
@@ -43,7 +44,7 @@ class CoordinatePair {
      *
      * @return
      */
-    Coordinate getC1() {
+    Point2 getC1() {
         return c1;
     }
 
@@ -52,7 +53,7 @@ class CoordinatePair {
      *
      * @return
      */
-    Coordinate getC2() {
+    Point2 getC2() {
         return c2;
     }
 
@@ -67,5 +68,17 @@ class CoordinatePair {
     @Override
     public int hashCode() {
         return hash;
+    }
+
+    @Override
+    public int compareTo(CoordinatePair other) {
+        if (this.equals(other))
+            return 0;
+        int comp = c1.compareTo(other.c1);
+        if (comp == 0) {
+            return c2.compareTo(other.c2);
+        } else {
+            return comp;
+        }
     }
 }

--- a/qupath-core/src/main/java/qupath/lib/geom/Point2.java
+++ b/qupath-core/src/main/java/qupath/lib/geom/Point2.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -37,44 +37,22 @@ import org.slf4j.LoggerFactory;
  * @author Pete Bankhead
  *
  */
-public class Point2 extends AbstractPoint implements Externalizable {
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		long temp;
-		temp = Double.doubleToLongBits(x);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(y);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		return result;
-	}
+public class Point2 extends AbstractPoint implements Externalizable, Comparable<Point2> {
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Point2 other = (Point2) obj;
-		if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
-			return false;
-		if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
-			return false;
-		return true;
-	}
+	private static final Logger logger = LoggerFactory.getLogger(Point2.class);
 
-	static Logger logger = LoggerFactory.getLogger(Point2.class);
-	
-	private double x, y;
-	
+	private double x;
+	private double y;
+
+	// Transient to avoid serializing the hashcode
+	private transient int hashCode = 0;
+
 	/**
 	 * Default constructor for a point at location (0,0).
 	 */
-	public Point2() {}
+	public Point2() {
+		this(0, 0);
+	}
 	
 	/**
 	 * Point constructor.
@@ -152,7 +130,32 @@ public class Point2 extends AbstractPoint implements Externalizable {
 	public String toString() {
 		return "Point: " + x + ", " + y;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		// Conceivably the hashcode *could* be zero, but it's unlikely
+		if (hashCode == 0)
+			hashCode = computeHashCode();
+		return hashCode;
+	}
+
+	private int computeHashCode() {
+		final int prime = 31;
+		int result = Double.hashCode(x);
+		result = prime * result + Double.hashCode(y);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj instanceof Point2 p) {
+			return x == p.x && y == p.y;
+		} else {
+			return false;
+		}
+	}
 
 	@Override
 	public void writeExternal(ObjectOutput out) throws IOException {
@@ -168,4 +171,16 @@ public class Point2 extends AbstractPoint implements Externalizable {
 		y = in.readDouble();
 	}
 
+	@Override
+	public int compareTo(Point2 other) {
+		if (y < other.y)
+			return -1;
+		if (y > other.y)
+			return 1;
+		if (x < other.x)
+			return -1;
+		if (x > other.x)
+			return 1;
+		return 0;
+	}
 }


### PR DESCRIPTION
Addendum to https://github.com/qupath/qupath/pull/1777

Replaces the frequent use of `Coordinate` with `Point2`, since it's a more minimal class and gives us more flexibility to optimize things in the future.

These changes reduced the contour generation time in the previous example further still, from ~15 seconds to under 13 seconds (with some variation).

The use of very large `HashSet` and `HashMap` instances continues to slow things down if the number of coordinates gets much higher; I haven't been able to find a straightforward solution to that.