### PR TITLE
More contours

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
@@ -798,7 +798,7 @@ public class ContourTracing {
 			logger.debug("Created {} with {} coordinates", geometry.getGeometryType(), geometry.getNumPoints());
 			return geometry;
 		} catch (Throwable e) {
-			logger.error("Error in polygonization: {}", e.getMessage());
+			logger.error("Error in polygonization: {}", e.getMessage(), e);
 			return factory.createEmpty(2);
 		}
 	}

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracing.java
@@ -48,18 +48,14 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.CoordinateXY;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.operation.polygonize.Polygonizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.common.ThreadTools;
-import qupath.lib.geom.Point2;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerMetadata;
 import qupath.lib.images.servers.ImageServers;
@@ -1299,9 +1295,9 @@ public class ContourTracing {
 		}
 
 		List<CoordinatePair> lines = new ArrayList<>();
-		Point2 lastHorizontalEdgeCoord = null;
-		Point2[] lastVerticalEdgeCoords = new Point2[xEnd-xStart+1];
-		Map<Point2, Point2> pointCache = new HashMap<>();
+		IntPoint lastHorizontalEdgeCoord = null;
+		IntPoint[] lastVerticalEdgeCoords = new IntPoint[xEnd-xStart+1];
+		Map<IntPoint, IntPoint> pointCache = new HashMap<>();
 		for (int y = yStart; y <= yEnd; y++) {
 			for (int x = xStart; x <= xEnd; x++) {
 				boolean isOn = inRange(image, x, y, min, max);
@@ -1309,14 +1305,14 @@ public class ContourTracing {
 				boolean onVerticalEdge = isOn != inRange(image, x-1, y, min, max);
 				// Check if on a horizontal edge with the previous row
 				if (onHorizontalEdge) {
-					var nextEdgeCoord = createCoordinate(pm, xOffset + x, yOffset + y, pointCache);
+					var nextEdgeCoord = createCoordinate( xOffset + x, yOffset + y, pointCache);
 					if (lastHorizontalEdgeCoord != null) {
 						lines.add(new CoordinatePair(lastHorizontalEdgeCoord, nextEdgeCoord));
 					}
 					lastHorizontalEdgeCoord = nextEdgeCoord;
 				} else {
 					if (lastHorizontalEdgeCoord != null) {
-						var nextEdgeCoord = createCoordinate(pm, xOffset + x, yOffset + y, pointCache);
+						var nextEdgeCoord = createCoordinate(xOffset + x, yOffset + y, pointCache);
 						lines.add(new CoordinatePair(lastHorizontalEdgeCoord, nextEdgeCoord));
 						lastHorizontalEdgeCoord = null;
 					}
@@ -1324,14 +1320,14 @@ public class ContourTracing {
 				// Check if on a vertical edge with the previous column
 				var lastVerticalEdgeCoord = lastVerticalEdgeCoords[x - xStart];
 				if (onVerticalEdge) {
-					var nextEdgeCoord = createCoordinate(pm, xOffset + x, yOffset + y, pointCache);
+					var nextEdgeCoord = createCoordinate( xOffset + x, yOffset + y, pointCache);
 					if (lastVerticalEdgeCoord != null) {
 						lines.add(new CoordinatePair(lastVerticalEdgeCoord, nextEdgeCoord));
 					}
 					lastVerticalEdgeCoords[x - xStart] = nextEdgeCoord;
 				} else {
 					if (lastVerticalEdgeCoord != null) {
-						var nextEdgeCoord = createCoordinate(pm, xOffset + x, yOffset + y, pointCache);
+						var nextEdgeCoord = createCoordinate( xOffset + x, yOffset + y, pointCache);
 						lines.add(new CoordinatePair(lastVerticalEdgeCoord, nextEdgeCoord));
 						lastVerticalEdgeCoords[x - xStart] = null;
 					}
@@ -1347,11 +1343,9 @@ public class ContourTracing {
 	 * This is intended to slightly reduce overhead by effectively making points singletons (at least where the cache
 	 * is shared).
 	 */
-	private static Point2 createCoordinate(PrecisionModel pm, double x, double y, Map<Point2, Point2> pointCache) {
-		double x2 = pm.makePrecise(x);
-		double y2 = pm.makePrecise(y);
+	private static IntPoint createCoordinate(int x, int y, Map<IntPoint, IntPoint> pointCache) {
 		// We don't avoid the overhead of *creating* the point, but at least it can be immediately garbage collected
-		var point = new Point2(x2, y2);
+		var point = new IntPoint(x, y);
 		return pointCache == null ? point : pointCache.computeIfAbsent(point, p -> p);
 	}
 

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
@@ -180,7 +180,7 @@ class ContourTracingUtils {
         var mergeable = new MinimalCoordinateMap<List<Point2>>(Math.max(100, (int)Math.sqrt(pairList.size())));
         for (var entry : firstDirection.entrySet()) {
             var list = entry.getValue();
-            for (var ls : buildLineStrings(list, nonMergeable::contains, factory, xOrigin, yOrigin, scale)) {
+            for (var ls : buildLineStrings(list, nonMergeable::contains, factory, 0, 0, 1)) {
                 var c1 = ls.getFirst();
                 var c2 = ls.getLast();
                 boolean isMergeable = false;
@@ -202,7 +202,7 @@ class ContourTracingUtils {
         var queued = new ArrayDeque<List<Point2>>();
         for (var entry : secondDirection.entrySet()) {
             var list = entry.getValue();
-            queued.addAll(buildLineStrings(list, nonMergeable::contains, factory, xOrigin, yOrigin, scale));
+            queued.addAll(buildLineStrings(list, nonMergeable::contains, factory, 0, 0, 1));
             while (!queued.isEmpty()) {
                 var ls = queued.pop();
                 if (isClosed(ls)) {
@@ -255,11 +255,14 @@ class ContourTracingUtils {
         lines.addAll(mergeable.values());
 
         var lineStrings = new ArrayList<LineString>();
+        var pm = factory.getPrecisionModel();
         for (var line : lines) {
             var coords = new Coordinate[line.size()];
             for (int i = 0; i < line.size(); i++) {
                 var c = line.get(i);
-                coords[i] = new Coordinate(c.getX(), c.getY());
+                double x = pm.makePrecise(xOrigin + c.getX() * scale);
+                double y = pm.makePrecise(yOrigin + c.getY() * scale);
+                coords[i] = new Coordinate(x, y);
             }
             lineStrings.add(factory.createLineString(coords));
         }

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
@@ -425,7 +425,7 @@ class ContourTracingUtils {
         void rebuild() {
             // Performance of hashset seems to degrate a lot when it's huge - so revert to binary search instead
             if (set.size() > 1_000_000) {
-                this.values = set.stream().mapToLong(IntPoint::getLongValue).sorted().toArray();
+                this.values = set.stream().mapToLong(IntPoint::value).sorted().toArray();
             }
         }
 
@@ -437,7 +437,7 @@ class ContourTracingUtils {
             if (Objects.equals(lastNotContained, p))
                 return false;
             if (values != null)
-                return Arrays.binarySearch(values, p.getLongValue()) >= 0;
+                return Arrays.binarySearch(values, p.value()) >= 0;
             if (set.contains(p)) {
                 lastContained = p;
                 return true;

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
@@ -94,8 +94,8 @@ class ContourTracingUtils {
 
     private static LineString createLineString(CoordinatePair pair, GeometryFactory factory, double xOrigin, double yOrigin, double scale) {
         var pm = factory.getPrecisionModel();
-        var c1 = pair.getC1();
-        var c2 = pair.getC2();
+        var c1 = pair.c1();
+        var c2 = pair.c2();
         double x1 = pm.makePrecise(xOrigin + c1.getX() * scale);
         double x2 =  pm.makePrecise(xOrigin + c2.getX() * scale);
         double y1 =  pm.makePrecise(yOrigin + c1.getY() * scale);
@@ -114,8 +114,8 @@ class ContourTracingUtils {
         // Extract all the coordinates
         var allCoordinates = new ArrayList<IntPoint>(pairList.size()*2);
         for (var p : pairList) {
-            allCoordinates.add(p.getC1());
-            allCoordinates.add(p.getC2());
+            allCoordinates.add(p.c1());
+            allCoordinates.add(p.c2());
         }
 
         // Sort the list so that we can count occurrences in a single pass
@@ -165,9 +165,9 @@ class ContourTracingUtils {
         var vertical = new TreeMap<Integer, List<CoordinatePair>>();
         for (var p : pairList) {
             if (p.isHorizontal())
-                horizontal.computeIfAbsent(p.getC1().getY(), y -> new ArrayList<>()).add(p);
+                horizontal.computeIfAbsent(p.c1().getY(), y -> new ArrayList<>()).add(p);
             else if (p.isVertical())
-                vertical.computeIfAbsent(p.getC1().getX(), x -> new ArrayList<>()).add(p);
+                vertical.computeIfAbsent(p.c2().getX(), x -> new ArrayList<>()).add(p);
         }
 
         // May not really matter if we start with horizontal or vertical
@@ -320,19 +320,19 @@ class ContourTracingUtils {
             return List.of();
 
         List<List<IntPoint>> lines = new ArrayList<>();
-        IntPoint firstCoord = pairs.getFirst().getC1();
-        IntPoint secondCoord = pairs.getFirst().getC2();
+        IntPoint firstCoord = pairs.getFirst().c1();
+        IntPoint secondCoord = pairs.getFirst().c2();
         for (int i = 1; i < pairs.size(); i++) {
             var p = pairs.get(i);
-            if (!secondCoord.equals(p.getC1()) || counter.test(secondCoord)) {
+            if (!secondCoord.equals(p.c1()) || counter.test(secondCoord)) {
                 // Finish the line we were building & start a new one
                 lines.add(createLineString(firstCoord, secondCoord));
-                firstCoord = p.getC1();
-                secondCoord = p.getC2();
+                firstCoord = p.c1();
+                secondCoord = p.c2();
                 continue;
             } else {
                 // Continue the line
-                secondCoord = p.getC2();
+                secondCoord = p.c2();
             }
         }
         lines.add(createLineString(firstCoord, secondCoord));

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
@@ -423,7 +423,7 @@ class ContourTracingUtils {
         }
 
         void rebuild() {
-            // Performance of hashset seems to degrate a lot when it's huge - so revert to binary search instead
+            // Performance of hashset seems to degrade a lot when it's huge - so revert to binary search instead
             if (set.size() > 1_000_000) {
                 this.values = set.stream().mapToLong(IntPoint::value).sorted().toArray();
             }

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/ContourTracingUtils.java
@@ -8,15 +8,14 @@ import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import qupath.lib.geom.Point2;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -113,7 +112,7 @@ class ContourTracingUtils {
      */
     private static MinimalCoordinateSet findNonMergeableCoordinates(Collection<CoordinatePair> pairList) {
         // Extract all the coordinates
-        var allCoordinates = new ArrayList<Point2>(pairList.size()*2);
+        var allCoordinates = new ArrayList<IntPoint>(pairList.size()*2);
         for (var p : pairList) {
             allCoordinates.add(p.getC1());
             allCoordinates.add(p.getC2());
@@ -124,8 +123,8 @@ class ContourTracingUtils {
 
         // Find which that can't be merged, i.e. they don't occur exactly twice
         int count = 0;
-        Point2 currentCoord = null;
-//        long startTime = System.currentTimeMillis();
+        IntPoint currentCoord = null;
+        long startTime = System.currentTimeMillis();
         var nonMergeable = new MinimalCoordinateSet(allCoordinates.size()/10);
         for (var c : allCoordinates) {
             if (Objects.equals(currentCoord, c)) {
@@ -139,8 +138,8 @@ class ContourTracingUtils {
         }
 
         nonMergeable.rebuild();
-//        long endTime = System.currentTimeMillis();
-//        System.err.println("Time to find non-mergeable coordinates: " + (endTime - startTime) + " ms");
+        long endTime = System.currentTimeMillis();
+        logger.trace("Time to find non-mergeable coordinates: " + (endTime - startTime) + " ms");
         return nonMergeable;
     }
 
@@ -152,7 +151,7 @@ class ContourTracingUtils {
      * a {@link org.locationtech.jts.operation.polygonize.Polygonizer} to build the final geometry.
      */
     static Geometry linesFromPairsFast(GeometryFactory factory, Collection<CoordinatePair> pairs,
-                                            double xOrigin, double yOrigin, double scale) {
+                                            double xOrigin, double yOrigin, double scale) throws InterruptedException {
 
         // Sort now to avoid sorting later
         var pairList = pairs.stream()
@@ -162,8 +161,8 @@ class ContourTracingUtils {
         var nonMergeable = findNonMergeableCoordinates(pairs);
 
         // Find horizontal & vertical edges, split by row and column
-        var horizontal = new TreeMap<Double, List<CoordinatePair>>();
-        var vertical = new TreeMap<Double, List<CoordinatePair>>();
+        var horizontal = new TreeMap<Integer, List<CoordinatePair>>();
+        var vertical = new TreeMap<Integer, List<CoordinatePair>>();
         for (var p : pairList) {
             if (p.isHorizontal())
                 horizontal.computeIfAbsent(p.getC1().getY(), y -> new ArrayList<>()).add(p);
@@ -175,12 +174,12 @@ class ContourTracingUtils {
         var firstDirection = horizontal.size() <= vertical.size() ? horizontal : vertical;
         var secondDirection = firstDirection == horizontal ? vertical : horizontal;
 
-        Collection<List<Point2>> lines = new ArrayList<>(pairs.size()/10);
-//        Map<Point2, List<Point2>> mergeable = HashMap.newHashMap(pairs.size());
-        var mergeable = new MinimalCoordinateMap<List<Point2>>(Math.max(100, (int)Math.sqrt(pairList.size())));
+        Collection<List<IntPoint>> lines = new ArrayList<>(pairs.size()/10);
+//        Map<IntPoint, List<IntPoint>> mergeable = HashMap.newHashMap(pairs.size()); // Retained for debugging & performance checks
+        var mergeable = new MinimalCoordinateMap<List<IntPoint>>(Math.max(100, (int)Math.sqrt(pairList.size())));
         for (var entry : firstDirection.entrySet()) {
             var list = entry.getValue();
-            for (var ls : buildLineStrings(list, nonMergeable::contains, factory, 0, 0, 1)) {
+            for (var ls : buildLineStrings(list, nonMergeable::contains)) {
                 var c1 = ls.getFirst();
                 var c2 = ls.getLast();
                 boolean isMergeable = false;
@@ -199,10 +198,10 @@ class ContourTracingUtils {
             }
         }
 
-        var queued = new ArrayDeque<List<Point2>>();
+        var queued = new ArrayDeque<List<IntPoint>>();
         for (var entry : secondDirection.entrySet()) {
             var list = entry.getValue();
-            queued.addAll(buildLineStrings(list, nonMergeable::contains, factory, 0, 0, 1));
+            queued.addAll(buildLineStrings(list, nonMergeable::contains));
             while (!queued.isEmpty()) {
                 var ls = queued.pop();
                 if (isClosed(ls)) {
@@ -210,7 +209,7 @@ class ContourTracingUtils {
                     continue;
                 }
                 if (Thread.interrupted())
-                    throw new RuntimeException("Interrupted");
+                    throw new InterruptedException("Contour tracing interrupted!");
                 var c1 = ls.getFirst();
                 var c2 = ls.getLast();
                 boolean c1Mergeable = !nonMergeable.contains(c1);
@@ -270,7 +269,7 @@ class ContourTracingUtils {
         return factory.buildGeometry(lineStrings);
     }
 
-    private static boolean isClosed(List<Point2> coords) {
+    private static boolean isClosed(List<IntPoint> coords) {
         return coords.size() > 2 && coords.getFirst().equals(coords.getLast());
     }
 
@@ -279,7 +278,7 @@ class ContourTracingUtils {
      * Important! It is assumed that neither line is required after merging.
      * This method is therefore permitted to reuse either list for the output, if it is mutable.
      */
-    private static List<Point2> mergeLines(List<Point2> l1, List<Point2> l2) {
+    private static List<IntPoint> mergeLines(List<IntPoint> l1, List<IntPoint> l2) {
         // TODO: This could be optimized by ensuring lists are mutable, and reusing an existing list
         var c1Start = l1.getFirst();
         var c1End = l1.getLast();
@@ -299,36 +298,35 @@ class ContourTracingUtils {
         }
     }
 
-    private static List<Point2> concat(List<Point2> l1, List<Point2> l2) {
+    private static List<IntPoint> concat(List<IntPoint> l1, List<IntPoint> l2) {
         int n = l1.size() + l2.size() - 1;
         // ArrayLists are mutable - so we can just add to them
-        if (l1 instanceof ArrayList<Point2> list) {
+        if (l1 instanceof ArrayList<IntPoint> list) {
             list.addAll(l2);
             return list;
-        } else if (l2 instanceof ArrayList<Point2> list) {
+        } else if (l2 instanceof ArrayList<IntPoint> list) {
             list.addAll(0, l1);
             return list;
         }
-        var list = new ArrayList<Point2>(n);
+        var list = new ArrayList<IntPoint>(n);
         list.addAll(l1);
         list.addAll(l2.subList(1, l2.size()));
         return list;
     }
 
 
-    private static List<List<Point2>> buildLineStrings(List<CoordinatePair> pairs, Predicate<Point2> counter,
-                                                           GeometryFactory factory, double xOrigin, double yOrigin, double scale) {
+    private static List<List<IntPoint>> buildLineStrings(List<CoordinatePair> pairs, Predicate<IntPoint> counter) {
         if (pairs.isEmpty())
             return List.of();
 
-        List<List<Point2>> lines = new ArrayList<>();
-        Point2 firstCoord = pairs.getFirst().getC1();
-        Point2 secondCoord = pairs.getFirst().getC2();
+        List<List<IntPoint>> lines = new ArrayList<>();
+        IntPoint firstCoord = pairs.getFirst().getC1();
+        IntPoint secondCoord = pairs.getFirst().getC2();
         for (int i = 1; i < pairs.size(); i++) {
             var p = pairs.get(i);
             if (!secondCoord.equals(p.getC1()) || counter.test(secondCoord)) {
                 // Finish the line we were building & start a new one
-                lines.add(createLineString(firstCoord, secondCoord, factory, xOrigin, yOrigin, scale));
+                lines.add(createLineString(firstCoord, secondCoord));
                 firstCoord = p.getC1();
                 secondCoord = p.getC2();
                 continue;
@@ -337,21 +335,12 @@ class ContourTracingUtils {
                 secondCoord = p.getC2();
             }
         }
-        lines.add(createLineString(firstCoord, secondCoord, factory, xOrigin, yOrigin, scale));
+        lines.add(createLineString(firstCoord, secondCoord));
         return lines;
     }
 
-    private static List<Point2> createLineString(Point2 c1, Point2 c2,
-                                                     GeometryFactory factory, double xOrigin, double yOrigin, double scale) {
-        if (xOrigin == 0 && yOrigin == 0 && scale == 1) {
-            return List.of(c1, c2);
-        }
-        var pm = factory.getPrecisionModel();
-        double x1 = pm.makePrecise(xOrigin + c1.getX() * scale);
-        double x2 =  pm.makePrecise(xOrigin + c2.getX() * scale);
-        double y1 =  pm.makePrecise(yOrigin + c1.getY() * scale);
-        double y2 =  pm.makePrecise(yOrigin + c2.getY() * scale);
-        return List.of(new Point2(x1, y1), new Point2(x2, y2));
+    private static List<IntPoint> createLineString(IntPoint c1, IntPoint c2) {
+        return List.of(c1, c2);
     }
 
 
@@ -363,26 +352,33 @@ class ContourTracingUtils {
     private static class MinimalCoordinateMap<T> {
 
         private final int numMappings;
-        private final Map<Double, Map<Double, T>> map;
+        private final Map<Integer, Map<Integer, T>> map;
 
         MinimalCoordinateMap(int numMappings) {
             this.numMappings = numMappings;
             this.map = HashMap.newHashMap(numMappings);
         }
 
-        T put(Point2 c, T val) {
+        T put(IntPoint c, T val) {
             return map.computeIfAbsent(c.getX(), x -> HashMap.newHashMap(numMappings)).put(c.getY(), val);
         }
 
-        T remove(Point2 c) {
-            return map.computeIfAbsent(c.getX(), x -> HashMap.newHashMap(numMappings)).remove(c.getY());
+        T remove(IntPoint c) {
+            var temp = map.getOrDefault(c.getX(), null);
+            if (temp != null) {
+                T value = temp.remove(c.getY());
+                if (temp.isEmpty())
+                    map.remove(c.getX());
+                return value;
+            }
+            return null;
         }
 
-        T get(Point2 c) {
+        T get(IntPoint c) {
             return getOrDefault(c, null);
         }
 
-        T getOrDefault(Point2 c, T defaultValue) {
+        T getOrDefault(IntPoint c, T defaultValue) {
             return map.getOrDefault(c.getX(), Collections.emptyMap()).getOrDefault(c.getY(), defaultValue);
         }
 
@@ -410,38 +406,38 @@ class ContourTracingUtils {
      */
     private static class MinimalCoordinateSet {
 
-        private Set<Point2> set;
+        private Set<IntPoint> set;
 
-        private Point2 lastContained;
-        private Point2 lastNotContained;
+        private IntPoint lastContained;
+        private IntPoint lastNotContained;
 
-        private final Map<Point2, Boolean> recentQueries = new LinkedHashMap<>(512, 0.75f, false) {
-            @Override
-            protected boolean removeEldestEntry(Map.Entry<Point2, Boolean> eldest) {
-                return size() > 256;
-            }
-        };
+        private long[] values;
 
         MinimalCoordinateSet(int numElements) {
             set = HashSet.newHashSet(numElements);
-//            set = new TreeSet<>();
         }
 
-        boolean add(Point2 p) {
+        boolean add(IntPoint p) {
+            this.values = null; // Reset values
             return set.add(p);
         }
 
         void rebuild() {
-            this.set = new HashSet<>(set);
+            // Performance of hashset seems to degrate a lot when it's huge - so revert to binary search instead
+            if (set.size() > 1_000_000) {
+                this.values = set.stream().mapToLong(IntPoint::getLongValue).sorted().toArray();
+            }
         }
 
-        boolean contains(Point2 p) {
+        boolean contains(IntPoint p) {
             // Querying the same points soon after each other is likely (due to how we scan the image),
             // so storing the last result can reduce at least some queries.
             if (Objects.equals(lastContained, p))
                 return true;
             if (Objects.equals(lastNotContained, p))
                 return false;
+            if (values != null)
+                return Arrays.binarySearch(values, p.getLongValue()) >= 0;
             if (set.contains(p)) {
                 lastContained = p;
                 return true;

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/CoordinatePair.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/CoordinatePair.java
@@ -1,18 +1,12 @@
 package qupath.lib.analysis.images;
 
 import java.util.Comparator;
-import java.util.Objects;
 
-class CoordinatePair implements Comparable<CoordinatePair> {
+record CoordinatePair(IntPoint c1, IntPoint c2) implements Comparable<CoordinatePair> {
 
     private static final Comparator<IntPoint> topLeftCoordinateComparator = Comparator.comparingDouble(IntPoint::getY)
             .thenComparingDouble(IntPoint::getX);
 
-
-    private final IntPoint c1;
-    private final IntPoint c2;
-
-    private final int hash;
 
     CoordinatePair(IntPoint c1, IntPoint c2) {
         var comp = topLeftCoordinateComparator.compare(c1, c2);
@@ -26,7 +20,6 @@ class CoordinatePair implements Comparable<CoordinatePair> {
             throw new IllegalArgumentException("Coordinates should not be the same!");
         if (!isHorizontal() && !isVertical())
             throw new IllegalArgumentException("Coordinate pairs should be horizontal or vertical!");
-        this.hash = Objects.hash(c1, c2);
     }
 
     boolean isHorizontal() {
@@ -35,38 +28,6 @@ class CoordinatePair implements Comparable<CoordinatePair> {
 
     boolean isVertical() {
         return c1.getX() == c2.getX() && c1.getY() != c2.getY();
-    }
-
-    /**
-     * This does <i>not</i> make a defensive copy; the caller should not modify the returned coordinate.
-     *
-     * @return
-     */
-    IntPoint getC1() {
-        return c1;
-    }
-
-    /**
-     * This does <i>not</i> make a defensive copy; the caller should not modify the returned coordinate.
-     *
-     * @return
-     */
-    IntPoint getC2() {
-        return c2;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o instanceof CoordinatePair pair) {
-            return c1.equals(pair.c1) && c2.equals(pair.c2);
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public int hashCode() {
-        return hash;
     }
 
     @Override

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/CoordinatePair.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/CoordinatePair.java
@@ -1,15 +1,9 @@
 package qupath.lib.analysis.images;
 
-import java.util.Comparator;
-
 record CoordinatePair(IntPoint c1, IntPoint c2) implements Comparable<CoordinatePair> {
 
-    private static final Comparator<IntPoint> topLeftCoordinateComparator = Comparator.comparingDouble(IntPoint::getY)
-            .thenComparingDouble(IntPoint::getX);
-
-
     CoordinatePair(IntPoint c1, IntPoint c2) {
-        var comp = topLeftCoordinateComparator.compare(c1, c2);
+        var comp = c1.compareTo(c2);
         if (comp < 0) {
             this.c1 = c1;
             this.c2 = c2;

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/CoordinatePair.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/CoordinatePair.java
@@ -1,22 +1,20 @@
 package qupath.lib.analysis.images;
 
-import qupath.lib.geom.Point2;
-
 import java.util.Comparator;
 import java.util.Objects;
 
 class CoordinatePair implements Comparable<CoordinatePair> {
 
-    private static final Comparator<Point2> topLeftCoordinateComparator = Comparator.comparingDouble(Point2::getY)
-            .thenComparingDouble(Point2::getX);
+    private static final Comparator<IntPoint> topLeftCoordinateComparator = Comparator.comparingDouble(IntPoint::getY)
+            .thenComparingDouble(IntPoint::getX);
 
 
-    private final Point2 c1;
-    private final Point2 c2;
+    private final IntPoint c1;
+    private final IntPoint c2;
 
     private final int hash;
 
-    CoordinatePair(Point2 c1, Point2 c2) {
+    CoordinatePair(IntPoint c1, IntPoint c2) {
         var comp = topLeftCoordinateComparator.compare(c1, c2);
         if (comp < 0) {
             this.c1 = c1;
@@ -44,7 +42,7 @@ class CoordinatePair implements Comparable<CoordinatePair> {
      *
      * @return
      */
-    Point2 getC1() {
+    IntPoint getC1() {
         return c1;
     }
 
@@ -53,16 +51,17 @@ class CoordinatePair implements Comparable<CoordinatePair> {
      *
      * @return
      */
-    Point2 getC2() {
+    IntPoint getC2() {
         return c2;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass())
+        if (o instanceof CoordinatePair pair) {
+            return c1.equals(pair.c1) && c2.equals(pair.c2);
+        } else {
             return false;
-        CoordinatePair that = (CoordinatePair) o;
-        return Objects.equals(c1, that.c1) && Objects.equals(c2, that.c2);
+        }
     }
 
     @Override

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/IntPoint.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/IntPoint.java
@@ -1,0 +1,62 @@
+package qupath.lib.analysis.images;
+
+/**
+ * Minimal class to represent a pair of integer coordinates.
+ * Value is stored in a packed long to try to maximize efficiency.
+ * See https://github.com/qupath/qupath/issues/1780
+ */
+final class IntPoint implements Comparable<IntPoint> {
+
+    private final long value;
+
+    public IntPoint(int x, int y) {
+        this(packLong(x, y));
+    }
+
+    public IntPoint(long packedValue) {
+        this.value = packedValue;
+    }
+
+    public static long packLong(int x, int y) {
+        return ((long) x << 32) | (y & 0xffffffffL);
+    }
+
+    public static int unpackX(long packedValue) {
+        return (int)(packedValue >> 32);
+    }
+
+    public static int unpackY(long packedValue) {
+        return (int)packedValue;
+    }
+
+    public int getX() {
+        return unpackX(value);
+    }
+
+    public int getY() {
+        return unpackY(value);
+    }
+
+    public long getLongValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof IntPoint p)
+           return this.value == p.value;
+        else
+            return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(value);
+    }
+
+    @Override
+    public int compareTo(IntPoint o) {
+        return Long.compare(value, o.value);
+    }
+
+}

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/IntPoint.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/IntPoint.java
@@ -5,16 +5,10 @@ package qupath.lib.analysis.images;
  * Value is stored in a packed long to try to maximize efficiency.
  * See https://github.com/qupath/qupath/issues/1780
  */
-final class IntPoint implements Comparable<IntPoint> {
-
-    private final long value;
+record IntPoint(long value) implements Comparable<IntPoint> {
 
     public IntPoint(int x, int y) {
         this(packLong(x, y));
-    }
-
-    public IntPoint(long packedValue) {
-        this.value = packedValue;
     }
 
     public static long packLong(int x, int y) {
@@ -39,19 +33,6 @@ final class IntPoint implements Comparable<IntPoint> {
 
     public long getLongValue() {
         return value;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other instanceof IntPoint p)
-           return this.value == p.value;
-        else
-            return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return Long.hashCode(value);
     }
 
     @Override

--- a/qupath-core/src/main/java/qupath/lib/analysis/images/IntPoint.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/images/IntPoint.java
@@ -31,10 +31,6 @@ record IntPoint(long value) implements Comparable<IntPoint> {
         return unpackY(value);
     }
 
-    public long getLongValue() {
-        return value;
-    }
-
     @Override
     public int compareTo(IntPoint o) {
         return Long.compare(value, o.value);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DownsampledShapeCache.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DownsampledShapeCache.java
@@ -48,7 +48,7 @@ public class DownsampledShapeCache {
     private static final double minDownsample = 4.0;
 
     // Downsamples calculated as multiples of this value
-    private static final double downsampleStep = 1.25;
+    private final double downsampleStep;
 
     private final DownsampledShape shape;
     private final boolean canSimplify;
@@ -91,10 +91,20 @@ public class DownsampledShapeCache {
         int nPoints = roi.getNumPoints();
         this.shape = new DownsampledShape(roi.getShape(), 1.0, nPoints);
         this.canSimplify = nPoints > pointCountThreshold && roi.isArea();
-        if (canSimplify)
+        if (canSimplify) {
+            // If we have an astronomically large number of points, we want to simplify for fewer steps
+            // (because it can be time-consuming and memory-intensive)
+            if (nPoints < 5_000_000)
+                downsampleStep = 1.25;
+            else if (nPoints < 10_000_000)
+                downsampleStep = 1.5;
+            else
+                downsampleStep = 2.0;
             downsampledShapes = new ArrayList<>();
-        else
+        } else {
+            downsampleStep = 2; // Not relevant
             downsampledShapes = Collections.emptyList();
+        }
     }
 
     private Shape getForDownsample(double downsample) {


### PR DESCRIPTION
Partially addresses https://github.com/qupath/qupath/issues/1780 by replacing `Point2` with `IntPoint2`, which stores its values in a packed `long`.

This doesn't make much difference to performance for the ~5 million vertices tracing, but it *did* make it possible to trace much larger regions - making `Polygonizer` the bottleneck.

For example, I could trace two regions - with 39,230,067 and 21,436,882 respectively, in 532 seconds.

Rendering was then slow again, and I couldn't *save* them because of memory issues... but I think it indicates that this PR improves the efficiency of some parts of the tracing.