### PR TITLE
Improve performance with large pixel classifiers

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
@@ -364,7 +364,7 @@ public class PixelClassifierTools {
 		if (labels == null)
 			labels = parseClassificationLabels(server.getMetadata().getClassificationLabels(), false);
 		
-		if (labels == null || labels.isEmpty())
+		if (labels.isEmpty())
 			throw new IllegalArgumentException("Cannot create objects for server - no classification labels are available!");
 		
 		ChannelThreshold[] thresholds;
@@ -390,9 +390,9 @@ public class PixelClassifierTools {
 			default:
 				probabilityThreshold = 0.5;
 			}
-			thresholds = labels.entrySet().stream().map(e -> ChannelThreshold.createAbove(e.getKey(), probabilityThreshold)).toArray(ChannelThreshold[]::new);
+			thresholds = labels.keySet().stream().map(pathClass -> ChannelThreshold.createAbove(pathClass, probabilityThreshold)).toArray(ChannelThreshold[]::new);
 		} else
-			thresholds = labels.entrySet().stream().map(e -> ChannelThreshold.create(e.getKey())).toArray(ChannelThreshold[]::new);
+			thresholds = labels.keySet().stream().map(ChannelThreshold::create).toArray(ChannelThreshold[]::new);
 			
 
 		if (roi != null && !roi.isArea()) {

--- a/qupath-core/src/main/java/qupath/lib/classifiers/pixel/PixelClassificationImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/classifiers/pixel/PixelClassificationImageServer.java
@@ -230,9 +230,10 @@ public class PixelClassificationImageServer extends AbstractTileableImageServer 
 			// If we can construct a path (however long) that includes the full serialization info, then cached tiles can be reused even if the server is recreated.
 			// However, because a serialized classifier might be many MB in size (resulting in performance issues with RegionRequest), 
 			// we truncate astronomical ones and add a UUID for uniqueness.
-			String json = GsonTools.getInstance().toJson(classifier);
+			String json = GsonTools.getInstance().toJson(classifier).intern();
 			String suffix;
-			if (json.length() < 1000)
+			int len = json.length();
+			if (len < 1_000_000)
 				suffix = json;
 			else {
 				suffix = idCache.computeIfAbsent(json, j -> json.substring(0, 1000) + "... (" + UUID.randomUUID() + ")");
@@ -240,7 +241,7 @@ public class PixelClassificationImageServer extends AbstractTileableImageServer 
 			return getClass().getName() + ": " + server.getPath() + "::" + suffix;
 		} catch (Exception e) {
 			logger.debug("Unable to serialize pixel classifier to JSON: {}", e.getLocalizedMessage());
-			return getClass().getName() + ": " + server.getPath() + "::" + UUID.randomUUID().toString();
+			return getClass().getName() + ": " + server.getPath() + "::" + UUID.randomUUID();
 		}
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -164,7 +164,7 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 	/**
 	 * Map of tiles currently being requested, so avoid duplicate requests (wait instead for the first request to return).
 	 */
-	private Map<TileRequest, TileTask> pendingTiles = new ConcurrentHashMap<>();
+	private final Map<TileRequest, TileTask> pendingTiles = new ConcurrentHashMap<>();
 	
 	/**
 	 * Count of how many duplicate requests are received for a pending tile.
@@ -267,10 +267,13 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 		// Check if we already have a tile for precisely this occasion - with the right server path
 		// Make a defensive copy, since the cache is critical
 		var cache = getCache();
-		BufferedImage img = request.getPath().equals(getPath()) && cache != null ? cache.get(request) : null;
-		if (img != null)
-			return BufferedImageTools.duplicate(img);
-		
+		var currentPath = request.getPath();
+		if (request.getPath().equals(currentPath)) {
+			BufferedImage img = cache.getOrDefault(request, null);
+			if (img != null)
+				return BufferedImageTools.duplicate(img);
+		}
+
 		// Figure out which tiles we need
 		Collection<TileRequest> tiles = getTileRequestManager().getTileRequests(request);
 		
@@ -417,7 +420,7 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 			imgResult = resizeIfNeeded(imgResult, width, height);
 
 			long endTime = System.currentTimeMillis();
-			logger.trace("Requested " + tiles.size() + " tiles in " + (endTime - startTime) + " ms (non-RGB)");
+            logger.trace("Requested {} tiles in {} ms (non-RGB)", tiles.size(), endTime - startTime);
 			return imgResult;
 		}
 	}

--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -268,7 +268,7 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 		// Make a defensive copy, since the cache is critical
 		var cache = getCache();
 		var currentPath = request.getPath();
-		if (request.getPath().equals(currentPath)) {
+		if (request.getPath().equals(currentPath) && cache != null) {
 			BufferedImage img = cache.getOrDefault(request, null);
 			if (img != null)
 				return BufferedImageTools.duplicate(img);

--- a/qupath-core/src/main/java/qupath/lib/roi/AWTAreaROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/AWTAreaROI.java
@@ -110,6 +110,16 @@ class AWTAreaROI extends AreaROI implements Serializable {
 
 	@Override
 	public Shape getShape() {
+		return createShape();
+	}
+
+	@Override
+	protected Shape getShapeInternal() {
+		return shape;
+	}
+
+	@Override
+	protected Shape createShape() {
 		return new Path2D.Float(shape);
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/roi/AbstractPathBoundedROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/AbstractPathBoundedROI.java
@@ -76,44 +76,6 @@ abstract class AbstractPathBoundedROI extends AbstractPathROI {
 		}
 	}
 	
-	
-//	public void updateAdjustment(double xx, double yy, boolean shiftDown) {
-//		if (isAdjusting) {
-//			// Update x & y
-//			// If pressing shift, constrain to be square
-//			if (shiftDown) {
-//				double w = x - xx;
-//				double h = y - yy;
-//				if (w != 0 && h != 0) {
-//					double len = Math.min(Math.abs(w), Math.abs(h));
-//					w = Math.signum(w) * len;
-//					h = Math.signum(h) * len;
-//				}
-//				x2 = x - w;
-//				y2 = y - h;		
-//			} else {
-//				x2 = xx;
-//				y2 = yy;
-//			}
-//		}
-//	}
-	
-	
-//	public void finishAdjusting(double x, double y, boolean shiftDown) {
-//		super.finishAdjusting(x, y, shiftDown);
-//		ensureOrder();
-//	}
-	
-	
-//	public boolean translate(double dx, double dy) {
-//		// Shift the bounds
-//		x += dx;
-//		y += dy;
-//		x2 += dx;
-//		y2 += dy;
-//		return dx != 0 || dy != 0;
-//	}
-	
 	@Override
 	public double getCentroidX() {
 		return (x + x2) * 0.5;
@@ -134,12 +96,12 @@ abstract class AbstractPathBoundedROI extends AbstractPathROI {
 	
 	@Override
 	public double getBoundsX() {
-		return x < x2 ? x : x2;
+		return Math.min(x, x2);
 	}
 	
 	@Override
 	public double getBoundsY() {
-		return y < y2 ? y : y2;
+		return Math.min(y, y2);
 	}
 	
 	@Override

--- a/qupath-core/src/main/java/qupath/lib/roi/EllipseROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/EllipseROI.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -63,7 +63,14 @@ public class EllipseROI extends AbstractPathBoundedROI implements Serializable {
 		double ry = getBoundsHeight() * 0.5;
 		return (dx*dx/(rx*rx) + dy*dy/(ry*ry)) <= 1;
 	}
-	
+
+	@Override
+	public boolean intersects(double x, double y, double width, double height) {
+		if (!intersectsBounds(x, y, width, height))
+			return false;
+		return getShapeInternal().intersects(x, y, width, height);
+	}
+
 	@Override
 	public String getRoiName() {
 		return "Ellipse";
@@ -158,28 +165,13 @@ public class EllipseROI extends AbstractPathBoundedROI implements Serializable {
 	
 	@Override
 	public Shape getShape() {
+		return createShape();
+	}
+
+	@Override
+	protected Shape createShape() {
 		return new Ellipse2D.Double(x, y, x2-x, y2-y);
 	}
-	
-//	@Override
-//	public double getMaxDiameter() {
-//		return Math.max(getBoundsWidth(), getBoundsHeight());
-//	}
-//	
-//	@Override
-//	public double getMinDiameter() {
-//		return Math.min(getBoundsWidth(), getBoundsHeight());
-//	}
-//	
-//	@Override
-//	public double getScaledMaxDiameter(double pixelWidth, double pixelHeight) {
-//		return Math.max(getBoundsWidth()*pixelWidth, getBoundsHeight()*pixelHeight);
-//	}
-//	
-//	@Override
-//	public double getScaledMinDiameter(double pixelWidth, double pixelHeight) {
-//		return Math.min(getBoundsWidth()*pixelWidth, getBoundsHeight()*pixelHeight);
-//	}
 	
 	private Object writeReplace() {
 		return new SerializationProxy(this);

--- a/qupath-core/src/main/java/qupath/lib/roi/LineROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/LineROI.java
@@ -25,6 +25,7 @@ package qupath.lib.roi;
 
 import java.awt.Shape;
 import java.awt.geom.Line2D;
+import java.awt.geom.Rectangle2D;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -210,10 +211,15 @@ public class LineROI extends AbstractPathROI implements Serializable {
 		return Arrays.asList(new Point2(x, y),
 				new Point2(x2, y2));
 	}
-	
-	
+
 	@Override
 	public Shape getShape() {
+		// Create a new line (it isn't expensive)
+		return createShape();
+	}
+
+	@Override
+	protected Line2D createShape() {
 		return new Line2D.Double(x, y, x2, y2);
 	}
 	
@@ -305,6 +311,13 @@ public class LineROI extends AbstractPathROI implements Serializable {
 	@Override
 	public boolean contains(double x, double y) {
 		return false;
+	}
+
+	@Override
+	public boolean intersects(double x, double y, double width, double height) {
+		if (!intersectsBounds(x, y, width, height))
+			return false;
+		return new Rectangle2D.Double(x, y, width, height).intersectsLine(getX1(), getY1(), getX2(), getY2());
 	}
 
 	@Override

--- a/qupath-core/src/main/java/qupath/lib/roi/PointsROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PointsROI.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -44,7 +44,7 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 	
 	private static final long serialVersionUID = 1L;
 	
-	private List<Point2> points = new ArrayList<>();
+	private final List<Point2> points = new ArrayList<>();
 	
 //	// Point radius no longer sorted internally (it's really a display thing)
 //	@Deprecated
@@ -58,7 +58,7 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 	PointsROI() {
 		this(Double.NaN, Double.NaN);
 	}
-	
+
 	private PointsROI(double x, double y) {
 		this(x, y, null);
 	}
@@ -387,7 +387,11 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 	public Shape getShape() throws UnsupportedOperationException {
 		throw new UnsupportedOperationException("PointROI does not support getShape()!");
 	}
-	
+
+	@Override
+	protected Shape createShape() {
+		throw new UnsupportedOperationException("PointROI does not support createShape()!");
+	}
 	
 //	/**
 //	 * throws UnsupportedOperationException
@@ -474,6 +478,19 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 	
 	@Override
 	public boolean contains(double x, double y) {
+		return false;
+	}
+
+	@Override
+	public boolean intersects(double x, double y, double width, double height) {
+		for (var p : points) {
+			double px = p.getX();
+			double py = p.getY();
+			// Note that other classes (e.g. Rectangle, Polygon) exclude on boundaries
+			if (px > x && py > y && px < x + width && py < y + height) {
+				return true;
+			}
+		}
 		return false;
 	}
 

--- a/qupath-core/src/main/java/qupath/lib/roi/RectangleROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RectangleROI.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
+import org.locationtech.jts.operation.predicate.RectangleIntersects;
 import qupath.lib.geom.Point2;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.interfaces.ROI;
@@ -61,7 +62,12 @@ public class RectangleROI extends AbstractPathBoundedROI implements Serializable
 	public boolean contains(double x, double y) {
 		return x >= this.x && x < x2 && y >= this.y && y < y2;
 	}
-	
+
+	@Override
+	public boolean intersects(double x, double y, double width, double height) {
+		return intersectsBounds(x, y, width, height);
+	}
+
 	@Override
 	public String getRoiName() {
 		return "Rectangle";
@@ -108,14 +114,13 @@ public class RectangleROI extends AbstractPathBoundedROI implements Serializable
 				new Point2(x, y2));
 	}
 
-//	@Override
-//	public Rectangle2D getShape() {
-//		return new Rectangle2D.Double(getBoundsX(), getBoundsY(), getBoundsWidth(), getBoundsHeight());
-//	}
-	
-	
 	@Override
 	public Shape getShape() {
+		return createShape();
+	}
+
+	@Override
+	protected Shape createShape() {
 		return new Rectangle2D.Double(x, y, x2-x, y2-y);
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/roi/interfaces/ROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/interfaces/ROI.java
@@ -31,6 +31,7 @@ import org.locationtech.jts.geom.Geometry;
 import qupath.lib.geom.Point2;
 import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.regions.ImagePlane;
+import qupath.lib.regions.ImageRegion;
 
 /**
  * Base interface for defining regions of interest (ROIs) within QuPath.
@@ -339,7 +340,35 @@ public interface ROI {
 	 * @return
 	 */
 	boolean contains(double x, double y);
-	
+
+	/**
+	 * Test if the ROI intersects a specified image region.
+	 * <p>
+	 * Note that this test is intended as a fast initial filter; a more detailed test using
+	 * {@link #getGeometry()} is recommended when exact results are needed.
+	 *
+	 * @param region the region to test
+	 * @return true if the ROI intersects the region, false otherwise
+	 */
+	default boolean intersects(ImageRegion region) {
+		return getZ() == region.getZ() && getT() == region.getT() &&
+				intersects(region.getX(), region.getY(), region.getWidth(), region.getHeight());
+	}
+
+	/**
+	 * Test if the ROI intersects a specified region.
+	 * <p>
+	 * Note that this test is intended as a fast initial filter; a more detailed test using
+	 * {@link #getGeometry()} is recommended when exact results are needed.
+	 *
+	 * @param x the x coordinate of the region bounding box
+	 * @param y the y coordinate of the region bounding box
+	 * @param width the width of the region bounding box
+	 * @param height the height of the region bounding box
+	 * @return true if the ROI intersects the region, false otherwise
+	 */
+	boolean intersects(double x, double y, double width, double height);
+
 	/**
 	 * Create a new ROI defining the same region on a different {@link ImagePlane}.
 	 * The original ROI is unchanged.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/images/stores/AbstractImageRegionStore.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/images/stores/AbstractImageRegionStore.java
@@ -129,10 +129,11 @@ abstract class AbstractImageRegionStore<T> implements ImageRegionStore<T> {
 				.concurrencyLevel(concurrencyLevel)
 //				.recordStats()
 				.removalListener(n -> {
-					if (n.getCause() == RemovalCause.COLLECTED)
-						logger.debug("Cached tile collected" + n.getKey() + " (cache size=" + cache.size()+")");
-					})
-				.build();
+					if (n.getCause() == RemovalCause.COLLECTED) {
+                        logger.debug("Cached tile collected: {} (cache size={})", n.getKey(), cache.size());
+					} else {
+						logger.trace("Cached tile removed due to {}: {} (cache size={})", n.getCause(), n.getKey(), cache.size());
+					}}).build();
 		cache = originalCache.asMap();
 
 		Cache<RegionRequest, T> originalThumbnailCache = CacheBuilder.newBuilder()

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/RegionFilter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/RegionFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -41,7 +41,7 @@ public interface RegionFilter extends BiPredicate<ImageData<?>, RegionRequest> {
 	/**
 	 * Standard classification regions (hopefully all you will ever need).
 	 */
-	public enum StandardRegionFilters implements RegionFilter {
+	enum StandardRegionFilters implements RegionFilter {
 	
 		/**
 		 * Accept all requests
@@ -120,10 +120,8 @@ public interface RegionFilter extends BiPredicate<ImageData<?>, RegionRequest> {
 					if (region.contains((int)p.getX(), (int)p.getY(), roi.getZ(), roi.getT()))
 						return true;
 				}
-			} else {
-				var shape = roi.getShape();
-				if (shape.intersects(region.getX(), region.getY(), region.getWidth(), region.getHeight()))
-					return true;
+			} else if (roi.intersects(region)) {
+				return true;
 			}
 		}
 		return false;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/PixelClassificationOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/PixelClassificationOverlay.java
@@ -38,7 +38,6 @@ import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.images.servers.ImageServerMetadata.ChannelType;
 import qupath.lib.images.servers.ServerTools;
 import qupath.lib.images.servers.TileRequest;
-import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathObject;
 import qupath.lib.regions.ImageRegion;
 import qupath.lib.regions.RegionRequest;
@@ -90,7 +89,7 @@ public class PixelClassificationOverlay extends AbstractImageOverlay  {
     private Map<RegionRequest, BufferedImage> cacheRGB = Collections.synchronizedMap(new HashMap<>());
     private Set<TileRequest> pendingRequests = Collections.synchronizedSet(new HashSet<>());
     private Set<TileRequest> currentRequests = Collections.synchronizedSet(new HashSet<>());
-    
+
     private int maxThreads = ThreadTools.getParallelism();
     private ThreadPoolExecutor pool;
     


### PR DESCRIPTION
This tries to improve the performance when working with large pixel classifiers in 3 main ways:

1. Add a `ROI.intersects()` method. The main motivation was that `RegionFilter` was very slow to test when a complex ROI intersected with bounding box. The reason turned out to me that requesting the `Shape` required everything to be copied, and that could be expensive. This changes makes it possible to do the calculations more quickly, because they don't need to make defensive copies.
2. Allow ImageServer IDs to be retained for much larger strings (previously truncated to 1000) characters. These IDs are retrieved via `ImageServer.getPath()` and help with caching tiles. The ID limit was introduced to avoid clogging up the cache with gigantic strings, but since we intern the strings it should (hopefully) be ok. Because the ID for a pixel classifier *embeds a JSON representation of the classifier itself*, using a random ID meant that tiles retrieved from the cache when a classifier was recreated (e.g. used interactively, then reloaded in a script to create objects). This meant that expensive prediction had to be called multiple times, even though the prediction results might already have been available in the cache.
3. Apply additional filtering in `ContourTracing` to avoid applying prediction in tiles that are outside of any clip bounds. Previously, we used all tiles that intersect with the bounding box of the clipped ROI - but this could result in a lot of unnecessary prediction.

Another potentially-significant change is that a `SoftReference` is used to store more `Shape` and `Geometry` objects within each `ROI`. These are generated lazily. It is hoped that they won't substantially increase memory requirements if not needed, and won't contribute to memory issues (since they'll be dropped) but could improve performance.