### PR TITLE
Improved MeasurementExporter

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/lazy/interfaces/LazyValue.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/lazy/interfaces/LazyValue.java
@@ -1,7 +1,5 @@
 package qupath.lib.lazy.interfaces;
 
-import qupath.lib.common.GeneralTools;
-
 import java.util.function.Function;
 
 /**
@@ -13,6 +11,12 @@ import java.util.function.Function;
  * @param <T> type of the output value
  */
 public interface LazyValue<S, T> {
+
+    /**
+     * Constant representing that the default number of decimal places should be used to convert floating
+     * point numbers to strings.
+     */
+    int DEFAULT_DECIMAL_PLACES = Integer.MIN_VALUE;
 
     /**
      * Create a {@link LazyValue} with specified name and help text.
@@ -117,11 +121,7 @@ public interface LazyValue<S, T> {
      */
     default String getStringValue(final S input, final int decimalPlaces) {
         var val = getValue(input);
-        return switch (val) {
-            case null -> null;
-            case Number num -> formatNumber(num.doubleValue(), decimalPlaces);
-            default -> val.toString();
-        };
+        return ValueFormatter.getStringValue(val, decimalPlaces);
     }
 
     /**
@@ -133,7 +133,7 @@ public interface LazyValue<S, T> {
      * @see #getValue(S)
      */
     default String getStringValue(final S input) {
-        return getStringValue(input, -1);
+        return getStringValue(input, DEFAULT_DECIMAL_PLACES);
     }
 
     /**
@@ -142,26 +142,5 @@ public interface LazyValue<S, T> {
      * @return the help text, or null if no help text is available
      */
     String getHelpText();
-
-
-    private static String formatNumber(double val, int decimalPlaces) {
-        if (Double.isNaN(val))
-            return "NaN";
-        if (decimalPlaces == 0)
-            return Long.toString(Math.round(val));
-        int dp = decimalPlaces;
-        // Format in some sensible way
-        if (decimalPlaces < 0) {
-            if (val > 1000)
-                dp = 1;
-            else if (val > 10)
-                dp = 2;
-            else if (val > 1)
-                dp = 3;
-            else
-                dp = 4;
-        }
-        return GeneralTools.formatNumber(val, dp);
-    }
 
 }

--- a/qupath-core-processing/src/main/java/qupath/lib/lazy/interfaces/ValueFormatter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/lazy/interfaces/ValueFormatter.java
@@ -1,0 +1,101 @@
+package qupath.lib.lazy.interfaces;
+
+import qupath.lib.common.GeneralTools;
+
+import java.math.BigInteger;
+import java.text.NumberFormat;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Helper class for formatting numbers to have specified decimal places.
+ */
+class ValueFormatter {
+
+    private static final Map<Locale, Map<Integer, NumberFormat>> formatters = new ConcurrentHashMap<>();
+
+    /**
+     * Get a string representation of an object for display in a table, or empty string if the object is null.
+     * See {@link #formatNumber(double, int)} for more detail of how {@code decimalPlaces} is deciphered.
+     */
+    static String getStringValue(final Object val, final int decimalPlaces) {
+        if (val == null)
+            return "";
+        if (val instanceof Number num) {
+            if (isFloat(num))
+                return formatNumber(num.doubleValue(), decimalPlaces);
+        }
+        return Objects.toString(val);
+    }
+
+    private static boolean isFloat(final Number val) {
+        // Probably double or possibly float, so check those first - then easier to exclude known integers
+        return (val instanceof Double || val instanceof Float || !isInteger(val));
+    }
+
+    private static boolean isInteger(final Number val) {
+        return val instanceof Integer ||
+                val instanceof Long ||
+                val instanceof BigInteger ||
+                val instanceof Byte ||
+                val instanceof Short ||
+                val instanceof AtomicInteger ||
+                val instanceof AtomicLong;
+    }
+
+    private static String formatNumber(double val, int decimalPlaces) {
+        if (Double.isNaN(val))
+            return "NaN";
+        if (decimalPlaces == 0)
+            // If no decimal places, just round
+            return Long.toString(Math.round(val));
+        if (decimalPlaces == LazyValue.DEFAULT_DECIMAL_PLACES) {
+            // Use default (adaptive) number of decimal places
+            return applyDefaultFormatting(val);
+        } else if (decimalPlaces == Integer.MAX_VALUE) {
+            // For max value, use the default string representation
+            return Double.toString(val);
+        } else {
+            // Get a formatter with a fixed number of decimal places
+            var locale = Locale.getDefault(Locale.Category.FORMAT);
+            var cache = formatters.computeIfAbsent(locale, k -> new ConcurrentHashMap<>());
+            var format = cache.computeIfAbsent(decimalPlaces, n -> createFormat(locale, decimalPlaces));
+            synchronized (format) {
+                return format.format(val);
+            }
+        }
+    }
+
+    private static String applyDefaultFormatting(double val) {
+        int dp;
+        if (val > 1000)
+            dp = 1;
+        else if (val > 10)
+            dp = 2;
+        else if (val > 1)
+            dp = 3;
+        else
+            dp = 4;
+        return GeneralTools.formatNumber(val, dp);
+    }
+
+    private static NumberFormat createFormat(Locale locale, int nDecimalPlaces) {
+        var format = NumberFormat.getInstance(locale);
+        format.setGroupingUsed(false); // Avoid adding extra commas or points!
+        if (nDecimalPlaces < 0) {
+            format.setMaximumFractionDigits(-nDecimalPlaces);
+        } else {
+            format.setMinimumFractionDigits(nDecimalPlaces);
+            format.setMaximumFractionDigits(nDecimalPlaces);
+        }
+        return format;
+    }
+
+
+
+
+}

--- a/qupath-core-processing/src/test/java/qupath/lib/lazy/interfaces/TestValueFormatter.java
+++ b/qupath-core-processing/src/test/java/qupath/lib/lazy/interfaces/TestValueFormatter.java
@@ -1,0 +1,78 @@
+package qupath.lib.lazy.interfaces;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestValueFormatter {
+
+    @Test
+    void testInteger() {
+        assertEquals("3", ValueFormatter.getStringValue(3, 2));
+        assertEquals("3", ValueFormatter.getStringValue(3, -2));
+        assertEquals("3", ValueFormatter.getStringValue(3, LazyValue.DEFAULT_DECIMAL_PLACES));
+    }
+
+    @Test
+    void testLong() {
+        assertEquals("4", ValueFormatter.getStringValue(4L, 2));
+        assertEquals("4", ValueFormatter.getStringValue(4L, -2));
+        assertEquals("4", ValueFormatter.getStringValue(4L, LazyValue.DEFAULT_DECIMAL_PLACES));
+    }
+
+    @Test
+    void testDouble() {
+        assertEquals("5.2", ValueFormatter.getStringValue(5.245, 1));
+        assertEquals("5.2", ValueFormatter.getStringValue(5.245, -1));
+        assertEquals("5.25", ValueFormatter.getStringValue(5.245, 2));
+        assertEquals("5.25", ValueFormatter.getStringValue(5.245, -2));
+        assertEquals("5.245", ValueFormatter.getStringValue(5.245, 3));
+        assertEquals("5.245", ValueFormatter.getStringValue(5.245, -3));
+        assertEquals("5.2450", ValueFormatter.getStringValue(5.245, 4));
+        assertEquals("5.245", ValueFormatter.getStringValue(5.245, -4));
+    }
+
+    @Test
+    void testNaN() {
+        assertEquals("NaN", ValueFormatter.getStringValue(Double.NaN, 5));
+        assertEquals("NaN", ValueFormatter.getStringValue(Double.NaN, -5));
+        assertEquals("NaN", ValueFormatter.getStringValue(Double.NaN, LazyValue.DEFAULT_DECIMAL_PLACES));
+    }
+
+    @Test
+    void testInfinity() {
+        assertEquals("∞", ValueFormatter.getStringValue(Double.POSITIVE_INFINITY, 5));
+        assertEquals("∞", ValueFormatter.getStringValue(Double.POSITIVE_INFINITY, -5));
+        assertEquals("∞", ValueFormatter.getStringValue(Double.POSITIVE_INFINITY, LazyValue.DEFAULT_DECIMAL_PLACES));
+    }
+
+    @Test
+    void testNegativeInfinity() {
+        assertEquals("-∞", ValueFormatter.getStringValue(Double.NEGATIVE_INFINITY, 5));
+        assertEquals("-∞", ValueFormatter.getStringValue(Double.NEGATIVE_INFINITY, -5));
+        assertEquals("-∞", ValueFormatter.getStringValue(Double.NEGATIVE_INFINITY, LazyValue.DEFAULT_DECIMAL_PLACES));
+    }
+
+    @Test
+    void testFloat() {
+        assertEquals("5.2", ValueFormatter.getStringValue(5.245f, 1));
+        assertEquals("5.2", ValueFormatter.getStringValue(5.245f, -1));
+        assertEquals("5.245", ValueFormatter.getStringValue(5.245f, 3));
+        assertEquals("5.245", ValueFormatter.getStringValue(5.245f, -3));
+        assertEquals("5.2450", ValueFormatter.getStringValue(5.245f, 4));
+        assertEquals("5.245", ValueFormatter.getStringValue(5.245f, -4));
+    }
+
+    @Test
+    void testNull() {
+        assertEquals("", ValueFormatter.getStringValue(null, 1));
+    }
+
+    @Test
+    void testString() {
+        assertEquals("any string", ValueFormatter.getStringValue("any string", 5));
+        assertEquals("any string", ValueFormatter.getStringValue("any string", -5));
+        assertEquals("any string", ValueFormatter.getStringValue("any string", LazyValue.DEFAULT_DECIMAL_PLACES));
+    }
+
+}

--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -575,7 +575,7 @@ public final class GeneralTools {
 	/**
 	 * Cache of NumberFormat objects
 	 */
-	private static Map<Locale, NumberFormat> formatters = new HashMap<>();
+	private static final Map<Locale, NumberFormat> formatters = new HashMap<>();
 	
 	/**
 	 * Format a value with a maximum number of decimal places, using the default Locale.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementExportCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementExportCommand.java
@@ -59,7 +59,6 @@ import javafx.scene.layout.GridPane;
 import qupath.fx.utils.FXUtils;
 import qupath.fx.dialogs.FileChoosers;
 import qupath.lib.common.GeneralTools;
-import qupath.lib.common.ThreadTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.fx.dialogs.Dialogs;
 import qupath.lib.gui.dialogs.ProjectDialogs;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/QPEx.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/QPEx.java
@@ -75,6 +75,7 @@ import qupath.lib.gui.measure.ObservableMeasurementTableData;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.tma.TMADataIO;
 import qupath.lib.gui.tools.GuiTools;
+import qupath.lib.gui.tools.MeasurementExporter;
 import qupath.lib.gui.tools.MenuTools;
 import qupath.fx.utils.GridPaneUtils;
 import qupath.lib.gui.viewer.QuPathViewer;
@@ -123,6 +124,8 @@ public class QPEx extends QP {
 			GridPaneUtils.class,
 			
 			LabeledImageServer.class,
+
+			MeasurementExporter.class,
 			
 			PathPrefs.class,
 			

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementExporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementExporter.java
@@ -229,7 +229,7 @@ public class MeasurementExporter {
 	 * @return this exporter
 	 */
 	public MeasurementExporter imageList(List<ProjectImageEntry<BufferedImage>> imageList) {
-		this.imageList = imageList;
+		this.imageList = List.copyOf(imageList);
 		return this;
 	}
 
@@ -385,6 +385,11 @@ public class MeasurementExporter {
 
 
 	private void doExport(OutputStream stream, String separator) throws IOException, InterruptedException {
+		if (imageList == null || imageList.isEmpty()) {
+			logger.warn("No images selected for export!");
+			return;
+		}
+
 		long startTime = System.currentTimeMillis();
 
 		int n = imageList.size();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementExporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/MeasurementExporter.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2022 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -33,18 +33,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
-
-import qupath.lib.gui.measure.ui.SummaryMeasurementTable;
-import qupath.lib.gui.commands.SummaryMeasurementTableCommand;
+import qupath.lib.gui.measure.PathTableData;
 import qupath.lib.gui.measure.ObservableMeasurementTableData;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.images.ImageData;
@@ -89,7 +86,7 @@ public class MeasurementExporter {
 	
 	/**
 	 * Specify the columns that will be included in the export.
-	 * The column names are case sensitive.
+	 * The column names are case-sensitive.
 	 * @param includeOnlyColumns
 	 * @return this exporter
 	 */
@@ -100,7 +97,7 @@ public class MeasurementExporter {
 	
 	/**
 	 * Specify the columns that will be excluded during the export.
-	 * The column names are case sensitive.
+	 * The column names are case-sensitive.
 	 * @param excludeColumns
 	 * @return this exporter
 	 */
@@ -210,107 +207,124 @@ public class MeasurementExporter {
 	 */
 	public void exportMeasurements(OutputStream stream) {
 		long startTime = System.currentTimeMillis();
-		
-		Map<ProjectImageEntry<?>, String[]> imageCols = new HashMap<>();
-		Map<ProjectImageEntry<?>, Integer> nImageEntries = new HashMap<>();
-		List<String> allColumns = new ArrayList<>();
-		Multimap<String, String> valueMap = LinkedListMultimap.create();
-		String pattern = "(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)";
-		
+
+		int nDecimalPlaces = -1;
+		Predicate<String> columnPredicate;
+		if (!includeOnlyColumns.isEmpty()) {
+			var set = Set.copyOf(includeOnlyColumns);
+			columnPredicate = set::contains;
+		} else if (!excludeColumns.isEmpty()) {
+			var set = Set.copyOf(excludeColumns);
+			columnPredicate = s -> !set.contains(s);
+		} else {
+			columnPredicate = s -> true;
+		}
+
+		boolean warningLogged = false;
+		var table = new MeasurementTable();
+
+		ObservableMeasurementTableData model = new ObservableMeasurementTableData();
 		for (ProjectImageEntry<?> entry: imageList) {
-			try {
-				ImageData<?> imageData = entry.readImageData();
-				ObservableMeasurementTableData model = new ObservableMeasurementTableData();
+			try (ImageData<?> imageData = entry.readImageData()) {
+
 				Collection<PathObject> pathObjects = imageData == null ? Collections.emptyList() : imageData.getHierarchy().getObjects(null, type);
 				if (filter != null)
 					pathObjects = pathObjects.stream().filter(filter).toList();
 				
 				model.setImageData(imageData, pathObjects);
-				List<String> data = SummaryMeasurementTable.getTableModelStrings(model, separator, excludeColumns);
-				
-				// Get header
-				String[] header;
-				String headerString = data.getFirst();
-				if (headerString.chars().filter(e -> e == '"').count() > 1)
-					header = headerString.split(separator.equals("\t") ? "\\" + separator : separator + pattern , -1);
-				else
-					header = headerString.split(separator);
-				
-				imageCols.put(entry, header);
-				nImageEntries.put(entry, data.size()-1);
-				
-				for (String col: header) {
-					if (!allColumns.contains(col)  && !excludeColumns.contains(col))
-						allColumns.add(col);
-				}
-				
-				// To keep the same column order, just delete non-relevant columns
-				if (!includeOnlyColumns.isEmpty())
-					allColumns.removeIf(n -> !includeOnlyColumns.contains(n));
-				
-				for (int i = 1; i < data.size(); i++) {
-					String[] row;
-					String rowString = data.get(i);
-					
-					// Check if some values in the row are escaped
-					if (rowString.chars().filter(e -> e == '"').count() > 1)
-						row = rowString.split(separator.equals("\t") ? "\\" + separator : separator + pattern , -1);
-					else
-						row = rowString.split(separator);
-					
-					// Put value in map
-					for (int elem = 0; elem < row.length; elem++) {
-						if (allColumns.contains(header[elem]))
-							valueMap.put(header[elem], row[elem]);
-					}
-				}
-				
+
+				var columns = model.getAllNames().stream().filter(columnPredicate).toList();
+				table.addRows(columns, model, nDecimalPlaces);
 			} catch (Exception e) {
-				logger.error(e.getLocalizedMessage(), e);
+				logger.error(e.getMessage(), e);
 			}
 		}
 		
 		try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(stream, StandardCharsets.UTF_8))){
-			writer.write(String.join(separator, allColumns));
-			writer.write(System.lineSeparator());
+			var header = table.getHeader();
+			writeRow(writer, header, separator);
 
-			Iterator[] its = new Iterator[allColumns.size()];
-			for (int col = 0; col < allColumns.size(); col++) {
-				its[col] = valueMap.get(allColumns.get(col)).iterator();
-			}
-
-			for (ProjectImageEntry<?> entry: imageList) {
-				
-				for (int nObject = 0; nObject < nImageEntries.get(entry); nObject++) {
-					for (int nCol = 0; nCol < allColumns.size(); nCol++) {
-						if (Arrays.stream(imageCols.get(entry)).anyMatch(allColumns.get(nCol)::equals)) {
-							String val = (String)its[nCol].next();
-							// NaN values -> blank
-							if (val.equals("NaN"))
-								val = "";
-							writer.write(val);
+			List<String> rowValues = new ArrayList<>();
+			for (int row = 0; row < table.size(); row++) {
+				rowValues.clear();
+				for (var h : header) {
+					var val = table.getString(row, h, null);
+					if (val == null) {
+						rowValues.add("");
+					} else if (val.contains(separator)) {
+						if (!warningLogged) {
+							logger.warn("Separator '{}' found in cell - " +
+									"this may cause the table to be misaligned in some software", separator);
+							warningLogged = true;
 						}
-						if (nCol < allColumns.size()-1)
-							writer.write(separator);
+						rowValues.add("\"" + val + "\"");
+					} else {
+						rowValues.add(val);
 					}
-					writer.write(System.lineSeparator());
 				}
+				writeRow(writer, rowValues, separator);
 			}
+
 		} catch (Exception e) {
-			logger.error("Error writing to file: " + e.getLocalizedMessage(), e);
+            logger.error("Error writing to file: {}", e.getMessage(), e);
 		}
 		
 		long endTime = System.currentTimeMillis();
 		
 		long timeMillis = endTime - startTime;
-		String time = null;
+		String time;
 		if (timeMillis > 1000*60)
 			time = String.format("Total processing time: %.2f minutes", timeMillis/(1000.0 * 60.0));
 		else if (timeMillis > 1000)
 			time = String.format("Total processing time: %.2f seconds", timeMillis/(1000.0));
 		else
-			time = String.format("Total processing time: %d milliseconds", timeMillis);
+			time = String.format("Total processing time: %d ms", timeMillis);
 		logger.info("Processed {} images", imageList.size());
 		logger.info(time);
 	}
+
+	private void writeRow(PrintWriter writer, List<String> strings, String delim) {
+		int n = strings.size();
+		for (int i = 0; i < n; i++) {
+			var val = strings.get(i);
+			if (val != null)
+				writer.write(val);
+			if (i < n-1)
+				writer.write(delim);
+		}
+		writer.write(System.lineSeparator());
+	}
+
+	private static class MeasurementTable {
+
+		private final Set<String> header = new LinkedHashSet<>();
+		private final List<Map<String, String>> data =  new ArrayList<>();
+
+		public <T> void addRows(Collection<String> headerColumns, PathTableData<T> table, int nDecimalPlaces) {
+			header.addAll(headerColumns);
+			int n = headerColumns.size();
+			for (var item : table.getItems()) {
+				// Try to avoid needing to resize the map
+				Map<String, String> row = new HashMap<>(n+1, 1f);
+				for (var h : headerColumns) {
+					row.put(h, table.getStringValue(item, h, nDecimalPlaces));
+				}
+				data.add(row);
+			}
+		}
+
+		public List<String> getHeader() {
+			return List.copyOf(header);
+		}
+
+		public String getString(int row, String column, String defaultValue) {
+			return data.get(row).getOrDefault(column, defaultValue);
+		}
+
+		public int size() {
+			return data.size();
+		}
+
+	}
+
 }


### PR DESCRIPTION
This consolidates the (project-wise) measurement export logic into a single `MeasurementExporter` class, and slightly updates the GUI for `MeasurementExportCommand`.

It also adds support to specify the number of decimal places used to export via a script with the following rules:
* Use `MeasurementExporter.DECIMAL_PLACES_DEFAULT` for the default (adaptive) value
* Use a positive number to specify that all non-integer values are export with a fixed number of decimal places
* Use a negative number to specify a maximum number of decimal places (sorry @alanocallaghan)

Addresses / fixes
* https://github.com/qupath/qupath/issues/1769
* https://github.com/qupath/qupath/issues/1045