### PR TITLE
Add icons to single measurement table

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/PathObjectLabels.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/PathObjectLabels.java
@@ -139,7 +139,7 @@ public class PathObjectLabels {
 
 	private static class PathObjectListCell extends ListCell<PathObject> {
 		
-		private PathObjectMiniPane miniPane;
+		private final PathObjectMiniPane miniPane;
 		
 		PathObjectListCell(Function<PathObject, String> stringExtractor) {
 			super();


### PR DESCRIPTION
The purpose is to:
* Make classifications stand out more (with color)
* Make it possible to distinguish measurements from the measurement list, from those calculated dynamically
  *  This is important since those in the measurement list don't update automatically, but they are the only ones that can be used with interactive object classifiers at this time
* Add a visual queue to 'Object type' to help distinguish between annotations, detections & TMA cores

The last of these is done by using the same icons used for show/hide in the toolbar. The hope is that this helps reinforce the association between object type and icon - and that cells/tiles are really subtypes of detection (because the icon is the same).

Note that the implementation is a bit messy because we don't currently have a way to query the type of a measurement from `ObservableMeasurementTableData` - so we rely on the names (keys). If/when this is refactored to reduce any JavaFX dependency, we should try to improve this; currently, it's not entirely robust, because someone *could* add measurements or metadata values with duplicate names. But I think that's an acceptable risk for now, because it would *already* be problematic when working with measurements, and it's not expected to occur in normal use.

<img width="729" alt="Screenshot 2025-03-10 at 12 27 12" src="https://github.com/user-attachments/assets/1b444069-759a-4007-9eb9-ba4fbe0bfc95" />