### PR TITLE
Zarr image writer

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
@@ -267,25 +267,24 @@ public class ConvertCommand implements Runnable, Subcommand {
 				}
 				case ZARR -> {
 					OMEZarrWriter.Builder builder = new OMEZarrWriter.Builder(server, outputFile.getAbsolutePath())
-							.setTileWidth(tileWidth)
-							.setTileHeight(tileHeight)
-							.setBoundingBox(boundingBox.orElse(null))
-							.setZSlices(zSlicesRange.start(), zSlicesRange.end())
-							.setTimepoints(timepointsRange.start(), timepointsRange.end());
+							.tileSize(tileWidth, tileHeight)
+							.region(boundingBox.orElse(null))
+							.zSlices(zSlicesRange.start(), zSlicesRange.end())
+							.timePoints(timepointsRange.start(), timepointsRange.end());
 
 					if (!parallelize) {
-						builder.setNumberOfThreads(1);
+						builder.parallelize(1);
 					}
 
 					if (pyramid > 1) {
-						builder.setDownsamples(DoubleStream.iterate(
+						builder.downsamples(DoubleStream.iterate(
 								downsample,
 								d -> (int) (server.getWidth() / d) > tileWidth &&
 										(int) (server.getHeight() / d) > tileHeight,
 								d -> d * pyramid
 						).toArray());
 					} else {
-						builder.setDownsamples(DoubleStream.concat(
+						builder.downsamples(DoubleStream.concat(
 								DoubleStream.of(downsample),
 								Arrays.stream(server.getPreferredDownsamples()).filter(d -> d > downsample)
 						).toArray());

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/ConvertCommand.java
@@ -266,7 +266,7 @@ public class ConvertCommand implements Runnable, Subcommand {
 					builder.build().writeSeries(outputFile.getAbsolutePath());
 				}
 				case ZARR -> {
-					OMEZarrWriter.Builder builder = new OMEZarrWriter.Builder(server, outputFile.getAbsolutePath())
+					OMEZarrWriter.Builder builder = new OMEZarrWriter.Builder(server)
 							.tileSize(tileWidth, tileHeight)
 							.region(boundingBox.orElse(null))
 							.zSlices(zSlicesRange.start(), zSlicesRange.end())
@@ -290,7 +290,7 @@ public class ConvertCommand implements Runnable, Subcommand {
 						).toArray());
 					}
 
-					try (OMEZarrWriter writer = builder.build()) {
+					try (OMEZarrWriter writer = builder.build(outputFile.getAbsolutePath())) {
 						writer.writeImage();
 					}
 				}

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrImageWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrImageWriter.java
@@ -69,9 +69,9 @@ public class OMEZarrImageWriter implements ImageWriter<BufferedImage> {
     @Override
     public void writeImage(ImageServer<BufferedImage> server, RegionRequest region, String pathOutput) throws IOException {
         try (
-                OMEZarrWriter writer = new OMEZarrWriter.Builder(server, pathOutput)
+                OMEZarrWriter writer = new OMEZarrWriter.Builder(server)
                         .region(region)
-                        .build()
+                        .build(pathOutput)
         ) {
             writer.writeImage();
         } catch (InterruptedException e) {

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrImageWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrImageWriter.java
@@ -23,7 +23,7 @@ public class OMEZarrImageWriter implements ImageWriter<BufferedImage> {
 
     @Override
     public String getName() {
-        return "OME zarr";
+        return "OME-Zarr";
     }
 
     @Override
@@ -63,7 +63,7 @@ public class OMEZarrImageWriter implements ImageWriter<BufferedImage> {
 
     @Override
     public String getDetails() {
-        return "Write image as an OME-zarr image. Format is flexible, preserving most image metadata.";
+        return "Write image as an OME-Zarr image. Format is flexible, preserving most image metadata.";
     }
 
     @Override

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrImageWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrImageWriter.java
@@ -1,0 +1,107 @@
+package qupath.lib.images.writers.ome.zarr;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.lib.images.servers.ImageServer;
+import qupath.lib.images.servers.WrappedBufferedImageServer;
+import qupath.lib.images.writers.ImageWriter;
+import qupath.lib.regions.RegionRequest;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.List;
+
+public class OMEZarrImageWriter implements ImageWriter<BufferedImage> {
+
+    private static final Logger logger = LoggerFactory.getLogger(OMEZarrImageWriter.class);
+    @Override
+    public String getName() {
+        return "OME zarr";
+    }
+
+    @Override
+    public Collection<String> getExtensions() {
+        return List.of("ome.zarr");
+    }
+
+    @Override
+    public boolean supportsT() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsZ() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsRGB() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsImageType(ImageServer<BufferedImage> server) {
+        return true;
+    }
+
+    @Override
+    public boolean supportsPyramidal() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsPixelSize() {
+        return true;
+    }
+
+    @Override
+    public String getDetails() {
+        return "Write image as an OME-zarr image. Format is flexible, preserving most image metadata.";
+    }
+
+    @Override
+    public Class<BufferedImage> getImageClass() {
+        return BufferedImage.class;
+    }
+
+    @Override
+    public void writeImage(ImageServer<BufferedImage> server, RegionRequest region, String pathOutput) throws IOException {
+        try (
+                OMEZarrWriter writer = new OMEZarrWriter.Builder(server, pathOutput)
+                        .region(region)
+                        .build()
+        ) {
+            writer.writeImage();
+        } catch (InterruptedException e) {
+            logger.debug("Zarr image writing to {} interrupted", pathOutput, e);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void writeImage(BufferedImage img, String pathOutput) throws IOException {
+        writeImage(new WrappedBufferedImageServer(null, img), pathOutput);
+    }
+
+    @Override
+    public void writeImage(ImageServer<BufferedImage> server, String pathOutput) throws IOException {
+        writeImage(server, RegionRequest.createInstance(server), pathOutput);
+    }
+
+    @Override
+    public void writeImage(ImageServer<BufferedImage> server, RegionRequest region, OutputStream stream) throws IOException {
+        throw new UnsupportedOperationException("Zarr images can't be written to output streams");
+    }
+
+    @Override
+    public void writeImage(BufferedImage img, OutputStream stream) throws IOException {
+        writeImage(new WrappedBufferedImageServer(null, img), stream);
+    }
+
+    @Override
+    public void writeImage(ImageServer<BufferedImage> server, OutputStream stream) throws IOException {
+        writeImage(server, RegionRequest.createInstance(server), stream);
+    }
+}

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrImageWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrImageWriter.java
@@ -13,9 +13,14 @@ import java.io.OutputStream;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * An {@link ImageWriter} for writing OME-zarr files. Use an {@link OMEZarrWriter} if
+ * you need greater control.
+ */
 public class OMEZarrImageWriter implements ImageWriter<BufferedImage> {
 
     private static final Logger logger = LoggerFactory.getLogger(OMEZarrImageWriter.class);
+
     @Override
     public String getName() {
         return "OME zarr";

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriterCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriterCommand.java
@@ -200,10 +200,9 @@ public class OMEZarrWriterCommand implements Runnable {
 
     private OMEZarrWriter.Builder createBuilder(ParameterList parameters, ImageData<BufferedImage> imageData, File fileOutput) {
         OMEZarrWriter.Builder builder = new OMEZarrWriter.Builder(imageData.getServer(), fileOutput.getAbsolutePath())
-                .setNumberOfThreads(parameters.getIntParameterValue("numberOfThreads"))
-                .setTileWidth(parameters.getIntParameterValue("tileSize"))
-                .setTileHeight(parameters.getIntParameterValue("tileSize"))
-                .setDownsamples(DoubleStream.iterate(
+                .parallelize(parameters.getIntParameterValue("numberOfThreads"))
+                .tileSize(parameters.getIntParameterValue("tileSize"))
+                .downsamples(DoubleStream.iterate(
                         1,
                         d -> (int) (imageData.getServer().getWidth() / d) > parameters.getIntParameterValue("tileSize") &&
                                 (int) (imageData.getServer().getHeight() / d) > parameters.getIntParameterValue("tileSize"),
@@ -211,15 +210,15 @@ public class OMEZarrWriterCommand implements Runnable {
                 );
 
         if (!parameters.getBooleanParameterValue("allZ")) {
-            builder.setZSlices(qupath.getViewer().getZPosition(), qupath.getViewer().getZPosition()+1);
+            builder.zSlices(qupath.getViewer().getZPosition(), qupath.getViewer().getZPosition()+1);
         }
         if (!parameters.getBooleanParameterValue("allT")) {
-            builder.setTimepoints(qupath.getViewer().getTPosition(), qupath.getViewer().getTPosition()+1);
+            builder.timePoints(qupath.getViewer().getTPosition(), qupath.getViewer().getTPosition()+1);
         }
 
         PathObject selected = imageData.getHierarchy().getSelectionModel().getSelectedObject();
         if (selected != null && selected.hasROI() && selected.getROI().isArea()) {
-            builder.setBoundingBox(ImageRegion.createInstance(selected.getROI()));
+            builder.region(ImageRegion.createInstance(selected.getROI()));
         }
 
         return builder;

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriterCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriterCommand.java
@@ -88,10 +88,10 @@ public class OMEZarrWriterCommand implements Runnable {
             return;
         }
 
-        OMEZarrWriter.Builder builder = createBuilder(parameters, imageData, fileOutput);
+        OMEZarrWriter.Builder builder = createBuilder(parameters, imageData);
 
         task = executor.submit(() -> {
-            try (OMEZarrWriter writer = builder.build()) {
+            try (OMEZarrWriter writer = builder.build(fileOutput.getAbsolutePath())) {
                 Dialogs.showInfoNotification(
                         QuPathResources.getString("Action.BioFormats.omeZarrWriter"),
                         MessageFormat.format(
@@ -198,8 +198,8 @@ public class OMEZarrWriterCommand implements Runnable {
         }
     }
 
-    private OMEZarrWriter.Builder createBuilder(ParameterList parameters, ImageData<BufferedImage> imageData, File fileOutput) {
-        OMEZarrWriter.Builder builder = new OMEZarrWriter.Builder(imageData.getServer(), fileOutput.getAbsolutePath())
+    private OMEZarrWriter.Builder createBuilder(ParameterList parameters, ImageData<BufferedImage> imageData) {
+        OMEZarrWriter.Builder builder = new OMEZarrWriter.Builder(imageData.getServer())
                 .parallelize(parameters.getIntParameterValue("numberOfThreads"))
                 .tileSize(parameters.getIntParameterValue("tileSize"))
                 .downsamples(DoubleStream.iterate(

--- a/qupath-extension-bioformats/src/main/resources/META-INF/services/qupath.lib.images.writers.ImageWriter
+++ b/qupath-extension-bioformats/src/main/resources/META-INF/services/qupath.lib.images.writers.ImageWriter
@@ -1,1 +1,2 @@
 qupath.lib.images.writers.ome.OMETiffWriter
+qupath.lib.images.writers.ome.zarr.OMEZarrImageWriter

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/TestConvertCommand.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/TestConvertCommand.java
@@ -46,7 +46,7 @@ public class TestConvertCommand {
 
             try (
                     ImageServer<BufferedImage> sampleServer = new SampleImageServer();
-                    OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleServer, inputImagePath).build()
+                    OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleServer).build(inputImagePath)
             ) {
                 writer.writeImage();
             }

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrWriter.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrWriter.java
@@ -251,7 +251,7 @@ public class TestOMEZarrWriter {
         double[] expectedDownsamples = sampleImageServer.getPreferredDownsamples();
 
         try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
-                .setDownsamples()
+                .downsamples()
                 .build()
         ) {
             writer.writeImage();
@@ -275,7 +275,7 @@ public class TestOMEZarrWriter {
         double[] expectedDownsamples = new double[] {1, 2, 4};
 
         try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
-                .setDownsamples(expectedDownsamples)
+                .downsamples(expectedDownsamples)
                 .build()
         ) {
             writer.writeImage();
@@ -299,7 +299,7 @@ public class TestOMEZarrWriter {
         int expectedTileWidth = sampleImageServer.getMetadata().getPreferredTileWidth();
 
         try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
-                .setTileWidth(-1)
+                .tileSize(-1)
                 .build()
         ) {
             writer.writeImage();
@@ -323,7 +323,7 @@ public class TestOMEZarrWriter {
         int expectedTileWidth = 64;
 
         try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
-                .setTileWidth(expectedTileWidth)
+                .tileSize(expectedTileWidth)
                 .build()
         ) {
             writer.writeImage();
@@ -347,7 +347,7 @@ public class TestOMEZarrWriter {
         int expectedTileHeight = sampleImageServer.getMetadata().getPreferredTileHeight();
 
         try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
-                .setTileHeight(-1)
+                .tileSize(-1)
                 .build()
         ) {
             writer.writeImage();
@@ -371,7 +371,7 @@ public class TestOMEZarrWriter {
         int expectedTileHeight = 64;
 
         try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
-                .setTileHeight(expectedTileHeight)
+                .tileSize(expectedTileHeight)
                 .build()
         ) {
             writer.writeImage();
@@ -398,7 +398,7 @@ public class TestOMEZarrWriter {
         BufferedImage expectedImage = sampleImageServer.readRegion(RegionRequest.createInstance(sampleImageServer.getPath(), 1, boundingBox));
 
         try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
-                .setBoundingBox(boundingBox)
+                .region(boundingBox)
                 .build()
         ) {
             writer.writeImage();
@@ -424,7 +424,7 @@ public class TestOMEZarrWriter {
         int expectedNumberOfZStacks = zEnd - zStart;
 
         try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
-                .setZSlices(zStart, zEnd)
+                .zSlices(zStart, zEnd)
                 .build()
         ) {
             writer.writeImage();
@@ -461,7 +461,7 @@ public class TestOMEZarrWriter {
         ));
 
         try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
-                .setZSlices(zStart, zEnd)
+                .zSlices(zStart, zEnd)
                 .build()
         ) {
             writer.writeImage();
@@ -487,7 +487,7 @@ public class TestOMEZarrWriter {
         int expectedNumberOfTimepoints = tEnd - tStart;
 
         try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
-                .setTimepoints(tStart, tEnd)
+                .timePoints(tStart, tEnd)
                 .build()
         ) {
             writer.writeImage();
@@ -524,7 +524,7 @@ public class TestOMEZarrWriter {
         ));
 
         try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
-                .setTimepoints(tStart, tEnd)
+                .timePoints(tStart, tEnd)
                 .build()
         ) {
             writer.writeImage();

--- a/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrWriter.java
+++ b/qupath-extension-bioformats/src/test/java/qupath/lib/images/writers/ome/zarr/TestOMEZarrWriter.java
@@ -40,7 +40,7 @@ public class TestOMEZarrWriter {
 
         Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                () -> new OMEZarrWriter.Builder(sampleImageServer).build(outputImagePath)
         );
 
         sampleImageServer.close();
@@ -56,7 +56,7 @@ public class TestOMEZarrWriter {
 
         Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+                () -> new OMEZarrWriter.Builder(sampleImageServer).build(outputImagePath)
         );
 
         sampleImageServer.close();
@@ -69,7 +69,7 @@ public class TestOMEZarrWriter {
         String outputImagePath = Paths.get(path.toString(), "image.ome.zarr").toString();
         SampleImageServer sampleImageServer = new SampleImageServer();
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath).build()) {
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer).build(outputImagePath)) {
             writer.writeImage();
         }
 
@@ -86,7 +86,7 @@ public class TestOMEZarrWriter {
         SampleImageServer sampleImageServer = new SampleImageServer();
         PixelType expectedPixelType = sampleImageServer.getMetadata().getPixelType();
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath).build()) {
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer).build(outputImagePath)) {
             writer.writeImage();
         }
 
@@ -107,7 +107,7 @@ public class TestOMEZarrWriter {
         SampleImageServer sampleImageServer = new SampleImageServer();
         PixelCalibration expectedPixelCalibration = sampleImageServer.getMetadata().getPixelCalibration();
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath).build()) {
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer).build(outputImagePath)) {
             writer.writeImage();
         }
 
@@ -128,7 +128,7 @@ public class TestOMEZarrWriter {
         SampleImageServer sampleImageServer = new SampleImageServer();
         List<ImageChannel> expectedChannels = sampleImageServer.getMetadata().getChannels();
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath).build()) {
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer).build(outputImagePath)) {
             writer.writeImage();
         }
 
@@ -149,7 +149,7 @@ public class TestOMEZarrWriter {
         SampleImageServer sampleImageServer = new SampleImageServer();
         double expectedMagnification = sampleImageServer.getMetadata().getMagnification();
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath).build()) {
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer).build(outputImagePath)) {
             writer.writeImage();
         }
 
@@ -181,7 +181,7 @@ public class TestOMEZarrWriter {
                 t
         );
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath).build()) {
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer).build(outputImagePath)) {
             writer.writeImage();
         }
 
@@ -221,7 +221,7 @@ public class TestOMEZarrWriter {
                 t
         );
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath).build()) {
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer).build(outputImagePath)) {
             writer.writeImage();
         }
 
@@ -250,9 +250,9 @@ public class TestOMEZarrWriter {
         SampleImageServer sampleImageServer = new SampleImageServer();
         double[] expectedDownsamples = sampleImageServer.getPreferredDownsamples();
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer)
                 .downsamples()
-                .build()
+                .build(outputImagePath)
         ) {
             writer.writeImage();
         }
@@ -274,9 +274,9 @@ public class TestOMEZarrWriter {
         SampleImageServer sampleImageServer = new SampleImageServer();
         double[] expectedDownsamples = new double[] {1, 2, 4};
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer)
                 .downsamples(expectedDownsamples)
-                .build()
+                .build(outputImagePath)
         ) {
             writer.writeImage();
         }
@@ -298,9 +298,9 @@ public class TestOMEZarrWriter {
         SampleImageServer sampleImageServer = new SampleImageServer();
         int expectedTileWidth = sampleImageServer.getMetadata().getPreferredTileWidth();
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer)
                 .tileSize(-1)
-                .build()
+                .build(outputImagePath)
         ) {
             writer.writeImage();
         }
@@ -322,9 +322,9 @@ public class TestOMEZarrWriter {
         SampleImageServer sampleImageServer = new SampleImageServer();
         int expectedTileWidth = 64;
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer)
                 .tileSize(expectedTileWidth)
-                .build()
+                .build(outputImagePath)
         ) {
             writer.writeImage();
         }
@@ -346,9 +346,9 @@ public class TestOMEZarrWriter {
         SampleImageServer sampleImageServer = new SampleImageServer();
         int expectedTileHeight = sampleImageServer.getMetadata().getPreferredTileHeight();
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer)
                 .tileSize(-1)
-                .build()
+                .build(outputImagePath)
         ) {
             writer.writeImage();
         }
@@ -370,9 +370,9 @@ public class TestOMEZarrWriter {
         SampleImageServer sampleImageServer = new SampleImageServer();
         int expectedTileHeight = 64;
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer)
                 .tileSize(expectedTileHeight)
-                .build()
+                .build(outputImagePath)
         ) {
             writer.writeImage();
         }
@@ -397,9 +397,9 @@ public class TestOMEZarrWriter {
         ImageRegion boundingBox = ImageRegion.createInstance(5, 5, 20, 25, z, t);
         BufferedImage expectedImage = sampleImageServer.readRegion(RegionRequest.createInstance(sampleImageServer.getPath(), 1, boundingBox));
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer)
                 .region(boundingBox)
-                .build()
+                .build(outputImagePath)
         ) {
             writer.writeImage();
         }
@@ -423,9 +423,9 @@ public class TestOMEZarrWriter {
         int zEnd = 3;
         int expectedNumberOfZStacks = zEnd - zStart;
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer)
                 .zSlices(zStart, zEnd)
-                .build()
+                .build(outputImagePath)
         ) {
             writer.writeImage();
         }
@@ -460,9 +460,9 @@ public class TestOMEZarrWriter {
                 t
         ));
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer)
                 .zSlices(zStart, zEnd)
-                .build()
+                .build(outputImagePath)
         ) {
             writer.writeImage();
         }
@@ -486,9 +486,9 @@ public class TestOMEZarrWriter {
         int tEnd = 2;
         int expectedNumberOfTimepoints = tEnd - tStart;
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer)
                 .timePoints(tStart, tEnd)
-                .build()
+                .build(outputImagePath)
         ) {
             writer.writeImage();
         }
@@ -523,9 +523,9 @@ public class TestOMEZarrWriter {
                 t
         ));
 
-        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer, outputImagePath)
+        try (OMEZarrWriter writer = new OMEZarrWriter.Builder(sampleImageServer)
                 .timePoints(tStart, tEnd)
-                .build()
+                .build(outputImagePath)
         ) {
             writer.writeImage();
         }


### PR DESCRIPTION
Add an `ImageWriter` implementation for the OME Zarr writer. This enable this kind of code:

```
var path = buildPathInProject("test.ome.zarr")
writeImage(getCurrentServer(), path)
```

Also made the OME Zarr writer API consistent with the `OMEPyramidWriter`.

When writing an image with the `OMEZarrWriter`, the output path is now given to the `builder.build()` function. This enable reusing the builder while preserving the `OMEZarrWriter.writeTile()` function. Is that enough or should we have another class `ZarrTileWriter`?