### PR TITLE
Add annotation count above annotation list

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/WandToolEventHandler.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/WandToolEventHandler.java
@@ -439,8 +439,8 @@ public class WandToolEventHandler extends BrushToolEventHandler {
 			}
 			if (coords.size() > 1) {
 				// Ensure closed
-				if (!coords.get(coords.size()-1).equals(coords.get(0)))
-					coords.add(coords.get(0));
+				if (!coords.getLast().equals(coords.getFirst()))
+					coords.add(coords.getFirst());
 				// Exclude single pixels
 				var polygon = factory.createPolygon(coords.toArray(Coordinate[]::new));
 				if (coords.size() > 5 || polygon.getArea() > 1)
@@ -453,7 +453,7 @@ public class WandToolEventHandler extends BrushToolEventHandler {
 			return null;
 		
 		// Handle the fact that OpenCV contours are defined using the 'pixel center' by dilating the boundary
-		var geometry = geometries.size() == 1 ? geometries.get(0) : GeometryCombiner.combine(geometries);
+		var geometry = geometries.size() == 1 ? geometries.getFirst() : GeometryCombiner.combine(geometries);
 		geometry = geometry.buffer(0.5);
 		
 		// Transform to map to integer pixel locations in the full-resolution image
@@ -467,7 +467,7 @@ public class WandToolEventHandler extends BrushToolEventHandler {
 			return null;
 		
 		long endTime = System.currentTimeMillis();
-		logger.trace(getClass().getSimpleName() + " time: " + (endTime - startTime));
+        logger.trace("{} time: {}", getClass().getSimpleName(), endTime - startTime);
 		
 		if (pLast == null)
 			pLast = new Point2D.Double(x, y);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
@@ -280,7 +280,15 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 			}
 		});
 
+		
 		var titled = GuiTools.createLeftRightTitledPane("Annotation list", btnProperties);
+		titled.textProperty().bind(Bindings.createStringBinding(() -> {
+			int n = allAnnotations.size();
+			if (n == 0)
+				return "Annotation list";
+			else
+				return "Annotation list (" + n + ")";
+				}, allAnnotations));
 		// TODO: Consider additional buttons (e.g. to delete)
 
 		titled.setContent(panelObjects);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/AnnotationPane.java
@@ -283,12 +283,15 @@ public class AnnotationPane implements PathObjectSelectionListener, ChangeListen
 		
 		var titled = GuiTools.createLeftRightTitledPane("Annotation list", btnProperties);
 		titled.textProperty().bind(Bindings.createStringBinding(() -> {
-			int n = allAnnotations.size();
-			if (n == 0)
+			int nAll = allAnnotations.size();
+			int nFiltered = filteredAnnotations.size();
+			if (nAll == 0)
 				return "Annotation list";
+			else if (nAll == nFiltered)
+				return "Annotation list (" + nAll + ")";
 			else
-				return "Annotation list (" + n + ")";
-				}, allAnnotations));
+				return "Annotation list (" + nFiltered + "/" + nAll + ")";
+		}, allAnnotations, filteredAnnotations));
 		// TODO: Consider additional buttons (e.g. to delete)
 
 		titled.setContent(panelObjects);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -1487,7 +1487,9 @@ public class GuiTools {
 		label.setAlignment(Pos.CENTER_LEFT);
 		label.setPadding(new Insets(0, 2, 0, 0));
 		var right = rightNodes.length == 1 ? rightNodes[0] : new HBox(rightNodes);
-		return createLeftRightTitledPane(label, right);
+		var pane = createLeftRightTitledPane(label, right);
+		pane.textProperty().bindBidirectional(label.textProperty());
+		return pane;
 	}
 
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
@@ -63,7 +63,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 	
-	private static Logger logger = LoggerFactory.getLogger(BrushToolEventHandler.class);
+	private static final Logger logger = LoggerFactory.getLogger(BrushToolEventHandler.class);
 	
 	/**
 	 * A collection of classes that should be ignored when
@@ -503,8 +503,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler {
 	private boolean creatingTiledROI = false;
 	
 	protected GeometryFactory getGeometryFactory() {
-		var factory = GeometryTools.getDefaultFactory();
-		return factory;
+        return GeometryTools.getDefaultFactory();
 	}
 
 	@Override


### PR DESCRIPTION
Makes it slightly easier to see how many annotations we have.

<img width="404" alt="Screenshot 2025-03-12 at 13 56 00" src="https://github.com/user-attachments/assets/6b963860-04dd-416a-ad10-ec410d64a4c2" />

Note that it gives the count of *all* annotations in the list, which doesn't change if the list is filtered. The count of displayed annotations could be used if needed.