### PR TITLE
Implement double click to select z/t slice

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -3148,7 +3148,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 			KeyCode code = event.getCode();
 						
 			// Handle backspace/delete to remove selected object
-			if (event.getEventType() == KeyEvent.KEY_RELEASED && (code == KeyCode.BACK_SPACE || code == KeyCode.DELETE)) {
+			if (canvas.isFocused() && event.getEventType() == KeyEvent.KEY_RELEASED && (code == KeyCode.BACK_SPACE || code == KeyCode.DELETE)) {
 				if (getROIEditor().hasActiveHandle() || getROIEditor().isTranslating()) {
 					logger.debug("Cannot delete object - ROI being edited");
 					return;


### PR DESCRIPTION
Enables double-clicking on Z and T sliders to set the position.

Does zero validation of inputs, so negative numbers or non-numbers will probably throw an uncaught exception.

I had to change the handling of backspace because otherwise it would (try to) delete objects if you make a mistake and retype

Incidentally, I think I like showing ticks and tick values on these sliders, but I'm possibly alone there...