### PR TITLE
Enable running jpackage with extensions

### DIFF
--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -1,31 +1,54 @@
 # This workflow will build a Java project with Gradle, then create an image with jpackage
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
- name: Build packages with jpackage
+name: Build packages with jpackage
 
- on: 
-  - workflow_dispatch
-  - workflow_call
+on:
+  workflow_dispatch:
+    inputs:
+      extensions:
+        description: Comma-separated list of extensions to build with.
+        default: qupath-extension-instanseg,qupath-extension-djl
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      extensions:
+        description: Comma-separated list of extensions to build with.
+        required: false
+        type: string
 
- jobs:
+jobs:
    build:
-
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-latest
-            name: Linux
-          - platform: macos-13 # x64
-            name: Mac-x64
-          - platform: macos-14 # aarch64
-            name: Mac-arm64
+#          - platform: ubuntu-latest
+#            name: Linux
+#          - platform: macos-13 # x64
+#            name: Mac-x64
+#          - platform: macos-14 # aarch64
+#            name: Mac-arm64
           - platform: windows-latest
             name: Windows
     runs-on: ${{ matrix.platform }}
     steps:
 
     - uses: actions/checkout@v4
+      with:
+        path: qupath
+
+    - name: Clone extensions
+      if: ${{ github.events.inputs.extensions != '' }}
+      run: |
+        IFS=',' read -ra EXT <<< "${{ inputs.extensions }}"
+        for i in "${EXT[@]}"; do
+          echo $i
+        done
 
     - name: Set QuPath version
       shell: bash

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Set QuPath version
       run: |
-        echo "QUPATH_VERSION=$(cat VERSION)" >> $GITHUB_ENV
+        echo "QUPATH_VERSION=$(cat qupath/VERSION)" >> $GITHUB_ENV
 
     - name: Set up JDK 21
       uses: actions/setup-java@v4

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -45,7 +45,7 @@ jobs:
         path: qupath
 
     - name: Clone extensions
-      if: ${{ github.events.inputs.extensions != '' }}
+      if: ${{ github.event.inputs.extensions != '' }}
       run: |
         IFS=',' read -ra EXT <<< "${{ inputs.extensions }}"
         for i in "${EXT[@]}"; do

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -8,7 +8,6 @@ on:
     inputs:
       extensions:
         description: Comma-separated list of extensions to build with.
-        default: qupath-extension-instanseg,qupath-extension-djl
         required: false
         type: string
   workflow_call:
@@ -29,12 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          - platform: ubuntu-latest
-#            name: Linux
-#          - platform: macos-13 # x64
-#            name: Mac-x64
-#          - platform: macos-14 # aarch64
-#            name: Mac-arm64
+          - platform: ubuntu-latest
+            name: Linux
+          - platform: macos-13 # x64
+            name: Mac-x64
+          - platform: macos-14 # aarch64
+            name: Mac-arm64
           - platform: windows-latest
             name: Windows
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Assemble javadocs
       run: |
         pushd qupath
-        ./qupath/gradlew assembleJavadocs
+        ./gradlew assembleJavadocs
         popd
 
     - name: Build with Gradle

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -48,9 +48,15 @@ jobs:
       if: ${{ github.event.inputs.extensions != '' }}
       run: |
         IFS=',' read -ra EXT <<< "${{ inputs.extensions }}"
+        echo "[includeBuild]" > qupath/include-extra
         for i in "${EXT[@]}"; do
-          echo $i
+          echo "../$i" >> qupath/include-extra
         done
+        echo "[dependencies]" >> qupath/include-extra
+        for i in "${EXT[@]}"; do
+          echo "io.github.qupath:$i" >> qupath/include-extra
+        done
+        cat qupath/include-extra
 
     - name: Set QuPath version
       run: |
@@ -69,28 +75,31 @@ jobs:
       run: ./gradlew assembleJavadocs
 
     - name: Build with Gradle
-      run: ./gradlew jpackage -P git-commit=true -P package=installer mergedJavadoc createChecksums -P toolchain=21
+      run: |
+        pushd qupath
+        ./gradlew jpackage -P git-commit=true -P package=installer mergedJavadoc createChecksums -P toolchain=21
+        popd
 
     - name: Make Linux tar.xz
       if: matrix.name == 'Linux'
       run: |
-        tar -c -C build/dist/ QuPath | xz > build/dist/QuPath-v${{ env.QUPATH_VERSION }}-${{ matrix.name }}.tar.xz
-        rm -r build/dist/QuPath/
+        tar -c -C qupath/build/dist/ QuPath | xz > qupath/build/dist/QuPath-v${{ env.QUPATH_VERSION }}-${{ matrix.name }}.tar.xz
+        rm -r qupath/build/dist/QuPath/
 
     - name: Clean windows artifact
       if: matrix.name == 'Windows'
       run: |
-        rm -r build/dist/QuPath-${{ env.QUPATH_VERSION }}
+        rm -r qupath/build/dist/QuPath-${{ env.QUPATH_VERSION }}
 
     - uses: actions/upload-artifact@v4
       with:
         name: QuPath-v${{ env.QUPATH_VERSION }}-${{ matrix.name }}
-        path: build/dist/QuPath*
+        path: qupath/build/dist/QuPath*
         retention-days: 1
 
     - uses: actions/upload-artifact@v4
       if: matrix.name == 'Mac-arm64'
       with:
         name: javadoc-QuPath-v${{ env.QUPATH_VERSION }}
-        path: build/docs-merged/javadoc
+        path: qupath/build/docs-merged/javadoc
         retention-days: 7

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -57,6 +57,7 @@ jobs:
           echo "io.github.qupath:$i" >> qupath/include-extra
         done
         cat qupath/include-extra
+        ls -lah
 
     - name: Set QuPath version
       run: |

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -72,7 +72,10 @@ jobs:
       uses: gradle/actions/setup-gradle@v4
 
     - name: Assemble javadocs
-      run: ./gradlew assembleJavadocs
+      run: |
+        pushd qupath
+        ./qupath/gradlew assembleJavadocs
+        popd
 
     - name: Build with Gradle
       run: |

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         IFS=',' read -ra EXTENSIONS <<< "${{ inputs.extensions }}"
         echo "[includeBuild]" > qupath/include-extra
-        for $EXTENSION in "${EXTENSIONS[@]}"; do
+        for EXTENSION in "${EXTENSIONS[@]}"; do
           git clone "https://github.com/qupath/$EXTENSION"
           echo "../$EXTENSION" >> qupath/include-extra
         done

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -47,14 +47,15 @@ jobs:
     - name: Clone extensions
       if: ${{ github.event.inputs.extensions != '' }}
       run: |
-        IFS=',' read -ra EXT <<< "${{ inputs.extensions }}"
+        IFS=',' read -ra EXTENSIONS <<< "${{ inputs.extensions }}"
         echo "[includeBuild]" > qupath/include-extra
-        for i in "${EXT[@]}"; do
-          echo "../$i" >> qupath/include-extra
+        for $EXTENSION in "${EXTENSIONS[@]}"; do
+          git clone "https://github.com/qupath/$EXTENSION"
+          echo "../$EXTENSION" >> qupath/include-extra
         done
         echo "[dependencies]" >> qupath/include-extra
-        for i in "${EXT[@]}"; do
-          echo "io.github.qupath:$i" >> qupath/include-extra
+        for EXTENSION in "${EXTENSIONS[@]}"; do
+          echo "io.github.qupath:$EXTENSION" >> qupath/include-extra
         done
         cat qupath/include-extra
         ls -lah


### PR DESCRIPTION
Adds an optional parameter for the jpackage build, which takes a comma-separated list of extensions that should be included in the build. These *must* be under the qupath org, or the build will fail.

Then, it clones qupath to ./qupath and each extension to ./qupath-extension-whatever, and adds each extension to `[includeBuild]` and `[dependencies]` of `include-extra`. Then it runs the gradle build as usual.

Example, setting the input to `qupath-extension-instanseg,qupath-extension-djl`:
![jpackage](https://github.com/user-attachments/assets/5fedf034-d507-47ca-acb8-3f847700635d)

It's an optional arg, so in case it's not set then the build will just run as before with no extra extensions.