### PR TITLE
Use spinners & progress bar for z and t selection in viewer

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/CommandFinderTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/CommandFinderTools.java
@@ -250,7 +250,6 @@ public class CommandFinderTools {
 			var viewers = qupath.getAllViewers();
 			for (var viewer: viewers) {
 				if (viewer instanceof QuPathViewerPlus) {
-//					((QuPathViewerPlus)viewer).setSlidersPosition(!n.equals(CommandBarDisplay.NEVER));
 					((QuPathViewerPlus)viewer).setSpinnersPosition(!n.equals(CommandBarDisplay.NEVER));
 				}
 			}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/CommandFinderTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/CommandFinderTools.java
@@ -250,7 +250,8 @@ public class CommandFinderTools {
 			var viewers = qupath.getAllViewers();
 			for (var viewer: viewers) {
 				if (viewer instanceof QuPathViewerPlus) {
-					((QuPathViewerPlus)viewer).setSlidersPosition(!n.equals(CommandBarDisplay.NEVER));
+//					((QuPathViewerPlus)viewer).setSlidersPosition(!n.equals(CommandBarDisplay.NEVER));
+					((QuPathViewerPlus)viewer).setSpinnersPosition(!n.equals(CommandBarDisplay.NEVER));
 				}
 			}
 		});

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -1394,8 +1394,8 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 	}
 
 
-	private IntegerProperty tPosition = new SimpleIntegerProperty(0);
-	private IntegerProperty zPosition = new SimpleIntegerProperty(0);
+	private final IntegerProperty tPosition = new SimpleIntegerProperty(0);
+	private final IntegerProperty zPosition = new SimpleIntegerProperty(0);
 
 	/**
 	 * Set the requested z-slice to be visible.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -56,6 +56,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javafx.beans.property.Property;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.metadata.IIOMetadata;
@@ -3090,6 +3091,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 
 	/**
 	 * Current z-position for the z-slice currently visible in the viewer.
+	 *
 	 * @return
 	 */
 	public IntegerProperty zPositionProperty() {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
@@ -35,7 +35,6 @@ import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
-import javafx.scene.control.Slider;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.Tooltip;
@@ -81,8 +80,6 @@ public class QuPathViewerPlus extends QuPathViewer {
 	private BorderPane panelLocation = new BorderPane();
 	private Label labelLocation = new Label(" ");
 	private BooleanProperty useCalibratedLocationString = PathPrefs.useCalibratedLocationStringProperty();
-	private Slider sliderZ = new Slider(0, 1, 0);
-	private Slider sliderT = new Slider(0, 1, 0);
 
 	private int padding = 10;
 	
@@ -96,13 +93,6 @@ public class QuPathViewerPlus extends QuPathViewer {
 	public QuPathViewerPlus(final DefaultImageRegionStore regionStore, final OverlayOptions overlayOptions,
 			final ViewerPlusDisplayOptions viewerDisplayOptions) {
 		super(regionStore, overlayOptions);
-		
-		
-//		sliderZ.setOrientation(Orientation.VERTICAL);
-//		sliderT.setOrientation(Orientation.HORIZONTAL);
-//
-//		sliderT.setSnapToTicks(true);
-//		sliderZ.setSnapToTicks(true);
 		
 		useCalibratedLocationString.addListener(v -> updateLocationString());
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
@@ -149,24 +149,34 @@ public class QuPathViewerPlus extends QuPathViewer {
 
 		spinnerZ.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 1));
 		spinnerZ.getValueFactory().valueProperty().addListener((v, o, n) -> zPositionProperty().set(n));
-		zPositionProperty().addListener((v, o, n) -> {
-			spinnerZ.getValueFactory().setValue((Integer) n);
-		});
+		zPositionProperty().addListener((v, o, n) -> spinnerZ.getValueFactory().setValue((Integer) n));
 		spinnerZ.setPrefWidth(70);
 		spinnerZ.setEditable(true);
 		FXUtils.resetSpinnerNullToPrevious(spinnerZ);
 
 		spinnerZHBox.setAlignment(Pos.CENTER_RIGHT);
 		spinnerZHBox.setVisible(false);
+		var tooltipZ = new Tooltip("Change z-slice");
+		tooltipZ.textProperty().bind(
+				Bindings.createStringBinding(
+						() -> "Z-slice (" + zPositionProperty().get() + "/" + getNZSlices() + ")",
+						zPositionProperty()
+		));
+
+		spinnerZ.setTooltip(tooltipZ);
 
 		spinnerT.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 1));
-		spinnerT.getValueFactory().valueProperty().addListener((v, o, n) -> {
-			tPositionProperty().set(n);
-		});
-		tPositionProperty().addListener((v, o, n) -> {
-			spinnerT.getValueFactory().setValue((Integer) n);
-		});
+		spinnerT.getValueFactory().valueProperty().addListener((v, o, n) -> tPositionProperty().set(n));
+		tPositionProperty().addListener((v, o, n) -> spinnerT.getValueFactory().setValue((Integer) n));
 		spinnerT.setPrefWidth(70);
+		var tooltipT = new Tooltip("Change time point");
+		tooltipT.textProperty().bind(
+				Bindings.createStringBinding(
+						() -> "Time point (" + tPositionProperty().get() + "/" + getNTimepoints() + ")",
+						tPositionProperty()
+		));
+		spinnerT.setTooltip(tooltipT);
+
 
 		spinnerTHBox.setAlignment(Pos.CENTER_RIGHT);
 		spinnerTHBox.setVisible(false);
@@ -195,6 +205,14 @@ public class QuPathViewerPlus extends QuPathViewer {
 		viewerDisplayOptions.showLocationProperty().addListener(locationListener);
 		viewerDisplayOptions.showOverviewProperty().addListener(overviewListener);
 		viewerDisplayOptions.showScalebarProperty().addListener(scalebarListener);
+	}
+
+	private int getNTimepoints() {
+		return getServer() == null ? 0 : getServer().nTimepoints();
+	}
+
+	private int getNZSlices() {
+		return getServer() == null ? 0 : getServer().nZSlices();
 	}
 
 	private void updateSpinners() {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
@@ -44,6 +44,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.text.TextAlignment;
 import qupath.lib.gui.images.stores.DefaultImageRegionStore;
@@ -61,8 +62,11 @@ public class QuPathViewerPlus extends QuPathViewer {
 
 	private final Spinner<Integer> spinnerZ = new Spinner<>();
 	private final Spinner<Integer> spinnerT = new Spinner<>();
-	private final HBox spinnerZHBox;
-	private final HBox spinnerTHBox;
+	private final Label labelZ = new Label("Z: ");
+	private final Label labelT = new Label("Time: ");
+	private final HBox spinnerZHBox = new HBox(labelZ, spinnerZ);
+	private final HBox spinnerTHBox = new HBox(labelT, spinnerT);
+	private final VBox spinnersVBox = new VBox(spinnerZHBox, spinnerTHBox);
 	private ViewerPlusDisplayOptions viewerDisplayOptions;
 	
 	private ChangeListener<Boolean> locationListener = (v, o, n) -> setLocationVisible(n);
@@ -148,8 +152,6 @@ public class QuPathViewerPlus extends QuPathViewer {
 			spinnerZ.getValueFactory().setValue((Integer) n);
 		});
 		spinnerZ.setPrefWidth(70);
-		Label labelZ = new Label("Z: ");
-		spinnerZHBox = new HBox(labelZ, spinnerZ);
 		spinnerZHBox.setAlignment(Pos.CENTER_RIGHT);
 		spinnerZHBox.setVisible(false);
 
@@ -161,8 +163,7 @@ public class QuPathViewerPlus extends QuPathViewer {
 			spinnerT.getValueFactory().setValue((Integer) n);
 		});
 		spinnerT.setPrefWidth(70);
-		Label labelT = new Label("Time: ");
-		spinnerTHBox = new HBox(labelT, spinnerT);
+
 		spinnerTHBox.setAlignment(Pos.CENTER_RIGHT);
 		spinnerTHBox.setVisible(false);
 
@@ -171,7 +172,9 @@ public class QuPathViewerPlus extends QuPathViewer {
 		var commandBarDisplay = CommandFinderTools.commandBarDisplayProperty().getValue();
 		setSpinnersPosition(!commandBarDisplay.equals(CommandFinderTools.CommandBarDisplay.NEVER));
 
-		basePane.getChildren().addAll(spinnerZHBox, spinnerTHBox);
+		spinnersVBox.setSpacing(padding);
+		spinnersVBox.setAlignment(Pos.CENTER_RIGHT);
+		basePane.getChildren().addAll(spinnersVBox);
 
 		updateSpinners();
 		
@@ -272,13 +275,16 @@ public class QuPathViewerPlus extends QuPathViewer {
 	public void setSpinnersPosition(boolean down) {
 		double spinnersTopPadding = (double)padding + (down ? 20 : 0);
 
-		// Set Z spinner' position
-		AnchorPane.setTopAnchor(spinnerZHBox, (double)padding*3 + spinnersTopPadding);
-		AnchorPane.setLeftAnchor(spinnerZHBox, (double)padding);
+		AnchorPane.setTopAnchor(spinnersVBox, spinnersTopPadding);
+		AnchorPane.setLeftAnchor(spinnersVBox, (double) padding);
 
-		// Set T spinner' position
-		AnchorPane.setTopAnchor(spinnerTHBox, spinnersTopPadding);
-		AnchorPane.setLeftAnchor(spinnerTHBox, (double)padding*3);
+//		// Set Z spinner' position
+//		AnchorPane.setTopAnchor(spinnerZHBox, (double)padding*3 + spinnersTopPadding);
+//		AnchorPane.setLeftAnchor(spinnerZHBox, (double)padding);
+//
+//		// Set T spinner' position
+//		AnchorPane.setTopAnchor(spinnerTHBox, spinnersTopPadding);
+//		AnchorPane.setLeftAnchor(spinnerTHBox, (double)padding);
 	}
 	
 	@Override

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -44,7 +44,6 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
-import javafx.scene.paint.Color;
 import javafx.scene.text.TextAlignment;
 import qupath.fx.utils.FXUtils;
 import qupath.lib.gui.images.stores.DefaultImageRegionStore;
@@ -83,7 +82,10 @@ public class QuPathViewerPlus extends QuPathViewer {
 	private BooleanProperty useCalibratedLocationString = PathPrefs.useCalibratedLocationStringProperty();
 
 	private int padding = 10;
-	
+
+
+
+
 	
 	/**
 	 * Create a new viewer.
@@ -113,15 +115,13 @@ public class QuPathViewerPlus extends QuPathViewer {
 		AnchorPane.setRightAnchor(overviewNode, (double)padding);
 
 		// Add the location label
-		labelLocation.setTextFill(Color.WHITE);
 		labelLocation.setTextAlignment(TextAlignment.CENTER);
 		var fontBinding = Bindings.createStringBinding(() -> {
 				var temp = PathPrefs.locationFontSizeProperty().get();
 				return temp == null ? null : "-fx-font-size: " + temp.getFontSize();
 		}, PathPrefs.locationFontSizeProperty());
 		labelLocation.styleProperty().bind(fontBinding);
-//		labelLocation.setStyle("-fx-font-size: 0.8em;");
-		panelLocation.setStyle("-fx-background-color: rgba(0, 0, 0, 0.4);");
+		panelLocation.getStyleClass().add("viewer-overlay");
 		panelLocation.setMinSize(140, 40);
 		panelLocation.setCenter(labelLocation);
 		panelLocation.setPadding(new Insets(5));
@@ -156,9 +156,8 @@ public class QuPathViewerPlus extends QuPathViewer {
 		spinnerZ.setTooltip(tooltipZ);
 		var progressZ = new ProgressBar();
 		progressZ.visibleProperty().bind(spinnerZHBox.visibleProperty());
+		progressZ.setMaxWidth(Double.MAX_VALUE);
 		progressZ.setPrefHeight(10);
-		progressZ.prefWidthProperty().bind(spinnerZHBox.widthProperty());
-		progressZ.translateXProperty().bind(spinnerZHBox.layoutXProperty());
 		if (spinnerZ.getValueFactory() instanceof SpinnerValueFactory.IntegerSpinnerValueFactory f) {
 			progressZ.progressProperty().bind(Bindings.createDoubleBinding(() -> {
 				return f.getValue().doubleValue() / (f.getMax() - 1);
@@ -184,8 +183,7 @@ public class QuPathViewerPlus extends QuPathViewer {
 		var progressT = new ProgressBar();
 		progressT.visibleProperty().bind(spinnerTHBox.visibleProperty());
 		progressT.setPrefHeight(10);
-		progressT.prefWidthProperty().bind(spinnerTHBox.widthProperty());
-		progressT.translateXProperty().bind(spinnerTHBox.layoutXProperty());
+		progressZ.setMaxWidth(Double.MAX_VALUE);
 		if (spinnerT.getValueFactory() instanceof SpinnerValueFactory.IntegerSpinnerValueFactory f) {
 			progressT.progressProperty().bind(Bindings.createDoubleBinding(() -> {
 				return f.getValue().doubleValue() / (f.getMax() - 1);
@@ -197,6 +195,8 @@ public class QuPathViewerPlus extends QuPathViewer {
 		var commandBarDisplay = CommandFinderTools.commandBarDisplayProperty().getValue();
 		setSpinnersPosition(!commandBarDisplay.equals(CommandFinderTools.CommandBarDisplay.NEVER));
 
+		spinnersVBox.getStyleClass().addAll("viewer-overlay", "viewer-dims");
+		spinnersVBox.setPadding(new Insets(10));
 		spinnersVBox.getChildren().setAll(spinnerZHBox, progressZ, spinnerTHBox, progressT);
 		spinnersVBox.setSpacing(padding);
 		spinnersVBox.setAlignment(Pos.CENTER_RIGHT);
@@ -309,17 +309,8 @@ public class QuPathViewerPlus extends QuPathViewer {
 	 */
 	public void setSpinnersPosition(boolean down) {
 		double spinnersTopPadding = (double)padding + (down ? 20 : 0);
-
 		AnchorPane.setTopAnchor(spinnersVBox, spinnersTopPadding);
 		AnchorPane.setLeftAnchor(spinnersVBox, (double) padding);
-
-//		// Set Z spinner' position
-//		AnchorPane.setTopAnchor(spinnerZHBox, (double)padding*3 + spinnersTopPadding);
-//		AnchorPane.setLeftAnchor(spinnerZHBox, (double)padding);
-//
-//		// Set T spinner' position
-//		AnchorPane.setTopAnchor(spinnerTHBox, spinnersTopPadding);
-//		AnchorPane.setLeftAnchor(spinnerTHBox, (double)padding);
 	}
 	
 	@Override
@@ -336,7 +327,7 @@ public class QuPathViewerPlus extends QuPathViewer {
 		String s = null;
 		if (labelLocation != null && hasServer())
 			s = getFullLocationString(useCalibratedLocationString());
-		if (s != null && s.length() > 0) {
+		if (s != null && !s.isEmpty()) {
 			labelLocation.setText(s);
 //			labelLocation.setTextAlignment(TextAlignment.CENTER);
 			panelLocation.setOpacity(1);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
@@ -35,6 +35,7 @@ import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.Tooltip;
@@ -153,6 +154,16 @@ public class QuPathViewerPlus extends QuPathViewer {
 		));
 
 		spinnerZ.setTooltip(tooltipZ);
+		var progressZ = new ProgressBar();
+		progressZ.visibleProperty().bind(spinnerZHBox.visibleProperty());
+		progressZ.setPrefHeight(10);
+		progressZ.prefWidthProperty().bind(spinnerZHBox.widthProperty());
+		progressZ.translateXProperty().bind(spinnerZHBox.layoutXProperty());
+		if (spinnerZ.getValueFactory() instanceof SpinnerValueFactory.IntegerSpinnerValueFactory f) {
+			progressZ.progressProperty().bind(Bindings.createDoubleBinding(() -> {
+				return f.getValue().doubleValue() / (f.getMax() - 1);
+			}, f.valueProperty(), f.maxProperty()));
+		}
 
 		spinnerT.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 1));
 		spinnerT.getValueFactory().valueProperty().addListener((v, o, n) -> tPositionProperty().set(n));
@@ -170,12 +181,23 @@ public class QuPathViewerPlus extends QuPathViewer {
 		spinnerTHBox.setAlignment(Pos.CENTER_RIGHT);
 		spinnerTHBox.setVisible(false);
 		spinnerT.setEditable(true);
+		var progressT = new ProgressBar();
+		progressT.visibleProperty().bind(spinnerTHBox.visibleProperty());
+		progressT.setPrefHeight(10);
+		progressT.prefWidthProperty().bind(spinnerTHBox.widthProperty());
+		progressT.translateXProperty().bind(spinnerTHBox.layoutXProperty());
+		if (spinnerT.getValueFactory() instanceof SpinnerValueFactory.IntegerSpinnerValueFactory f) {
+			progressT.progressProperty().bind(Bindings.createDoubleBinding(() -> {
+				return f.getValue().doubleValue() / (f.getMax() - 1);
+			}, f.valueProperty(), f.maxProperty()));
+		}
 		FXUtils.resetSpinnerNullToPrevious(spinnerT);
 		
 		// Set spinners' position so they make space for command bar (only if needed!)
 		var commandBarDisplay = CommandFinderTools.commandBarDisplayProperty().getValue();
 		setSpinnersPosition(!commandBarDisplay.equals(CommandFinderTools.CommandBarDisplay.NEVER));
 
+		spinnersVBox.getChildren().setAll(spinnerZHBox, progressZ, spinnerTHBox, progressT);
 		spinnersVBox.setSpacing(padding);
 		spinnersVBox.setAlignment(Pos.CENTER_RIGHT);
 		basePane.getChildren().addAll(spinnersVBox);
@@ -228,7 +250,7 @@ public class QuPathViewerPlus extends QuPathViewer {
 		vf.setMax(min);
 		vf.setMax(max);
 		vf.setValue(position);
-		hbox.setOpacity(0.25);
+		hbox.setOpacity(0.5);
 		hbox.setOnMouseEntered(e -> {
 			hbox.setOpacity(1);
 		});

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewerPlus.java
@@ -32,7 +32,6 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
-import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Label;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerDimensionControls.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerDimensionControls.java
@@ -1,0 +1,170 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2025 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.gui.viewer;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.value.ObservableValue;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.control.Separator;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Pane;
+import qupath.fx.utils.FXUtils;
+import qupath.lib.common.GeneralTools;
+
+/**
+ * Controls to navigate z slices and time points in the viewer.
+ * @since v0.6.0
+ */
+class ViewerDimensionControls {
+
+    private final IntegerProperty zPositionProperty = new SimpleIntegerProperty();
+    private final IntegerProperty zMaxProperty = new SimpleIntegerProperty();
+
+    private final IntegerProperty tPositionProperty = new SimpleIntegerProperty();
+    private final IntegerProperty tMaxProperty = new SimpleIntegerProperty();
+
+    private final DoubleProperty contentOpacityProperty = new SimpleDoubleProperty(1.0);
+
+    private final Spinner<Integer> spinnerZ = createSpinner(zPositionProperty, zMaxProperty, "Z-slice");
+    private final Spinner<Integer> spinnerT = createSpinner(tPositionProperty, tMaxProperty, "Time point");
+
+    private final ProgressBar progressZ = createProgressBar(zPositionProperty, zMaxProperty);
+    private final ProgressBar progressT = createProgressBar(tPositionProperty, tMaxProperty);
+
+    private final Label labelZ = createLabel("Z: ", spinnerZ);
+    private final Label labelT = createLabel("Time: ", spinnerT);
+
+    private final GridPane pane = new GridPane();
+
+    ViewerDimensionControls() {
+        pane.getStyleClass().addAll("viewer-overlay", "viewer-dims");
+        pane.setOnMouseEntered(e -> contentOpacityProperty.set(1.0));
+        pane.setOnMouseExited(e -> contentOpacityProperty.set(0.5));
+        pane.setVgap(4);
+
+        zMaxProperty.addListener(this::handleChange);
+        tMaxProperty.addListener(this::handleChange);
+        updateContents();
+    }
+
+    private ProgressBar createProgressBar(IntegerProperty property, IntegerProperty maxProperty) {
+        var progress = new ProgressBar();
+        progress.setMaxWidth(Double.MAX_VALUE);
+        progress.setPrefHeight(10);
+        progress.progressProperty().bind(Bindings.createDoubleBinding(() -> property.doubleValue() / (maxProperty.get() - 1),
+                property, maxProperty));
+        progress.opacityProperty().bind(contentOpacityProperty);
+        progress.setOnMouseClicked(e -> updateFromProgress(progress, e.getX(), property, maxProperty));
+        progress.setOnMouseDragged(e -> updateFromProgress(progress, e.getX(), property, maxProperty));
+        return progress;
+    }
+
+    private void updateFromProgress(ProgressBar progress, double x, IntegerProperty prop, IntegerProperty max) {
+        int val = (int)Math.round(x / progress.getWidth() * max.doubleValue());
+        prop.setValue(GeneralTools.clipValue(val, 0, max.get()));
+    }
+
+    private Spinner<Integer> createSpinner(IntegerProperty property, IntegerProperty maxProperty,
+                                           String name) {
+        var factory = new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 1);
+        factory.maxProperty().bind(maxProperty);
+        var spinner = new Spinner<>(factory);
+        factory.valueProperty().addListener((v, o, n) -> property.setValue(n));
+        property.addListener((v, o, n) -> factory.setValue((Integer) n));
+        spinner.setPrefWidth(70);
+        spinner.setEditable(true);
+        FXUtils.resetSpinnerNullToPrevious(spinner);
+
+        var tooltip = new Tooltip();
+        tooltip.textProperty().bind(
+                Bindings.createStringBinding(
+                        () -> name + " (" + property.get() + "/" + maxProperty.get() + ")",
+                        property, maxProperty
+                ));
+        spinner.setTooltip(tooltip);
+
+        spinner.opacityProperty().bind(contentOpacityProperty);
+        return spinner;
+    }
+
+    private Label createLabel(String text, Node node) {
+        var label = new Label(text);
+        label.setLabelFor(node);
+        label.setContentDisplay(ContentDisplay.RIGHT);
+        label.setAlignment(Pos.CENTER_RIGHT);
+        label.setMaxWidth(Double.MAX_VALUE);
+        label.opacityProperty().bind(contentOpacityProperty);
+        return label;
+    }
+
+    private void handleChange(ObservableValue<? extends Number> val, Number oldValue, Number newValue) {
+        updateContents();
+    }
+
+    private void updateContents() {
+        pane.getChildren().clear();
+        int row = 0;
+        if (tMaxProperty.get() > 1) {
+            pane.addRow(row++, labelT, spinnerT);
+            pane.add(progressT, 0, row++, 2, 1);
+        }
+        if (zMaxProperty.get() > 1) {
+            if (row > 0)
+                pane.add(new Separator(), 0, row++, 2, 1);
+            pane.addRow(row++, labelZ, spinnerZ);
+            pane.add(progressZ, 0, row++, 2, 1);
+        }
+        pane.setVisible(!pane.getChildren().isEmpty());
+    }
+
+    IntegerProperty zMaxProperty() {
+        return zMaxProperty;
+    }
+
+    IntegerProperty tMaxProperty() {
+        return tMaxProperty;
+    }
+
+    IntegerProperty zPositionProperty() {
+        return zPositionProperty;
+    }
+
+    IntegerProperty tPositionProperty() {
+        return tPositionProperty;
+    }
+
+    Pane getPane() {
+        return pane;
+    }
+
+}

--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -45,7 +45,22 @@
 
 }
 
-/* Text objects used as placeholders */
+/* Location text, slider backgrounds to show on the viewer */
+.viewer-overlay {
+  -fx-background-color: rgba(0, 0, 0, 0.4);
+  -fx-base: rgb(45, 48, 50);
+  -fx-background: derive(-fx-base, -10%);
+  -fx-control-inner-background: derive(-fx-base, 10%);
+  -fx-control-inner-background-alt: derive(-fx-control-inner-background,1%);
+  -fx-light-text-color: white;
+}
+
+.viewer-overlay.viewer-dims {
+  -fx-padding: 10;
+  -fx-background-radius: 5;
+}
+
+  /* Text objects used as placeholders */
 .text-placeholder {
   -fx-fill: -fx-text-base-color;
   -fx-opacity: 0.8;


### PR DESCRIPTION
Basically https://github.com/qupath/qupath/pull/1799

Replaces sliders to navigate `z` and `t` in the viewer with spinners and progress bars.

<img width="228" alt="new-z-t-sliders" src="https://github.com/user-attachments/assets/f97e4fe3-539b-4cd2-97e8-9a8bbcc3755f" />

Values can be changed by:
* Typing a number
* Pressing an up or down button
* Clicking (or dragging) on the progress bar

A tooltip also shows the number of slices.