### PR TITLE
Attempt to fix obscure file deletion bug on macOS

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -857,7 +857,7 @@ class DefaultProject implements Project<BufferedImage> {
 				if (desktop.isSupported(Desktop.Action.MOVE_TO_TRASH)) {
 					// See https://github.com/qupath/qupath/issues/1738
 					// It's not clear if this will help, but Desktop sometimes cares about the event dispatch thread
-					if (SwingUtilities.isEventDispatchThread()) {
+					if (SwingUtilities.isEventDispatchThread() || !GeneralTools.isWindows()) {
 						if (desktop.moveToTrash(path.toFile()))
 							return;
 					} else {


### PR DESCRIPTION
One proposed approach to fix a deadlock occurring when deleting files on macOS - but only under some circumstances.

This is really a placeholder to make sure we remember to fix it before the next release - @Rylern please feel free to fix in another, better way if you like and we can close this.