### PR TITLE
Support color deconvolution for non-8-bit images

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
@@ -232,8 +232,20 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 			Roi roi = null;
 			if (pathROI != null)
 				roi = IJTools.convertToIJRoi(pathROI, pathImage);
-			if (ip instanceof ColorProcessor && stains != null && isBrightfield) {
-				FloatProcessor[] fps = IJTools.colorDeconvolve((ColorProcessor)ip, stains);
+			if (stains != null && isBrightfield) {
+				FloatProcessor[] fps;
+				if (ip instanceof ColorProcessor cp) {
+					fps = IJTools.colorDeconvolve(cp, stains);
+				} else if (pathImage.getImage().getNChannels() == 3) {
+					var imp = pathImage.getImage();
+					fps = IJTools.colorDeconvolve(
+							imp.getStack().getProcessor(1),
+							imp.getStack().getProcessor(2),
+							imp.getStack().getProcessor(3),
+							stains);
+				} else {
+					throw new IllegalArgumentException("Unsupported image for color deconvolution: " + pathImage.getImage());
+				}
 				for (int i = 0; i < 3; i++) {
 					StainVector stain = stains.getStain(i+1);
 					if (!stain.isResidual()) {

--- a/qupath-core-processing/src/main/java/qupath/imagej/superpixels/SLICSuperpixelsPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/superpixels/SLICSuperpixelsPlugin.java
@@ -197,6 +197,7 @@ public class SLICSuperpixelsPlugin extends AbstractTileableDetectionPlugin<Buffe
 			
 			ImageProcessor[] ipColor;
 			if (imp.getType() == ImagePlus.COLOR_RGB) {
+				// TODO: Consider adding support for non-8-bit color deconvolution
 				ColorProcessor cp = (ColorProcessor)imp.getProcessor();
 				if (doDeconvolve && imageData.isBrightfield() && imageData.getColorDeconvolutionStains() != null) {
 					ipColor = IJTools.colorDeconvolve(cp, imageData.getColorDeconvolutionStains());

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
@@ -1214,4 +1214,19 @@ public class IJTools {
 		return new FloatProcessor[] {fpStain1, fpStain2, fpStain3};
 	}
 
+	public static FloatProcessor[] colorDeconvolve(ImageProcessor ipRed, ImageProcessor ipGreen, ImageProcessor ipBlue, ColorDeconvolutionStains stains) {
+		// convertToFloatProcessor makes a copy if the input is already a FloatProcessor
+		int w = ipRed.getWidth();
+		int h = ipRed.getHeight();
+		var red = (float[])ipRed.convertToFloatProcessor().getPixels();
+		var green = (float[])ipGreen.convertToFloatProcessor().getPixels();
+		var blue = (float[])ipBlue.convertToFloatProcessor().getPixels();
+		ColorTransformer.colorDeconvolve(red, green, blue, stains);
+		return new FloatProcessor[] {
+				new FloatProcessor(w, h, red),
+				new FloatProcessor(w, h, green),
+				new FloatProcessor(w, h, blue)
+		};
+	}
+
 }

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
@@ -1198,11 +1198,12 @@ public class IJTools {
 	}
 
 	/**
-	 * Apply color deconvolution, outputting 3 'stain' images in the same order as the stain vectors.
+	 * Apply color deconvolution to an RGB image, outputting 3 'stain' images in the same order as the stain vectors.
 	 * 
 	 * @param cp      input RGB color image
 	 * @param stains  color deconvolution stain vectors
 	 * @return array containing three {@code FloatProcessor}s, representing the deconvolved stains
+	 * @see #colorDeconvolve(ImageProcessor, ImageProcessor, ImageProcessor, ColorDeconvolutionStains)
 	 */
 	public static FloatProcessor[] colorDeconvolve(ColorProcessor cp, ColorDeconvolutionStains stains) {
 		int width = cp.getWidth();
@@ -1214,14 +1215,26 @@ public class IJTools {
 		return new FloatProcessor[] {fpStain1, fpStain2, fpStain3};
 	}
 
-	public static FloatProcessor[] colorDeconvolve(ImageProcessor ipRed, ImageProcessor ipGreen, ImageProcessor ipBlue, ColorDeconvolutionStains stains) {
+	/**
+	 * Apply color deconvolution to RGB channels, outputting 3 'stain' images in the same order as the stain vectors.
+	 * This exists to support color deconvolution of non-RGB images.
+	 *
+	 * @param ipRed   input red channel
+	 * @param ipGreen input green channel
+	 * @param ipBlue  input blue channel
+	 * @param stains  color deconvolution stain vectors
+	 * @return array containing three {@code FloatProcessor}s, representing the deconvolved stains
+	 * @see #colorDeconvolve(ColorProcessor, ColorDeconvolutionStains)
+	 */
+	public static FloatProcessor[] colorDeconvolve(ImageProcessor ipRed, ImageProcessor ipGreen, ImageProcessor ipBlue,
+												   ColorDeconvolutionStains stains) {
 		// convertToFloatProcessor makes a copy if the input is already a FloatProcessor
 		int w = ipRed.getWidth();
 		int h = ipRed.getHeight();
 		var red = (float[])ipRed.convertToFloatProcessor().getPixels();
 		var green = (float[])ipGreen.convertToFloatProcessor().getPixels();
 		var blue = (float[])ipBlue.convertToFloatProcessor().getPixels();
-		ColorTransformer.colorDeconvolve(red, green, blue, stains);
+		ColorDeconvolutionHelper.colorDeconvolve(red, green, blue, stains);
 		return new FloatProcessor[] {
 				new FloatProcessor(w, h, red),
 				new FloatProcessor(w, h, green),

--- a/qupath-core-processing/src/main/java/qupath/lib/analysis/algorithms/EstimateStainVectors.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/analysis/algorithms/EstimateStainVectors.java
@@ -95,9 +95,9 @@ public class EstimateStainVectors {
 			red = raster.getSamples(0, 0, raster.getWidth(), raster.getHeight(), 0, (float[])null);
 			green = raster.getSamples(0, 0, raster.getWidth(), raster.getHeight(), 1, (float[])null);
 			blue = raster.getSamples(0, 0, raster.getWidth(), raster.getHeight(), 2, (float[])null);
-			ColorTransformer.convertToOpticalDensity(red, stainsOriginal.getMaxRed());
-			ColorTransformer.convertToOpticalDensity(green, stainsOriginal.getMaxGreen());
-			ColorTransformer.convertToOpticalDensity(blue, stainsOriginal.getMaxBlue());
+			ColorDeconvolutionHelper.convertToOpticalDensity(red, stainsOriginal.getMaxRed());
+			ColorDeconvolutionHelper.convertToOpticalDensity(green, stainsOriginal.getMaxGreen());
+			ColorDeconvolutionHelper.convertToOpticalDensity(blue, stainsOriginal.getMaxBlue());
 		}
 		return estimateStains(red, green, blue, stainsOriginal, minStain, maxStain, ignorePercentage, checkColors);
 	}

--- a/qupath-core/src/main/java/qupath/lib/color/ColorDeconvolutionHelper.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorDeconvolutionHelper.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -23,6 +23,7 @@
 
 package qupath.lib.color;
 
+import java.awt.image.Raster;
 import java.util.Arrays;
 
 import org.slf4j.Logger;
@@ -141,6 +142,43 @@ public class ColorDeconvolutionHelper {
 		for (int i = 0; i < px.length; i++)
 			px[i] = (float)makeODByLUT(ColorTools.red(rgb[i]), od_lut);
 		return px;
+	}
+
+
+	/**
+	 * Extract a band from a raster and convert the pixel values to optical densities, using the specified maximum value.
+	 *
+	 * @param raster the input image
+	 * @param band the band (channel) to extract
+	 * @param maxValue the maximum value used for normalization whe calculating optical densities
+	 * @param px optional array used for output
+	 * @return a float array containing the optical density values (may be the same as {@code px})
+	 */
+	public static float[] getOpticalDensities(Raster raster, int band, double maxValue, float[] px) {
+		px = getPixels(raster, band, px);
+		ColorTransformer.convertToOpticalDensity(px, maxValue);
+		return px;
+	}
+
+	/**
+	 * Extract a band from a raster and return the values in a float array.
+	 * @param raster the input raster
+	 * @param band the band (channel) to extract
+	 * @param px optional array used for output
+	 * @return a float array containing the pixel values (may be the same as {@code px})
+	 */
+	public static float[] getPixels(Raster raster, int band, float[] px) {
+		return raster.getSamples(0, 0, raster.getWidth(), raster.getHeight(), band, px);
+	}
+
+	/**
+	 * Extract a band from a raster and return the values in a float array.
+	 * @param raster the input raster
+	 * @param band the band (channel) to extract
+	 * @return a new float array containing the pixel values
+	 */
+	public static float[] getPixels(Raster raster, int band) {
+		return getPixels(raster, band, null);
 	}
 
 	/**

--- a/qupath-core/src/main/java/qupath/lib/color/ColorTransformer.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorTransformer.java
@@ -24,15 +24,12 @@
 package qupath.lib.color;
 
 import java.awt.Color;
-import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.IndexColorModel;
-import java.awt.image.WritableRaster;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import qupath.lib.awt.common.BufferedImageTools;
 import qupath.lib.color.ColorDeconvolutionStains.DefaultColorDeconvolutionStains;
 import qupath.lib.common.ColorTools;
 
@@ -312,77 +309,6 @@ public class ColorTransformer {
 	 */
 	public static float[] getSimpleTransformedPixels(final int[] buf, final ColorTransformMethod method, float[] pixels) {
 		return getTransformedPixels(buf, method, pixels, null);
-	}
-
-
-	public static float[] colorDeconvolve(BufferedImage img, final ColorDeconvolutionStains stains, int stainNumber, float[] pixels) {
-		if (BufferedImageTools.is8bitColorType(img.getType())) {
-			int[] rgb = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
-			ColorTransformMethod method;
-			if (stainNumber == 0)
-				method = ColorTransformMethod.Stain_1;
-			else if (stainNumber == 1)
-				method = ColorTransformMethod.Stain_2;
-			else if (stainNumber == 2)
-				method = ColorTransformMethod.Stain_3;
-			else
-				throw new IllegalArgumentException("Unsupported stain number: " + stainNumber);
-			return getTransformedPixels(rgb, method, pixels, stains);
-		} else {
-			var raster = img.getRaster();
-			var r = getChannelOpticalDensity(raster, 0, stains.getMaxRed());
-			var g = getChannelOpticalDensity(raster, 1, stains.getMaxGreen());
-			var b = getChannelOpticalDensity(raster, 2, stains.getMaxBlue());
-
-			var invMat = stains.getMatrixInverse();
-			double rScale = invMat[0][stainNumber];
-			double gScale = invMat[1][stainNumber];
-			double bScale = invMat[2][stainNumber];
-			if (pixels == null || pixels.length < r.length)
-				pixels = new float[r.length];
-			for (int i = 0; i < pixels.length; i++) {
-				pixels[i] = (float)(r[i] * rScale + g[i] * gScale + b[i] * bScale);
-			}
-			return pixels;
-		}
-	}
-
-	/**
-	 * Apply color deconvolution in-place for RGB channels.
-	 * @param red
-	 * @param green
-	 * @param blue
-	 * @param stains
-	 */
-	public static void colorDeconvolve(float[] red, float[] green, float[] blue, final ColorDeconvolutionStains stains) {
-		convertToOpticalDensity(red, stains.getMaxRed());
-		convertToOpticalDensity(green, stains.getMaxGreen());
-		convertToOpticalDensity(blue, stains.getMaxBlue());
-
-		var invMat = stains.getMatrixInverse();
-		int n = red.length;
-		for (int i = 0; i < n; i++) {
-			double r = red[i];
-			double g = green[i];
-			double b = blue[i];
-
-			red[i] = (float)(r * invMat[0][0] + g * invMat[1][0] + b * invMat[2][0]);
-			green[i] = (float)(r * invMat[0][1] + g * invMat[1][1] + b * invMat[2][1]);
-			blue[i] = (float)(r * invMat[0][2] + g * invMat[1][2] + b * invMat[2][2]);
-		}
-	}
-
-	private static float[] getChannelOpticalDensity(WritableRaster raster, int channel, double max) {
-		float[] arr = raster.getSamples(0, 0, raster.getWidth(), raster.getHeight(), channel, (float[]) null);
-		convertToOpticalDensity(arr, max);
-		return arr;
-	}
-
-	public static void convertToOpticalDensity(float[] pixels, double max) {
-		double minValue = 1.0/255.0; // Mimic 8-bit calculation
-		for (int i = 0; i < pixels.length; i++) {
-			pixels[i] = (float)-Math.log10(Math.max(pixels[i] / max, minValue));
-		}
 	}
 
 

--- a/qupath-core/src/main/java/qupath/lib/images/ImageData.java
+++ b/qupath-core/src/main/java/qupath/lib/images/ImageData.java
@@ -331,7 +331,7 @@ public class ImageData<T> implements WorkflowListener, PathObjectHierarchyListen
 		if (this.type == type)
 			return;
 
-		if (isBrightfield(type) && !getServerMetadata().isRGB()) {
+		if (isBrightfield(type) && !(getServerMetadata().isRGB() || getServerMetadata().getChannels().size() == 3)) {
 			throw new IllegalArgumentException("Type for non-RGB image cannot be set to " + type);
 		}
 

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ColorDeconvolutionImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ColorDeconvolutionImageServer.java
@@ -186,7 +186,7 @@ class ColorDeconvolutionImageServer extends TransformingImageServer<BufferedImag
 		} else {
 			float[] pixels = new float[w * h];
 			for (int b = 0; b < methods.size(); b++) {
-				ColorTransformer.colorDeconvolve(img, stains, stainNumbers[b], pixels);
+				ColorDeconvolutionHelper.colorDeconvolve(img, stains, stainNumbers[b]-1, pixels);
 				raster.setSamples(0, 0, img.getWidth(), img.getHeight(), b, pixels);
 			}
 		}

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ColorDeconvolutionImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ColorDeconvolutionImageServer.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2022, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -38,6 +38,8 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import qupath.lib.awt.common.BufferedImageTools;
+import qupath.lib.color.ColorDeconvolutionHelper;
 import qupath.lib.color.ColorDeconvolutionStains;
 import qupath.lib.color.ColorModelFactory;
 import qupath.lib.color.ColorTransformer;
@@ -173,19 +175,22 @@ class ColorDeconvolutionImageServer extends TransformingImageServer<BufferedImag
 		float[][] bytes = new float[nChannels][w*h];
 		DataBufferFloat buffer = new DataBufferFloat(bytes, w*h);
 		WritableRaster raster = Raster.createWritableRaster(model, buffer, null);
-		
-		int[] rgb = img.getRGB(0, 0, w, h, null, 0, img.getWidth());
-		float[] pixels = new float[w * h];
-		for (int b = 0; b < methods.size(); b++) {
-			ColorTransformer.getTransformedPixels(rgb, methods.get(b), pixels, stains);			
-			raster.setSamples(0, 0, img.getWidth(), img.getHeight(), b, pixels);
+
+		if (BufferedImageTools.is8bitColorType(img.getType())) {
+			int[] rgb = img.getRGB(0, 0, w, h, null, 0, img.getWidth());
+			float[] pixels = new float[w * h];
+			for (int b = 0; b < methods.size(); b++) {
+				ColorTransformer.getTransformedPixels(rgb, methods.get(b), pixels, stains);
+				raster.setSamples(0, 0, img.getWidth(), img.getHeight(), b, pixels);
+			}
+		} else {
+			float[] pixels = new float[w * h];
+			for (int b = 0; b < methods.size(); b++) {
+				ColorTransformer.colorDeconvolve(img, stains, stainNumbers[b], pixels);
+				raster.setSamples(0, 0, img.getWidth(), img.getHeight(), b, pixels);
+			}
 		}
 		return new BufferedImage(getColorModel(), Raster.createWritableRaster(model, buffer, null), false, null);
-		
-//		WritableRaster raster = WritableRaster.createInterleavedRaster(DataBuffer.TYPE_FLOAT, img.getWidth(), img.getHeight(), 1, null);
-//		ColorTransformer.getTransformedPixels(rgb, method, pixels, stains);
-//		raster.setSamples(0, 0, img.getWidth(), img.getHeight(), 0, pixels);
-//		return new BufferedImage(colorModel, raster, false, null);
 	}
 
 	@Override

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
@@ -40,6 +40,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
+import qupath.lib.awt.common.BufferedImageTools;
 import qupath.lib.color.ColorDeconvolutionStains;
 import qupath.lib.color.ColorTransformer;
 import qupath.lib.color.ColorTransformer.ColorTransformMethod;
@@ -623,8 +624,12 @@ public class ColorTransforms {
 
 		@Override
 		public float[] extractChannel(ImageServer<BufferedImage> server, BufferedImage img, float[] pixels) {
-			int[] rgb = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
-			return ColorTransformer.getTransformedPixels(rgb, method, pixels, stains);
+			if (BufferedImageTools.is8bitColorType(img.getType())) {
+				int[] rgb = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
+				return ColorTransformer.getTransformedPixels(rgb, method, pixels, stains);
+			} else {
+				throw new UnsupportedOperationException("Unsupported image type: " + img);
+			}
 		}
 
 		@Override

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
@@ -41,6 +41,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import qupath.lib.awt.common.BufferedImageTools;
+import qupath.lib.color.ColorDeconvolutionHelper;
 import qupath.lib.color.ColorDeconvolutionStains;
 import qupath.lib.color.ColorTransformer;
 import qupath.lib.color.ColorTransformer.ColorTransformMethod;
@@ -628,7 +629,7 @@ public class ColorTransforms {
 				int[] rgb = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
 				return ColorTransformer.getTransformedPixels(rgb, method, pixels, stains);
 			} else {
-				return ColorTransformer.colorDeconvolve(img, stains, stainNumber-1, null);
+				return ColorDeconvolutionHelper.colorDeconvolve(img, stains, stainNumber-1, null);
 			}
 		}
 

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ColorTransforms.java
@@ -628,13 +628,13 @@ public class ColorTransforms {
 				int[] rgb = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
 				return ColorTransformer.getTransformedPixels(rgb, method, pixels, stains);
 			} else {
-				throw new UnsupportedOperationException("Unsupported image type: " + img);
+				return ColorTransformer.colorDeconvolve(img, stains, stainNumber-1, null);
 			}
 		}
 
 		@Override
 		public boolean supportsImage(ImageServer<BufferedImage> server) {
-			return server.isRGB() && server.getPixelType() == PixelType.UINT8;
+			return server.nChannels() == 3;
 		}
 
 		@Override

--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerMetadata.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerMetadata.java
@@ -434,7 +434,11 @@ public class ImageServerMetadata {
 
 //			if (metadata.path == null || metadata.path.isBlank())
 //				throw new IllegalArgumentException("Invalid metadata - path must be set (and not be blank)");
-						
+
+			// Set RGB channels, if needed
+			if (metadata.isRGB && (metadata.channels == null || metadata.channels.isEmpty()))
+				metadata.channels = ImageChannel.getDefaultRGBChannels();
+
 			// Set sensible tile sizes, if required
 			if (metadata.preferredTileWidth <= 0) {
 				if (metadata.levels.length == 1)

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/AdditiveChannelInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/AdditiveChannelInfo.java
@@ -1,0 +1,107 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2025 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.display;
+
+import qupath.lib.common.ColorTools;
+import qupath.lib.images.ImageData;
+
+import java.awt.image.BufferedImage;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Class for combining channels additively, then providing controls on the resulting RGB image.
+ * This is useful for non-RGB images that need to be modified as if they are RGB.
+ * 
+ * @author Pete Bankhead
+ */
+class AdditiveChannelInfo extends AbstractChannelInfo {
+
+	private final List<DirectServerChannelInfo> channels;
+
+	public AdditiveChannelInfo(final ImageData<BufferedImage> imageData,
+							   final List<DirectServerChannelInfo> channels) {
+		super(imageData);
+		this.channels = List.copyOf(channels);
+		setMinMaxAllowed(0, 255);
+		setClipToAllowed(true);
+	}
+
+	@Override
+	public String getName() {
+		return "Original (composite)";
+	}
+
+	@Override
+	public String getValueAsString(BufferedImage img, int x, int y) {
+		return channels.stream()
+				.map(c -> c.getValueAsString(img, x, y))
+				.collect(Collectors.joining(", "));
+	}
+
+	@Override
+	public int getRGB(BufferedImage img, int x, int y, ChannelDisplayMode mode) {
+		int r = 0, g = 0, b = 0;
+		for (var channel : channels) {
+			int val = channel.getRGB(img, x, y, mode);
+			r += ColorTools.red(val);
+			g += ColorTools.green(val);
+			b += ColorTools.blue(val);
+		}
+		return (do8BitRangeCheck(r) << 16) +
+				(do8BitRangeCheck(g) << 8) +
+				do8BitRangeCheck(b);
+	}
+
+	@Override
+	public int[] getRGB(BufferedImage img, int[] rgb, ChannelDisplayMode mode) {
+		if (rgb == null) {
+			rgb = new int[img.getWidth() * img.getHeight()];
+		}
+		for (var c : channels) {
+			c.updateRGBAdditive(img, rgb, ChannelDisplayMode.COLOR);
+		}
+		return RGBDirectChannelInfo.transformRGB(rgb, rgb, mode, getOffset(), getScaleToByte());
+	}
+
+	@Override
+	public void updateRGBAdditive(BufferedImage img, int[] rgb, ChannelDisplayMode mode) {
+		throw new UnsupportedOperationException(this + " does not support additive display");
+
+	}
+
+	@Override
+	public boolean doesSomething() {
+		return !channels.isEmpty();
+	}
+
+	@Override
+	public boolean isAdditive() {
+		return false;
+	}
+
+	@Override
+	public Integer getColor() {
+		return null;
+	}
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/AdditiveChannelInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/AdditiveChannelInfo.java
@@ -30,18 +30,20 @@ import java.util.stream.Collectors;
 
 /**
  * Class for combining channels additively, then providing controls on the resulting RGB image.
- * This is useful for non-RGB images that need to be modified as if they are RGB.
- * 
- * @author Pete Bankhead
+ * <p>
+ * This was created to support the display of non-8-bit brightfield images in a similar way to
+ * RGB images.
+ *
+ * @since v0.6.0
  */
-class AdditiveChannelInfo extends AbstractChannelInfo {
+public class AdditiveChannelInfo extends AbstractChannelInfo {
 
 	private final List<DirectServerChannelInfo> channels;
 
 	public AdditiveChannelInfo(final ImageData<BufferedImage> imageData,
 							   final List<DirectServerChannelInfo> channels) {
 		super(imageData);
-		this.channels = List.copyOf(channels);
+		this.channels = channels == null ? List.of() : List.copyOf(channels);
 		setMinMaxAllowed(0, 255);
 		setClipToAllowed(true);
 	}
@@ -102,6 +104,14 @@ class AdditiveChannelInfo extends AbstractChannelInfo {
 	@Override
 	public Integer getColor() {
 		return null;
+	}
+
+	/**
+	 * Get an unmodifiable list of the channels that are merged here for display.
+	 * @return a list of channels
+	 */
+	public List<DirectServerChannelInfo> getChannels() {
+		return channels;
 	}
 
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ColorDeconvolutionInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ColorDeconvolutionInfo.java
@@ -157,7 +157,7 @@ class ColorDeconvolutionInfo extends AbstractSingleChannelInfo {
 				}
 				return array;
 			} else {
-				return ColorTransformer.colorDeconvolve(img, stains, stainNumber - 1, array);
+				return ColorDeconvolutionHelper.colorDeconvolve(img, stains, stainNumber - 1, array);
 			}
 		}
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ColorDeconvolutionInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ColorDeconvolutionInfo.java
@@ -21,11 +21,7 @@
 
 package qupath.lib.display;
 
-import java.awt.image.BufferedImage;
-import java.awt.image.ColorModel;
-import java.awt.image.IndexColorModel;
-import java.util.Objects;
-
+import qupath.lib.awt.common.BufferedImageTools;
 import qupath.lib.color.ColorDeconvolutionHelper;
 import qupath.lib.color.ColorDeconvolutionStains;
 import qupath.lib.color.ColorToolsAwt;
@@ -34,7 +30,12 @@ import qupath.lib.color.ColorTransformer.ColorTransformMethod;
 import qupath.lib.common.ColorTools;
 import qupath.lib.images.ImageData;
 
-class RBGColorDeconvolutionInfo extends AbstractSingleChannelInfo {
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.IndexColorModel;
+import java.util.Objects;
+
+class ColorDeconvolutionInfo extends AbstractSingleChannelInfo {
 
 	private transient int stainNumber;
 	private transient ColorDeconvolutionStains stains;
@@ -44,7 +45,7 @@ class RBGColorDeconvolutionInfo extends AbstractSingleChannelInfo {
 
 	private ColorTransformMethod method;
 
-	public RBGColorDeconvolutionInfo(final ImageData<BufferedImage> imageData, ColorTransformMethod method) {
+	public ColorDeconvolutionInfo(final ImageData<BufferedImage> imageData, ColorTransformMethod method) {
 		super(imageData);
 		this.method = method;
 		switch (method) {
@@ -94,14 +95,32 @@ class RBGColorDeconvolutionInfo extends AbstractSingleChannelInfo {
 					true);
 		}
 	}
-	
-	
+
+	private static boolean isRGB(BufferedImage img) {
+		return BufferedImageTools.is8bitColorType(img.getType());
+	}
 
 	@Override
 	public float getValue(BufferedImage img, int x, int y) {
 		ensureStainsUpdated();
 		if (stains == null)
 			return 0f;
+		if (isRGB(img)) {
+			return getValueRGB(img, x, y);
+		} else {
+			float r = img.getRaster().getSampleFloat(x, y, 0);
+			float g = img.getRaster().getSampleFloat(x, y, 1);
+			float b = img.getRaster().getSampleFloat(x, y, 2);
+			if (method == ColorTransformer.ColorTransformMethod.Optical_density_sum) {
+				return r + g + b;
+			} else {
+				var invMat = stains.getMatrixInverse();
+				return (float) (r * invMat[0][stainNumber - 1] + g * invMat[1][stainNumber - 1] + b * invMat[2][stainNumber - 1]);
+			}
+		}
+	}
+
+	private float getValueRGB(BufferedImage img, int x, int y) {
 		int rgb = img.getRGB(x, y);
 		if (method == null)
 			return ColorTransformer.colorDeconvolveRGBPixel(rgb, stains, stainNumber-1);
@@ -110,7 +129,7 @@ class RBGColorDeconvolutionInfo extends AbstractSingleChannelInfo {
 			int g = ColorTools.green(rgb);
 			int b = ColorTools.blue(rgb);
 			return (float)(ColorDeconvolutionHelper.makeOD(r, stains.getMaxRed()) +
-					ColorDeconvolutionHelper.makeOD(g, stains.getMaxGreen()) + 
+					ColorDeconvolutionHelper.makeOD(g, stains.getMaxGreen()) +
 					ColorDeconvolutionHelper.makeOD(b, stains.getMaxBlue()));
 		} else
 			return ColorTransformer.getPixelValue(rgb, method, stains);
@@ -124,6 +143,26 @@ class RBGColorDeconvolutionInfo extends AbstractSingleChannelInfo {
 				return new float[w * h];
 			return array;
 		}
+		if (isRGB(img)) {
+			return getValuesRGB(img, x, y, w, h, array);
+		} else {
+			if (method == ColorTransformer.ColorTransformMethod.Optical_density_sum) {
+				// Reuse the array if we can
+				float[] r = ColorDeconvolutionHelper.getOpticalDensities(img.getRaster(), 0, stains.getMaxRed(), array);
+				float[] g = ColorDeconvolutionHelper.getOpticalDensities(img.getRaster(), 1, stains.getMaxGreen(), null);
+				float[] b = ColorDeconvolutionHelper.getOpticalDensities(img.getRaster(), 2, stains.getMaxBlue(), null);
+				array = r;
+				for (int i = 0; i < array.length; i++) {
+					array[i] = r[i] + g[i] + b[i];
+				}
+				return array;
+			} else {
+				return ColorTransformer.colorDeconvolve(img, stains, stainNumber - 1, array);
+			}
+		}
+	}
+
+	private float[] getValuesRGB(BufferedImage img, int x, int y, int w, int h, float[] array) {
 		int[] buffer = RGBDirectChannelInfo.getRGBIntBuffer(img);
 		if (buffer == null)
 			buffer = img.getRGB(x, y, w, h, null, 0, w);
@@ -183,7 +222,7 @@ class RBGColorDeconvolutionInfo extends AbstractSingleChannelInfo {
 	}
 	
 	@Override
-	public ColorTransformer.ColorTransformMethod getMethod() {
+	public ColorTransformMethod getMethod() {
 		return method;
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -168,7 +168,12 @@ public class ImageDisplay extends AbstractImageRenderer {
 	 */
 	public ImageDisplay() {
 		useGrayscaleLuts.addListener(this::handleUseGrayscaleLutsChange);
+		useInvertedBackground.addListener(this::handleInvertedBackgroundChange);
 		selectedChannels.addListener(this::handleSelectedChannelsChange);
+	}
+
+	private void handleInvertedBackgroundChange(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
+		saveChannelColorProperties();
 	}
 
 	private void handleSelectedChannelsChange(ListChangeListener.Change<? extends ChannelDisplayInfo> change) {
@@ -452,7 +457,7 @@ public class ImageDisplay extends AbstractImageRenderer {
 					.toList();
 		}
 
-		if (!availableChannels.equals(tempSelectedChannels)) {
+		if (!availableChannels.equals(tempChannelOptions)) {
 			availableChannels.setAll(tempChannelOptions);
 		}
 		if (!selectedChannels.equals(tempSelectedChannels)) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
@@ -232,9 +232,9 @@ class EstimateStainVectorsCommand {
 				rgb[i] = ColorTools.packRGB(r, g, b);
 			}
 
-			ColorTransformer.convertToOpticalDensity(red, stains.getMaxRed());
-			ColorTransformer.convertToOpticalDensity(green, stains.getMaxGreen());
-			ColorTransformer.convertToOpticalDensity(blue, stains.getMaxBlue());
+			ColorDeconvolutionHelper.convertToOpticalDensity(red, stains.getMaxRed());
+			ColorDeconvolutionHelper.convertToOpticalDensity(green, stains.getMaxGreen());
+			ColorDeconvolutionHelper.convertToOpticalDensity(blue, stains.getMaxBlue());
 		}
 
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -25,6 +25,7 @@ package qupath.lib.gui.commands;
 
 import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
+import java.awt.image.ImagingOpException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,9 +53,11 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.paint.Color;
 import qupath.lib.analysis.algorithms.EstimateStainVectors;
+import qupath.lib.awt.common.BufferedImageTools;
 import qupath.lib.color.ColorDeconvolutionHelper;
 import qupath.lib.color.ColorDeconvolutionStains;
 import qupath.lib.color.ColorToolsAwt;
+import qupath.lib.color.ColorTransformer;
 import qupath.lib.color.StainVector;
 import qupath.lib.common.ColorTools;
 import qupath.lib.common.GeneralTools;
@@ -89,12 +92,12 @@ class EstimateStainVectorsCommand {
 	private enum AxisColor {RED, GREEN, BLUE;
 		@Override
 		public String toString() {
-			switch(this) {
-			case RED: return "Red";
-			case GREEN: return "Green";
-			case BLUE: return "Blue";
-			default: throw new IllegalArgumentException();
-			}
+            return switch (this) {
+                case RED -> "Red";
+                case GREEN -> "Green";
+                case BLUE -> "Blue";
+                default -> throw new IllegalArgumentException();
+            };
 		}
 	};
 
@@ -104,13 +107,13 @@ class EstimateStainVectorsCommand {
 			GuiTools.showNoImageError(TITLE);
 			return;
 		}
-		if (!imageData.isBrightfield() || imageData.getServer() == null || !imageData.getServer().isRGB()) {
-			Dialogs.showErrorMessage(TITLE, "No brightfield, RGB image selected!");
+		if (!imageData.isBrightfield() || imageData.getServer() == null || imageData.getServer().nChannels() != 3) {
+			Dialogs.showErrorMessage(TITLE, "No brightfield, 3-channel image selected!");
 			return;
 		}
 		ColorDeconvolutionStains stains = imageData.getColorDeconvolutionStains();
 		if (stains == null || !stains.getStain(3).isResidual()) {
-			Dialogs.showErrorMessage(TITLE, "Sorry, stain editing is only possible for brightfield, RGB images with 2 stains");
+			Dialogs.showErrorMessage(TITLE, "Sorry, stain estimation is only possible for brightfield, 3-channel images with 2 stains");
 			return;
 		}
 		
@@ -128,23 +131,39 @@ class EstimateStainVectorsCommand {
 		} catch (IOException e) {
 			Dialogs.showErrorMessage("Estimate stain vectors", e);
 			logger.error("Unable to obtain pixels for {}", request, e);
+			return;
 		}
 		
 		// Apply small amount of smoothing to reduce compression artefacts
-		img = EstimateStainVectors.smoothImage(img);
+		try {
+			img = EstimateStainVectors.smoothImage(img);
+		} catch (ImagingOpException e) {
+				logger.warn("Unable to convolve image - will attempt stain estimation without smoothing");
+				logger.debug(e.getMessage(), e);
+		}
 		
 		// Check modes for background
-		int[] rgb = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
-		int[] rgbMode = EstimateStainVectors.getModeRGB(rgb);
-		int rMax = rgbMode[0];
-		int gMax = rgbMode[1];
-		int bMax = rgbMode[2];
-		
+		double rMax, gMax, bMax;
+		if (BufferedImageTools.is8bitColorType(img.getType())) {
+			int[] rgb = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
+			int[] rgbMode = EstimateStainVectors.getModeRGB(rgb);
+			rMax = rgbMode[0];
+			gMax = rgbMode[1];
+			bMax = rgbMode[2];
+		} else {
+			rMax = EstimateStainVectors.getMode(ColorDeconvolutionHelper.getPixels(img.getRaster(), 0), 256);
+			gMax = EstimateStainVectors.getMode(ColorDeconvolutionHelper.getPixels(img.getRaster(), 1), 256);
+			bMax = EstimateStainVectors.getMode(ColorDeconvolutionHelper.getPixels(img.getRaster(), 2), 256);
+		}
+
 		// Check if the background values may need to be changed
 		if (rMax != stains.getMaxRed() || gMax != stains.getMaxGreen() || bMax != stains.getMaxBlue()) {
 			ButtonType response =
 					Dialogs.showYesNoCancelDialog(TITLE,
-							String.format("Modal RGB values %d, %d, %d do not match current background values - do you want to use the modal values?", rMax, gMax, bMax));
+							String.format("Modal RGB values %s, %s, %s do not match current background values - do you want to use the modal values?",
+									GeneralTools.formatNumber(rMax, 2),
+									GeneralTools.formatNumber(gMax, 2),
+									GeneralTools.formatNumber(bMax, 2)));
 			if (response == ButtonType.CANCEL)
 				return;
 			else if (response == ButtonType.YES) {
@@ -155,13 +174,12 @@ class EstimateStainVectorsCommand {
 		
 		
 		ColorDeconvolutionStains stainsUpdated = null;
-		logger.info("Requesting region for stain vector editing: {}", request);
+		logger.info("Requesting region for stain vector estimation: {}", request);
 		try {
 			stainsUpdated = showStainEditor(img, stains);
 		} catch (Exception e) {
 			Dialogs.showErrorMessage(TITLE, "Error with stain estimation: " + e.getLocalizedMessage());
-			logger.error("{}", e.getLocalizedMessage(), e);
-//			JOptionPane.showMessageDialog(qupath.getFrame(), "Error with stain estimation: " + e.getLocalizedMessage(), "Estimate stain vectors", JOptionPane.ERROR_MESSAGE, null);
+			logger.error(e.getMessage(), e);
 			return;
 		}
 		if (!stains.equals(stainsUpdated)) {
@@ -188,16 +206,37 @@ class EstimateStainVectorsCommand {
 	
 	@SuppressWarnings("unchecked")
 	public static ColorDeconvolutionStains showStainEditor(final BufferedImage img, final ColorDeconvolutionStains stains) {
-		
-		// 
-		int[] buf = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
-//		int[] rgb = buf;
-		int[] rgb = EstimateStainVectors.subsample(buf, 10000);
-		
-		float[] red = ColorDeconvolutionHelper.getRedOpticalDensities(rgb, stains.getMaxRed(), null);
-		float[] green = ColorDeconvolutionHelper.getGreenOpticalDensities(rgb, stains.getMaxGreen(), null);
-		float[] blue = ColorDeconvolutionHelper.getBlueOpticalDensities(rgb, stains.getMaxBlue(), null);
-		
+
+		float[] red, green, blue;
+		int[] rgb;
+
+		if (BufferedImageTools.is8bitColorType(img.getType())) {
+			int[] buf = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
+			rgb = EstimateStainVectors.subsample(buf, 10000);
+
+			red = ColorDeconvolutionHelper.getRedOpticalDensities(rgb, stains.getMaxRed(), null);
+			green = ColorDeconvolutionHelper.getGreenOpticalDensities(rgb, stains.getMaxGreen(), null);
+			blue = ColorDeconvolutionHelper.getBlueOpticalDensities(rgb, stains.getMaxBlue(), null);
+		} else {
+			red = ColorDeconvolutionHelper.getPixels(img.getRaster(), 0, null);
+			green = ColorDeconvolutionHelper.getPixels(img.getRaster(), 1, null);
+			blue = ColorDeconvolutionHelper.getPixels(img.getRaster(), 2, null);
+
+			// TODO: Try to generate a sensible RGB color for each pixel
+			int n = red.length;
+			rgb = new int[n];
+			for (int i = 0; i < n; i++) {
+				int r = (int)GeneralTools.clipValue(red[i]/stains.getMaxRed()*255, 0, 255);
+				int g = (int)GeneralTools.clipValue(green[i]/stains.getMaxGreen()*255, 0, 255);
+				int b = (int)GeneralTools.clipValue(blue[i]/stains.getMaxBlue()*255, 0, 255);
+				rgb[i] = ColorTools.packRGB(r, g, b);
+			}
+
+			ColorTransformer.convertToOpticalDensity(red, stains.getMaxRed());
+			ColorTransformer.convertToOpticalDensity(green, stains.getMaxGreen());
+			ColorTransformer.convertToOpticalDensity(blue, stains.getMaxBlue());
+		}
+
 		
 //		panelPlots.setBorder(BorderFactory.createTitledBorder(null, "Stain vector scatterplots", TitledBorder.CENTER, TitledBorder.TOP));
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastHistogramPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastHistogramPane.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.lib.analysis.stats.Histogram;
 import qupath.lib.common.ColorTools;
+import qupath.lib.display.AdditiveChannelInfo;
 import qupath.lib.display.ChannelDisplayInfo;
 import qupath.lib.display.ImageDisplay;
 import qupath.lib.gui.charts.ChartThresholdPane;
@@ -174,6 +175,21 @@ public class BrightnessContrastHistogramPane extends BorderPane {
                     "original".equalsIgnoreCase(channelSelected.getName())) {
                 var allHistograms = getRGBHistograms(imageDisplay);
                 histogramChart.getHistogramData().setAll(allHistograms);
+            } else if (channelSelected instanceof AdditiveChannelInfo additive){
+                // The following code is commented out because it doesn't work as expected...
+                // The problem is that the histogram can exceed the 8-bit range that we use to control
+                // the min/max values for this image.
+                // This means that the histogram might be clipped in a confusing way.
+//                var newHistograms = new ArrayList<HistogramChart.HistogramData>();
+//                for (var channel : additive.getChannels()) {
+//                    var hist = imageDisplay.getHistogram(channel);
+//                    if (hist != null) {
+//                        var histogramData = HistogramChart.createHistogramData(hist, getColor(channel));
+//                        newHistograms.add(histogramData);
+//                    }
+//                }
+//                histogramChart.getHistogramData().setAll(newHistograms);
+                histogramChart.getHistogramData().clear();
             } else {
                 histogramChart.getHistogramData().clear();
             }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ImageDetailsPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ImageDetailsPane.java
@@ -379,7 +379,7 @@ public class ImageDetailsPane implements ChangeListener<ImageData<BufferedImage>
 	public static boolean promptToSetImageType(ImageData<BufferedImage> imageData, ImageType defaultType) {
 		double size = 32;
 		var group = new ToggleGroup();
-		boolean isRGB = imageData.getServer().isRGB();
+		boolean isRGB = imageData.getServerMetadata().getChannels().size() == 3; // v0.6.0 supports non-8-bit color deconvolution
 		if (defaultType == null)
 			defaultType = ImageType.UNSET;
 		var buttonMap = new LinkedHashMap<ImageType, ToggleButton>();


### PR DESCRIPTION
This PR relaxes the requirement that only 8-bit RGB images can be color deconvolved and/or set as brightfield.

It's intended to deal with the fact that whole slide scanners increasingly write brightfield images that aren't `uint8`, and QuPath would currently require the files to be converted. This can't easily be done automatically, because we don't know in general what the right 'maximum' value is to rescale each channel.

For example, see
* https://forum.image.sc/t/estimating-stain-vectors-no-brightfield-rgb-image-selected-error-message-keeps-popping-up-and-cannot-resolve/66246/9
* https://forum.image.sc/t/image-type-brightfield-not-available/67536/2
* https://forum.image.sc/t/vsi-and-qupath-detecting-stains-w-10bit-images/107221/4
* https://forum.image.sc/t/qupath-ihc-analysis-cell-detection-not-counted/109552/17

The PR doesn't currently support non-8-bit color deconvolution in *all* scenarios, but it should handle the main ones:
* Cell detection
* Display in the viewer
* Pixel classification
* Estimate stain vectors
* Use of `TransformedServerBuilder`

More might be added in time if they are needed.

> **Important!** This doesn't mean it's *recommended* to use a higher bit depth with brightfield images. QuPath is still expected to behave better and faster when handling brightfield images that can be represented using a packed (A)RGB integer for each pixel. I wouldn't expect a higher bit-depth to offer a meaningful improvement in precision, given the limitations of color deconvolution in general.