### PR TITLE
Fix deadlock when deleting image data on MacOS

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
+++ b/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java
@@ -861,7 +861,11 @@ class DefaultProject implements Project<BufferedImage> {
 						if (desktop.moveToTrash(path.toFile()))
 							return;
 					} else {
-						SwingUtilities.invokeLater(this::moveDataToTrash);
+						SwingUtilities.invokeLater(() -> {
+							if (!desktop.moveToTrash(path.toFile())) {
+								logger.warn("Unable to move {} to trash - please delete manually if required", path);
+							}
+						});
 						return;
 					}
 				}


### PR DESCRIPTION
This is an alternative to #1806 that fixes the following issue:

On MacOS with the latest build of QuPath, if I:

* Start QuPath.
* Create a new project.
* Import one image to the project, set the image type, save the image.
* Import another image to the project, set the image type, save the image.
* Restart QuPath.
* Open the project.
* Delete the first image entry with all associated image data.
* Delete the second image entry with all associated image data.

Then QuPath is stuck on the line [desktop.moveToTrash(path.toFile())](https://github.com/qupath/qupath/blob/a7084c636717c1d99d7e5a4d7e3d851ffc68bce5/qupath-core/src/main/java/qupath/lib/projects/DefaultProject.java#L861C11-L861C45), and the corresponding image data files are not sent to trash.

This may happen because the `moveDataToTrash()` function is `synchronized`. Since there is a recursive call within `moveDataToTrash()` from a different thread, a deadlock may appear (not 100% sure of the explananation). This PR removes the recursive call.