### PR TITLE
Add `ROI.hashCode()`, `ROI.equals()` and some tests

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
@@ -1163,8 +1163,6 @@ public class IJTools {
 //		if (roi instanceof ShapeRoi)
 //			return convertToAreaROI((ShapeRoi)roi, cal, downsampleFactor);
 //		// Shape ROIs should be able to handle most eventualities
-		if (roi instanceof ShapeRoi)
-			return ROIConverterIJ.convertToAreaROI((ShapeRoi)roi, xOrigin, yOrigin, downsampleFactor, c, z, t);
 		if (roi.isArea())
 			return ROIConverterIJ.convertToPolygonOrAreaROI(roi, xOrigin, yOrigin, downsampleFactor, c, z, t);
 		if (roi instanceof PolygonRoi) {

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/ROIConverterIJ.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/ROIConverterIJ.java
@@ -168,16 +168,10 @@ class ROIConverterIJ {
 	}
 	
 	static ROI convertToPolygonOrAreaROI(Roi roi, double xOrigin, double yOrigin, double downsampleFactor, final int c, final int z, final int t) {
-		Shape shape;
 		if (roi instanceof ShapeRoi shapeRoi)
-			shape = shapeRoi.getShape();
+			return convertToAreaROI(shapeRoi, xOrigin, yOrigin, downsampleFactor, c, z, t);
 		else
-			shape = new ShapeRoi(roi).getShape();
-		AffineTransform transform = new AffineTransform();
-		transform.scale(downsampleFactor, downsampleFactor);
-		transform.translate(roi.getXBase(), roi.getYBase());
-		transform.translate(-xOrigin, -yOrigin);
-		return ROIs.createAreaROI(new Area(transform.createTransformedShape(shape)), ImagePlane.getPlaneWithChannel(c, z, t));
+			return convertToAreaROI(new ShapeRoi(roi), xOrigin, yOrigin, downsampleFactor, c, z, t);
 	}
 	
 	static ROI convertToAreaROI(ShapeRoi roi, double xOrigin, double yOrigin, double downsampleFactor, final int c, final int z, final int t) {
@@ -186,7 +180,9 @@ class ROIConverterIJ {
 		transform.scale(downsampleFactor, downsampleFactor);
 		transform.translate(roi.getXBase(), roi.getYBase());
 		transform.translate(-xOrigin, -yOrigin);
-		return ROIs.createAreaROI(new Area(transform.createTransformedShape(shape)), ImagePlane.getPlaneWithChannel(c, z, t));
+		return RoiTools.getShapeROI(
+				new Area(transform.createTransformedShape(shape)),
+				ImagePlane.getPlaneWithChannel(c, z, t));
 	}
 	
 	

--- a/qupath-core/src/main/java/qupath/lib/roi/AbstractPathBoundedROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/AbstractPathBoundedROI.java
@@ -25,6 +25,8 @@ package qupath.lib.roi;
 
 import qupath.lib.regions.ImagePlane;
 
+import java.util.Objects;
+
 /**
  * Abstract implementation of any ROI that can be defined based on a bounding box, 
  * i.e. a rectangle or ellipse (both unrotated).
@@ -113,6 +115,21 @@ abstract class AbstractPathBoundedROI extends AbstractPathROI {
 	public double getBoundsHeight() {
 		return Math.abs(y - y2);
 	}
-	
-		
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass())
+			return false;
+		AbstractPathBoundedROI that = (AbstractPathBoundedROI) o;
+		return Double.compare(x, that.x) == 0 &&
+				Double.compare(y, that.y) == 0 &&
+				Double.compare(x2, that.x2) == 0 &&
+				Double.compare(y2, that.y2) == 0 &&
+				getImagePlane().equals(that.getImagePlane());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(x, y, x2, y2, getImagePlane());
+	}
 }

--- a/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
@@ -32,6 +32,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.locationtech.jts.geom.Geometry;
 
@@ -314,7 +315,19 @@ public class AreaROI extends AbstractPathROI implements Serializable {
 	public ROI updatePlane(ImagePlane plane) {
 		throw new UnsupportedOperationException("Updating the plane for an AreaROI is not supported!");
 	}
-	
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass())
+			return false;
+		AreaROI that = (AreaROI) o;
+		return Objects.equals(getImagePlane(), that.getImagePlane()) && Objects.equals(getGeometry(), that.getGeometry());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getGeometry(), getImagePlane());
+	}
 	
 	private Object writeReplace() {
 		return new SerializationProxy(this);

--- a/qupath-core/src/main/java/qupath/lib/roi/ConvexHull.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/ConvexHull.java
@@ -43,23 +43,21 @@ public class ConvexHull {
 
 	
 	/**
-	 * TODO: Consider a more efficient convex hull calculation.
-	 * 
 	 * For implementation details, see
 	 * <ul>
 	 * 	<li>http://en.wikipedia.org/wiki/Gift_wrapping_algorithm</li>
 	 * 	<li>http://en.wikipedia.org/wiki/Graham_scan</li>
 	 * </ul>
 	 * 
-	 * @param points 
-	 * @return
+	 * @param points a list of points from which a convex hull should be determined
+	 * @return a new list containing only points on the convex hull of the original points
 	 */
 	public static List<Point2> getConvexHull(List<Point2> points) {
 		if (points == null || points.isEmpty())
 			return null;
 		
 		// Find the left-most point
-		Point2 pointOnHull = points.get(0);
+		Point2 pointOnHull = points.getFirst();
 		for (Point2 p : points) {
 			if (p.getX() < pointOnHull.getX())
 				pointOnHull = p;
@@ -69,7 +67,7 @@ public class ConvexHull {
 		while (true) {
 //			logger.info("Adding: " + pointOnHull);
 			hull.add(pointOnHull);
-			Point2 endPoint = points.get(0);
+			Point2 endPoint = points.getFirst();
 			double dx = endPoint.getX() - pointOnHull.getX();
 			double dy = endPoint.getY() - pointOnHull.getY();
 			for (Point2 s : points) {
@@ -82,12 +80,10 @@ public class ConvexHull {
 				}
 			}
 			pointOnHull = endPoint;
-			if (endPoint.equals(hull.get(0))) {
+			if (endPoint.equals(hull.getFirst())) {
 				logger.trace("Original points: {}, Convex hull points: {}", points.size(), hull.size());
 				return hull;
 			}
-//			if (endPoint == hull.get(0) || endPoint.distanceSq(hull.get(0)) < 0.00000001)
-//				return hull;
 		}
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/roi/DefaultMutableVertices.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/DefaultMutableVertices.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -24,6 +24,7 @@
 package qupath.lib.roi;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,9 +41,9 @@ import qupath.lib.geom.Point2;
  */
 class DefaultMutableVertices implements Vertices, MutableVertices {
 	
-	static Logger logger = LoggerFactory.getLogger(DefaultMutableVertices.class);
+	private static final Logger logger = LoggerFactory.getLogger(DefaultMutableVertices.class);
 	
-	private DefaultVertices vertices;
+	private final DefaultVertices vertices;
 	
 	DefaultMutableVertices(final DefaultVertices vertices) {
 		this.vertices = vertices;
@@ -202,7 +203,19 @@ class DefaultMutableVertices implements Vertices, MutableVertices {
 		return new DefaultMutableVertices((DefaultVertices)vertices.duplicate());
 	}
 
-//	@Override
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+		DefaultMutableVertices that = (DefaultMutableVertices) o;
+		return Objects.equals(vertices, that.vertices);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(vertices);
+	}
+
+	//	@Override
 //	public VerticesIterator getIterator() {
 //		return vertices.getIterator();
 //	}

--- a/qupath-core/src/main/java/qupath/lib/roi/DefaultVertices.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/DefaultVertices.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2020, 2022, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -26,6 +26,7 @@ package qupath.lib.roi;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +46,7 @@ import qupath.lib.geom.Point2;
  */
 class DefaultVertices implements Vertices {
 	
-	static Logger logger = LoggerFactory.getLogger(DefaultVertices.class);
+	private static final Logger logger = LoggerFactory.getLogger(DefaultVertices.class);
 	
 	static int DEFAULT_CAPACITY = 16;
 	
@@ -181,7 +182,7 @@ class DefaultVertices implements Vertices {
 	 */
 	@Override
 	public List<Point2> getPoints() {
-		List<Point2> points = new ArrayList<>();
+		List<Point2> points = new ArrayList<>(size);
 		for (int i = 0; i < size; i++)
 			points.add(new Point2(x[i], y[i]));
 		return points;
@@ -233,7 +234,19 @@ class DefaultVertices implements Vertices {
 		return v;
 	}
 
-//	@Override
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+		DefaultVertices that = (DefaultVertices) o;
+		return size == that.size && Objects.deepEquals(x, that.x) && Objects.deepEquals(y, that.y);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(size, Arrays.hashCode(x), Arrays.hashCode(y));
+	}
+
+	//	@Override
 //	public VerticesIterator getIterator() {
 //		return new DefaultVerticesIterator(this);
 //	}

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryROI.java
@@ -27,6 +27,7 @@ import java.awt.geom.Path2D;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.locationtech.jts.algorithm.locate.IndexedPointInAreaLocator;
 import org.locationtech.jts.algorithm.locate.PointOnGeometryLocator;
@@ -103,6 +104,11 @@ public class GeometryROI extends AbstractPathROI implements Serializable {
 		if (geometry instanceof Polygonal && geometry.getNumPoints() > 1000) {
 			logger.trace("Creating IndexedPointInAreaLocator for large geometry");
 			cachedLocator = new IndexedPointInAreaLocator(geometry);
+		}
+		// Check the precision model & warn if it doesn't match
+		if (!Objects.equals(geometry.getPrecisionModel(), GeometryTools.getDefaultFactory().getPrecisionModel())) {
+			logger.warn("Geometry precision model for ROI {} does not match default precision model {}",
+					geometry.getPrecisionModel(), GeometryTools.getDefaultFactory().getPrecisionModel());
 		}
 	}
 

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryROI.java
@@ -74,6 +74,9 @@ public class GeometryROI extends AbstractPathROI implements Serializable {
 	
 	private transient GeometryStats stats = null;
 
+	// May be expensive
+	private transient int hashCode;
+
 	/**
 	 * Cache a locator for faster 'contains' checks.
 	 */
@@ -374,7 +377,22 @@ public class GeometryROI extends AbstractPathROI implements Serializable {
 				plane);
 	}
 
-//	@Override
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+		GeometryROI that = (GeometryROI) o;
+		return Objects.equals(getImagePlane(), that.getImagePlane()) && Objects.equals(geometry, that.geometry);
+	}
+
+	@Override
+	public int hashCode() {
+		if (hashCode == 0) {
+			hashCode = Objects.hash(geometry, getImagePlane());
+		}
+		return hashCode;
+	}
+
+	//	@Override
 //	public double getMaxDiameter() {
 //		return getGeometryStats().getMaxDiameter();
 //	}

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -423,13 +423,23 @@ public class GeometryTools {
     
     /**
      * Convert a JTS Geometry to a QuPath ROI.
-     * @param geometry
-     * @param plane 
-     * @return
+	 * @param geometry the geometry from which to create a ROI
+     * @param plane the plane that should contain the ROI
+     * @return a new ROI
      */
     public static ROI geometryToROI(Geometry geometry, ImagePlane plane) {
     	return DEFAULT_INSTANCE.geometryToROI(geometry, plane);
     }
+
+	/**
+	 * Convert a JTS Geometry to a QuPath ROI on the default image plane.
+	 * @param geometry the geometry from which to create a ROI
+	 * @return a new ROI
+	 * @see ImagePlane#getDefaultPlane()
+	 */
+	public static ROI geometryToROI(Geometry geometry) {
+		return geometryToROI(geometry, ImagePlane.getDefaultPlane());
+	}
     
     /**
      * Convert to QuPath ROI to a JTS Geometry.
@@ -1037,8 +1047,8 @@ public class GeometryTools {
 	    }
 	    
 	    private Geometry areaToGeometry(ROI roi) {
-	    	if (roi.isEmpty())
-	    		return factory.createPolygon();
+//	    	if (roi.isEmpty())
+//	    		return factory.createPolygon();
 	    	if (roi instanceof EllipseROI || roi instanceof RectangleROI) {
 	    		var shapeFactory = new GeometricShapeFactory(factory);
 	    		shapeFactory.setEnvelope(
@@ -1081,9 +1091,15 @@ public class GeometryTools {
 //		    	polygonizer.add(lineString.union());
 //		    	return polygonizer.getGeometry();
 //	    	}
-	    	
-	    	Area shape = RoiTools.getArea(roi);
-	    	return areaToGeometry(shape);
+
+			if (roi.isEmpty()) {
+				var shape = RoiTools.getShape(roi);
+				var iterator = shape.getPathIterator(transform, flatness);
+				return getShapeReader().read(iterator);
+			} else {
+				Area area = RoiTools.getArea(roi);
+				return areaToGeometry(area);
+			}
 	    }
 	    
 	    private Geometry shapeToGeometry(Shape shape) {
@@ -1447,9 +1463,25 @@ public class GeometryTools {
 	    		List<Point2> points = Arrays.stream(coords).map(c -> new Point2(c.x, c.y)).toList();
 	    		return ROIs.createPointsROI(points, plane);
 	    	}
-	    	// For anything complicated, return a Geometry ROI
-	    	if (geometry.getNumGeometries() > 1 || (geometry instanceof Polygon && ((Polygon)geometry).getNumInteriorRing() > 0))
+	    	// For multi-part geometries, return a Geometry ROI
+	    	if (geometry.getNumGeometries() > 1)
 	    		return new GeometryROI(geometry, plane);
+			if (geometry instanceof Polygon polygon) {
+				// For polygons with holes, return a Geometry ROI
+				if (polygon.getNumInteriorRing() > 0)
+					return new GeometryROI(polygon, plane);
+				// For non-rectangular polygons without holes, return a polygon ROI
+				// This avoid the issue where a polygon with zero area can lead to a 'general'
+				// empty ROI being returned, rather than one with the appropriate vertices
+				if (!polygon.isRectangle()) {
+					var points = Arrays.stream(polygon.getCoordinates())
+							.map(coord -> new Point2(coord.x, coord.y))
+							.toList();
+					// TODO: Consider if/when we could convert this to a Rectangle when it *is* a
+					// rectangle with zero area
+					return ROIs.createPolygonROI(points, plane);
+				}
+			}
 	    	// Otherwise return a (possibly easier to edit) ROI
 	        return RoiTools.getShapeROI(geometryToShape(geometry), plane, flatness);
 	    }

--- a/qupath-core/src/main/java/qupath/lib/roi/LineROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/LineROI.java
@@ -31,6 +31,7 @@ import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import qupath.lib.geom.Point2;
 import qupath.lib.regions.ImagePlane;
@@ -239,7 +240,23 @@ public class LineROI extends AbstractPathROI implements Serializable {
 	public ROI getConvexHull() {
 		return this;
 	}
-	
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+		LineROI lineROI = (LineROI) o;
+		return Double.compare(x, lineROI.x) == 0 &&
+				Double.compare(y, lineROI.y) == 0 &&
+				Double.compare(x2, lineROI.x2) == 0 &&
+				Double.compare(y2, lineROI.y2) == 0 &&
+				getImagePlane().equals(lineROI.getImagePlane());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(x, y, x2, y2, getImagePlane());
+	}
+
 	private Object writeReplace() {
 		return new SerializationProxy(this);
 	}

--- a/qupath-core/src/main/java/qupath/lib/roi/PointsROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PointsROI.java
@@ -30,6 +30,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+
 import qupath.lib.geom.Point2;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.interfaces.ROI;
@@ -46,15 +48,10 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 	
 	private final List<Point2> points = new ArrayList<>();
 	
-//	// Point radius no longer sorted internally (it's really a display thing)
-//	@Deprecated
-//	protected double pointRadius = -1;
-	
 	private transient double xMin = Double.NaN, yMin = Double.NaN, xMax = Double.NaN, yMax = Double.NaN;
 	private transient double xCentroid = Double.NaN, yCentroid = Double.NaN;
 	private transient ROI convexHull = null;
-//	protected transient Point2 pointAdjusting = null;
-	
+
 	PointsROI() {
 		this(Double.NaN, Double.NaN);
 	}
@@ -84,25 +81,6 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 			addPoint(x[i], y[i]);
 		recomputeBounds();
 	}
-	
-	
-	
-	
-	
-//	public double getPointRadius() {
-//		if (pointRadius >= 0)
-//			return pointRadius;
-//		return defaultPointRadius;
-//	}
-//	
-//	
-//	/**
-//	 * Set radius for drawing points; if < 0, the default radius (specified in PathPrefs) will be used.
-//	 * @param radius
-//	 */
-//	public void setPointRadius(double radius) {
-//		pointRadius = radius;
-//	}
 
 
 	@Override
@@ -157,34 +135,6 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 		}
 		return pClosest;
 	}
-
-
-//	@Deprecated
-//	public boolean startAdjusting(double x, double y, int modifiers) {
-//		Point2 pNearest = getNearest(x, y, PointsROI.getDefaultPointRadius());
-//		if (pNearest == null)
-//			return false;
-////		logger.info("STARTING: " + p);
-//		pointAdjusting = pNearest;
-//		pNearest.setLocation(x, y);
-//		isAdjusting = true;
-//		return true;
-//	}
-//
-//	@Override
-//	public void finishAdjusting(double x, double y, boolean shiftDown) {
-//		super.finishAdjusting(x, y, shiftDown);
-//		pointAdjusting = null;
-//		recomputeBounds();
-//	}
-//	
-//	
-//	@Override
-//	public void updateAdjustment(double x, double y, boolean shiftDown) {
-//		if (pointAdjusting != null) {
-//			pointAdjusting.setLocation(x, y);
-//		}
-//	}
 	
 	
 	protected void recomputeBounds() {
@@ -213,19 +163,6 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 			yMax = y;
 	}
 	
-	
-//	public boolean removePoint(Point2 p) {
-////		logger.info("Removing " + p + " from " + points.size());
-//		if (points.remove(p)) {
-//			// Update the bounds (this is overly-conservative... if checked how far inside, update may be unnecessary)
-//			recomputeBounds();
-//			// Reset convex hull (again overly-conservative...)
-//			convexHull = null;
-//			return true;
-//		}
-//		return false;
-//	}
-	
 	private void addPoint(double x, double y) {
 //		addPoint(x, y, -1);
 		// Can't add NaN
@@ -233,18 +170,7 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 			return;
 		points.add(new Point2(x, y));
 	}
-	
-	
-	
-//	public void updateAdjustment(double x, double y, double maxDist, int modifiers) {
-//		if ((modifiers & MouseEvent.ALT_DOWN_MASK) != 0) {
-//			Point2D p = getNearest(x, y, maxDist);
-//			if (p != null)
-//				points.remove(p);
-//		}
-//		else
-//			points.add(new Point2D.Double(x, y));
-//	}
+
 
 	/**
 	 * A Points ROI is empty if it contains no points (*not* if its bounds have no width or height...
@@ -263,8 +189,6 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 	
 	@Override
 	public String toString() {
-//		if (getName() != null)
-//			return String.format("%s (%d points)", getName(), points.size());			
 		return String.format("%s (%d points)", getRoiName(), points.size());
 	}
 	
@@ -288,9 +212,7 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 	@Override
 	@Deprecated
 	public ROI duplicate() {
-		PointsROI roi = new PointsROI(points, getImagePlane());
-//		roi.setPointRadius(pointRadius);
-		return roi;
+		return new PointsROI(points, getImagePlane());
 	}
 
 	@Override
@@ -304,22 +226,6 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 		return convexHull;
 	}
 
-//	@Override
-//	public double getConvexArea() {
-//		PathArea hull = getConvexHull();
-//		if (hull != null)
-//			return hull.getArea();
-//		return Double.NaN;
-//	}
-//	
-//	@Override
-//	public double getScaledConvexArea(double pixelWidth, double pixelHeight) {
-//		PathArea hull = getConvexHull();
-//		if (hull != null)
-//			return hull.getScaledArea(pixelWidth, pixelHeight);
-//		return Double.NaN;
-//	}
-
 	
 	private void resetBounds() {
 		xMin = Double.NaN;
@@ -327,11 +233,6 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 		xMax = Double.NaN;
 		yMax = Double.NaN;		
 	}
-	
-//	public void resetMeasurements() {
-//		resetBounds();
-//		convexHull = null;
-//	}
 
 	@Override
 	public double getBoundsX() {
@@ -352,32 +253,6 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 	public double getBoundsHeight() {
 		return yMax - yMin;
 	}
-
-//	@Override
-//	public void writeExternal(ObjectOutput out) throws IOException {
-//		out.writeInt(1); // Version
-//		out.writeDouble(pointRadius);
-//		out.writeInt(points.size());
-//		for (Point2 p : points) {
-//			out.writeDouble(p.getX());
-//			out.writeDouble(p.getY());
-//		}
-//	}
-//
-//	@Override
-//	public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-//		int version = in.readInt();
-//		if (version != 1) {
-//			logger.error("Unknown Point ROI version " + version);
-//		}
-//		pointRadius = in.readDouble();
-//		int nPoints = in.readInt();
-//		points = new ArrayList<>();
-//		for (int i = 0; i < nPoints; i++) {
-//			points.add(new Point2(in.readDouble(), in.readDouble()));
-//		}
-//	}
-	
 	
 	/**
 	 * It is not possible to convert a PointROI to a java.awt.Shape.
@@ -393,14 +268,6 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 		throw new UnsupportedOperationException("PointROI does not support createShape()!");
 	}
 	
-//	/**
-//	 * throws UnsupportedOperationException
-//	 */
-//	@Override
-//	public Geometry getGeometry() throws UnsupportedOperationException {
-//		throw new UnsupportedOperationException("PointROI does not support getGeometry()!");
-//	}
-	
 	
 	@Override
 	public RoiType getRoiType() {
@@ -414,8 +281,28 @@ public class PointsROI extends AbstractPathROI implements Serializable {
 				points,
 				plane);
 	}
-	
-	
+
+
+	/**
+	 * Test if this ROI is equal to another.
+	 * Note that this requires the other object to be a PointsROI on the same plane, with the same points in the
+	 * same order.
+	 * @param o the object to test
+	 * @return true if the objects are equal, false otherwise
+	 */
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+		PointsROI pointsROI = (PointsROI) o;
+		return Objects.equals(points, pointsROI.points)
+				&& Objects.equals(getImagePlane(), pointsROI.getImagePlane());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(points, getImagePlane());
+	}
+
 	private Object writeReplace() {
 		return new SerializationProxy(this);
 	}

--- a/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
@@ -90,7 +90,7 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 //		vertices.close();
 	}
 	
-	PolygonROI(List<Point2> points, ImagePlane plane) {
+	PolygonROI(List<? extends Point2> points, ImagePlane plane) {
 		super(plane);
 //		vertices = VerticesFactory.createMutableVertices(points.size()+1);
 //		setPoints(points);

--- a/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
@@ -30,6 +30,8 @@ import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.lang.ref.SoftReference;
 import java.util.List;
+import java.util.Objects;
+
 import org.locationtech.jts.geom.Geometry;
 
 import org.locationtech.jts.operation.predicate.RectangleIntersects;
@@ -63,6 +65,9 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 	 */
 	private transient SoftReference<Geometry> cachedGeometry;
 
+	// Hash code may be expensive to calculate
+	private transient int hashCode;
+
 	PolygonROI() {
 		super();
 	}
@@ -85,16 +90,10 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 	PolygonROI(double x, double y, ImagePlane plane) {
 		super(plane);
 		vertices = VerticesFactory.createVertices(new float[]{(float)x, (float)x}, new float[]{(float)y, (float)y}, false);
-//		vertices = VerticesFactory.createMutableVertices();
-//		vertices.add(x, y);
-//		vertices.close();
 	}
 	
 	PolygonROI(List<? extends Point2> points, ImagePlane plane) {
 		super(plane);
-//		vertices = VerticesFactory.createMutableVertices(points.size()+1);
-//		setPoints(points);
-//		vertices.close();
 		float[] x = new float[points.size()];
 		float[] y = new float[points.size()];
 		for (int i = 0; i < points.size(); i++) {
@@ -108,13 +107,6 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 	
 	PolygonROI(float[] x, float[] y, ImagePlane plane) {
 		this(x, y, plane, true);
-//		List<Point2> points = new ArrayList<>();
-//		for (int i = 0; i < x.length; i++) {
-//			points.add(new Point2(x[i], y[i]));
-//		}
-//		vertices = VerticesFactory.createMutableVertices(points.size()+1);
-//		setPoints(points);
-//		vertices.close();
 	}
 	
 	
@@ -122,14 +114,6 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 		super(plane);
 		vertices = VerticesFactory.createVertices(x, y, copyVertices);
 	}
-	
-	
-//	public PolygonROI(Vertices vertices, int c, int z, int t) {
-//		super(c, z, t);
-//		this.vertices = Vertices.createMutableVertices(vertices.size());
-//		setPoints(vertices.getPoints()); // TODO: Implement this more efficiency, if it remains...
-//		isAdjusting = false;
-//	}
 
 
 	@Override
@@ -177,6 +161,8 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 	 */
 	@Override
 	public double getCentroidX() {
+		if (vertices.size() == 1)
+			return vertices.getX(0);
 		if (stats == null)
 			calculateShapeMeasurements();
 		return stats.getCentroidX();
@@ -187,6 +173,8 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 	 */
 	@Override
 	public double getCentroidY() {
+		if (vertices.size() == 1)
+			return vertices.getY(0);
 		if (stats == null)
 			calculateShapeMeasurements();
 		return stats.getCentroidY();
@@ -248,6 +236,8 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 	 */
 	@Override
 	public double getArea() {
+		if (vertices.size() <= 2)
+			return 0;
 		if (stats == null)
 			calculateShapeMeasurements();
 		return stats.getArea();
@@ -258,6 +248,8 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 	 */
 	@Override
 	public double getLength() {
+		if (getNumPoints() <= 1)
+			return 0;
 		if (stats == null)
 			calculateShapeMeasurements();
 		return stats.getPerimeter();
@@ -320,25 +312,10 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 		return vertices;
 	}
 	
-//	public VerticesIterator getVerticesIterator() {
-//		return vertices.getIterator();
-//	}
-	
 	
 	void calculateShapeMeasurements() {
 		stats = new ClosedShapeStatistics(vertices);
 	}
-	
-	
-//	void setPoints(List<Point2> points) {
-//		vertices.clear();
-//		vertices.ensureCapacity(points.size() + 1);
-//		for (Point2 p : points) {
-//			vertices.add(p.getX(), p.getY());
-//		}
-//		vertices.close();
-//		resetCachedMeasurements();
-//	}
 
 
 	/* (non-Javadoc)
@@ -407,24 +384,24 @@ public class PolygonROI extends AbstractPathROI implements Serializable {
 		return stats.getBoundsHeight();
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+		PolygonROI that = (PolygonROI) o;
+		// TODO: Consider that this may be inefficient
+		return Objects.equals(getImagePlane(), that.getImagePlane()) &&
+				vertices.size() == that.vertices.size() &&
+				Objects.equals(vertices.getPoints(), that.vertices.getPoints());
+	}
 
-//	@Override
-//	public void writeExternal(ObjectOutput out) throws IOException {
-//		// Write x & y arrays (reusing same array)
-//		float[] x = vertices.getX(null);
-//		super.wr
-//		out.writeObject(x);
-//		out.writeObject(vertices.getY(x));
-//	}
-//
-//
-//	@Override
-//	public void readExternal(ObjectInput in) throws IOException,
-//			ClassNotFoundException {
-//		// TODO Auto-generated method stub
-//		
-//	}
-	
+	@Override
+	public int hashCode() {
+		if (hashCode == 0) {
+			hashCode = Objects.hash(vertices.getPoints(), getImagePlane());
+		}
+		return hashCode;
+	}
+
 	private Object writeReplace() {
 		return new SerializationProxy(this);
 	}

--- a/qupath-core/src/main/java/qupath/lib/roi/PolylineROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PolylineROI.java
@@ -54,9 +54,7 @@ public class PolylineROI extends AbstractPathROI implements Serializable {
 	
 	private transient PolylineStats stats;
 
-	private transient SoftReference<Shape> shape;
-	
-	PolylineROI(List<Point2> points, ImagePlane plane) {
+	PolylineROI(List<? extends Point2> points, ImagePlane plane) {
 		super(plane);
 		float[] x = new float[points.size()];
 		float[] y = new float[points.size()];

--- a/qupath-core/src/main/java/qupath/lib/roi/PolylineROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PolylineROI.java
@@ -31,6 +31,8 @@ import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.lang.ref.SoftReference;
 import java.util.List;
+import java.util.Objects;
+
 import qupath.lib.common.GeneralTools;
 import qupath.lib.geom.Point2;
 import qupath.lib.regions.ImagePlane;
@@ -53,6 +55,9 @@ public class PolylineROI extends AbstractPathROI implements Serializable {
 	private Vertices vertices;
 	
 	private transient PolylineStats stats;
+
+	// Hash code may be expensive to calculate
+	private transient int hashCode;
 
 	PolylineROI(List<? extends Point2> points, ImagePlane plane) {
 		super(plane);
@@ -175,7 +180,7 @@ public class PolylineROI extends AbstractPathROI implements Serializable {
 		private double length = 0;
 		
 		PolylineStats(final Vertices vertices, final double pixelWidth, final double pixelHeight) {
-			if (vertices.size() == 0) {
+			if (vertices.isEmpty()) {
 				return;
 			}
 			this.length = 0;
@@ -290,6 +295,22 @@ public class PolylineROI extends AbstractPathROI implements Serializable {
 		return getShapeInternal().intersects(x, y, width, height);
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+		PolylineROI that = (PolylineROI) o;
+		return getImagePlane().equals(that.getImagePlane()) &&
+				vertices.size() == that.vertices.size() &&
+				Objects.equals(vertices.getPoints(), that.vertices.getPoints());
+	}
+
+	@Override
+	public int hashCode() {
+		if (hashCode == 0) {
+			hashCode = Objects.hash(getImagePlane(), vertices);
+		}
+		return hashCode;
+	}
 
 	private Object writeReplace() {
 		return new SerializationProxy(this);

--- a/qupath-core/src/main/java/qupath/lib/roi/ROIs.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/ROIs.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.locationtech.jts.geom.Geometry;
 import qupath.lib.geom.Point2;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.regions.ImageRegion;
@@ -43,7 +44,7 @@ import qupath.lib.roi.interfaces.ROI;
 public class ROIs {
 
 	/**
-	 * Create an 'empty' ROI with no length or area.
+	 * Create an 'empty' ROI with no length or area on the default image plane.
 	 * 
 	 * <p>The only guarantee is that it will return {@code isEmpty() == true}
 	 * 
@@ -67,22 +68,36 @@ public class ROIs {
 	
 	/**
 	 * Create a rectangle ROI defined by its bounding box.
-	 * 
-	 * @param x
-	 * @param y
-	 * @param width
-	 * @param height
-	 * @param plane
-	 * @return
+	 *
+	 * @param x x coordinate of the top left of the rectangle
+	 * @param y y coordinate of the top left of the rectangle
+	 * @param width width of the rectangle
+	 * @param height height of the rectangle
+	 * @param plane the image plane where the rectangle should be located
+	 * @return a new rectangle ROI
 	 */
 	public static ROI createRectangleROI(double x, double y, double width, double height, ImagePlane plane) {
 		return new RectangleROI(x, y, width, height, plane);
 	}
+
+	/**
+	 * Create a rectangle ROI defined by its bounding box on the default image plane.
+	 *
+	 * @param x x coordinate of the top left of the rectangle
+	 * @param y y coordinate of the top left of the rectangle
+	 * @param width width of the rectangle
+	 * @param height height of the rectangle
+	 * @return a new rectangle ROI
+	 * @see ImagePlane#getDefaultPlane()
+	 */
+	public static ROI createRectangleROI(double x, double y, double width, double height) {
+		return createRectangleROI(x, y, width, height, ImagePlane.getDefaultPlane());
+	}
 	
 	/**
 	 * Create a rectangle ROI that matches an ImageRegion.
-	 * @param region
-	 * @return
+	 * @param region an image region defining the rectangle location
+	 * @return a new rectangle ROI
 	 */
 	public static ROI createRectangleROI(ImageRegion region) {
 		return new RectangleROI(region.getX(), region.getY(), region.getWidth(), region.getHeight(), region.getImagePlane());
@@ -90,23 +105,37 @@ public class ROIs {
 
 	/**
 	 * Create an ellipse ROI defined by its bounding box.
-	 * 
-	 * @param x
-	 * @param y
-	 * @param width
-	 * @param height
-	 * @param plane
-	 * @return
+	 *
+	 * @param x x coordinate of the top left of the ellipse bounding box
+	 * @param y y coordinate of the top left of the ellipse bounding box
+	 * @param width width of the ellipse bounding box
+	 * @param height height of the ellipse bounding box
+	 * @param plane the image plane where the rectangle should be located
+	 * @return a new ellipse ROI
 	 */
 	public static ROI createEllipseROI(double x, double y, double width, double height, ImagePlane plane) {
 		return new EllipseROI(x, y, width, height, plane);
 	}
 
 	/**
+	 * Create an ellipse ROI defined by its bounding box on the default image plane.
+	 *
+	 * @param x x coordinate of the top left of the ellipse bounding box
+	 * @param y y coordinate of the top left of the ellipse bounding box
+	 * @param width width of the ellipse bounding box
+	 * @param height height of the ellipse bounding box
+	 * @return a new ellipse ROI
+	 * @see ImagePlane#getDefaultPlane()
+	 */
+	public static ROI createEllipseROI(double x, double y, double width, double height) {
+		return createEllipseROI(x, y, width, height, ImagePlane.getDefaultPlane());
+	}
+
+	/**
 	 * Create an ellipse ROI defined by its bounding box.
 	 *
-	 * @param region
-	 * @return
+	 * @param region an image region defining the ellipse location
+	 * @return a new ellipse ROI
 	 */
 	public static ROI createEllipseROI(ImageRegion region) {
 		return createEllipseROI(region.getX(), region.getY(), region.getWidth(), region.getHeight(), region.getImagePlane());
@@ -115,24 +144,38 @@ public class ROIs {
 	/**
 	 * Create a line ROI with start and end coordinates.
 	 * 
-	 * @param x
-	 * @param y
-	 * @param x2
-	 * @param y2
-	 * @param plane
-	 * @return
+	 * @param x the start x coordinate
+	 * @param y the start y coordinate
+	 * @param x2 the end x coordinate
+	 * @param y2 the end y coordinate
+	 * @param plane the plane containing the ROI
+	 * @return a new line ROI
 	 */
 	public static ROI createLineROI(double x, double y, double x2, double y2, ImagePlane plane) {
 		return new LineROI(x, y, x2, y2, plane);
 	}
 
 	/**
+	 * Create a line ROI with start and end coordinates on the default image plane.
+	 *
+	 * @param x the start x coordinate
+	 * @param y the start y coordinate
+	 * @param x2 the end x coordinate
+	 * @param y2 the end y coordinate
+	 * @return a new line ROI
+	 * @see ImagePlane#getDefaultPlane()
+	 */
+	public static ROI createLineROI(double x, double y, double x2, double y2) {
+		return createLineROI(x, y, x2, y2, ImagePlane.getDefaultPlane());
+	}
+
+	/**
 	 * Create a ROI representing a line with zero length.
 	 * 
-	 * @param x
-	 * @param y
-	 * @param plane
-	 * @return
+	 * @param x the start and end x coordinate
+	 * @param y the start and end y coordinate
+	 * @param plane the plane containing the ROI
+	 * @return a new line ROI
 	 */
 	public static ROI createLineROI(double x, double y, ImagePlane plane) {
 		return createLineROI(x, y, x, y, plane);
@@ -140,43 +183,73 @@ public class ROIs {
 	
 	/**
 	 * Create an empty points ROI.
-	 * 
-	 * @param plane
-	 * @return
+	 * @param plane the plane that should contain the ROI
+	 * @return a new points ROI
 	 */
 	public static ROI createPointsROI(ImagePlane plane) {
 		return createPointsROI(Double.NaN, Double.NaN, plane);
 	}
 
 	/**
+	 * Create an empty points ROI on the default image plane.
+	 * @return a new points ROI
+	 * @see ImagePlane#getDefaultPlane()
+	 */
+	public static ROI createPointsROI() {
+		return createPointsROI(ImagePlane.getDefaultPlane());
+	}
+
+	/**
 	 * Create a points ROI containing a single point.
-	 * @param x
-	 * @param y
-	 * @param plane
-	 * @return
+	 * @param x x coordinate of the point
+	 * @param y y coordinate of the point
+	 * @param plane the plane that should contain the ROI
+	 * @return a new point ROI
 	 */
 	public static ROI createPointsROI(double x, double y, ImagePlane plane) {
 		return new PointsROI(x, y, plane);
 	}
+
+	/**
+	 * Create a points ROI containing a single point on the default image plane.
+	 * @param x x coordinate of the point
+	 * @param y y coordinate of the point
+	 * @return a new point ROI
+	 * @see ImagePlane#getDefaultPlane()
+	 */
+	public static ROI createPointsROI(double x, double y) {
+		return createPointsROI(x, y, ImagePlane.getDefaultPlane());
+	}
 	
 	/**
 	 * Create a points ROI from a list of points.
-	 * @param points
-	 * @param plane
-	 * @return
+	 * @param points a list of points to include
+	 * @param plane the image plane containing the ROI
+	 * @return a new points ROI
 	 */
 	public static ROI createPointsROI(List<? extends Point2> points, ImagePlane plane) {
 		return new PointsROI(points, plane);
 	}
+
+	/**
+	 * Create a points ROI from a list of points on the default image plane.
+	 * @param points a list of points to include
+	 * @return a new points ROI
+	 * @see ImagePlane#getDefaultPlane()
+	 */
+	public static ROI createPointsROI(List<? extends Point2> points) {
+		return createPointsROI(points, ImagePlane.getDefaultPlane());
+	}
 	
 	/**
 	 * Create a points ROI from an array of x and y coordinates.
-	 * @param x
-	 * @param y
-	 * @param plane
-	 * @return
+	 * @param x x coordinates for the points
+	 * @param y y coordinates for the points
+	 * @param plane the image plane to contain the ROI
+	 * @return a new points ROI
+	 * @throws IllegalArgumentException if x and y have a different length
 	 */
-	public static ROI createPointsROI(double[] x, double[] y, ImagePlane plane) {
+	public static ROI createPointsROI(double[] x, double[] y, ImagePlane plane) throws IllegalArgumentException {
 		if (x.length != y.length)
 			throw new IllegalArgumentException("Point arrays have different lengths!");
 		var points = new ArrayList<Point2>();
@@ -187,22 +260,33 @@ public class ROIs {
 
 	/**
 	 * Create a closed polygon ROI from a list of points.
-	 * @param points
-	 * @param plane
-	 * @return
+	 * @param points the vertices of the polygon
+	 * @param plane the plane containing the ROI
+	 * @return a new polygon ROI
 	 */
-	public static PolygonROI createPolygonROI(List<Point2> points, ImagePlane plane) {
+	public static PolygonROI createPolygonROI(List<? extends Point2> points, ImagePlane plane) {
 		return new PolygonROI(points, plane);
+	}
+
+	/**
+	 * Create a closed polygon ROI from a list of points on the default image plane.
+	 * @param points the vertices of the polygon
+	 * @return a new polygon ROI
+	 * @see ImagePlane#getDefaultPlane()
+	 */
+	public static PolygonROI createPolygonROI(List<? extends Point2> points) {
+		return createPolygonROI(points, ImagePlane.getDefaultPlane());
 	}
 	
 	/**
 	 * Create a polygon ROI from an array of x and y coordinates.
-	 * @param x
-	 * @param y
-	 * @param plane
-	 * @return
+	 * @param x x coordinates of the polygon vertices
+	 * @param y y coordinates of the polygon vertices
+	 * @param plane the plane containing the ROI
+	 * @return a new polygon ROI
+	 * @throws IllegalArgumentException if x and y have a different length
 	 */
-	public static ROI createPolygonROI(double[] x, double[] y, ImagePlane plane) {
+	public static ROI createPolygonROI(double[] x, double[] y, ImagePlane plane) throws IllegalArgumentException {
 		if (x.length != y.length)
 			throw new IllegalArgumentException("Arrays have different lengths!");
 		var points = new ArrayList<Point2>();
@@ -215,10 +299,10 @@ public class ROIs {
 	/**
 	 * Create an empty, closed polygon ROI consisting of a single point.
 	 * 
-	 * @param x
-	 * @param y
-	 * @param plane
-	 * @return
+	 * @param x x coordinate for the only polygon point
+	 * @param y y coordinate for the only polygon point
+	 * @param plane the image plane containing the ROI
+	 * @return a new polygon ROI
 	 */
 	public static PolygonROI createPolygonROI(double x, double y, ImagePlane plane) {
 		return new PolygonROI(Collections.singletonList(new Point2(x, y)), plane);
@@ -266,13 +350,15 @@ public class ROIs {
 	 * <p>
 	 * The resulting ROI may consist of multiple disconnected regions, possibly containing holes.
 	 * 
-	 * @param shape
-	 * @param plane
-	 * @return
+	 * @param shape the shape for the ROI
+	 * @param plane the plane that should contain the ROI
+	 * @return a new ROI representing the shape
+	 * @deprecated v0.6.0, use {@link RoiTools#getShapeROI(Shape, ImagePlane, double)} instead.
+	 *             This method does not necessarily give the expected results for shapes that do not represent an area.
 	 */
+	@Deprecated
 	public static ROI createAreaROI(Shape shape, ImagePlane plane) {
 		return new GeometryROI(GeometryTools.shapeToGeometry(shape), plane);
-//		return new AWTAreaROI(shape, plane);
 	}
 
 }

--- a/qupath-core/src/main/java/qupath/lib/roi/ROIs.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/ROIs.java
@@ -89,6 +89,7 @@ public class ROIs {
 	 * @param height height of the rectangle
 	 * @return a new rectangle ROI
 	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
 	 */
 	public static ROI createRectangleROI(double x, double y, double width, double height) {
 		return createRectangleROI(x, y, width, height, ImagePlane.getDefaultPlane());
@@ -126,6 +127,7 @@ public class ROIs {
 	 * @param height height of the ellipse bounding box
 	 * @return a new ellipse ROI
 	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
 	 */
 	public static ROI createEllipseROI(double x, double y, double width, double height) {
 		return createEllipseROI(x, y, width, height, ImagePlane.getDefaultPlane());
@@ -164,6 +166,7 @@ public class ROIs {
 	 * @param y2 the end y coordinate
 	 * @return a new line ROI
 	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
 	 */
 	public static ROI createLineROI(double x, double y, double x2, double y2) {
 		return createLineROI(x, y, x2, y2, ImagePlane.getDefaultPlane());
@@ -194,6 +197,7 @@ public class ROIs {
 	 * Create an empty points ROI on the default image plane.
 	 * @return a new points ROI
 	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
 	 */
 	public static ROI createPointsROI() {
 		return createPointsROI(ImagePlane.getDefaultPlane());
@@ -216,6 +220,7 @@ public class ROIs {
 	 * @param y y coordinate of the point
 	 * @return a new point ROI
 	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
 	 */
 	public static ROI createPointsROI(double x, double y) {
 		return createPointsROI(x, y, ImagePlane.getDefaultPlane());
@@ -236,6 +241,7 @@ public class ROIs {
 	 * @param points a list of points to include
 	 * @return a new points ROI
 	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
 	 */
 	public static ROI createPointsROI(List<? extends Point2> points) {
 		return createPointsROI(points, ImagePlane.getDefaultPlane());
@@ -259,6 +265,19 @@ public class ROIs {
 	}
 
 	/**
+	 * Create a points ROI from an array of x and y coordinates on the default image plane.
+	 * @param x x coordinates for the points
+	 * @param y y coordinates for the points
+	 * @return a new points ROI
+	 * @throws IllegalArgumentException if x and y have a different length
+	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
+	 */
+	public static ROI createPointsROI(double[] x, double[] y) throws IllegalArgumentException {
+		return createPointsROI(x, y, ImagePlane.getDefaultPlane());
+	}
+
+	/**
 	 * Create a closed polygon ROI from a list of points.
 	 * @param points the vertices of the polygon
 	 * @param plane the plane containing the ROI
@@ -273,6 +292,7 @@ public class ROIs {
 	 * @param points the vertices of the polygon
 	 * @return a new polygon ROI
 	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
 	 */
 	public static PolygonROI createPolygonROI(List<? extends Point2> points) {
 		return createPolygonROI(points, ImagePlane.getDefaultPlane());
@@ -295,6 +315,19 @@ public class ROIs {
 		return new PolygonROI(points, plane);
 	}
 
+	/**
+	 * Create a polygon ROI from an array of x and y coordinates on the default image plane
+	 * @param x x coordinates of the polygon vertices
+	 * @param y y coordinates of the polygon vertices
+	 * @return a new polygon ROI
+	 * @throws IllegalArgumentException if x and y have a different length
+	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
+	 */
+	public static ROI createPolygonROI(double[] x, double[] y) throws IllegalArgumentException {
+		return createPolygonROI(x, y, ImagePlane.getDefaultPlane());
+	}
+
 	
 	/**
 	 * Create an empty, closed polygon ROI consisting of a single point.
@@ -307,42 +340,91 @@ public class ROIs {
 	public static PolygonROI createPolygonROI(double x, double y, ImagePlane plane) {
 		return new PolygonROI(Collections.singletonList(new Point2(x, y)), plane);
 	}
+
+	/**
+	 * Create an empty, closed polygon ROI consisting of a single point on the default image plane.
+	 *
+	 * @param x x coordinate for the only polygon point
+	 * @param y y coordinate for the only polygon point
+	 * @return a new polygon ROI
+	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
+	 */
+	public static PolygonROI createPolygonROI(double x, double y) {
+		return createPolygonROI(x, y, ImagePlane.getDefaultPlane());
+	}
 	
 	/**
 	 * Create a polyline ROI from a list of points.
-	 * @param points
-	 * @param plane
-	 * @return
+	 * @param points the vertices of the polyline
+	 * @param plane the plane containing the ROI
+	 * @return a new polyline ROI
 	 */
-	public static PolylineROI createPolylineROI(List<Point2> points, ImagePlane plane) {
+	public static PolylineROI createPolylineROI(List<? extends Point2> points, ImagePlane plane) {
 		return new PolylineROI(points, plane);
+	}
+
+	/**
+	 * Create a polyline ROI from a list of points on the default image plane.
+	 * @param points the vertices of the polyline
+	 * @return a new polyline ROI
+	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
+	 */
+	public static PolylineROI createPolylineROI(List<? extends Point2> points) {
+		return createPolylineROI(points, ImagePlane.getDefaultPlane());
 	}
 	
 	/**
 	 * Create an empty polyline ROI consisting of a single point.
-	 * @param x
-	 * @param y
-	 * @param plane
-	 * @return
+	 * @param x x coordinate of the point
+	 * @param y y coordinate of the point
+	 * @param plane the image plane containing the ROI
+	 * @return a new polyline ROI
 	 */
 	public static PolylineROI createPolylineROI(double x, double y, ImagePlane plane) {
-		return new PolylineROI(Collections.singletonList(new Point2(x, y)), plane);
+		return createPolylineROI(Collections.singletonList(new Point2(x, y)), plane);
+	}
+
+	/**
+	 * Create an empty polyline ROI consisting of a single point on the default iamge plane.
+	 * @param x x coordinate of the point
+	 * @param y y coordinate of the point
+	 * @return a new polyline ROI
+	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
+	 */
+	public static PolylineROI createPolylineROI(double x, double y) {
+		return createPolylineROI(x, y, ImagePlane.getDefaultPlane());
 	}
 	
 	/**
-	 * Create a polygon ROI from an array of x and y coordinates.
-	 * @param x
-	 * @param y
-	 * @param plane
-	 * @return
+	 * Create a polyline ROI from an array of x and y coordinates.
+	 * @param x x coordinates of the polyline vertices
+	 * @param y y coordinates of the polyline vertices
+	 * @return a new polygon ROI
+	 * @throws IllegalArgumentException if x and y have a different length
 	 */
-	public static ROI createPolylineROI(double[] x, double[] y, ImagePlane plane) {
+	public static ROI createPolylineROI(double[] x, double[] y, ImagePlane plane) throws IllegalArgumentException {
 		if (x.length != y.length)
 			throw new IllegalArgumentException("Arrays have different lengths!");
 		var points = new ArrayList<Point2>();
 		for (int i = 0; i < x.length; i++)
 			points.add(new Point2(x[i], y[i]));
 		return new PolylineROI(points, plane);
+	}
+
+	/**
+	 * Create a polyline ROI from an array of x and y coordinates on the default image plane.
+	 * @param x x coordinates of the polyline vertices
+	 * @param y y coordinates of the polyline vertices
+	 * @return a new polygon ROI
+	 * @throws IllegalArgumentException if x and y have a different length
+	 * @see ImagePlane#getDefaultPlane()
+	 * @since v0.6.0
+	 */
+	public static ROI createPolylineROI(double[] x, double[] y) throws IllegalArgumentException {
+		return createPolylineROI(x, y, ImagePlane.getDefaultPlane());
 	}
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -456,14 +456,14 @@ public class RoiTools {
 				// Remove end point if it is a duplicate of the start point
 				// since the polygon will be closed anyway
 				// This avoids a point being 'doubled-up' when rotating a rectangle
-				var pStart = points.get(0);
-				var pEnd = points.get(points.size()-1);
+				var pStart = points.getFirst();
+				var pEnd = points.getLast();
 				if (pEnd.equals(pStart))
-					points.remove(points.size()-1);
+					points.removeLast();
 			}
 			return ROIs.createPolygonROI(points, plane);
 		}
-		return ROIs.createAreaROI(area, plane);		
+		return new GeometryROI(GeometryTools.shapeToGeometry(area), plane);
 	}
 	
 	
@@ -709,7 +709,7 @@ public class RoiTools {
 						tile = ROIs.createRectangleROI(bounds2.getX(), bounds2.getY(), bounds2.getWidth(), bounds2.getHeight(), roi.getImagePlane());
 					}
 					else
-						tile = ROIs.createAreaROI(tileArea, roi.getImagePlane());
+						tile = RoiTools.getShapeROI(tileArea, roi.getImagePlane());
 				}
 				//				tile.setName("Tile " + (++ind));
 				tiles.add(tile);

--- a/qupath-core/src/main/java/qupath/lib/roi/Vertices.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/Vertices.java
@@ -35,29 +35,29 @@ import qupath.lib.geom.Point2;
  */
 interface Vertices {
 
-	public abstract boolean isEmpty();
+	boolean isEmpty();
 
-	public abstract int size();
+	int size();
 
-	public abstract float[] getX(float[] xArray);
+	float[] getX(float[] xArray);
 
-	public abstract float[] getY(float[] yArray);
+	float[] getY(float[] yArray);
 
-	public abstract Point2 get(int idx);
+	Point2 get(int idx);
 
-	public abstract float getX(int idx);
+	float getX(int idx);
 
-	public abstract float getY(int idx);
+	float getY(int idx);
 
-	public abstract List<Point2> getPoints();
+	List<Point2> getPoints();
 	
-	public Vertices duplicate();
+	Vertices duplicate();
 
 	/**
 	 * Compact the storage if possible, e.g. by trimming arrays used internally.
 	 */
-	public abstract void compact();
+	abstract void compact();
 		
-//	public VerticesIterator getIterator();
+//	VerticesIterator getIterator();
 
 }

--- a/qupath-core/src/test/java/qupath/lib/roi/TestEllipseROI.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestEllipseROI.java
@@ -1,0 +1,100 @@
+package qupath.lib.roi;
+
+import org.junit.jupiter.api.Test;
+import qupath.lib.regions.ImagePlane;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class TestEllipseROI {
+
+    @Test
+    public void testArea() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 20);
+        assertEquals(Math.PI * 10 * 10, roi.getArea());
+    }
+
+    @Test
+    public void testPerimeter() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 20);
+        assertEquals(Math.PI * 20, roi.getLength());
+    }
+
+    @Test
+    public void testEquals() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 30);
+        var roi2 = ROIs.createEllipseROI(0, 10, 20, 30);
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testEqualsDuplicate() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 30);
+        var roi2 = roi.duplicate();
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testEqualsConvex() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 30);
+        var roi2 = roi.getConvexHull();
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsX() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 30);
+        var roi2 = ROIs.createEllipseROI(1, 10, 20, 30);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsY() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 30);
+        var roi2 = ROIs.createEllipseROI(0, 9, 20, 30);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsWidth() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 30);
+        var roi2 = ROIs.createEllipseROI(0, 10, 21, 30);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsHeight() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 30);
+        var roi2 = ROIs.createEllipseROI(0, 10, 20, 31);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneZ() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 30, ImagePlane.getDefaultPlane());
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(1, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneT() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 30, ImagePlane.getDefaultPlane());
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(0, 1));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneC() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 30, ImagePlane.getDefaultPlane());
+        var roi2 = roi.updatePlane(ImagePlane.getPlaneWithChannel(1, 0, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsRectangle() {
+        var roi = ROIs.createEllipseROI(0, 10, 20, 30);
+        var roi2 = ROIs.createRectangleROI(0, 10, 20, 30);
+        assertNotEquals(roi, roi2);
+    }
+
+}

--- a/qupath-core/src/test/java/qupath/lib/roi/TestGeometryROI.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestGeometryROI.java
@@ -1,0 +1,101 @@
+package qupath.lib.roi;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.GeometryFactory;
+import qupath.lib.regions.ImagePlane;
+import qupath.lib.roi.interfaces.ROI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestGeometryROI {
+
+    private static final GeometryFactory factory = GeometryTools.getDefaultFactory();
+
+    @Test
+    public void testArea() {
+        var roi = GeometryTools.createRectangle(0, 10, 20, 30);
+        assertEquals(20*30, roi.getArea());
+    }
+
+    @Test
+    public void testEmpty() {
+        var roi = GeometryTools.geometryToROI(factory.createEmpty(2));
+        assertTrue(roi.isEmpty());
+    }
+
+    @Test
+    public void testNotEmpty() {
+        var roi = GeometryTools.createRectangle(0, 1, 2, 3);
+        assertFalse(roi.isEmpty());
+    }
+
+    @Test
+    public void testEmptyCentroid() {
+        // This test fails! Polygon.isRectangle() returns false if the width or height is 0,
+        // and conversion to a Java Area results in an empty area... leading to an empty ROI.
+        var roi = GeometryTools.geometryToROI(
+                GeometryTools.createRectangle(0, 1, 2, 0));
+        assertEquals(1, roi.getCentroidX());
+        assertEquals(1, roi.getCentroidY());
+    }
+
+    private static ROI createGeometryROI(double x, double y) {
+        var rect = GeometryTools.createRectangle(x, y, 100, 200);
+        var geom = rect.difference(rect.buffer(-10));
+        return GeometryTools.geometryToROI(geom);
+    }
+
+    @Test
+    public void testEquals() {
+        var roi = createGeometryROI(5, 10);
+        var roi2 = createGeometryROI(5, 10);
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testEqualsDuplicate() {
+        var roi = createGeometryROI(5, 10);
+        var roi2 = roi.duplicate();
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsX() {
+        var roi = createGeometryROI(5, 10);
+        var roi2 = createGeometryROI(6, 10);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsY() {
+        var roi = createGeometryROI(5, 10);
+        var roi2 = createGeometryROI(5, 11);
+        assertNotEquals(roi, roi2);
+    }
+
+
+    @Test
+    public void testNotEqualsPlaneZ() {
+        var roi = createGeometryROI(5, 10);
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(1, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneT() {
+        var roi = createGeometryROI(5, 10);
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(0, 1));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneC() {
+        var roi = createGeometryROI(5, 10);
+        var roi2 = roi.updatePlane(ImagePlane.getPlaneWithChannel(1, 0, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+}

--- a/qupath-core/src/test/java/qupath/lib/roi/TestLineROI.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestLineROI.java
@@ -1,0 +1,113 @@
+package qupath.lib.roi;
+
+import org.junit.jupiter.api.Test;
+import qupath.lib.regions.ImagePlane;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestLineROI {
+
+    @Test
+    public void testArea() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30);
+        assertEquals(0, roi.getArea());
+    }
+
+    @Test
+    public void testEmpty() {
+        var roi = ROIs.createLineROI(0, 10, 0, 10);
+        assertTrue(roi.isEmpty());
+    }
+
+    @Test
+    public void testNotEmpty() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30);
+        assertFalse(roi.isEmpty());
+    }
+
+    @Test
+    public void testLength() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30);
+        assertEquals(Math.sqrt(800), roi.getLength());
+    }
+
+    @Test
+    public void testNumPoints() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30);
+        assertEquals(2, roi.getNumPoints());
+    }
+
+    @Test
+    public void testEquals() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30);
+        var roi2 = ROIs.createLineROI(0, 10, 20, 30);
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testEqualsDuplicate() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30);
+        var roi2 = roi.duplicate();
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testEqualsConvex() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30);
+        var roi2 = roi.getConvexHull();
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsX() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30);
+        var roi2 = ROIs.createLineROI(1, 10, 20, 30);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsY() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30);
+        var roi2 = ROIs.createLineROI(0, 9, 20, 30);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsX2() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30);
+        var roi2 = ROIs.createLineROI(0, 10, 21, 30);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsY2() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30);
+        var roi2 = ROIs.createLineROI(0, 10, 20, 31);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneZ() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30, ImagePlane.getDefaultPlane());
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(1, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneT() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30, ImagePlane.getDefaultPlane());
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(0, 1));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneC() {
+        var roi = ROIs.createLineROI(0, 10, 20, 30, ImagePlane.getDefaultPlane());
+        var roi2 = roi.updatePlane(ImagePlane.getPlaneWithChannel(1, 0, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+}

--- a/qupath-core/src/test/java/qupath/lib/roi/TestPointsROI.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestPointsROI.java
@@ -1,0 +1,120 @@
+package qupath.lib.roi;
+
+import org.junit.jupiter.api.Test;
+import qupath.lib.geom.Point2;
+import qupath.lib.regions.ImagePlane;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestPointsROI {
+
+    @Test
+    public void testArea() {
+        var roi = ROIs.createPointsROI(0, 10);
+        assertEquals(0, roi.getArea());
+    }
+
+    @Test
+    public void testEmpty() {
+        var roi = ROIs.createPointsROI();
+        assertTrue(roi.isEmpty());
+        assertEquals(0, roi.getNumPoints());
+    }
+
+    private static List<Point2> createPoints(int n) {
+        List<Point2> points = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            points.add(new Point2(i, i*2+1));
+        }
+        return points;
+    }
+
+    @Test
+    public void testNotEmpty() {
+        var roi = ROIs.createPointsROI(0, 10);
+        assertFalse(roi.isEmpty());
+    }
+
+    @Test
+    public void testLength() {
+        var roi = ROIs.createPointsROI(createPoints(10));
+        assertEquals(0, roi.getLength());
+    }
+
+    @Test
+    public void testNumPoints() {
+        int n = 10;
+        var roi = ROIs.createPointsROI(createPoints(n));
+        assertEquals(n, roi.getNumPoints());
+    }
+
+    @Test
+    public void testEquals() {
+        var roi = ROIs.createPointsROI(createPoints(5));
+        var roi2 = ROIs.createPointsROI(createPoints(5));
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testEqualsDuplicate() {
+        var roi = ROIs.createPointsROI(createPoints(5));
+        var roi2 = roi.duplicate();
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsX() {
+        var roi = ROIs.createPointsROI(0, 10);
+        var roi2 = ROIs.createPointsROI(1, 10);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsY() {
+        var roi = ROIs.createPointsROI(0, 10);
+        var roi2 = ROIs.createPointsROI(0, 11);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsX2() {
+        var roi = ROIs.createPointsROI(List.of(new Point2(1, 1), new Point2(2, 2), new Point2(3, 3)));
+        var roi2 = ROIs.createPointsROI(List.of(new Point2(1, 1), new Point2(1, 2), new Point2(3, 3)));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsY2() {
+        var roi = ROIs.createPointsROI(List.of(new Point2(1, 1), new Point2(2, 2), new Point2(3, 3)));
+        var roi2 = ROIs.createPointsROI(List.of(new Point2(1, 1), new Point2(2, 1), new Point2(3, 3)));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneZ() {
+        var roi = ROIs.createPointsROI(createPoints(4));
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(1, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneT() {
+        var roi = ROIs.createPointsROI(createPoints(4));
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(0, 1));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneC() {
+        var roi = ROIs.createPointsROI(createPoints(4));
+        var roi2 = roi.updatePlane(ImagePlane.getPlaneWithChannel(1, 0, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+}

--- a/qupath-core/src/test/java/qupath/lib/roi/TestPolygonROI.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestPolygonROI.java
@@ -1,0 +1,145 @@
+package qupath.lib.roi;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import qupath.lib.geom.Point2;
+import qupath.lib.regions.ImagePlane;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestPolygonROI {
+
+    @Test
+    public void testArea() {
+        var roi = ROIs.createPolygonROI(0, 10);
+        assertEquals(0, roi.getArea());
+    }
+
+    @Test
+    public void testEmpty() {
+        var roi = ROIs.createPolygonROI(createPoints(1));
+        assertTrue(roi.isEmpty());
+        assertEquals(1, roi.getNumPoints());
+    }
+
+    private static List<Point2> createPoints(int n) {
+        List<Point2> points = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            points.add(new Point2(i, i*2+1));
+        }
+        return points;
+    }
+
+    @Test
+    public void testNotEmpty() {
+        var roi = ROIs.createPolygonROI(List.of(new Point2(0, 0), new Point2(0, 1), new Point2(1, 0)));
+        assertFalse(roi.isEmpty());
+    }
+
+    @Test
+    public void testEmptyCentroid() {
+        var roi = ROIs.createPolygonROI(List.of(new Point2(0, 1), new Point2(1, 2)));
+        assertEquals(0.5, roi.getCentroidX());
+        assertEquals(1.5, roi.getCentroidY());
+    }
+
+    @Test
+    public void testGeometryEmptyCentroid() {
+        var roi = ROIs.createPolygonROI(List.of(new Point2(0, 1), new Point2(1, 2)));
+        var geom = roi.getGeometry();
+        assertEquals(new Coordinate(0.5, 1.5), geom.getCentroid().getCoordinate());
+    }
+
+    @Test
+    public void testGeometryNonEmptyCentroid() {
+        var roi = ROIs.createPolygonROI(List.of(new Point2(0, 100), new Point2(100, 200), new Point2(0, 300)));
+        var geom = roi.getGeometry();
+        var centroid = geom.getCentroid().getCoordinate();
+        assertEquals(roi.getCentroidX(), centroid.getX(), 1e-2);
+        assertEquals(roi.getCentroidY(), centroid.getY(), 1e-2);
+    }
+
+    @Test
+    public void testLength() {
+        var points = createPoints(2);
+        var roi = ROIs.createPolygonROI(points);
+        assertEquals(points.getFirst().distance(points.getLast())*2, roi.getLength());
+    }
+
+    @Test
+    public void testNumPoints() {
+        int n = 10;
+        var roi = ROIs.createPolygonROI(createPoints(n));
+        assertEquals(n, roi.getNumPoints());
+    }
+
+    @Test
+    public void testEquals() {
+        var roi = ROIs.createPolygonROI(createPoints(5));
+        var roi2 = ROIs.createPolygonROI(createPoints(5));
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testEqualsDuplicate() {
+        var roi = ROIs.createPolygonROI(createPoints(5));
+        var roi2 = roi.duplicate();
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsX() {
+        var roi = ROIs.createPolygonROI(0, 10);
+        var roi2 = ROIs.createPolygonROI(1, 10);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsY() {
+        var roi = ROIs.createPolygonROI(0, 10);
+        var roi2 = ROIs.createPolygonROI(0, 11);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsX2() {
+        var roi = ROIs.createPolygonROI(List.of(new Point2(1, 1), new Point2(2, 2), new Point2(3, 3)));
+        var roi2 = ROIs.createPolygonROI(List.of(new Point2(1, 1), new Point2(1, 2), new Point2(3, 3)));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsY2() {
+        var roi = ROIs.createPolygonROI(List.of(new Point2(1, 1), new Point2(2, 2), new Point2(3, 3)));
+        var roi2 = ROIs.createPolygonROI(List.of(new Point2(1, 1), new Point2(2, 1), new Point2(3, 3)));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneZ() {
+        var roi = ROIs.createPolygonROI(createPoints(4));
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(1, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneT() {
+        var roi = ROIs.createPolygonROI(createPoints(4));
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(0, 1));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneC() {
+        var roi = ROIs.createPolygonROI(createPoints(4));
+        var roi2 = roi.updatePlane(ImagePlane.getPlaneWithChannel(1, 0, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+}

--- a/qupath-core/src/test/java/qupath/lib/roi/TestPolylineROI.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestPolylineROI.java
@@ -1,0 +1,145 @@
+package qupath.lib.roi;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import qupath.lib.geom.Point2;
+import qupath.lib.regions.ImagePlane;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestPolylineROI {
+
+    @Test
+    public void testArea() {
+        var roi = ROIs.createPolylineROI(0, 10);
+        assertEquals(0, roi.getArea());
+    }
+
+    @Test
+    public void testEmpty() {
+        var roi = ROIs.createPolylineROI(List.of());
+        assertTrue(roi.isEmpty());
+        assertEquals(0, roi.getNumPoints());
+    }
+
+    private static List<Point2> createPoints(int n) {
+        List<Point2> points = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            points.add(new Point2(i, i*2+1));
+        }
+        return points;
+    }
+
+    @Test
+    public void testNotEmpty() {
+        var roi = ROIs.createPolylineROI(List.of(new Point2(0, 0), new Point2(0, 1), new Point2(1, 0)));
+        assertFalse(roi.isEmpty());
+    }
+
+    @Test
+    public void testEmptyCentroid() {
+        var roi = ROIs.createPolylineROI(List.of(new Point2(0, 1), new Point2(1, 2)));
+        assertEquals(0.5, roi.getCentroidX());
+        assertEquals(1.5, roi.getCentroidY());
+    }
+
+    @Test
+    public void testGeometryEmptyCentroid() {
+        var roi = ROIs.createPolylineROI(List.of(new Point2(0, 1), new Point2(1, 2)));
+        var geom = roi.getGeometry();
+        assertEquals(new Coordinate(0.5, 1.5), geom.getCentroid().getCoordinate());
+    }
+
+    @Test
+    public void testGeometryNonEmptyCentroid() {
+        var roi = ROIs.createPolylineROI(List.of(new Point2(0, 100), new Point2(100, 200), new Point2(0, 300)));
+        var geom = roi.getGeometry();
+        var centroid = geom.getCentroid().getCoordinate();
+        assertEquals(roi.getCentroidX(), centroid.getX(), 1e-2);
+        assertEquals(roi.getCentroidY(), centroid.getY(), 1e-2);
+    }
+
+    @Test
+    public void testLength() {
+        var points = createPoints(2);
+        var roi = ROIs.createPolylineROI(points);
+        assertEquals(points.getFirst().distance(points.getLast()), roi.getLength());
+    }
+
+    @Test
+    public void testNumPoints() {
+        int n = 10;
+        var roi = ROIs.createPolylineROI(createPoints(n));
+        assertEquals(n, roi.getNumPoints());
+    }
+
+    @Test
+    public void testEquals() {
+        var roi = ROIs.createPolylineROI(createPoints(5));
+        var roi2 = ROIs.createPolylineROI(createPoints(5));
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testEqualsDuplicate() {
+        var roi = ROIs.createPolylineROI(createPoints(5));
+        var roi2 = roi.duplicate();
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsX() {
+        var roi = ROIs.createPolylineROI(0, 10);
+        var roi2 = ROIs.createPolylineROI(1, 10);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsY() {
+        var roi = ROIs.createPolylineROI(0, 10);
+        var roi2 = ROIs.createPolylineROI(0, 11);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsX2() {
+        var roi = ROIs.createPolylineROI(List.of(new Point2(1, 1), new Point2(2, 2), new Point2(3, 3)));
+        var roi2 = ROIs.createPolylineROI(List.of(new Point2(1, 1), new Point2(1, 2), new Point2(3, 3)));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsY2() {
+        var roi = ROIs.createPolylineROI(List.of(new Point2(1, 1), new Point2(2, 2), new Point2(3, 3)));
+        var roi2 = ROIs.createPolylineROI(List.of(new Point2(1, 1), new Point2(2, 1), new Point2(3, 3)));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneZ() {
+        var roi = ROIs.createPolylineROI(createPoints(4));
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(1, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneT() {
+        var roi = ROIs.createPolylineROI(createPoints(4));
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(0, 1));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneC() {
+        var roi = ROIs.createPolylineROI(createPoints(4));
+        var roi2 = roi.updatePlane(ImagePlane.getPlaneWithChannel(1, 0, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+}

--- a/qupath-core/src/test/java/qupath/lib/roi/TestRectangleROI.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestRectangleROI.java
@@ -1,0 +1,99 @@
+package qupath.lib.roi;
+
+import org.junit.jupiter.api.Test;
+import qupath.lib.regions.ImagePlane;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class TestRectangleROI {
+
+    @Test
+    public void testArea() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30);
+        assertEquals(600, roi.getArea());
+    }
+
+    @Test
+    public void testPerimeter() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30);
+        assertEquals(100, roi.getLength());
+    }
+
+    @Test
+    public void testNumPoints() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30);
+        assertEquals(4, roi.getNumPoints());
+    }
+
+    @Test
+    public void testEquals() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30);
+        var roi2 = ROIs.createRectangleROI(0, 10, 20, 30);
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testEqualsDuplicate() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30);
+        var roi2 = roi.duplicate();
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testEqualsConvex() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30);
+        var roi2 = roi.getConvexHull();
+        assertEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsX() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30);
+        var roi2 = ROIs.createRectangleROI(1, 10, 20, 30);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsY() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30);
+        var roi2 = ROIs.createRectangleROI(0, 9, 20, 30);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsWidth() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30);
+        var roi2 = ROIs.createRectangleROI(0, 10, 21, 30);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsHeight() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30);
+        var roi2 = ROIs.createRectangleROI(0, 10, 20, 31);
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneZ() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30, ImagePlane.getDefaultPlane());
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(1, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneT() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30, ImagePlane.getDefaultPlane());
+        var roi2 = roi.updatePlane(ImagePlane.getPlane(0, 1));
+        assertNotEquals(roi, roi2);
+    }
+
+    @Test
+    public void testNotEqualsPlaneC() {
+        var roi = ROIs.createRectangleROI(0, 10, 20, 30, ImagePlane.getDefaultPlane());
+        var roi2 = roi.updatePlane(ImagePlane.getPlaneWithChannel(1, 0, 0));
+        assertNotEquals(roi, roi2);
+    }
+
+}


### PR DESCRIPTION
This is a PR that escalated...

The original idea: make it easy to check if two ROIs are the same. Until now, `ROI.equals(ROI.duplicate())` does *not* return `true`, because `ROI.equals()` is not implemented.

Along the way, I also introduced methods to `ROIs` that use the default image plane, e.g. `ROIs.createRectangleROI(x, y, w, h)`, to avoid requiring the more awkward `ROIs.createRectangleROI(x, y, w, h, ImagePlane.getDefaultPlane())`.

What happened was that, when I started adding tests, various corner cases emerged - especially related to handling 'empty' ROIs. Specifically
* PolygonROI would fail to give a centroid if the ROI area was 0 (this has now been addressed)
* Converting a JTS Polygon representing a rectangle with 0 width or height produces a 'general' empty ROI, and *not* one that preserves the Polygon's vertices (partially addressed)

In general, QuPath's ROI and JTS's Geometry class have a different idea of what `isEmpty()` should mean - which meant that sometimes when converting between representations, we'd create an 'empty' ROI or Geometry whenever the input really did have vertices that could/should have been preserved.

The issues may not fully be resolved, but hopefully have little impact because it's not usual to work with areas that have an area of 0, or lines that have a length of 0.

But I note this hear by way of explanation for whenever future investigations of some new weirdness lead back to this PR.