### PR TITLE
Filter ROIs for distinct when creating map

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/utils/ObjectMerger.java
@@ -66,7 +66,6 @@ public class ObjectMerger implements ObjectProcessor {
 
     private final BiPredicate<PathObject, PathObject> compatibilityTest;
     private final BiPredicate<Geometry, Geometry> mergeTest;
-
     private final double searchDistance;
 
     /**
@@ -524,6 +523,7 @@ public class ObjectMerger implements ObjectProcessor {
         var map = pathObjects.parallelStream()
                 .filter(PathObject::hasROI)
                 .map(PathObject::getROI)
+                .distinct()
                 .collect(Collectors.toConcurrentMap(Function.identity(), ROI::getGeometry));
 
         // We have no mutability guarantees from Collectors.toConcurrentMap


### PR DESCRIPTION
With the addition of hashcode and equal, a distinct step is necessary to avoid IllegalStateExceptions given that a map cannot contain duplicate keys.