### PR TITLE
Minor fixes features

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/CellTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/CellTools.java
@@ -265,7 +265,9 @@ public class CellTools {
 			try {
 				var geomCell = face;
 				try {
-					geomCell = face.intersection(bounds);
+					// Important to use this order - the bounds should use the right precision model,
+					// but the face might not (because the subdivision can use a FLOATING rather than FIXED model)
+					geomCell = bounds.intersection(face);
 					geomCell = GeometryTools.ensurePolygonal(geomCell);
 					geomCell = VWSimplifier.simplify(geomCell, 1.0);
 				} catch (Exception e) {
@@ -292,7 +294,12 @@ public class CellTools {
 					}
 					roiCell = GeometryTools.geometryToROI(geomCell, roiNucleus.getImagePlane());
 				}
-				cells.add(PathObjects.createCellObject(roiCell, roiNucleus, detection.getPathClass(), detection.getMeasurementList()));
+				var cell = PathObjects.createCellObject(roiCell, roiNucleus, detection.getPathClass(), detection.getMeasurementList());
+				cell.setName(detection.getName());
+				if (detection.getColor() != null) {
+					cell.setColor(detection.getColor());
+				}
+				cells.add(cell);
 			} catch (Exception ex) {
 				logger.warn("Exception creating cell for {} - will skip", PathObjectTools.getROI(detection, true));
 			}

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -38,6 +38,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.Map.Entry;
@@ -52,6 +53,7 @@ import org.locationtech.jts.index.strtree.STRtree;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import qupath.lib.common.ColorTools;
 import qupath.lib.geom.Point2;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
@@ -1025,6 +1027,36 @@ public class PathObjectTools {
 			.stream()
 			.filter(p -> supportedClasses.stream().anyMatch(s -> s.isInstance(p)))
 			.toList();
+	}
+
+	/**
+	 * Reset the color to null for the specified objects.
+	 * @param pathObjects the objects whose color should be reset
+	 */
+	public static void resetColors(Collection<? extends PathObject> pathObjects) {
+		pathObjects.forEach(p -> p.setColor(null));
+	}
+
+	/**
+	 * Set each of the specified objects to have a random color.
+	 * @param pathObjects the objects whose color should be set
+	 */
+	public static void setRandomColors(Collection<? extends PathObject> pathObjects) {
+		setRandomColors(pathObjects, new Random());
+	}
+
+	/**
+	 * Set each of the specified objects to have a random color.
+	 * @param pathObjects the objects whose color should be set
+	 * @param rng optional random number generator; if null, a new generator will be created.
+	 */
+	public static void setRandomColors(Collection<? extends PathObject> pathObjects, Random rng) {
+		var rng2 = rng == null ? new Random() : rng;
+		pathObjects.forEach(p -> p.setColor(
+				rng2.nextInt(255),
+				rng2.nextInt(255),
+				rng2.nextInt(255)
+		));
 	}
 
 	/**

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -286,7 +286,33 @@ public class GeometryTools {
 		geometry = DouglasPeuckerSimplifier.simplify(geometry, 0.0);
 		return geometry;
 	}
-	
+
+	/**
+	 * Update a geometry to have the precision model of the default factory.
+	 * This can help ensure consistency among geometries used in QuPath.
+	 * @param geometry the input geometry
+	 * @return the input geometry if it already had the required precision model,
+	 *         or a duplicate geometry after precision reduction.
+	 */
+	public static Geometry ensurePrecision(Geometry geometry) {
+		return ensurePrecision(geometry, GeometryTools.getDefaultFactory().getPrecisionModel());
+	}
+
+	/**
+	 * Update a geometry to have the specified precision model.
+	 * @param geometry the input geometry
+	 * @param precisionModel the target precision model
+	 * @return the input geometry if it already had the required precision model,
+	 *         or a duplicate geometry after precision reduction.
+	 */
+	public static Geometry ensurePrecision(Geometry geometry, PrecisionModel precisionModel) {
+		if (geometry.getFactory().getPrecisionModel() == precisionModel)
+			return geometry;
+		var reducer = new GeometryPrecisionReducer(precisionModel);
+		reducer.setChangePrecisionModel(true);
+		return reducer.reduce(geometry);
+	}
+
 	/**
 	 * Compute the intersection of a Geometry and a specified bounding box.
 	 * The original Geometry <i>may</i> be returned unchanged if no changes are required to fit within the bounds.

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -441,20 +441,18 @@ public class ImageDisplay extends AbstractImageRenderer {
 		}
 		
 		List<ChannelDisplayInfo> tempChannelOptions = channelManager.getAvailableChannels(showAllRGBTransforms.get());
-		List<ChannelDisplayInfo> tempSelectedChannels;
+		List<ChannelDisplayInfo> tempSelectedChannels = selectedChannels.stream()
+				.filter(tempChannelOptions::contains)
+				.collect(Collectors.toCollection(ArrayList::new));
 		// Select all the channels
-		if (serverChanged) {
+		if (serverChanged || tempSelectedChannels.isEmpty()) {
 			tempSelectedChannels = new ArrayList<>();
-			if (metadata.isRGB() || !useColorLUTs())
+			if (tempChannelOptions.getFirst() instanceof RGBDirectChannelInfo || !useColorLUTs()) {
 				tempSelectedChannels.add(tempChannelOptions.getFirst());
-			else if (useColorLUTs())
+			} else if (useColorLUTs())
 				tempSelectedChannels.addAll(
 						tempChannelOptions.stream()
 						.filter(c -> c instanceof DirectServerChannelInfo).toList());
-		} else {
-			tempSelectedChannels = selectedChannels.stream()
-					.filter(tempChannelOptions::contains)
-					.toList();
 		}
 
 		if (!availableChannels.equals(tempChannelOptions)) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -1714,11 +1714,11 @@ public class PathPrefs {
     	return strokeThickThickness;
     }
 
-	private static BooleanProperty newDetectionRendering = new SimpleBooleanProperty(false);
+	private static final BooleanProperty newDetectionRendering = createPersistentPreference("newDetectionRendering", true);
 
 	/**
 	 * Flag to enable the new rendering strategy for detections.
-	 * This can be used to temporarily turn on/off the rendering, to help refine the behavior.
+	 * This can be used to turn on/off the rendering, in case users prefer the 'old' approach.
 	 * @return
 	 * @since v0.6.0
 	 */

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -864,8 +864,8 @@ Prefs.Objects.annotationLineThickness = Annotation line thickness
 Prefs.Objects.annotationLineThickness.description = Thickness (in display pixels) for annotation/TMA core object outlines (default = 2)
 Prefs.Objects.detectionLineThickness = Detection line thickness
 Prefs.Objects.detectionLineThickness.description = Thickness (in image pixels) for detection object outlines (default = 2)
-Prefs.Objects.newDetectionRendering = Dynamic detection line thickness (experimental)
-Prefs.Objects.newDetectionRendering.description = Experimental feature to render detection objects with a stroke thickness that scales with the zoom level
+Prefs.Objects.newDetectionRendering = Update detection line thickness with zoom
+Prefs.Objects.newDetectionRendering.description = Render detection objects with a stroke thickness that scales with the zoom level at high magnification (new in v0.6.0)
 Prefs.Objects.useSelectedColor = Use selected color
 Prefs.Objects.useSelectedColor.description = Highlight selected objects by recoloring them; otherwise, a slightly thicker line thickness will be used
 Prefs.Objects.selectedColor = Selected object color

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -25,6 +25,8 @@ ContextHelp.warning.unseenErrors = There are errors reported in the log that hav
                             Please check the log for details.
 ContextHelp.warning.pixelSizeMissing = Pixel size information is not set.\n\
                             This is required for some commands, and can be set under the 'Image' tab.
+ContextHelp.warning.pixelSizeDpi = Pixel size value is suspicious.\n\
+                            It looks like it is a dots-per-inch resolution value, which may be incorrect.
 ContextHelp.warning.imageTypeMissing = The image type is not set.\n\
                             This is required for some commands, and can be set under the 'Image' tab.
 ContextHelp.warning.largeNonPyramidalImage = The image is large, but not pyramidal (i.e. multi-resolution).\n\


### PR DESCRIPTION
Some fixes and minor features:
* Fix https://github.com/qupath/qupath/issues/1804 (and a related geometry precision issue)
* Add context help warnings when a pixel size suspiciously resembles 300 dpi (or other common screen resolutions)
* Make dynamic detection line thickness the default, and make the preference persistent
* Add new methods to `PathObjectTools` to help work with colors

For the last, here are two Groovy lines showing it in action (but which should be run separately... or you'll end up back where you started):
```groovy
PathObjectTools.setRandomColors(getDetectionObjects())
PathObjectTools.resetColors(getDetectionObjects())
```