### PR TITLE
Reuse tooltips in measurement tables

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ui/BasicTableCell.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ui/BasicTableCell.java
@@ -6,10 +6,9 @@ import javafx.scene.control.Tooltip;
 
 class BasicTableCell<S, T> extends TableCell<S, T> {
 
-    public BasicTableCell(String tooltipText) {
+    public BasicTableCell(Tooltip tooltip) {
         setAlignment(Pos.CENTER);
-        if (tooltipText != null && !tooltipText.isEmpty())
-            setTooltip(new Tooltip(tooltipText));
+        setTooltip(tooltip);
     }
 
     @Override

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ui/NumericTableCell.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ui/NumericTableCell.java
@@ -3,17 +3,20 @@ package qupath.lib.gui.measure.ui;
 import javafx.geometry.Pos;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.Tooltip;
+import javafx.scene.input.MouseEvent;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.charts.HistogramDisplay;
+import qupath.lib.lazy.interfaces.LazyValue;
 
 class NumericTableCell<T> extends TableCell<T, Number> {
 
     private final HistogramDisplay histogramDisplay;
 
-    public NumericTableCell(String tooltipText, HistogramDisplay histogramDisplay) {
+    public NumericTableCell(Tooltip tooltip, HistogramDisplay histogramDisplay) {
         this.histogramDisplay = histogramDisplay;
-        if (tooltipText != null && !tooltipText.isEmpty())
-            setTooltip(new Tooltip(tooltipText));
+        setTooltip(tooltip);
+        if (histogramDisplay != null)
+            setOnMouseClicked(this::handleMouseClick);
     }
 
 
@@ -25,25 +28,28 @@ class NumericTableCell<T> extends TableCell<T, Number> {
             setStyle("");
         } else {
             setAlignment(Pos.CENTER);
-            if (Double.isNaN(item.doubleValue()))
+            if (item instanceof Integer || item instanceof Long) {
+                setText(item.toString());
+            } else if (Double.isNaN(item.doubleValue())) {
                 setText("-");
-            else {
-                if (item.doubleValue() >= 1000)
-                    setText(GeneralTools.formatNumber(item.doubleValue(), 1));
-                else if (item.doubleValue() >= 10)
-                    setText(GeneralTools.formatNumber(item.doubleValue(), 2));
+            } else {
+                double value = item.doubleValue();
+                if (value >= 1000)
+                    setText(GeneralTools.formatNumber(value, 1));
+                else if (value >= 10)
+                    setText(GeneralTools.formatNumber(value, 2));
                 else
-                    setText(GeneralTools.formatNumber(item.doubleValue(), 3));
+                    setText(GeneralTools.formatNumber(value, 3));
             }
-
-
-            setOnMouseClicked(e -> {
-                if (e.isAltDown() && histogramDisplay != null) {
-                    histogramDisplay.showHistogram(getTableColumn().getText());
-                    e.consume();
-                }
-            });
         }
     }
+
+    private void handleMouseClick(MouseEvent event) {
+        if (event.isAltDown() && histogramDisplay != null) {
+            histogramDisplay.showHistogram(getTableColumn().getText());
+            event.consume();
+        }
+    }
+
 
 }


### PR DESCRIPTION
Tooltips can be reused across nodes.

Applying this to cells of measurement tables can have a significant performance impact, especially if there are large numbers of columns. For a multiplexed image, this took about 1 second off the time required to show the table (although it is still too slow... around 4-5 seconds)