### PR TITLE
Remove objects touching ROI boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Some things may be added, some things may be removed, and some things may look d
 (These are not yet ordered by interestingness)
 
 * Support system light/dark color themes
+* Commands to remove objects touching the bounds of the image or other objects (https://github.com/qupath/qupath/pull/1821)
+  * _Objects → Delete... → Delete objects on image bounds_
+  * _Objects → Delete... → Delete objects touching selected ROI bounds..._
 * Window menu to help find lost windows (https://github.com/qupath/qupath/pull/1790)
 * Improved display of annotation names (https://github.com/qupath/qupath/pull/1532)
 * Better performance for large pixel classifiers (https://github.com/qupath/qupath/pull/1782)

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -4829,10 +4829,30 @@ public class QP {
 	
 	/**
 	 * Get the logger associated with this class.
-	 * @return
+	 * @return the logger
 	 */
 	public static Logger getLogger() {
 		return logger;
+	}
+
+	/**
+	 * Get a logger with a specified name.
+	 * @param name the name of the logger
+	 * @return the logger
+	 * @since v0.6.0
+	 */
+	public static Logger getLogger(String name) {
+		return LoggerFactory.getLogger(name);
+	}
+
+	/**
+	 * Get a logger associated with a specified class.
+	 * @param cls the class used to determine the logger name
+	 * @return the logger
+	 * @since v0.6.0
+	 */
+	public static Logger getLogger(Class<?> cls) {
+		return LoggerFactory.getLogger(cls);
 	}
 	
 	
@@ -5161,6 +5181,48 @@ public class QP {
 		 hierarchy.fireHierarchyChangedEvent(QP.class);
 		 return changes;
 	 }
+
+
+
+	public static boolean removeTouchingImageBoundary() {
+		return removeTouchingImageBoundary(getCurrentImageData());
+	}
+
+	public static boolean removeTouchingImageBoundary(ImageData<?> imageData) {
+		 if (imageData == null)
+			 return false;
+		 return PathObjectTools.removeTouchingImageBoundary(imageData);
+	}
+
+	public static boolean removeTouchingSelectedObjectBoundary() {
+		return removeTouchingSelectedObjectBoundary(getCurrentHierarchy());
+	}
+
+	public static boolean removeTouchingSelectedObjectBoundary(PathObjectHierarchy hierarchy) {
+		if (hierarchy == null)
+			return false;
+		var selected = List.copyOf(hierarchy.getSelectionModel().getSelectedObjects());
+		boolean changes = false;
+		for (var obj : selected) {
+			changes = changes | PathObjectTools.removeTouchingBoundary(hierarchy, obj);
+		}
+		return changes;
+	}
+
+	public static boolean removeChildObjectsOnBoundary() {
+		return removeChildObjectsOnBoundary(getCurrentHierarchy());
+	}
+
+	public static boolean removeChildObjectsOnBoundary(PathObjectHierarchy hierarchy) {
+		if (hierarchy == null)
+			return false;
+		var selected = List.copyOf(hierarchy.getSelectionModel().getSelectedObjects());
+		boolean changes = false;
+		for (var obj : selected) {
+			changes = changes | PathObjectTools.removeTouchingBoundary(hierarchy, obj, p -> Objects.equals(obj, p.getParent()));
+		}
+		return changes;
+	}
 
 	 
 	 /*

--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -5183,43 +5183,114 @@ public class QP {
 	 }
 
 
-
-	public static boolean removeTouchingImageBoundary() {
-		return removeTouchingImageBoundary(getCurrentImageData());
+	/**
+	 * Remove all objects that touch the boundary of the current image.
+	 * @return true if objects were removed, false otherwise
+	 * @since v0.6.0
+	 */
+	public static boolean removeObjectsTouchingImageBounds() {
+		return removeObjectsTouchingImageBounds(null);
 	}
 
-	public static boolean removeTouchingImageBoundary(ImageData<?> imageData) {
+	/**
+	 * Remove all objects that touch the boundary of the current image.
+	 * @param filter optional filter to identify which objects can be removed (e.g. only detections, only annotations)
+	 * @return true if objects were removed, false otherwise
+	 * @since v0.6.0
+	 */
+	public static boolean removeObjectsTouchingImageBounds(Predicate<PathObject> filter) {
+		return removeObjectsTouchingImageBounds(getCurrentImageData(), filter);
+	}
+
+	/**
+	 * Remove objects that touch the boundary of the specified image.
+	 * @param imageData the image to process
+	 * @param filter optional filter to restrict which objects can be removed (e.g. only detections, only annotations)
+	 * @return true if objects were removed, false otherwise
+	 * @since v0.6.0
+	 */
+	public static boolean removeObjectsTouchingImageBounds(ImageData<?> imageData, Predicate<PathObject> filter) {
 		 if (imageData == null)
 			 return false;
-		 return PathObjectTools.removeTouchingImageBoundary(imageData);
+		 return PathObjectTools.removeTouchingImageBounds(imageData, filter);
 	}
 
-	public static boolean removeTouchingSelectedObjectBoundary() {
-		return removeTouchingSelectedObjectBoundary(getCurrentHierarchy());
+	/**
+	 * Remove all objects that touch or overlap the bounds of the selected objects in the current image.
+	 * @return true if objects were removed, false otherwise
+	 * @since v0.6.0
+	 */
+	public static boolean removeObjectsTouchingSelectedBounds() {
+		return removeObjectsTouchingSelectedBounds(null);
 	}
 
-	public static boolean removeTouchingSelectedObjectBoundary(PathObjectHierarchy hierarchy) {
+	/**
+	 * Remove objects that touch or overlap the bounds of the selected objects in the current image.
+	 * @param filter optional filter to restrict which objects can be removed (e.g. only detections, only annotations)
+	 * @return true if objects were removed, false otherwise
+	 * @since v0.6.0
+	 */
+	public static boolean removeObjectsTouchingSelectedBounds(Predicate<PathObject> filter) {
+		return removeObjectsTouchingSelectedBounds(getCurrentHierarchy(), filter);
+	}
+
+	/**
+	 * Remove objects that touch or overlap the bounds of the selected objects in the specified object hierarchy.
+	 * @param hierarchy the object hierarchy to use
+	 * @param filter optional filter to restrict which objects can be removed (e.g. only detections, only annotations)
+	 * @return true if objects were removed, false otherwise
+	 * @since v0.6.0
+	 */
+	public static boolean removeObjectsTouchingSelectedBounds(PathObjectHierarchy hierarchy, Predicate<PathObject> filter) {
 		if (hierarchy == null)
 			return false;
 		var selected = List.copyOf(hierarchy.getSelectionModel().getSelectedObjects());
 		boolean changes = false;
 		for (var obj : selected) {
-			changes = changes | PathObjectTools.removeTouchingBoundary(hierarchy, obj);
+			changes = changes | PathObjectTools.removeTouchingBounds(hierarchy, obj, filter);
 		}
 		return changes;
 	}
 
-	public static boolean removeChildObjectsOnBoundary() {
-		return removeChildObjectsOnBoundary(getCurrentHierarchy());
+	/**
+	 * Remove all objects that touch or overlap the bounds of the selected objects in the current image,
+	 * and are direct children of the selected objects.
+	 * @return true if objects were removed, false otherwise
+	 * @since v0.6.0
+	 */
+	public static boolean removeChildObjectsTouchingSelectedBounds() {
+		return removeChildObjectsTouchingSelectedBounds(null);
 	}
 
-	public static boolean removeChildObjectsOnBoundary(PathObjectHierarchy hierarchy) {
+	/**
+	 * Remove objects that touch or overlap the bounds of the selected objects in the current image,
+	 * and are direct children of the selected objects.
+	 * @param filter optional filter to restrict which objects can be removed (e.g. only detections, only annotations)
+	 * @return true if objects were removed, false otherwise
+	 * @since v0.6.0
+	 */
+	public static boolean removeChildObjectsTouchingSelectedBounds(Predicate<PathObject> filter) {
+		return removeChildObjectsTouchingSelectedBounds(getCurrentHierarchy(), filter);
+	}
+
+	/**
+	 * Remove objects that touch or overlap the bounds of the selected objects in the specified image,
+	 * and are direct children of the selected objects.
+	 * @param hierarchy the object hierarchy to use
+	 * @param filter optional filter to restrict which objects can be removed (e.g. only detections, only annotations)
+	 * @return true if objects were removed, false otherwise
+	 * @since v0.6.0
+	 */
+	public static boolean removeChildObjectsTouchingSelectedBounds(PathObjectHierarchy hierarchy, Predicate<PathObject> filter) {
 		if (hierarchy == null)
 			return false;
 		var selected = List.copyOf(hierarchy.getSelectionModel().getSelectedObjects());
 		boolean changes = false;
 		for (var obj : selected) {
-			changes = changes | PathObjectTools.removeTouchingBoundary(hierarchy, obj, p -> Objects.equals(obj, p.getParent()));
+			Predicate<PathObject> predicate = (PathObject p) -> Objects.equals(obj, p.getParent());
+			if (filter != null)
+				predicate = filter.and(predicate);
+			changes = changes | PathObjectTools.removeTouchingBounds(hierarchy, obj, predicate);
 		}
 		return changes;
 	}

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -1275,10 +1275,10 @@ public class PathObjectTools {
 	 * 		   Note that this may contain objects that have the specified parent ROI, since it is considered to touch
 	 * 		   or cross itself.
 	 * @since v0.6.0
-	 * @see #findTouchingImageBoundary(ImageServer, Collection)
+	 * @see #findTouchingImageBounds(ImageServer, Collection)
 	 */
-	public static List<PathObject> findTouchingBoundary(ROI roi, Collection<? extends PathObject> pathObjects) {
-		return findTouchingBoundary(roi, pathObjects, roi.getImagePlane());
+	public static List<PathObject> findTouchingBounds(ROI roi, Collection<? extends PathObject> pathObjects) {
+		return findTouchingBounds(roi, pathObjects, roi.getImagePlane());
 	}
 
 	/**
@@ -1288,14 +1288,14 @@ public class PathObjectTools {
 	 * @param pathObjects the objects that may touch the image boundary
 	 * @return a list containing the objects from the input that touch or cross the image boundary
 	 * @since v0.6.0
-	 * @see #findTouchingBoundary(ROI, Collection)
+	 * @see #findTouchingBounds(ROI, Collection)
 	 */
-	public static List<PathObject> findTouchingImageBoundary(ImageServer<?> server, Collection<? extends PathObject> pathObjects) {
+	public static List<PathObject> findTouchingImageBounds(ImageServer<?> server, Collection<? extends PathObject> pathObjects) {
 		var roi = ROIs.createRectangleROI(0, 0, server.getWidth(), server.getHeight());
-		return findTouchingBoundary(roi, pathObjects, null);
+		return findTouchingBounds(roi, pathObjects, null);
 	}
 
-	private static List<PathObject> findTouchingBoundary(ROI roi, Collection<? extends PathObject> pathObjects, ImagePlane plane) {
+	private static List<PathObject> findTouchingBounds(ROI roi, Collection<? extends PathObject> pathObjects, ImagePlane plane) {
 		// Internal method where the plane is passed as a parameter, rather than determined from the ROI.
 		// This is to make it possible to pass null, and apply the test to the ROI on any plane
 		if (roi == null)
@@ -1329,11 +1329,11 @@ public class PathObjectTools {
 	 * @param parent the parent object
 	 * @return true if objects were removed, false otherwise
 	 * @since v0.6.0
-	 * @see #findTouchingBoundary(ROI, Collection)
-	 * @see #removeTouchingBoundary(PathObjectHierarchy, PathObject, Predicate)
+	 * @see #findTouchingBounds(ROI, Collection)
+	 * @see #removeTouchingBounds(PathObjectHierarchy, PathObject, Predicate)
 	 */
-	public static boolean removeTouchingBoundary(PathObjectHierarchy hierarchy, PathObject parent) {
-		return removeTouchingBoundary(hierarchy, parent, null);
+	public static boolean removeTouchingBounds(PathObjectHierarchy hierarchy, PathObject parent) {
+		return removeTouchingBounds(hierarchy, parent, null);
 	}
 
 	/**
@@ -1348,10 +1348,10 @@ public class PathObjectTools {
 	 *               method to only consider removing detection objects.
 	 * @return true if objects were removed, false otherwise
 	 * @since v0.6.0
-	 * @see #findTouchingBoundary(ROI, Collection)
-	 * @see #removeTouchingBoundary(PathObjectHierarchy, PathObject)
+	 * @see #findTouchingBounds(ROI, Collection)
+	 * @see #removeTouchingBounds(PathObjectHierarchy, PathObject)
 	 */
-	public static boolean removeTouchingBoundary(PathObjectHierarchy hierarchy, PathObject parent, Predicate<PathObject> filter) {
+	public static boolean removeTouchingBounds(PathObjectHierarchy hierarchy, PathObject parent, Predicate<PathObject> filter) {
 		Predicate<PathObject> predicate = (PathObject p) -> {
 			return p.hasROI() && !p.isTMACore() && !Objects.equals(parent, p);
 		};
@@ -1361,7 +1361,7 @@ public class PathObjectTools {
 				.stream()
 				.filter(predicate)
 				.toList();
-		var touching = findTouchingBoundary(parent.getROI(), pathObjects);
+		var touching = findTouchingBounds(parent.getROI(), pathObjects);
 		if (touching.isEmpty()) {
 			return false;
 		}
@@ -1375,11 +1375,11 @@ public class PathObjectTools {
 	 * @param imageData the image data
 	 * @return true if objects were deleted, false otherwise
 	 * @since v0.6.0
-	 * @see #findTouchingImageBoundary(ImageServer, Collection)
-	 * @see #removeTouchingImageBoundary(ImageData, Predicate)
+	 * @see #findTouchingImageBounds(ImageServer, Collection)
+	 * @see #removeTouchingImageBounds(ImageData, Predicate)
 	 */
-	public static boolean removeTouchingImageBoundary(ImageData<?> imageData) {
-		return removeTouchingImageBoundary(imageData, null);
+	public static boolean removeTouchingImageBounds(ImageData<?> imageData) {
+		return removeTouchingImageBounds(imageData, null);
 	}
 
 	/**
@@ -1391,10 +1391,10 @@ public class PathObjectTools {
 	 *               method to only consider removing detection objects.
 	 * @return true if objects were deleted, false otherwise
 	 * @since v0.6.0
-	 * @see #findTouchingImageBoundary(ImageServer, Collection)
-	 * @see #removeTouchingImageBoundary(ImageData)
+	 * @see #findTouchingImageBounds(ImageServer, Collection)
+	 * @see #removeTouchingImageBounds(ImageData)
 	 */
-	public static boolean removeTouchingImageBoundary(ImageData<?> imageData, Predicate<PathObject> filter) {
+	public static boolean removeTouchingImageBounds(ImageData<?> imageData, Predicate<PathObject> filter) {
 		if (imageData == null)
 			return false;
 		var server = imageData.getServer();
@@ -1405,7 +1405,7 @@ public class PathObjectTools {
 				.filter(p -> !p.isTMACore())
 				.filter(filter == null ? p -> true : filter)
 				.toList();
-		var touching = findTouchingImageBoundary(server, pathObjects);
+		var touching = findTouchingImageBounds(server, pathObjects);
 		if (touching.isEmpty()) {
 			return false;
 		}

--- a/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObjectTools.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -54,7 +54,6 @@ import org.locationtech.jts.index.strtree.STRtree;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import qupath.lib.common.ColorTools;
 import qupath.lib.geom.Point2;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
@@ -1284,7 +1283,7 @@ public class PathObjectTools {
 		var region = ImageRegion.createInstance(roi);
 		var potential = pathObjects.stream()
 				.filter(PathObject::hasROI)
-				.filter(p -> RoiTools.intersectsRegion(p.getROI(), region))
+				.filter(p -> roi.getZ() == p.getROI().getZ() && roi.getT() == p.getROI().getT())
 				.map(p -> (PathObject)p)
 				.toList();
 		if (potential.isEmpty()) {

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools.java
@@ -212,7 +212,7 @@ public class TestPathObjectTools extends TestPathObjectMethods {
 		}
 
 		// Test contains centroid
-		// One ROI is separate, all other intersect
+		// One ROI is separate, all others intersect
 		assertEquals(List.of(roiSeparate),
 				PathObjectTools.filterByROIContainsCentroid(roiSeparate, pathObjects).stream().map(PathObject::getROI).toList());
 		for (var roi : List.of(roiRect, roiEllipse, roiDiamond, roiOverlaps, roiOverlaps2)) {

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools3.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools3.java
@@ -1,0 +1,99 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2025 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.lib.objects;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import qupath.lib.objects.hierarchy.PathObjectHierarchy;
+import qupath.lib.regions.ImagePlane;
+import qupath.lib.roi.ROIs;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+public class TestPathObjectTools3 {
+
+    @Test
+    public void test_findTouchingBoundary() {
+        // Check we can find objects that touch a ROI boundary
+        var parent = ROIs.createRectangleROI(0, 0, 100, 100);
+        var intersecting = PathObjects.createDetectionObject(ROIs.createRectangleROI(99, 99, 10, 10));
+        var touchingCorner = PathObjects.createDetectionObject(ROIs.createRectangleROI(100, 100, 10, 10));
+        var touchingSide = PathObjects.createDetectionObject(ROIs.createRectangleROI(50, 100, 10, 10));
+        var inside = PathObjects.createDetectionObject(ROIs.createRectangleROI(50, 50, 10, 10));
+        var outside = PathObjects.createDetectionObject(ROIs.createRectangleROI(150, 150, 10, 10));
+
+        var results = PathObjectTools.findTouchingBoundary(parent, List.of(intersecting, touchingCorner, touchingSide, inside, outside));
+        Assertions.assertEquals(Set.of(intersecting, touchingCorner, touchingSide), Set.copyOf(results));
+    }
+
+    @Test
+    public void test_findTouchingBoundaryDifferentPlane() {
+        // Check we do *not* find objects that touch a ROI boundary, but are on the wrong plane
+        var parent = ROIs.createRectangleROI(0, 0, 100, 100);
+        var touchingSide = PathObjects.createDetectionObject(ROIs.createRectangleROI(50, 100, 10, 10));
+        var touchingSideDiffZ = PathObjects.createDetectionObject(touchingSide.getROI().updatePlane(ImagePlane.getPlaneWithChannel(0, 1, 0)));
+        var touchingSideDiffT= PathObjects.createDetectionObject(touchingSide.getROI().updatePlane(ImagePlane.getPlaneWithChannel(0, 0, 1)));
+        var results = PathObjectTools.findTouchingBoundary(parent, List.of(touchingSide, touchingSideDiffZ, touchingSideDiffT));
+        Assertions.assertEquals(Set.of(touchingSide), Set.copyOf(results));
+    }
+
+    @Test
+    public void test_removeTouchingBoundary() {
+        // Check that we can remove objects that touch a ROI boundary
+        var parent = PathObjects.createAnnotationObject(ROIs.createRectangleROI(0, 0, 100, 100));
+
+        var intersecting = PathObjects.createDetectionObject(ROIs.createRectangleROI(99, 99, 10, 10));
+        var touchingCorner = PathObjects.createDetectionObject(ROIs.createRectangleROI(100, 100, 10, 10));
+        var touchingSide = PathObjects.createDetectionObject(ROIs.createRectangleROI(50, 100, 10, 10));
+        var inside = PathObjects.createDetectionObject(ROIs.createRectangleROI(50, 50, 10, 10));
+        var outside = PathObjects.createDetectionObject(ROIs.createRectangleROI(150, 150, 10, 10));
+
+        // Check using no filter
+        var hierarchy = createHierarchy(parent, intersecting, touchingCorner, touchingSide, inside, outside);
+        var result = PathObjectTools.removeTouchingBoundary(hierarchy, parent);
+        Assertions.assertTrue(result);
+        Assertions.assertEquals(Set.of(parent, inside, outside), Set.copyOf(hierarchy.getAllObjects(false)));
+
+        // Check using detecton filter
+        var hierarchy2 = createHierarchy(parent, intersecting, touchingCorner, touchingSide, inside, outside);
+        var resultRemoveDetections = PathObjectTools.removeTouchingBoundary(hierarchy2, parent, PathObject::isDetection);
+        Assertions.assertTrue(resultRemoveDetections);
+        Assertions.assertEquals(Set.of(parent, inside, outside), Set.copyOf(hierarchy2.getAllObjects(false)));
+
+        // Check using annotation filter
+        var hierarchy3 = createHierarchy(parent, intersecting, touchingCorner, touchingSide, inside, outside);
+        var resultRemoveAnnotations = PathObjectTools.removeTouchingBoundary(hierarchy3, parent, PathObject::isAnnotation);
+        Assertions.assertFalse(resultRemoveAnnotations);
+        Assertions.assertEquals(Set.of(parent, intersecting, touchingCorner, touchingSide, inside, outside),
+                hierarchy3.getAllObjects(false));
+    }
+
+    private static PathObjectHierarchy createHierarchy(PathObject... pathObjects) {
+        var hierarchy = new PathObjectHierarchy();
+        hierarchy.addObjects(Arrays.asList(pathObjects));
+        return hierarchy;
+    }
+
+}

--- a/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools3.java
+++ b/qupath-core/src/test/java/qupath/lib/objects/TestPathObjectTools3.java
@@ -35,7 +35,7 @@ import java.util.Set;
 public class TestPathObjectTools3 {
 
     @Test
-    public void test_findTouchingBoundary() {
+    public void test_findTouchingBounds() {
         // Check we can find objects that touch a ROI boundary
         var parent = ROIs.createRectangleROI(0, 0, 100, 100);
         var intersecting = PathObjects.createDetectionObject(ROIs.createRectangleROI(99, 99, 10, 10));
@@ -44,23 +44,23 @@ public class TestPathObjectTools3 {
         var inside = PathObjects.createDetectionObject(ROIs.createRectangleROI(50, 50, 10, 10));
         var outside = PathObjects.createDetectionObject(ROIs.createRectangleROI(150, 150, 10, 10));
 
-        var results = PathObjectTools.findTouchingBoundary(parent, List.of(intersecting, touchingCorner, touchingSide, inside, outside));
+        var results = PathObjectTools.findTouchingBounds(parent, List.of(intersecting, touchingCorner, touchingSide, inside, outside));
         Assertions.assertEquals(Set.of(intersecting, touchingCorner, touchingSide), Set.copyOf(results));
     }
 
     @Test
-    public void test_findTouchingBoundaryDifferentPlane() {
+    public void test_findTouchingBoundsDifferentPlane() {
         // Check we do *not* find objects that touch a ROI boundary, but are on the wrong plane
         var parent = ROIs.createRectangleROI(0, 0, 100, 100);
         var touchingSide = PathObjects.createDetectionObject(ROIs.createRectangleROI(50, 100, 10, 10));
         var touchingSideDiffZ = PathObjects.createDetectionObject(touchingSide.getROI().updatePlane(ImagePlane.getPlaneWithChannel(0, 1, 0)));
         var touchingSideDiffT= PathObjects.createDetectionObject(touchingSide.getROI().updatePlane(ImagePlane.getPlaneWithChannel(0, 0, 1)));
-        var results = PathObjectTools.findTouchingBoundary(parent, List.of(touchingSide, touchingSideDiffZ, touchingSideDiffT));
+        var results = PathObjectTools.findTouchingBounds(parent, List.of(touchingSide, touchingSideDiffZ, touchingSideDiffT));
         Assertions.assertEquals(Set.of(touchingSide), Set.copyOf(results));
     }
 
     @Test
-    public void test_removeTouchingBoundary() {
+    public void test_removeTouchingBounds() {
         // Check that we can remove objects that touch a ROI boundary
         var parent = PathObjects.createAnnotationObject(ROIs.createRectangleROI(0, 0, 100, 100));
 
@@ -72,19 +72,19 @@ public class TestPathObjectTools3 {
 
         // Check using no filter
         var hierarchy = createHierarchy(parent, intersecting, touchingCorner, touchingSide, inside, outside);
-        var result = PathObjectTools.removeTouchingBoundary(hierarchy, parent);
+        var result = PathObjectTools.removeTouchingBounds(hierarchy, parent);
         Assertions.assertTrue(result);
         Assertions.assertEquals(Set.of(parent, inside, outside), Set.copyOf(hierarchy.getAllObjects(false)));
 
         // Check using detecton filter
         var hierarchy2 = createHierarchy(parent, intersecting, touchingCorner, touchingSide, inside, outside);
-        var resultRemoveDetections = PathObjectTools.removeTouchingBoundary(hierarchy2, parent, PathObject::isDetection);
+        var resultRemoveDetections = PathObjectTools.removeTouchingBounds(hierarchy2, parent, PathObject::isDetection);
         Assertions.assertTrue(resultRemoveDetections);
         Assertions.assertEquals(Set.of(parent, inside, outside), Set.copyOf(hierarchy2.getAllObjects(false)));
 
         // Check using annotation filter
         var hierarchy3 = createHierarchy(parent, intersecting, touchingCorner, touchingSide, inside, outside);
-        var resultRemoveAnnotations = PathObjectTools.removeTouchingBoundary(hierarchy3, parent, PathObject::isAnnotation);
+        var resultRemoveAnnotations = PathObjectTools.removeTouchingBounds(hierarchy3, parent, PathObject::isAnnotation);
         Assertions.assertFalse(resultRemoveAnnotations);
         Assertions.assertEquals(Set.of(parent, intersecting, touchingCorner, touchingSide, inside, outside),
                 hierarchy3.getAllObjects(false));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/menus/ObjectsMenuActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/menus/ObjectsMenuActions.java
@@ -108,15 +108,25 @@ public class ObjectsMenuActions implements MenuActions {
 		public final Action SEP_1 = ActionTools.createSeparator();
 		
 		@ActionConfig("Action.Objects.Delete.all")
-		public final Action CLEAR_HIERARCHY = qupath.createImageDataAction(imageData -> Commands.promptToDeleteObjects(imageData, null));
+		public final Action DELETE_ALL = qupath.createImageDataAction(imageData -> Commands.promptToDeleteObjects(imageData, null));
 
 		@ActionConfig("Action.Objects.Delete.annotations")
-		public final Action CLEAR_ANNOTATIONS = qupath.createImageDataAction(imageData -> Commands.promptToDeleteObjects(imageData, PathAnnotationObject.class));
+		public final Action DELETE_ANNOTATION = qupath.createImageDataAction(imageData -> Commands.promptToDeleteObjects(imageData, PathAnnotationObject.class));
 		
 		@ActionConfig("Action.Objects.Delete.detections")
-		public final Action CLEAR_DETECTIONS = qupath.createImageDataAction(imageData -> Commands.promptToDeleteObjects(imageData, PathDetectionObject.class));
+		public final Action DELETE_DETECTIONS = qupath.createImageDataAction(imageData -> Commands.promptToDeleteObjects(imageData, PathDetectionObject.class));
 
-		
+		public final Action SEP_2 = ActionTools.createSeparator();
+
+		@ActionConfig("Action.Objects.Delete.imageBoundary")
+		public final Action DELETE_IMAGE_BOUNDARY = qupath.createImageDataAction(Commands::removeOnImageBounds);
+
+		@ActionConfig("Action.Objects.Delete.selectedBoundary")
+		public final Action DELETE_SELECTED_BOUNDARY = qupath.createImageDataAction(Commands::removeTouchingSelectedROIBoundary);
+
+		@ActionConfig("Action.Objects.Delete.childSelectedBoundary")
+		public final Action DELETE_CHILD_SELECTED_BOUNDARY = qupath.createImageDataAction(Commands::removeChildObjectsOnSelectedBoundary);
+
 	}
 
 	public class SelectActions {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/menus/ObjectsMenuActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/menus/ObjectsMenuActions.java
@@ -33,6 +33,7 @@ import qupath.lib.gui.actions.annotations.ActionAccelerator;
 import qupath.lib.gui.actions.annotations.ActionConfig;
 import qupath.lib.gui.actions.annotations.ActionMenu;
 import qupath.lib.gui.commands.Commands;
+import qupath.lib.gui.commands.DeleteObjectsOnBoundsCommand;
 import qupath.lib.gui.commands.objects.SplitAnnotationsByLineCommand;
 import qupath.lib.gui.localization.QuPathResources;
 import qupath.lib.gui.tools.GuiTools;
@@ -121,11 +122,10 @@ public class ObjectsMenuActions implements MenuActions {
 		@ActionConfig("Action.Objects.Delete.imageBoundary")
 		public final Action DELETE_IMAGE_BOUNDARY = qupath.createImageDataAction(Commands::removeOnImageBounds);
 
-		@ActionConfig("Action.Objects.Delete.selectedBoundary")
-		public final Action DELETE_SELECTED_BOUNDARY = qupath.createImageDataAction(Commands::removeTouchingSelectedROIBoundary);
+		private final DeleteObjectsOnBoundsCommand deleteOnBoundsCommand = new DeleteObjectsOnBoundsCommand(qupath);
 
-		@ActionConfig("Action.Objects.Delete.childSelectedBoundary")
-		public final Action DELETE_CHILD_SELECTED_BOUNDARY = qupath.createImageDataAction(Commands::removeChildObjectsOnSelectedBoundary);
+		@ActionConfig("Action.Objects.Delete.selectedBoundary")
+		public final Action DELETE_SELECTED_BOUNDARY = qupath.createImageDataAction(deleteOnBoundsCommand::runForImage);
 
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -1278,7 +1278,60 @@ public class Commands {
 				logger.warn("Cannot remove all objects for class {}", cls);
 		}
 	}
-	
+
+
+
+	/**
+	 * Delete all objects touching the image boundary.
+	 * @param imageData the image data
+	 */
+	public static void removeOnImageBounds(ImageData<?> imageData) {
+		if (imageData == null) {
+			logger.warn("No image available!");
+			return;
+		}
+		QP.removeTouchingImageBoundary(imageData);
+		imageData.getHistoryWorkflow().addStep(
+				new DefaultScriptableWorkflowStep(
+						"Remove objects on image boundary",
+						"removeTouchingImageBoundary()")
+		);
+	}
+
+	/**
+	 * Delete all objects touching the boundaries of the selected ROIs.
+	 * @param imageData the image data
+	 */
+	public static void removeTouchingSelectedROIBoundary(ImageData<?> imageData) {
+		if (imageData == null) {
+			logger.warn("No image available!");
+			return;
+		}
+		QP.removeTouchingSelectedObjectBoundary(imageData.getHierarchy());
+		imageData.getHistoryWorkflow().addStep(
+				new DefaultScriptableWorkflowStep(
+						"Remove objects touching selected ROIs",
+						"removeTouchingSelectedObjectBoundary()")
+		);
+	}
+
+	/**
+	 * Delete all child objects touching the boundaries of the selected ROIs.
+	 * @param imageData the image data
+	 */
+	public static void removeChildObjectsOnSelectedBoundary(ImageData<?> imageData) {
+		if (imageData == null) {
+			logger.warn("No image available!");
+			return;
+		}
+		QP.removeChildObjectsOnBoundary(imageData.getHierarchy());
+		imageData.getHistoryWorkflow().addStep(
+				new DefaultScriptableWorkflowStep(
+						"Remove child objects touching selected ROI boundaries",
+						"removeChildObjectsOnBoundary()")
+		);
+	}
+
 	
 	/**
 	 * Reset QuPath's preferences, after confirming with the user.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/Commands.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -1290,45 +1290,11 @@ public class Commands {
 			logger.warn("No image available!");
 			return;
 		}
-		QP.removeTouchingImageBoundary(imageData);
+		QP.removeObjectsTouchingImageBounds(imageData, null);
 		imageData.getHistoryWorkflow().addStep(
 				new DefaultScriptableWorkflowStep(
 						"Remove objects on image boundary",
-						"removeTouchingImageBoundary()")
-		);
-	}
-
-	/**
-	 * Delete all objects touching the boundaries of the selected ROIs.
-	 * @param imageData the image data
-	 */
-	public static void removeTouchingSelectedROIBoundary(ImageData<?> imageData) {
-		if (imageData == null) {
-			logger.warn("No image available!");
-			return;
-		}
-		QP.removeTouchingSelectedObjectBoundary(imageData.getHierarchy());
-		imageData.getHistoryWorkflow().addStep(
-				new DefaultScriptableWorkflowStep(
-						"Remove objects touching selected ROIs",
-						"removeTouchingSelectedObjectBoundary()")
-		);
-	}
-
-	/**
-	 * Delete all child objects touching the boundaries of the selected ROIs.
-	 * @param imageData the image data
-	 */
-	public static void removeChildObjectsOnSelectedBoundary(ImageData<?> imageData) {
-		if (imageData == null) {
-			logger.warn("No image available!");
-			return;
-		}
-		QP.removeChildObjectsOnBoundary(imageData.getHierarchy());
-		imageData.getHistoryWorkflow().addStep(
-				new DefaultScriptableWorkflowStep(
-						"Remove child objects touching selected ROI boundaries",
-						"removeChildObjectsOnBoundary()")
+						"removeObjectsTouchingImageBounds()")
 		);
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/DeleteObjectsOnBoundsCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/DeleteObjectsOnBoundsCommand.java
@@ -1,0 +1,145 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2025 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+package qupath.lib.gui.commands;
+
+import javafx.scene.control.ButtonType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.fx.dialogs.Dialogs;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.gui.dialogs.ParameterPanelFX;
+import qupath.lib.gui.tools.GuiTools;
+import qupath.lib.images.ImageData;
+import qupath.lib.objects.PathObjectFilter;
+import qupath.lib.plugins.parameters.ParameterList;
+import qupath.lib.plugins.workflow.DefaultScriptableWorkflowStep;
+import qupath.lib.plugins.workflow.WorkflowStep;
+import qupath.lib.scripting.QP;
+
+import java.util.Arrays;
+
+/**
+ * Interactive command to remove objects with ROIs that touch or overlap the boundary of other objects.
+ * <br/>
+ * This can be used to remove detections that are clipped by their parent annotation,
+ * or to remove objects falling along a specified line or other boundary.
+ *
+ * @since v0.6.0
+ */
+public class DeleteObjectsOnBoundsCommand {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeleteObjectsOnBoundsCommand.class);
+
+    private static final String title = "Remove on bounds";
+
+    private final QuPathGUI qupath;
+
+    private enum ObjectType {
+        ANY_OBJECTS,
+        ANNOTATIONS,
+        DETECTIONS;
+
+        public String toString() {
+            return switch(this) {
+                case ANY_OBJECTS -> "Any objects";
+                case ANNOTATIONS -> "Annotations";
+                case DETECTIONS -> "Detections";
+            };
+        }
+    }
+
+    private ObjectType typeToRemove = ObjectType.ANY_OBJECTS;
+    private boolean childObjectsOnly = true;
+
+    public DeleteObjectsOnBoundsCommand(QuPathGUI qupath) {
+        this.qupath = qupath;
+    }
+
+    /**
+     * Run the command interactively for the specified image.
+     * @param imageData the current image
+     */
+    public void runForImage(ImageData<?> imageData) {
+        if (imageData == null) {
+            GuiTools.showNoImageError(title);
+            return;
+        }
+        if (imageData.getHierarchy().getSelectionModel().noSelection()) {
+            Dialogs.showErrorMessage(title, "No objects are selected!");
+            return;
+        }
+
+        var params = new ParameterList()
+                .addChoiceParameter("objectType", "Type of objects to remove",
+                        typeToRemove, Arrays.asList(ObjectType.values()),
+                        "Specify which type of objects to remove")
+                .addBooleanParameter("childObjectsOnly", "Child objects only", childObjectsOnly,
+                        "Only remove direct child objects of the selected objects.\n" +
+                                "This is typically used to remove objects (e.g. cells) that touch the bounds\n" +
+                                "of their parent object in which they were detected.");
+
+        var result = Dialogs.builder()
+                .owner(qupath.getStage())
+                .title(title)
+                .content(new ParameterPanelFX(params).getPane())
+                .buttons(ButtonType.APPLY, ButtonType.CANCEL)
+                .showAndWait()
+                .orElse(ButtonType.CANCEL);
+
+        if (!ButtonType.APPLY.equals(result)) {
+            return;
+        }
+
+        typeToRemove = (ObjectType)params.getChoiceParameterValue("objectType");
+        childObjectsOnly = params.getBooleanParameterValue("childObjectsOnly");
+
+        PathObjectFilter filter = switch(typeToRemove) {
+            case ANNOTATIONS -> PathObjectFilter.ANNOTATIONS;
+            case DETECTIONS -> PathObjectFilter.DETECTIONS_ALL;
+            case ANY_OBJECTS -> null;
+        };
+
+        WorkflowStep step;
+        if (childObjectsOnly) {
+            QP.removeChildObjectsTouchingSelectedBounds(imageData.getHierarchy(), filter);
+            if (filter == null) {
+                step = new DefaultScriptableWorkflowStep("Delete child objects on bounds",
+                        "removeChildObjectsTouchingSelectedBounds()");
+            } else {
+                step = new DefaultScriptableWorkflowStep("Delete child objects on bounds",
+                        "removeChildObjectsTouchingSelectedBounds(PathObjectFilter." + filter.name() + ")");
+            }
+        } else {
+            QP.removeObjectsTouchingSelectedBounds(imageData.getHierarchy(), filter);
+            if (filter == null) {
+                step = new DefaultScriptableWorkflowStep("Delete objects on bounds",
+                        "removeObjectsTouchingSelectedBounds()");
+            } else {
+                step = new DefaultScriptableWorkflowStep("Delete objects on bounds",
+                        "removeObjectsTouchingSelectedBounds(PathObjectFilter." + filter.name() + ")");
+            }
+        }
+        imageData.getHistoryWorkflow().addStep(step);
+    }
+
+}

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -439,7 +439,7 @@ Action.Objects.Delete.detections.description = Delete all detection objects for 
 
 Action.Objects.Delete.imageBoundary = Delete objects on image bounds
 Action.Objects.Delete.imageBoundary.description = Delete all objects touching or crossing the image boundary
-Action.Objects.Delete.selectedBoundary = Delete objects touching selected ROI bounds
+Action.Objects.Delete.selectedBoundary = Delete objects touching selected ROI bounds...
 Action.Objects.Delete.selectedBoundary.description = Delete all objects touching or crossing the boundary of the selected objects
 
 Action.Objects.Select.reset = Reset selection

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -437,6 +437,14 @@ Action.Objects.Delete.annotations.description = Delete all annotation objects fo
 Action.Objects.Delete.detections = Delete all detections
 Action.Objects.Delete.detections.description = Delete all detection objects for the current image
 
+Action.Objects.Delete.imageBoundary = Delete objects on image boundary
+Action.Objects.Delete.imageBoundary.description = Delete all objects touching or crossing the image boundary
+Action.Objects.Delete.selectedBoundary = Delete objects on selected boundaries
+Action.Objects.Delete.selectedBoundary.description = Delete all objects touching or crossing the boundary of the selected objects
+Action.Objects.Delete.childSelectedBoundary = Delete child objects on selected boundaries
+Action.Objects.Delete.childSelectedBoundary.description = Delete all objects touching or crossing the boundary of the selected objects, if they are also child
+
+
 Action.Objects.Select.reset = Reset selection
 Action.Objects.Select.reset.description = Reset the selected objects for the current image
 Action.Objects.Select.tmaCores = Select TMA cores

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -437,13 +437,10 @@ Action.Objects.Delete.annotations.description = Delete all annotation objects fo
 Action.Objects.Delete.detections = Delete all detections
 Action.Objects.Delete.detections.description = Delete all detection objects for the current image
 
-Action.Objects.Delete.imageBoundary = Delete objects on image boundary
+Action.Objects.Delete.imageBoundary = Delete objects on image bounds
 Action.Objects.Delete.imageBoundary.description = Delete all objects touching or crossing the image boundary
-Action.Objects.Delete.selectedBoundary = Delete objects on selected boundaries
+Action.Objects.Delete.selectedBoundary = Delete objects touching selected ROI bounds
 Action.Objects.Delete.selectedBoundary.description = Delete all objects touching or crossing the boundary of the selected objects
-Action.Objects.Delete.childSelectedBoundary = Delete child objects on selected boundaries
-Action.Objects.Delete.childSelectedBoundary.description = Delete all objects touching or crossing the boundary of the selected objects, if they are also child
-
 
 Action.Objects.Select.reset = Reset selection
 Action.Objects.Select.reset.description = Reset the selected objects for the current image


### PR DESCRIPTION
New methods int `PathObjectTools` to identify & remove objects that touch the boundary of a specified ROI.

This can be used to identify & discard clipped objects after detection.

Examples:

### Original image
![image](https://github.com/user-attachments/assets/e3c0f984-7102-459b-aa1f-152868bb6b25)

### Remove all objects touching the selected object
```groovy
PathObjectTools.removeTouchingBoundary(
    getCurrentHierarchy(),
    getSelectedObject()
)
```

![image](https://github.com/user-attachments/assets/6b0b2c4c-a12b-495d-a56c-e94f1bfa35f1)


### Remove only detections touching the selected object

```groovy
PathObjectTools.removeTouchingBoundary(
    getCurrentHierarchy(),
    getSelectedObject(),
    PathObject::isDetection
)
```

![image](https://github.com/user-attachments/assets/8222766f-2024-4b81-b8a5-94087d006271)

### Remove child objects touching the selected object

```groovy
PathObjectTools.removeTouchingBoundary(
    getCurrentHierarchy(),
    getSelectedObject(),
    p -> p.getParent() == getSelectedObject()
)
```

The output in this case is the same as filtering to remove detections only.
