### PR TITLE
Pixel classifier fixes & clearer buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,6 +579,7 @@ Here's an abridged version of the main changes, grouped by category.
   * Making measurements is *much* faster in some circumstances (https://github.com/qupath/qupath/pull/1076)
   * It's possible to restrict live prediction more closely to annotated regions ((https://github.com/qupath/qupath/pull/1076))
   * Warn if trying to train a pixel classifier with too many features (https://github.com/qupath/qupath/issues/947)
+  * Improve the layout of the buttons at the bottom of the pixel classifier pane (https://github.com/qupath/qupath/pull/1823)
 * New 'Analyze > Spatial analysis > Signed distance to annotations 2D' command (https://github.com/qupath/qupath/issues/1032)
 * New 'Objects > Lock... >' commands
   * Enables annotations & TMA cores to be locked, so they cannot accidentally be moved or edited (deletion is still possible)

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageDataOp.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageDataOp.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2021, 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -86,6 +86,6 @@ public interface ImageDataOp extends UriResource {
 	 * @param inputType the pixel type of the input image
 	 * @return the output pixel type
 	 */
-	public PixelType getOutputType(PixelType inputType);
+	PixelType getOutputType(PixelType inputType);
 	
 }

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/MultiscaleFeatures.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/MultiscaleFeatures.java
@@ -526,9 +526,9 @@ public class MultiscaleFeatures {
 		 */
 		public FeatureMap build(List<Mat> mats, int ind) {
 			if (sigmaZ > 0) {
-				return build3D(mats, ind).get(0);
+				return build3D(mats, ind).getFirst();
 			}
-			return build2D(Collections.singletonList(mats.get(ind))).get(0);
+			return build2D(Collections.singletonList(mats.get(ind))).getFirst();
 		}
 		
 		/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -773,6 +773,14 @@ public class ImageDisplay extends AbstractImageRenderer {
 				availableChannels.parallelStream()
 						.filter(c -> !(c instanceof DirectServerChannelInfo))
 						.forEach(this::autoSetDisplayRangeWithoutUpdate);
+				if (!server.isRGB()) {
+					// For direct 8-bit, non-RGB set using the min and max from the histogram
+					// This is intended to deal with labeled images, e.g. a pixel classifier's output -
+					// where the values are usually low
+					availableChannels.parallelStream()
+							.filter(c -> c instanceof DirectServerChannelInfo)
+							.forEach(c -> autoSetDisplayRange(c, 0));
+				}
 			} else {
 				availableChannels.parallelStream()
 						.forEach(this::autoSetDisplayRangeWithoutUpdate);


### PR DESCRIPTION
Improvements to the pixel classifier, including:
* 2x2 button panel for what to do with the output, instead of 1x3 with extras
* Activate buttons even if the classifier hasn't been saved - then warn the user (rather than leave them confused why the buttons are inactive)
* Don't show unusable middle eigenvalue features (meaningful only in 3D)
* Add an extra local normalization method... even though it's not much better than the existing ones

The local normalization may be regrettable, but having written the code it was hard to just throw away. The idea is that it dilates and erode an image, then uses this to do a local min/max normalization - optionally smoothing the dilated and eroded images to reduce discontinuities. It still isn't *recommended*, but maybe it's useful somewhere.

Screenshot showing the new buttons:

<img width="1385" alt="classifier-buttons" src="https://github.com/user-attachments/assets/9637f22a-80e3-4b8e-ad88-e8201c01366c" />

One goal of this is to make 'Save prediction' more prominent, since this now supports ome.zarr as well as ome.tiff (and therefore is potentially more useful).