### PR TITLE
Add tolerance when resolving hierarchy based on ROI.covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Some things may be added, some things may be removed, and some things may look d
 * Optionally build QuPath *and* Fiji together (https://github.com/qupath/qupath/pull/1728)
 * Support for z-projection overlays (https://github.com/qupath/qupath/pull/1810)
   * Also new controls to navigate z-slices / time points (https://github.com/qupath/qupath/pull/1802)
+* Add tolerance when resolving object hierarchy (https://github.com/qupath/qupath/pull/1824)
+
 
 ### Enhancements
 (These are not yet ordered by interestingness)
@@ -28,6 +30,8 @@ Some things may be added, some things may be removed, and some things may look d
 * Support system light/dark color themes
 * Menu items uses ellipsis to indicate more input will be needed
   * Standard UX convention we didn't know about...
+* 'Update detection line thickness with zoom' preference (https://github.com/qupath/qupath/pull/1623)
+  * New preference that changes how detections are displayed at high magnifications (to avoid thick lines obscuring the image)
 * Commands to remove objects touching the bounds of the image or other objects (https://github.com/qupath/qupath/pull/1821)
   * _Objects → Delete... → Delete objects on image bounds_
   * _Objects → Delete... → Delete objects touching selected ROI bounds..._
@@ -78,8 +82,6 @@ Some things may be added, some things may be removed, and some things may look d
 ### Experimental features
 These features are included for testing and feedback.
 They may change or be removed in future versions.
-* 'Dynamic detection line thickness (experimental)' preference (https://github.com/qupath/qupath/pull/1623)
-  * Experimental preference to adjust how detections are displayed when zoomed in
 * New toolbar button to show/hide 'neighbors' in the viewer (https://github.com/qupath/qupath/pull/1597)
   * Note that the *Delaunay cluster features 2D* command is now deprecated - see https://github.com/qupath/qupath/issues/1590 for details
     * If you use this command, the calculated connections are displayed instead of the default neighbor connections for compatibility.

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java
@@ -850,19 +850,18 @@ public final class PathObjectHierarchy implements Serializable {
 		if (pathObjects.isEmpty() || !roi.isArea() || roi.isEmpty())
 			return Collections.emptyList();
 		
-		var locator = tileCache.getLocator(roi);
-		var preparedGeometry = tileCache.getPreparedGeometry(tileCache.getGeometry(roi));
 		// Note: JTS 1.17.0 does not support parallel requests, see https://github.com/locationtech/jts/issues/571
 		// A change in getLocator() overcomes this - but watch out for future problems
+		var relate = tileCache.getRoiRelate(roi);
 		return pathObjects.parallelStream().filter(child -> {
 			// Test plane first
 			if (!sameZT(roi, child.getROI()))
 				return false;
-			
+
 			if (child.isDetection())
-				return tileCache.containsCentroid(locator, child);
+				return relate.containsCentroid(child.getROI());
 			else {
-				return tileCache.covers(preparedGeometry, tileCache.getGeometry(child));
+				return relate.coversWithTolerance(child.getROI());
 			}
 		}).collect(Collectors.toCollection(ArrayList::new));
 	}

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
@@ -75,11 +75,6 @@ class PathObjectTileCache implements PathObjectHierarchyListener {
 	private static final Envelope MAX_ENVELOPE = new Envelope(-Double.MAX_VALUE, Double.MAX_VALUE, -Double.MAX_VALUE, Double.MAX_VALUE);
 	
 	/**
-	 * Keep a map of envelopes per ROI; ROIs should be immutable.
-	 */
-	private final Map<ROI, Envelope> envelopeMap = new WeakHashMap<>();
-	
-	/**
 	 * Store a spatial index according to the class of PathObject.
 	 */
 	private final Map<Class<? extends PathObject>, SpatialIndex> map = new HashMap<>();
@@ -228,18 +223,10 @@ class PathObjectTileCache implements PathObjectHierarchyListener {
 	}
 	
 	private Envelope getEnvelope(ROI roi) {
-		boolean useCache = false;
-		if (useCache)
-			return envelopeMap.computeIfAbsent(roi, PathObjectTileCache::computeEnvelope);
-		else
-			return computeEnvelope(roi);
-	}
-
-	private static Envelope computeEnvelope(ROI roi) {
 		return new Envelope(roi.getBoundsX(), roi.getBoundsX() + roi.getBoundsWidth(),
 				roi.getBoundsY(), roi.getBoundsY() + roi.getBoundsHeight());
 	}
-	
+
 	private Envelope getEnvelope(ImageRegion region) {
 		return new Envelope(region.getMinX(), region.getMaxX(),
 				region.getMinY(), region.getMaxY());

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectTileCache.java
@@ -35,24 +35,17 @@ import java.util.WeakHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.locationtech.jts.algorithm.locate.IndexedPointInAreaLocator;
-import org.locationtech.jts.algorithm.locate.PointOnGeometryLocator;
 import org.locationtech.jts.algorithm.locate.SimplePointInAreaLocator;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Location;
-import org.locationtech.jts.geom.Polygonal;
-import org.locationtech.jts.geom.prep.PreparedGeometry;
-import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.locationtech.jts.index.SpatialIndex;
 import org.locationtech.jts.index.quadtree.Quadtree;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import qupath.lib.objects.PathObject;
-import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.TemporaryObject;
 import qupath.lib.objects.hierarchy.events.PathObjectHierarchyEvent;
 import qupath.lib.objects.hierarchy.events.PathObjectHierarchyListener;
@@ -66,7 +59,7 @@ import qupath.lib.roi.interfaces.ROI;
  * responding to its change events.
  * <p>
  * In practice, the cache itself is constructed lazily whenever a request is made 
- * through getObjectsForRegion, so as to avoid rebuilding it too often when the hierarchy
+ * through getObjectsForRegion, to avoid rebuilding it too often when the hierarchy
  * is changing a lot.
  * 
  * @author Pete Bankhead
@@ -95,7 +88,12 @@ class PathObjectTileCache implements PathObjectHierarchyListener {
 	 * Map to cache Geometries, specifically for annotations.
 	 */
 	private static final Map<ROI, Geometry> geometryMap = Collections.synchronizedMap(new WeakHashMap<>());
-	private static final Map<ROI, PointOnGeometryLocator> locatorMap = Collections.synchronizedMap(new WeakHashMap<>());
+
+	/**
+	 * Map to cache helper classes to determine the relationship between ROIs.
+	 * This is important when relationships are expensive (e.g. for complex geometries).
+	 */
+	private static final Map<ROI, RoiRelate> relateMap = Collections.synchronizedMap(new WeakHashMap<>());
 
 	private final PathObjectHierarchy hierarchy;
 	private boolean isActive = false;
@@ -130,7 +128,7 @@ class PathObjectTileCache implements PathObjectHierarchyListener {
 				map.remove(limitToClass);
 			addToCache(hierarchy.getRootObject(), true, limitToClass);
 			long endTime = System.currentTimeMillis();
-			logger.debug("Cache reconstructed in " + (endTime - startTime)/1000.);
+            logger.debug("Cache reconstructed in {} ms", endTime - startTime);
 		} finally {
 			w.unlock();
 		}
@@ -183,98 +181,46 @@ class PathObjectTileCache implements PathObjectHierarchyListener {
 		else
 			return geometry;
 	}
-	
-	Geometry getGeometry(PathObject pathObject) {
-		ROI roi = pathObject.getROI();
-		Geometry geometry = geometryMap.get(roi);
-		if (geometry == null) {
-			geometry = roi.getGeometry();
-			if (pathObject.isAnnotation() || pathObject.isTMACore() || geometry.getNumPoints() > 100) {
-				geometryMap.put(roi, geometry);
-			}
-		}
-		return geometry;
-	}
-	
-	private Coordinate getCentroidCoordinate(PathObject pathObject) {
-		ROI roi = PathObjectTools.getROI(pathObject, true);
+
+	private Coordinate getCentroidCoordinate(ROI roi) {
 		// It's faster not to rely on a synchronized map
 		return new Coordinate(roi.getCentroidX(), roi.getCentroidY());
 	}
-	
-	PointOnGeometryLocator getLocator(ROI roi) {
-		var locator = locatorMap.get(roi);
-		if (locator == null) {
-			var geometry = getGeometry(roi);
-			if (geometry instanceof Polygonal || geometry instanceof LinearRing)
-				locator = new IndexedPointInAreaLocator(geometry);
-			else
-				locator = new SimplePointInAreaLocator(geometry);
-			// Workaround for multithreading bug in JTS 1.17.0 - see https://github.com/locationtech/jts/issues/571
-			locator.locate(new Coordinate());
-			locatorMap.put(roi, locator);
-		}
-		return locator;
-	}
-	
-	private final Map<Geometry, PreparedGeometry> preparedGeometryMap = new WeakHashMap<>();
-	
-	PreparedGeometry getPreparedGeometry(Geometry geometry) {
-		var prepared = preparedGeometryMap.get(geometry);
-		if (prepared != null)
-			return prepared;
-		
-		synchronized (preparedGeometryMap) {
-			prepared = preparedGeometryMap.get(geometry);
-			if (prepared != null)
-				return prepared;
-			prepared = PreparedGeometryFactory.prepare(geometry);
-			preparedGeometryMap.put(geometry, prepared);
-			return prepared;
-		}
-	}
-	
+
 	boolean covers(PathObject possibleParent, PathObject possibleChild) {
-		var child = getGeometry(possibleChild);
-		// If we have an annotation, do a quick check for a single coordinate outside
-		if (possibleParent.isAnnotation()) {
-			if (getLocator(possibleParent.getROI()).locate(child.getCoordinate()) == Location.EXTERIOR)
-				return false;
-		}
-		var parent = getGeometry(possibleParent);
-		return covers(parent, child);
+		var roi = possibleParent.getROI();
+		var roiChild = possibleChild.getROI();
+		if (roi == null || roi.isEmpty() || roiChild == null || roiChild.isEmpty())
+			return false;
+		return getRoiRelate(roi).coversWithTolerance(roiChild);
 	}
-	
-	boolean covers(PreparedGeometry parent, Geometry child) {
-		return parent.covers(child);
+
+	RoiRelate getRoiRelate(ROI roi) {
+		return relateMap.computeIfAbsent(roi, r -> new RoiRelate(r, getGeometry(r)));
 	}
-	
-	boolean covers(Geometry parent, Geometry child) {
-		return covers(getPreparedGeometry(parent), child);
-	}
-	
+
 	boolean containsCentroid(PathObject possibleParent, PathObject possibleChild) {
-		Coordinate centroid = getCentroidCoordinate(possibleChild);
-		if (possibleParent.isDetection())
+		getRoiRelate(possibleParent.getROI());
+		return containsCentroid(possibleParent.getROI(), possibleChild.getROI());
+	}
+
+	private boolean containsCentroid(ROI roi, ROI roiChild) {
+		if (roi == null || roi.isEmpty())
+			return false;
+
+		Coordinate centroid = getCentroidCoordinate(roiChild);
+		// Use a RoiRelate if we have one, but don't create a new one if we don't
+		var relate = relateMap.getOrDefault(roi, null);
+		if (relate != null)
+			return relate.contains(centroid);
+		else
 			return SimplePointInAreaLocator.locate(
-					centroid, getGeometry(possibleParent)) != Location.EXTERIOR;
-		return getLocator(possibleParent.getROI()).locate(centroid) != Location.EXTERIOR;
-	}
-	
-	boolean containsCentroid(PointOnGeometryLocator locator, PathObject possibleChild) {
-		Coordinate centroid = getCentroidCoordinate(possibleChild);
-		return locator.locate(centroid) != Location.EXTERIOR;
-	}
-	
-	boolean containsCentroid(Geometry possibleParent, PathObject possibleChild) {
-		Coordinate centroid = getCentroidCoordinate(possibleChild);
-		return SimplePointInAreaLocator.locate(centroid, possibleParent) != Location.EXTERIOR;
+					centroid, getGeometry(roi)) != Location.EXTERIOR;
 	}
 	
 	
 	private SpatialIndex createSpatialIndex() {
 		return new Quadtree();
-//		return new STRtree();
 	}
 	
 	private Envelope getEnvelope(PathObject pathObject) {

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/RoiRelate.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/RoiRelate.java
@@ -1,0 +1,117 @@
+package qupath.lib.objects.hierarchy;
+
+import org.locationtech.jts.algorithm.PointLocator;
+import org.locationtech.jts.algorithm.distance.DiscreteHausdorffDistance;
+import org.locationtech.jts.algorithm.locate.IndexedPointInAreaLocator;
+import org.locationtech.jts.algorithm.locate.PointOnGeometryLocator;
+import org.locationtech.jts.algorithm.locate.SimplePointInAreaLocator;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Location;
+import org.locationtech.jts.geom.Polygonal;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
+import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
+import qupath.lib.roi.interfaces.ROI;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+class RoiRelate {
+
+    private final ROI roi;
+    private final Geometry geometry;
+    private volatile PreparedGeometry preparedGeometry;
+    private volatile PointOnGeometryLocator locator;
+
+    private final Map<ROI, Boolean> coversMap = new WeakHashMap<>();
+
+    RoiRelate(ROI roi, Geometry geometry) {
+        this.roi = roi;
+        this.geometry = geometry == null ? roi.getGeometry() : geometry;
+    }
+
+    public boolean coversWithTolerance(ROI roi) {
+        return coversMap.computeIfAbsent(roi, this::computeCoversWithTolerance);
+    }
+
+    private boolean computeCoversWithTolerance(ROI roi) {
+        var child = roi.getGeometry();
+        var parent = getPreparedGeometry();
+
+        if (child.isEmpty())
+            return false;
+        if (parent.covers(child))
+            return true;
+        if (parent.disjoint(child) || parent.touches(child))
+            return false;
+
+        double parentArea = parent.getGeometry().getArea();
+        double childArea = child.getArea();
+        if (parentArea < childArea || childArea == 0)
+            return false;
+
+//		double dist = Math.max(1e-3, 1.0/parent.getGeometry().getFactory().getPrecisionModel().getScale());
+        double dist = Math.max(1e-3, 2.0/parent.getGeometry().getFactory().getPrecisionModel().getScale());
+
+        var env = parent.getGeometry().getEnvelopeInternal();
+        env.expandBy(dist);
+        if (!env.covers(child.getEnvelopeInternal()))
+            return false;
+
+        var intersection = parent.getGeometry().intersection(child);
+        double actualDist = DiscreteHausdorffDistance.distance(intersection, child, 0.01);
+        return actualDist < dist;
+    }
+
+    public boolean containsCentroid(ROI roi) {
+        return contains(new Coordinate(roi.getCentroidX(), roi.getCentroidY()));
+    }
+
+    public boolean contains(double x, double y) {
+        var coord = new Coordinate(x, y);
+        if (contains(coord))
+            return true;
+        geometry.getFactory().getPrecisionModel().makePrecise(coord);
+        return contains(coord);
+    }
+
+    public boolean contains(Coordinate coord) {
+        return getLocator().locate(coord) != Location.EXTERIOR;
+    }
+
+
+    private PreparedGeometry getPreparedGeometry() {
+        if (preparedGeometry == null) {
+            synchronized (this) {
+                if (preparedGeometry == null) {
+                    preparedGeometry = PreparedGeometryFactory.prepare(geometry);
+                }
+            }
+        }
+        return preparedGeometry;
+    }
+
+    private PointOnGeometryLocator getLocator() {
+        if (locator == null) {
+            synchronized (this) {
+                if (locator == null) {
+                    locator = createLocator(geometry);
+                }
+            }
+        }
+        return locator;
+    }
+
+    private static synchronized PointOnGeometryLocator createLocator(Geometry geometry) {
+        PointOnGeometryLocator locator;
+        if (geometry instanceof Polygonal || geometry instanceof LinearRing)
+            locator = new IndexedPointInAreaLocator(geometry);
+        else
+            locator = new SimplePointInAreaLocator(geometry);
+        // Workaround for multithreading bug in JTS 1.17.0 - see https://github.com/locationtech/jts/issues/571
+        locator.locate(new Coordinate());
+        return locator;
+    }
+
+}

--- a/qupath-core/src/main/java/qupath/lib/objects/hierarchy/RoiRelate.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/hierarchy/RoiRelate.java
@@ -122,6 +122,7 @@ class RoiRelate {
         if (!env.covers(child.getEnvelopeInternal()))
             return false;
 
+        // Expensive calculation!
         var intersection = parent.getGeometry().intersection(child);
         double actualDist = DiscreteHausdorffDistance.distance(intersection, child, 0.01);
         return actualDist < tolerance;


### PR DESCRIPTION
One proposed approach to address https://github.com/qupath/qupath/issues/1771

It focusses on incorporating some tolerance when checking if one ROI 'covers' another, which is used to set the relationship between annotations in the object hierarchy.

The issue can be explored using the script at https://gist.github.com/petebankhead/29129565fb9f59446f0dfcc1e66dc45c

With this PR, the tests pass - albeit running more slowly (~5 seconds). Without this PR, the code runs more quickly (~1 second) but gives more surprising results.

---

The strategy remains a bit convoluted, because it tries to avoid changing the `ROI` class itself. This means we need to be requesting geometries outside, and caching things in a `WeakHashMap`. This can add considerable overhead, especially for really large geometries: if we moved the logic *inside* the `ROI` implementations, we wouldn't need to make defensive copies of every `Geometry` being returned.

On the other hand, adding complexity to `ROI` needs careful consideration since we've tried to keep this interface fairly minimal. We could dive in fully and add methods to the `ROI` interface such as
```java
public ROI union(ROI);
public ROI intersection(ROI);
public ROI covers(ROI);
```
which is *probably* desirable, and allows us to reduce reliance on `RoiTools`... but is a pretty major change.