### PR TITLE
Fix decimal places with measurement export

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ObservableMeasurementTableData.java
@@ -41,6 +41,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import qupath.lib.common.GeneralTools;
+import qupath.lib.lazy.objects.MeasurementListValue;
 import qupath.lib.lazy.objects.PathObjectLazyValues;
 import qupath.lib.lazy.interfaces.LazyValue;
 import qupath.lib.gui.prefs.PathPrefs;
@@ -305,7 +306,7 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 
 	@Override
 	public String getStringValue(PathObject pathObject, String column) {
-		return getStringValue(pathObject, column, -1);
+		return getStringValue(pathObject, column, PathTableData.DEFAULT_DECIMAL_PLACES);
 	}
 
 	/**
@@ -324,6 +325,10 @@ public class ObservableMeasurementTableData implements PathTableData<PathObject>
 	@Override
 	public String getStringValue(PathObject pathObject, String column, int decimalPlaces) {
 		LazyValue<PathObject, ?> builder = builderMap.get(column);
+		// Temporary hack! This restores v0.6.0 behavior to be similar to previous versions, but it would be better
+		// to suppose specifying the number of decimal places through a preference & apply it consistently
+		if (decimalPlaces == PathTableData.DEFAULT_DECIMAL_PLACES && builder instanceof MeasurementListValue)
+			decimalPlaces = -4;
 		if (builder != null)
 			return builder.getStringValue(pathObject, decimalPlaces);
 		

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ui/SummaryMeasurementTable.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ui/SummaryMeasurementTable.java
@@ -864,7 +864,7 @@ public class SummaryMeasurementTable {
      */
     public static <T> List<String> getTableModelStrings(final PathTableData<T> model, final String delim, Collection<String> excludeColumns) {
         var toExclude = Set.of(excludeColumns.toArray(String[]::new));
-        return model.getRowStrings(delim, -1, s -> !toExclude.contains(s));
+        return model.getRowStrings(delim, PathTableData.DEFAULT_DECIMAL_PLACES, s -> !toExclude.contains(s));
     }
 
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryViewer.java
@@ -1766,7 +1766,7 @@ public class TMASummaryViewer {
 
 		@Override
 		public String getStringValue(TMAEntry entry, String column) {
-			return getStringValue(entry, column, -1);
+			return getStringValue(entry, column, PathTableData.DEFAULT_DECIMAL_PLACES);
 		}
 
 		@Override


### PR DESCRIPTION
Fixes saveDetectionMeasurements and related commands to use the same number of decimal places by default as in v0.5.1