### PR TITLE
Offer to open the extension manager

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -35,6 +35,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import javafx.beans.property.BooleanProperty;
+import javafx.geometry.Pos;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +50,7 @@ import javafx.application.Platform;
 import javafx.stage.Stage;
 import qupath.lib.common.GeneralTools;
 import qupath.fx.dialogs.Dialogs;
+import qupath.lib.gui.commands.Commands;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.projects.Project;
 import qupath.lib.projects.ProjectIO;
@@ -79,11 +87,15 @@ public class QuPathApp extends Application {
 		tryToRegisterOpenFilesHandler(qupath);
 		
 		if (!params.requestQuietLaunch()) {
-			
+
 			if (PathPrefs.showStartupMessageProperty().get()) {
 				showWelcomeMessage(qupath);
 			}
-			
+
+			if (promptForExtensions.get() && QuPathGUI.getExtensionCatalogManager().getCatalogManagedInstalledJars().isEmpty()) {
+				promptToOpenExtensionManager(qupath);
+			}
+
 			// If code is running from a directory (not a jar), we're likely running 
 			// from source (not an official package) - so we don't want to check 
 			// for updates unnecessarily.
@@ -96,12 +108,36 @@ public class QuPathApp extends Application {
 		}
 		
 	}
+
+	private static final BooleanProperty promptForExtensions =
+			PathPrefs.createPersistentPreference("showExtensionManagerOnStartup", true);
+
+	private static void promptToOpenExtensionManager(QuPathGUI qupath) {
+		var labelContent = new Label("Add extra features by installing optional extensions.");
+		var hyperlink = new Hyperlink("Find out more (website)");
+		hyperlink.setOnAction(e -> QuPathGUI.openInBrowser(Urls.getExtensionsDocsUrl()));
+		var cbAskAgain = new CheckBox("Remind me next time");
+		cbAskAgain.setSelected(promptForExtensions.get());
+		var content = new VBox(labelContent, hyperlink, cbAskAgain);
+		content.setSpacing(5);
+		content.setAlignment(Pos.CENTER);
+		if (Dialogs.builder()
+				.headerText("Do you want to open QuPath's Extension Manager?")
+				.content(content)
+				.title("Extensions")
+				.buttons(ButtonType.YES, ButtonType.NO)
+				.showAndWait()
+				.orElse(ButtonType.NO) == ButtonType.YES) {
+			Commands.showInstalledExtensions(qupath);
+		}
+		promptForExtensions.set(cbAskAgain.isSelected());
+	}
 			
 	private static void openProjectOrLogException(QuPathGUI qupath, String projectParameter) {
 		try {
 			tryToOpenProject(qupath, projectParameter);
 		} catch (IOException | URISyntaxException e) {
-			logger.error("Unable to open project " + projectParameter, e);
+            logger.error("Unable to open project {}", projectParameter, e);
 		}
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/Urls.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/Urls.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2023-2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -55,7 +55,7 @@ public final class Urls {
 	 * Get the base URL for the QuPath documentation (independent of version).
 	 * @return
 	 */
-	public static final String getDocsUrl() {
+	public static String getDocsUrl() {
 		return "https://qupath.readthedocs.io";
 	}
 	
@@ -63,7 +63,7 @@ public final class Urls {
 	 * Get the base URL for the QuPath documentation, specifically for this software version.
 	 * @return
 	 */
-	public static final String getVersionedDocsUrl() {
+	public static String getVersionedDocsUrl() {
 		return "https://qupath.readthedocs.io/en/" + DOCS_VERSION;
 	}
 
@@ -73,7 +73,7 @@ public final class Urls {
 	 * @param relative
 	 * @return
 	 */
-	public static final String getVersionedDocsUrl(String relative) {
+	public static String getVersionedDocsUrl(String relative) {
 		return "https://qupath.readthedocs.io/en/" + DOCS_VERSION + "/docs/" + relative;
 	}
 	
@@ -81,7 +81,7 @@ public final class Urls {
 	 * Get a URL pointing to a page that explains how to cite this version of QuPath in a publication.
 	 * @return
 	 */
-	public static final String getCitationUrl() {
+	public static String getCitationUrl() {
 		// Would ideally use latest or stable, not the current version - but that would break if the 
 		// doc pages are renamed
 		return getVersionedDocsUrl("intro/citing.html");
@@ -91,15 +91,23 @@ public final class Urls {
 	 * Get a URL pointing to a page that explains how to install this version of QuPath.
 	 * @return
 	 */
-	public static final String getInstallationUrl() {
+	public static String getInstallationUrl() {
 		return getVersionedDocsUrl("intro/installation.html");
+	}
+
+	/**
+	 * Get a URL pointing to a page that explains how to install QuPath extensions.
+	 * @return
+	 */
+	public static String getExtensionsDocsUrl() {
+		return getVersionedDocsUrl("intro/extensions.html");
 	}
 
 	/**
 	 * Get a URL pointing to the QuPath YouTube channel.
 	 * @return
 	 */
-	public static final String getYouTubeUrl() {
+	public static String getYouTubeUrl() {
 		return "https://www.youtube.com/c/QuPath";
 	}
 	
@@ -107,7 +115,7 @@ public final class Urls {
 	 * Get a URL pointing to the main QuPath GitHub repo.
 	 * @return
 	 */
-	public static final String getGitHubRepoUrl() {
+	public static String getGitHubRepoUrl() {
 		return "https://github.com/qupath/qupath";
 	}
 	
@@ -115,7 +123,7 @@ public final class Urls {
 	 * Get a URL pointing to the main GitHub issues page.
 	 * @return
 	 */
-	public static final String getGitHubIssuesUrl() {
+	public static String getGitHubIssuesUrl() {
 		return "https://github.com/qupath/qupath/issues";
 	}
 
@@ -123,7 +131,7 @@ public final class Urls {
 	 * Get a URL pointing to the main QuPath user forum.
 	 * @return
 	 */
-	public static final String getUserForumUrl() {
+	public static String getUserForumUrl() {
 		return "https://forum.image.sc/tags/qupath";
 	}
 


### PR DESCRIPTION
Add a prompt immediately after the welcome screen to open the extension manager.

This will appear on startup so long as
- no managed extensions are installed
- the user hasn't deselected 'Remind me next time'

The aim is to improve the discoverability of extensions, while highlighting the extension manager for new users (so that they use it instead of drag & drop installation).

<img src="https://github.com/user-attachments/assets/b0db8f86-a443-462f-9895-a61d069ff2a6" width=50% />