### PR TITLE
Show selected objects in scatterplots

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ui/SummaryMeasurementTable.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/measure/ui/SummaryMeasurementTable.java
@@ -201,7 +201,7 @@ public class SummaryMeasurementTable {
      */
     private static BooleanProperty createPartiallyBoundProperty(BooleanProperty prop) {
         var prop2 = new SimpleBooleanProperty(prop.getValue());
-        prop.bind(prop2);
+        prop2.addListener((observable, oldValue, newValue) -> prop.setValue(newValue));
         return prop2;
     }
 


### PR DESCRIPTION
Also fix a 'bound property cannot be set' bug that occurred if the preference pane was opened after a measurement table.