### PR TITLE
Pixel classifier fixes

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
@@ -169,7 +169,6 @@ public class ObjectClassifierCommand implements Runnable {
 	public void run() {
 		if (dialog == null) {
 			dialog = new Stage();
-			FXUtils.addCloseWindowShortcuts(dialog);
 			if (qupath != null)
 				dialog.initOwner(qupath.getStage());
 			dialog.setTitle(name);

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
@@ -519,7 +519,6 @@ public class PixelClassifierPane {
 		pane.setPadding(new Insets(5));
 		
 		stage = new Stage();
-		FXUtils.addCloseWindowShortcuts(stage);
 		stage.setScene(new Scene(fullPane));
 		
 		stage.setMinHeight(400);


### PR DESCRIPTION
Fixes unintuitive behavior whereby pixel classifier measurements wouldn't appear, despite predictions *seeming* to be made for an image region.

This is because the overlay could merrily show RGB renderings of the prediction whenever the predictions themselves had been ejected from the tile cache... and consequently the predictions were never requested again, since the RGB tile *was* present.

This probably isn't a new bug, and could be replicated by using the memory monitor to clear the tile cache when a pixel classification overlay was visible.

The fix here is to use the prediction image as a key to a weakhashmap used to store RGB tiles (when necessary). The downside is that, when classifying a large image, tiles can start to disappear... although it's probably better than an out of memory error.

--

Also, don't add escape shortcut to close windows when training pixel or object classifiers... since it's really annoying to this accidentally.