### PR TITLE
Export docs & extension loading

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,7 +143,7 @@ tasks.register<JavaExec>("exportDocs") {
         println("Making docs dir in ${docsDir.absolutePath}")
         docsDir.mkdirs()
     }
-    classpath = sourceSets["main"].runtimeClasspath
+    classpath = sourceSets.main.get().runtimeClasspath
     mainClass = "qupath.lib.gui.tools.DocGenerator"
     args = listOf(docsDir.absolutePath, "--all")
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionLoader.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ExtensionLoader.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.ext.extensionmanager.core.ExtensionCatalogManager;
 import qupath.fx.dialogs.Dialogs;
+import qupath.fx.utils.FXUtils;
 import qupath.lib.common.Version;
 import qupath.lib.gui.extensions.QuPathExtension;
 import qupath.lib.gui.localization.QuPathResources;
@@ -56,8 +57,7 @@ class ExtensionLoader {
             for (QuPathExtension extension : ServiceLoader.load(QuPathExtension.class, extensionClassLoader)) {
                 if (!loadedExtensions.contains(extension.getClass())) {
                     loadedExtensions.add(extension.getClass());
-
-                    Platform.runLater(() -> loadExtension(extension, showNotifications));
+                    FXUtils.runOnApplicationThread(() -> loadExtension(extension, showNotifications));
                 }
             }
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/ActionTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/ActionTools.java
@@ -87,7 +87,7 @@ import qupath.fx.localization.LocalizedResourceManager;
  */
 public class ActionTools {
 	
-	private static Logger logger = LoggerFactory.getLogger(ActionTools.class);
+	private static final Logger logger = LoggerFactory.getLogger(ActionTools.class);
 	
 	private static final String ACTION_KEY = ActionTools.class.getName();
 
@@ -348,9 +348,8 @@ public class ActionTools {
 				if (!f.canAccess(obj))
 					f.setAccessible(true);
 				var value = f.get(obj);
-				if (value instanceof Action) {
-					var action = (Action)value;
-					parseAnnotations(action, f, baseMenu);
+				if (value instanceof Action action) {
+                    parseAnnotations(action, f, baseMenu);
 					actions.add(action);
 				} else if (value instanceof Action[]) {
 					for (var temp : (Action[])value) {
@@ -473,7 +472,7 @@ public class ActionTools {
 	}
 
 	private static String getActionText(KeyCombination accelerator, String description) {
-		return accelerator == null ?
+		return accelerator == null || accelerator.getDisplayText().isBlank() ?
 				description :
 				"(" + accelerator.getDisplayText() + ") " + description;
 	}


### PR DESCRIPTION
Try to fix `DocGenerator` - which was skipping any commands added through extensions, even built-in extensions.

This is what's used to create the reference page in the docs, e.g. https://qupath.readthedocs.io/en/0.5/docs/reference/commands.html

This involved making a change to `ExtensionLoader`, so that it loads extensions immediately if called from the Platform thread, rather than delayed with `runLater`. This means that calling code that creates a new `QuPathGUI` instance can rely on extensions being available immediately (well, assuming that the *extension* hasn't delayed its own initialisation...).

@Rylern does this seem ok to you, or there a reason why `runLater` is essential within `ExtensionLoader`?