### PR TITLE
Harmonise pixel & object classifier names

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/PixelClassifierPane.java
@@ -660,11 +660,7 @@ public class PixelClassifierPane {
 	private void updateTitle() {
 		if (stage == null)
 			return;
-//		var imageData = viewer.getImageData();
-//		if (imageData == null)
-			stage.setTitle("Pixel classifier");
-//		else
-//			stage.setTitle("Pixel classifier (" + imageData.getServer().getDisplayedImageName() + ")");
+		stage.setTitle("Train pixel classifier");
 	}
 	
 	private MouseListener mouseListener = new MouseListener();


### PR DESCRIPTION
Change the pixel classifier window title from "Pixel classifier" to "Train pixel classifier", matching the object classifier window title ("Train object classifier")