### PR TITLE
Add dock button to keep description pane open

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -242,6 +242,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 		TextArea textDescription = new TextArea();
 		textDescription.textProperty().bind(descriptionText);
 		textDescription.setWrapText(true);
+		textDescription.setEditable(false);
 
 		ToggleButton keepDescriptionOpenButton = new ToggleButton(
 				null,

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -243,6 +243,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 				null,
 				IconFactory.createNode(FontAwesome.Glyph.PENCIL, 13)
 		);
+		editDescriptionButton.setTooltip(new Tooltip("Edit description"));
 		editDescriptionButton.setOnAction(e -> promptToEditSelectedImageDescription());
 		editDescriptionButton.visibleProperty().bind(Bindings.createBooleanBinding(
 				() -> tree.getSelectionModel().getSelectedItem() != null && tree.getSelectionModel().getSelectedItem().getValue().getType().equals(Type.IMAGE),

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -56,6 +56,7 @@ import javafx.scene.Node;
 import javafx.scene.control.RadioMenuItem;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
+import javafx.scene.layout.HBox;
 import org.controlsfx.control.MasterDetailPane;
 import org.controlsfx.control.action.Action;
 import org.controlsfx.control.action.ActionUtils;
@@ -137,7 +138,6 @@ import qupath.lib.projects.ProjectImageEntry;
 public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> {
 
 	private static final Logger logger = LoggerFactory.getLogger(ProjectBrowser.class);
-	private static final int KEEP_DESCRIPTION_OPEN_ICON_SIZE = 12;
 	private static final BooleanProperty keepDescriptionPaneOpenPref = PathPrefs.createPersistentPreference(
 			"keepDescriptionOpen",
 			false
@@ -239,20 +239,34 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			}
 		});
 
-		TextArea textDescription = new TextArea();
-		textDescription.textProperty().bind(descriptionText);
-		textDescription.setWrapText(true);
-		textDescription.setEditable(false);
+		Button editDescriptionButton = new Button(
+				null,
+				IconFactory.createNode(FontAwesome.Glyph.PENCIL, 13)
+		);
+		editDescriptionButton.setOnAction(e -> promptToEditSelectedImageDescription());
+		editDescriptionButton.visibleProperty().bind(Bindings.createBooleanBinding(
+				() -> tree.getSelectionModel().getSelectedItem() != null && tree.getSelectionModel().getSelectedItem().getValue().getType().equals(Type.IMAGE),
+				tree.getSelectionModel().selectedItemProperty()
+		));
+		editDescriptionButton.managedProperty().bind(editDescriptionButton.visibleProperty());
+		editDescriptionButton.setMaxHeight(Double.MAX_VALUE);
 
 		ToggleButton keepDescriptionOpenButton = new ToggleButton(
 				null,
-				IconFactory.createNode(FontAwesome.Glyph.THUMB_TACK, KEEP_DESCRIPTION_OPEN_ICON_SIZE)
+				IconFactory.createNode(FontAwesome.Glyph.THUMB_TACK, 12)
 		);
 		keepDescriptionOpenButton.selectedProperty().set(keepDescriptionPaneOpenPref.get());
 		keepDescriptionOpenButton.selectedProperty().addListener((p, o, n) -> keepDescriptionPaneOpenPref.set(n));
 		keepDescriptionOpenButton.setTooltip(new Tooltip("Keep description pane open"));
 
-		TitledPane textDescriptionContainer = GuiTools.createLeftRightTitledPane("Description", keepDescriptionOpenButton);
+		TitledPane textDescriptionContainer = GuiTools.createLeftRightTitledPane(
+				"Description",
+				new HBox(5, editDescriptionButton, keepDescriptionOpenButton)
+		);
+		TextArea textDescription = new TextArea();
+		textDescription.textProperty().bind(descriptionText);
+		textDescription.setWrapText(true);
+		textDescription.setEditable(false);
 		textDescriptionContainer.setContent(textDescription);
 
 		MasterDetailPane mdTree = new MasterDetailPane(Side.BOTTOM, tree, textDescriptionContainer, false);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -250,15 +250,15 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 				tree.getSelectionModel().selectedItemProperty()
 		));
 		editDescriptionButton.managedProperty().bind(editDescriptionButton.visibleProperty());
-		editDescriptionButton.setMaxHeight(Double.MAX_VALUE);
 
 		ToggleButton keepDescriptionOpenButton = new ToggleButton(
 				null,
-				IconFactory.createNode(FontAwesome.Glyph.THUMB_TACK, 12)
+				IconFactory.createNode(FontAwesome.Glyph.THUMB_TACK, 13)
 		);
 		keepDescriptionOpenButton.selectedProperty().set(keepDescriptionPaneOpenPref.get());
 		keepDescriptionOpenButton.selectedProperty().addListener((p, o, n) -> keepDescriptionPaneOpenPref.set(n));
 		keepDescriptionOpenButton.setTooltip(new Tooltip("Keep description pane open"));
+		keepDescriptionOpenButton.setPadding(new Insets(1,9,1,9));
 
 		TitledPane textDescriptionContainer = GuiTools.createLeftRightTitledPane(
 				"Description",

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -137,7 +137,7 @@ import qupath.lib.projects.ProjectImageEntry;
 public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> {
 
 	private static final Logger logger = LoggerFactory.getLogger(ProjectBrowser.class);
-	private static final int KEEP_DESCRIPTION_OPEN_ICON_SIZE = 11;
+	private static final int KEEP_DESCRIPTION_OPEN_ICON_SIZE = 12;
 	private static final BooleanProperty keepDescriptionPaneOpenPref = PathPrefs.createPersistentPreference(
 			"keepDescriptionOpen",
 			false
@@ -245,7 +245,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 
 		ToggleButton keepDescriptionOpenButton = new ToggleButton(
 				null,
-				IconFactory.createNode(FontAwesome.Glyph.ANCHOR, KEEP_DESCRIPTION_OPEN_ICON_SIZE)
+				IconFactory.createNode(FontAwesome.Glyph.THUMB_TACK, KEEP_DESCRIPTION_OPEN_ICON_SIZE)
 		);
 		keepDescriptionOpenButton.selectedProperty().set(keepDescriptionPaneOpenPref.get());
 		keepDescriptionOpenButton.selectedProperty().addListener((p, o, n) -> keepDescriptionPaneOpenPref.set(n));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -788,12 +788,14 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 	static boolean showDescriptionEditor(ProjectImageEntry<?> entry) {
 		TextArea editor = new TextArea();
 		editor.setWrapText(true);
+		editor.setPromptText(String.format("Enter description for %s", entry.getImageName()));
 		editor.setText(entry.getDescription());
 		Dialog<ButtonType> dialog = new Dialog<>();
 		dialog.getDialogPane().getButtonTypes().setAll(ButtonType.OK, ButtonType.CANCEL);
 		dialog.setTitle("Image description");
 		dialog.getDialogPane().setHeaderText(entry.getImageName());
 		dialog.getDialogPane().setContent(editor);
+		Platform.runLater(editor::requestFocus);
 		Optional<ButtonType> result = dialog.showAndWait();
 		if (result.isPresent() && result.get() == ButtonType.OK && editor.getText() != null) {	
 			var text = editor.getText();


### PR DESCRIPTION
This PR aims at fixing [this issue](https://forum.image.sc/t/improved-descriptions-for-project-images/111854).

It is done by adding a button to keep the description pane of an image entry open:
![image](https://github.com/user-attachments/assets/f50f108e-f088-4402-967b-9f233361b293)

If this button is on, then the description pane will stay visible, even if the selected image entry doesn't have any description.
A preference was added to save the button status when QuPath restarts.

An edit button was also added to easily edit the description. It is only shown when an image is currently selected.

The caret in the description pane is not visible anymore.