### PR TITLE
Save project when -s parameter set

### DIFF
--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -400,6 +400,9 @@ class ScriptCommand implements Runnable {
 						imageData.getServer().close();						
 					}
 				}
+				if (save) {
+					project.syncChanges();
+				}
 			} else if (imagePath != null && !imagePath.equals("")) {
 				String path = QuPath.getEncodedPath(imagePath);
 				URI uri = GeneralTools.toURI(path);


### PR DESCRIPTION
When executing a QuPath script from the command line, there's a `-s` or `--save` parameter to "Request that data files are updated for each image in the project". In effect, when this parameter is set, `entry.saveImageData(imageData)`  is called at the end of each execution of the script.
 
Some scripts modify the metadata of the image (see https://forum.image.sc/t/specifying-pixel-size-using-the-command-line/111972). In those situations, changes are only saved if `getProject().syncChanges()` is called, which is not the case with the `-s` parameter. This PR fixes that.