### PR TITLE
More flexible zarr matcher

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -101,6 +101,8 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 /**
@@ -138,6 +140,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer implement
 	 * Default tile size - when no other value is available.
 	 */
 	private static int DEFAULT_TILE_SIZE = 512;
+	private static final Pattern ZARR_FILE_PATTERN = Pattern.compile("\\.zarr/?(\\d+/?)?$");
 
 //	/**
 //	 * Maximum tile size - larger values will be ignored.
@@ -1292,7 +1295,8 @@ public class BioFormatsImageServer extends AbstractTileableImageServer implement
 			}
 			
 			IFormatReader imageReader;
-			if (new File(id).isDirectory() || id.toLowerCase().endsWith(".zarr") || id.toLowerCase().endsWith(".zarr/")) {
+			Matcher zarrMatcher = ZARR_FILE_PATTERN.matcher(id.toLowerCase());
+			if (new File(id).isDirectory() || zarrMatcher.find()) {
 				// Using new ImageReader() on a directory won't work
 				imageReader = new ZarrReader();
 				if (id.startsWith("https") && imageReader.getMetadataOptions() instanceof DynamicMetadataOptions zarrOptions) {


### PR DESCRIPTION
Currently, an URI is detected as a zarr file only if it ends with `.zarr` or `.zarr/`. This means that links like https://storage.googleapis.com/jax-public-ngff/example_v2/LacZ_ctrl.zarr/0 where useful pixels are located in a zarr group within the zarr image are not recognized.

This PR fixes that by detecting zarr files when one of the following condition is correct:

* The URI ends with .zarr.
* The URI ends with .zarr/.
* The URI ends with .zarr/i where i is a positive integer or zero.
* The URI ends with .zarr/i/ where i is a positive integer or zero.