### PR TITLE
Set default file of zarr export

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriterCommand.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriterCommand.java
@@ -175,7 +175,7 @@ public class OMEZarrWriterCommand implements Runnable {
     private static File promptOutputDirectory() {
         File fileOutput = FileChoosers.promptToSaveFile(
                 QuPathResources.getString("Action.BioFormats.writeOMEZarr"),
-                null,
+                new File(""),
                 FileChoosers.createExtensionFilter(QuPathResources.getString("Action.BioFormats.omeZarr"), ".ome.zarr")
         );
 


### PR DESCRIPTION
Set a default empty file name when exporting a Zarr image. This fixes a bug on Windows where the default output file name was `Untitled.ome.zarr.ome.zarr.ome.zarr`.