### PR TITLE
Selected measurements to max 4 d.p.

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/SelectedMeasurementTableView.java
@@ -94,8 +94,8 @@ public class SelectedMeasurementTableView implements PathObjectSelectionListener
 	
 	private static final Logger logger = LoggerFactory.getLogger(SelectedMeasurementTableView.class);
 	
-	private static int nDecimalPlaces = 4;
-	
+	private static int nDecimalPlaces = -4;
+
 	/**
 	 * Retain reference to prevent garbage collection.
 	 */


### PR DESCRIPTION
This should be similar to v0.5.x and previous behavior. Currently, numbers are shown to 4 decimal places even when that isn't necessary.

For example, running this script on an annotation
```groovy
getSelectedObject().measurements["Hello"] = 1
```
would result in 
<img width="397" alt="decimal-places" src="https://github.com/user-attachments/assets/811447f3-8743-4510-86ba-5113272ed3ea" />

This PR causes the measurement to display as `1` instead.