### PR TITLE
Fix 'stuck' points on scatterplot

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/PathObjectScatterChart.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/charts/PathObjectScatterChart.java
@@ -279,6 +279,12 @@ public class PathObjectScatterChart extends ScatterChart<Number, Number> {
         var y = yFun.apply(pathObject);
         if (!Objects.equals(item.getYValue(), y))
             item.setYValue(y);
+
+        // Workaround for https://github.com/qupath/qupath/issues/1877
+        // May be preferable to exclude non-finite values earlier, so that we only subsample points that could
+        // actually be included - but that is likely to be more complex (at least to do it efficiently if measurement
+        // calculations are expensive)
+        circle.setVisible(x != null && y != null && Double.isFinite(x.doubleValue()) && Double.isFinite(y.doubleValue()));
     }
 
     /**


### PR DESCRIPTION
Workaround to fix https://github.com/qupath/qupath/issues/1877

This sets points to not be visible if their values aren't finite. It might be preferable to identify points with non-finite values *before* subsampling, so that we don't 'waste' points with values that won't be seen.

But I think this approach is sufficient for now. In the future it would be even better to have charts that can scale to very large numbers of points, and therefore don't require subsampling at all.