### PR TITLE
Update to DJL v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,7 +150,7 @@ They may change or be removed in future versions.
 * Bio-Formats 8.1.1
 * Commonmark 0.24.0
 * ControlsFX 11.2.2
-* DeepJavaLibrary 0.31.1
+* DeepJavaLibrary 0.33.0
 * Groovy 4.0.26
 * Gson 2.13.1
 * Guava 33.4.6-jre

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ commonsMath3    = "3.6.1"
 commonsText     = "1.10.0"
 controlsFX      = "11.2.2"
 
-deepJavaLibrary = "0.32.0"
+deepJavaLibrary = "0.33.0"
 
 groovy          = "4.0.26"
 gson            = "2.13.1"


### PR DESCRIPTION
@alanocallaghan any thoughts on the wisdom of this for v0.6.0?

For me it seems to work for InstanSeg without trouble - although it will require downloading the updated JNI for PyTorch (but not necessarily `libtorch`).

Release notes: https://github.com/deepjavalibrary/djl/releases/tag/v0.33.0