### PR TITLE
Add onTileWritten parameter in zarr writer

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriter.java
@@ -10,6 +10,7 @@ import com.bc.zarr.ZarrGroup;
 import loci.formats.gui.AWTImageTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import qupath.lib.common.ThreadTools;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServers;
 import qupath.lib.images.servers.TileRequest;
@@ -29,9 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 /**
@@ -98,19 +97,7 @@ public class OMEZarrWriter implements AutoCloseable {
 
         this.executorService = Executors.newFixedThreadPool(
                 builder.numberOfThreads,
-                new ThreadFactory() {
-                    private static final AtomicInteger poolCounter = new AtomicInteger(0);
-                    private final AtomicInteger threadCounter = new AtomicInteger(0);
-                    private final int poolNumber = poolCounter.getAndIncrement();
-
-                    @Override
-                    public Thread newThread(Runnable r) {
-                        return new Thread(
-                                r,
-                                String.format("zarr_writer_pool-%d-thread-%d", poolNumber, threadCounter.getAndIncrement())
-                        );
-                    }
-                }
+                ThreadTools.createThreadFactory("zarr_writer_", false)
         );
         this.onTileWritten = builder.onTileWritten;
     }

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriter.java
@@ -189,7 +189,7 @@ public class OMEZarrWriter implements AutoCloseable {
         private static final String FILE_EXTENSION = ".ome.zarr";
         private final ImageServer<BufferedImage> server;
         private Compressor compressor = CompressorFactory.createDefaultCompressor();
-        private int numberOfThreads = Runtime.getRuntime().availableProcessors();
+        private int numberOfThreads = ThreadTools.getParallelism();
         private double[] downsamples = new double[0];
         private int maxNumberOfChunks = 50;
         private int tileWidth = 512;

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrWriter.java
@@ -202,7 +202,7 @@ public class OMEZarrWriter implements AutoCloseable {
         private static final String FILE_EXTENSION = ".ome.zarr";
         private final ImageServer<BufferedImage> server;
         private Compressor compressor = CompressorFactory.createDefaultCompressor();
-        private int numberOfThreads = 12;
+        private int numberOfThreads = Runtime.getRuntime().availableProcessors();
         private double[] downsamples = new double[0];
         private int maxNumberOfChunks = 50;
         private int tileWidth = 512;


### PR DESCRIPTION
Add an `onTileWritten` function that will be called by the Zarr writer each time a tile is (successfully or unsuccessfully) written. This is used to have an idea of the progress when writing an image. An associated unit test was also added to this PR.

This PR also set the names of threads created by the Zarr writer.