### PR TITLE
Prevent translation of entire group of points

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/MoveToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/MoveToolEventHandler.java
@@ -130,7 +130,8 @@ public class MoveToolEventHandler extends AbstractPathToolEventHandler {
 				if (!e.isConsumed() && canAdjust(currentObject) &&
 						(RoiTools.areaContains(currentROI, xx, yy) || ToolUtils.getSelectableObjectList(viewer, xx, yy).contains(currentObject))) {
 					// If we have a translatable ROI, try starting translation
-					if (editor.startTranslation(xx, yy, PathPrefs.usePixelSnappingProperty().get() && currentROI.isArea()))
+					// No translation should happen if we have points, because we never want to move all points together
+					if (!editor.getROI().isPoint() && editor.startTranslation(xx, yy, PathPrefs.usePixelSnappingProperty().get() && currentROI.isArea()))
 						e.consume();
 				}
 				if (e.isConsumed()) {


### PR DESCRIPTION
A proposal to fix #1872.

Currently, there is an area around a point where the point itself cannot be selected, but the points ROI can. When the user clicks on this area, the whole ROI (so all points) can be translated. This area is relevant for some ROIs (for example the polyline, we want to move the whole line when we click on the line and not an edge), but not for points ROI.

This PR fixes that by removing this area when the ROI is a list of points. It is still possible to move a single point but not all at the same time.