### PR TITLE
Increase number of decimals of stain values when creating workflow step

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/color/ColorDeconvolutionStains.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorDeconvolutionStains.java
@@ -588,7 +588,7 @@ public class ColorDeconvolutionStains implements Externalizable {
 	@Override
 	public void writeExternal(ObjectOutput out) throws IOException {
 		out.writeInt(version);
-		out.writeObject(getColorDeconvolutionStainsAsString(this, 8));
+		out.writeObject(getColorDeconvolutionStainsAsString(this, 32));
 	}
 
 

--- a/qupath-core/src/main/java/qupath/lib/images/ImageData.java
+++ b/qupath-core/src/main/java/qupath/lib/images/ImageData.java
@@ -25,12 +25,10 @@ package qupath.lib.images;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -360,7 +358,7 @@ public class ImageData<T> implements WorkflowListener, PathObjectHierarchyListen
 			return;
 		}
 		
-		String arg = ColorDeconvolutionStains.getColorDeconvolutionStainsAsString(imageData.getColorDeconvolutionStains(), 17);
+		String arg = ColorDeconvolutionStains.getColorDeconvolutionStainsAsString(imageData.getColorDeconvolutionStains(), 32);
 		Map<String, String> map = GeneralTools.parseArgStringValues(arg);
 		WorkflowStep lastStep = imageData.getHistoryWorkflow().getLastStep();
 		String commandName = "Set color deconvolution stains";

--- a/qupath-core/src/main/java/qupath/lib/images/ImageData.java
+++ b/qupath-core/src/main/java/qupath/lib/images/ImageData.java
@@ -360,7 +360,7 @@ public class ImageData<T> implements WorkflowListener, PathObjectHierarchyListen
 			return;
 		}
 		
-		String arg = ColorDeconvolutionStains.getColorDeconvolutionStainsAsString(imageData.getColorDeconvolutionStains(), 5);
+		String arg = ColorDeconvolutionStains.getColorDeconvolutionStainsAsString(imageData.getColorDeconvolutionStains(), 17);
 		Map<String, String> map = GeneralTools.parseArgStringValues(arg);
 		WorkflowStep lastStep = imageData.getHistoryWorkflow().getLastStep();
 		String commandName = "Set color deconvolution stains";


### PR DESCRIPTION
An proposal to fix #1851.

It is done by increasing the number of decimals of stain values from 5 to 17 when creating a workflow step.

With this PR, the line `println getCurrentImageData().getColorDeconvolutionStains().getStain(1).array as List` and the corresponding workflow step give the same values.