### PR TITLE
Add viewer placeholder

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
@@ -788,7 +788,20 @@ public class ViewerManager implements QuPathViewerListener {
 	private void setupViewer(final QuPathViewerPlus viewer) {
 		
 		viewer.getView().setFocusTraversable(true);
-		
+
+		// Create placeholder text for when no image is showing
+		var placeholder = Bindings.createStringBinding(() -> {
+			if (viewer.getImageData() != null) {
+				return null;
+			}
+			if (qupath.getProject() == null) {
+				return "Drag & drop an image file or project folder";
+			} else {
+				return "Drag & drop image files to add to the project";
+			}
+		}, viewer.imageDataProperty(), qupath.projectProperty());
+		viewer.placeholderTextProperty().bind(placeholder);
+
 		// Update active viewer as required
 		viewer.getView().focusedProperty().addListener((e, f, nowFocussed) -> {
 			if (nowFocussed) {


### PR DESCRIPTION
Make it more obvious that drag & drop can be used to open images, by adding a placeholder to the viewer.

Currently, 2 different messages are included.

## No image or project open

![image](https://github.com/user-attachments/assets/2ebacd6b-c8cc-4134-95f8-ff52c9adb188)

## No image open

![image](https://github.com/user-attachments/assets/f69c2614-525f-4adf-a6b3-376149af01a7)

Either way, it looks weird whenever multiple viewers are open.

![image](https://github.com/user-attachments/assets/c67120a2-1a59-4544-b064-51101436be3b)

My main questions:
* Any improvements on the wording?
  * If you have a project open, the message should maybe be to double-click an image under the project tab...  but that is wordy, and the fact you can use drag & drop for import may be less obvious
* Any opinions on whether only the active viewer should show the text, or all viewers?