### PR TITLE
Add license message on startup

### DIFF
--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -144,7 +144,7 @@ public class QuPath {
 		try {
 			pr = cmd.parseArgs(args);
 		} catch (Exception e) {
-			logger.error("An error has occurred, please type -h to display help message.\n" + e.getLocalizedMessage());
+            logger.error("An error has occurred, please type -h to display help message.\n{}", e.getLocalizedMessage());
 			return;
 		}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
@@ -122,7 +122,7 @@ public class QuPathApp extends Application {
 	private static void showLicenseMessage(QuPathGUI qupath) {
 		var labelLicense = new Label(
                 "QuPath is open-source software that is shared\n" +
-				"under the terms of the General Public License v3");
+				"under the terms of the GNU General Public License v3");
 		labelLicense.setTextAlignment(TextAlignment.CENTER);
 
 		var hyperlink = new Hyperlink("Show licenses");

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
@@ -117,8 +117,7 @@ public class QuPathApp extends Application {
 		
 	}
 
-	private static final BooleanProperty showLicenseMessage =
-			PathPrefs.createPersistentPreference("showUseMessage", true);
+	private static final BooleanProperty showLicenseMessage = PathPrefs.showLicenseMessageOnStartupProperty();
 
 	private static void showLicenseMessage(QuPathGUI qupath) {
 		var labelLicense = new Label(
@@ -134,7 +133,7 @@ public class QuPathApp extends Application {
 		labelContent.setStyle("-fx-font-weight: bold;");
 
 		var cbAskAgain = new CheckBox("Don't show this again (always accept)");
-		cbAskAgain.setSelected(showLicenseMessage.get());
+		cbAskAgain.setSelected(!showLicenseMessage.get());
 		cbAskAgain.setPadding(new Insets(5, 0, 0, 0));
 		var content = new VBox(labelLicense, hyperlink, labelContent, cbAskAgain);
 
@@ -152,7 +151,7 @@ public class QuPathApp extends Application {
 			.orElse(exit).equals(accept)) {
 			System.exit(0);
 		}
-		showLicenseMessage.set(cbAskAgain.isSelected());
+		showLicenseMessage.set(!cbAskAgain.isSelected());
 	}
 
 	private static final BooleanProperty promptForExtensions =

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/CommonActions.java
@@ -121,6 +121,9 @@ public class CommonActions {
 	@ActionIcon(PathIcons.HELP)
 	@ActionConfig("CommonActions.showHelp")
 	public final Action HELP_VIEWER;
+
+	@ActionConfig("Action.Help.license")
+	public final Action SHOW_LICENSE;
 	
 	private QuPathGUI qupath;
 	
@@ -167,6 +170,8 @@ public class CommonActions {
 
 		INPUT_DISPLAY = ActionTools.createSelectableCommandAction(qupath.showInputDisplayProperty());
 		MEMORY_MONITOR = Commands.createSingleStageAction(() -> Commands.createMemoryMonitorDialog(qupath));
+
+		SHOW_LICENSE = Commands.createSingleStageAction(() -> Commands.createLicensesWindow(qupath));
 
 		// This has the effect of applying the annotations
 		ActionTools.getAnnotatedActions(this);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/menus/HelpMenuActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/menus/HelpMenuActions.java
@@ -97,7 +97,7 @@ public class HelpMenuActions implements MenuActions {
 		public final Action SEP_3 = ActionTools.createSeparator();
 
 		@ActionConfig("Action.Help.license")
-		public final Action LICENSE = Commands.createSingleStageAction(() -> Commands.createLicensesWindow(qupath));
+		public final Action LICENSE = qupath.getCommonActions().SHOW_LICENSE;
 		
 		@ActionConfig("Action.Help.systemInfo")
 		public final Action INFO = Commands.createSingleStageAction(() -> Commands.createShowSystemInfoDialog(qupath));

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowLicensesCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ShowLicensesCommand.java
@@ -76,7 +76,7 @@ class ShowLicensesCommand {
 			sbQuPath.append(licenseText);
 		} catch (Exception e) {
 			sbQuPath.append("Error reading license information!\n\n");
-			sbQuPath.append("For the most up-to-date QuPath license information, see " + Urls.getGitHubRepoUrl());
+			sbQuPath.append("For the most up-to-date QuPath license information, see ").append(Urls.getGitHubRepoUrl());
 			logger.error("Cannot read license information", e);
 		}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -228,6 +228,9 @@ public class PreferencePane {
 		@BooleanPref("Prefs.General.showStartupMessage")
 		public final BooleanProperty startupMessage = PathPrefs.showStartupMessageProperty();
 
+		@BooleanPref("Prefs.General.showLicenseMessage")
+		public final BooleanProperty licenseMessage = PathPrefs.showLicenseMessageOnStartupProperty();
+
 		@FilePref(value = "Prefs.General.startupScriptPath", extensions = "*.groovy")
 		public final StringProperty startupScriptPath = PathPrefs.startupScriptProperty();
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -318,13 +318,24 @@ public class PathPrefs {
 	
 	private static BooleanProperty showStartupMessage = createPersistentPreference("showStartupMessage", true);
 	
-	
+
 	/**
 	 * Show a startup message when QuPath is launched.
 	 * @return
 	 */
 	public static BooleanProperty showStartupMessageProperty() {
 		return showStartupMessage;
+	}
+
+
+	private static BooleanProperty showLicenseMessageProperty = createPersistentPreference("showLicenseMessage", true);
+
+	/**
+	 * Show a startup message about license when QuPath is launched.
+	 * @return
+	 */
+	public static BooleanProperty showLicenseMessageOnStartupProperty() {
+		return showLicenseMessageProperty;
 	}
 
 

--- a/qupath-gui-fx/src/main/resources/license/QuPathLicenseDescription.txt
+++ b/qupath-gui-fx/src/main/resources/license/QuPathLicenseDescription.txt
@@ -1,6 +1,6 @@
 --------------------
 
-Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
 Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
 
 QuPath is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -779,6 +779,8 @@ Prefs.Appearance.systemMenubar.description = Use the system menubar, rather than
 
 Prefs.General.showStartupMessage = Show welcome message
 Prefs.General.showStartupMessage.description = Show the welcome message with links to the docs, forum & code every time QuPath is launched.\nYou can access this message at any time through the 'Help' menu.
+Prefs.General.showLicenseMessage = Show license message
+Prefs.General.showLicenseMessage.description = Show a message about license and use when starting QuPath.
 Prefs.General.startupScriptPath = Startup script path
 Prefs.General.startupScriptPath.description = Optionally select a Groovy script file to run immediately after QuPath is launched.
 Prefs.General.checkForUpdates = Check for updates on startup


### PR DESCRIPTION
Show a message when QuPath is first launched to clarify its open-source license, and that it is **not** intended for clinical use.

The user can either accept this, or exit.

It's possible to select that the message is always accepted, but then it can be reset to appear in the preferences.

<img width="365" alt="dialog-attempt3" src="https://github.com/user-attachments/assets/dfae5de3-28d1-45d5-a44f-f1dafbe30d62" />
