### PR TITLE
Make zoom-to-fit a regular button

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
@@ -138,7 +138,7 @@ class ToolBarComponent {
 		nodes.add(createSeparator());
 
 		nodes.add(magLabel);
-		nodes.add(createToggleButton(viewerManagerActions.ZOOM_TO_FIT));
+		nodes.add(createButton(viewerManagerActions.ZOOM_TO_FIT));
 
 		nodes.add(createSeparator());
 


### PR DESCRIPTION
It used to toggle a mode that locked zoom-to-fit on - but that was confusing. Still, it remained a toggle button unnecessarily.... until now.