### PR TITLE
Add map to set or get color deconvolution stains

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -81,6 +81,7 @@ import qupath.lib.classifiers.object.ObjectClassifier;
 import qupath.lib.classifiers.object.ObjectClassifiers;
 import qupath.lib.classifiers.pixel.PixelClassifier;
 import qupath.lib.color.ColorDeconvolutionStains;
+import qupath.lib.color.StainVector;
 import qupath.lib.common.ColorTools;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.common.LogTools;
@@ -1906,7 +1907,33 @@ public class QP {
 		imageData.setColorDeconvolutionStains(stains);
 		return true;
 	}
-	
+
+	/**
+	 * Set the color deconvolution stains for the current image data.
+	 *
+	 * @param name the name of the color deconvolution stains
+	 * @param stains a map of stain name to stain values. Each stain value must be a list containing at least three elements
+	 *               (otherwise the value is skipped). A 'Background' stain must be provided. A stain with the name of 'Residual'
+	 *               will be set as {@link StainVector#isResidual() residual}, others won't. The order of the map matters: the first
+	 *               entry will be the first stain (unless it's the background), and so on.
+	 * @return whether color deconvolution stains were set (which will be false if there is no current image
+	 * data for example. The exact reason will be logged with the DEBUG level)
+	 */
+	public static boolean setColorDeconvolutionStains(String name, Map<String, List<Number>> stains) {
+		ImageData<?> imageData = getCurrentImageData();
+		if (imageData == null) {
+			logger.debug("No current image data. Cannot set color deconvolution stains");
+			return false;
+		}
+
+		try {
+			imageData.setColorDeconvolutionStains(ColorDeconvolutionStains.parseColorDeconvolutionStains(name, stains));
+			return true;
+		} catch (IllegalArgumentException e) {
+			logger.debug("Cannot set color deconvolution stains {}", stains, e);
+			return false;
+		}
+	}
 	
 //	public static void classifyDetection(final Predicate<PathObject> p, final String className) {
 //		PathObjectHierarchy hierarchy = getCurrentHierarchy();

--- a/qupath-core/src/main/java/qupath/lib/color/StainVector.java
+++ b/qupath-core/src/main/java/qupath/lib/color/StainVector.java
@@ -29,6 +29,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Locale;
 import java.util.Locale.Category;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -245,6 +246,24 @@ public class StainVector implements Externalizable {
 	@Override
 	public String toString() {
 		return name + ": " + arrayAsString(Locale.getDefault(Category.FORMAT));
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+
+		StainVector that = (StainVector) o;
+		return r == that.r && g == that.g && b == that.b && isResidual == that.isResidual && Objects.equals(name, that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = Double.hashCode(r);
+		result = 31 * result + Double.hashCode(g);
+		result = 31 * result + Double.hashCode(b);
+		result = 31 * result + Objects.hashCode(name);
+		result = 31 * result + Boolean.hashCode(isResidual);
+		return result;
 	}
 
 //	private static StainVector parseStainVector(String s) {

--- a/qupath-core/src/test/java/qupath/lib/color/TestColorDeconvolutionStains.java
+++ b/qupath-core/src/test/java/qupath/lib/color/TestColorDeconvolutionStains.java
@@ -1,0 +1,205 @@
+package qupath.lib.color;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestColorDeconvolutionStains {
+
+    @Test
+    void Check_Parsed_Color_Deconvolution_Stains_With_Null_Name() {
+        Assertions.assertThrows(NullPointerException.class, () -> ColorDeconvolutionStains.parseColorDeconvolutionStains(null, Map.of()));
+    }
+
+    @Test
+    void Check_Parsed_Color_Deconvolution_Stains_With_Null_Map() {
+        Assertions.assertThrows(NullPointerException.class, () -> ColorDeconvolutionStains.parseColorDeconvolutionStains("", null));
+    }
+
+    @Test
+    void Check_Parsed_Color_Deconvolution_Stains_With_No_Background_Stain() {
+        Map<String, List<Number>> stains = Map.of(
+                "Stain 1", List.of(1, 2, 3),
+                "Stain 2", List.of(4, 5, 6)
+        );
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ColorDeconvolutionStains.parseColorDeconvolutionStains("", stains));
+    }
+
+    @Test
+    void Check_Parsed_Color_Deconvolution_Stains_With_Not_Enough_Stains() {
+        Map<String, List<Number>> stains = Map.of(
+                "Stain 1", List.of(1, 2, 3),
+                "Background", List.of(4, 5, 6)
+        );
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ColorDeconvolutionStains.parseColorDeconvolutionStains("", stains));
+    }
+
+    @Test
+    void Check_Parsed_Color_Deconvolution_Stains_With_Not_Enough_Stains_Values() {
+        Map<String, List<Number>> stains = Map.of(
+                "Stain 1", List.of(1, 2, 3),
+                "Stain 2", List.of(),
+                "Background", List.of(4, 5, 6)
+        );
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ColorDeconvolutionStains.parseColorDeconvolutionStains("", stains));
+    }
+
+    @Test
+    void Check_Parsed_Color_Deconvolution_Stains_With_Two_Stains() {
+        String name = "some name";
+        Map<String, List<Number>> stains = new LinkedHashMap<>();       // LinkedHashMap to conserve order
+        stains.put("Stain 1", List.of(1, 2, 3));
+        stains.put("Stain 2", List.of(4, 5, 6));
+        stains.put("Background", List.of(7, 8, 9));
+        ColorDeconvolutionStains expectedColorDeconvolutionStains = new ColorDeconvolutionStains(
+                name,
+                new StainVector("Stain 1", 1, 2, 3, false),
+                new StainVector("Stain 2", 4, 5, 6, false),
+                7,
+                8,
+                9
+        );
+
+        ColorDeconvolutionStains colorDeconvolutionStains = ColorDeconvolutionStains.parseColorDeconvolutionStains(name, stains);
+
+        Assertions.assertEquals(expectedColorDeconvolutionStains, colorDeconvolutionStains);
+    }
+
+    @Test
+    void Check_Parsed_Color_Deconvolution_Stains_With_Three_Stains() {
+        String name = "some name";
+        Map<String, List<Number>> stains = new LinkedHashMap<>();       // LinkedHashMap to conserve order
+        stains.put("Stain 1", List.of(1, 2, 3));
+        stains.put("Stain 2", List.of(4, 5, 6));
+        stains.put("Stain 3", List.of(7, 8, 9));
+        stains.put("Background", List.of(10, 11, 12));
+        ColorDeconvolutionStains expectedColorDeconvolutionStains = new ColorDeconvolutionStains(
+                name,
+                new StainVector("Stain 1", 1, 2, 3, false),
+                new StainVector("Stain 2", 4, 5, 6, false),
+                new StainVector("Stain 3", 7, 8, 9, false),
+                10,
+                11,
+                12
+        );
+
+        ColorDeconvolutionStains colorDeconvolutionStains = ColorDeconvolutionStains.parseColorDeconvolutionStains(name, stains);
+
+        Assertions.assertEquals(expectedColorDeconvolutionStains, colorDeconvolutionStains);
+    }
+
+    @Test
+    void Check_Parsed_Color_Deconvolution_Stains_With_A_Residual_Stain() {
+        String name = "some name";
+        Map<String, List<Number>> stains = new LinkedHashMap<>();       // LinkedHashMap to conserve order
+        stains.put("Stain 1", List.of(1, 2, 3));
+        stains.put("Stain 2", List.of(4, 5, 6));
+        stains.put("Residual", List.of(7, 8, 9));
+        stains.put("Background", List.of(10, 11, 12));
+        ColorDeconvolutionStains expectedColorDeconvolutionStains = new ColorDeconvolutionStains(
+                name,
+                new StainVector("Stain 1", 1, 2, 3, false),
+                new StainVector("Stain 2", 4, 5, 6, false),
+                new StainVector("Residual", 7, 8, 9, true),
+                10,
+                11,
+                12
+        );
+
+        ColorDeconvolutionStains colorDeconvolutionStains = ColorDeconvolutionStains.parseColorDeconvolutionStains(name, stains);
+
+        Assertions.assertEquals(expectedColorDeconvolutionStains, colorDeconvolutionStains);
+    }
+
+    @Test
+    void Check_Parsed_Color_Deconvolution_Stains_With_Missing_Values_In_Stains() {
+        String name = "some name";
+        Map<String, List<Number>> stains = new LinkedHashMap<>();       // LinkedHashMap to conserve order
+        stains.put("Stain 1", List.of(1, 2, 3));
+        stains.put("Stain 2", List.of(4));
+        stains.put("Stain 3", List.of(7, 8, 9));
+        stains.put("Background", List.of(10, 11, 12));
+        ColorDeconvolutionStains expectedColorDeconvolutionStains = new ColorDeconvolutionStains(
+                name,
+                new StainVector("Stain 1", 1, 2, 3, false),
+                new StainVector("Stain 3", 7, 8, 9, false),
+                10,
+                11,
+                12
+        );
+
+        ColorDeconvolutionStains colorDeconvolutionStains = ColorDeconvolutionStains.parseColorDeconvolutionStains(name, stains);
+
+        Assertions.assertEquals(expectedColorDeconvolutionStains, colorDeconvolutionStains);
+    }
+
+    @Test
+    void Check_Color_Deconvolution_Stains_As_Map_With_Two_Stains() {
+        ColorDeconvolutionStains colorDeconvolutionStains = new ColorDeconvolutionStains(
+                "",
+                new StainVector("Stain 1", 1.0, 0.0, 0.0, false),
+                new StainVector("Stain 2", 0.0, 1.0, 0.0, false),
+                10.0,
+                11.0,
+                12.0
+        );
+        Map<String, List<Number>> expectedStains = new LinkedHashMap<>();       // LinkedHashMap to conserve order
+        expectedStains.put("Stain 1", List.of(1.0, 0.0, 0.0));
+        expectedStains.put("Stain 2", List.of(0.0, 1.0, 0.0));
+        expectedStains.put("Residual", List.of(0.0, 0.0, 1.0));
+        expectedStains.put("Background", List.of(10.0, 11.0, 12.0));
+
+        Map<String, List<Number>> stains = colorDeconvolutionStains.getColorDeconvolutionStainsAsMap();
+
+        Assertions.assertEquals(expectedStains, stains);
+    }
+
+    @Test
+    void Check_Color_Deconvolution_Stains_As_Map_With_Three_Stains() {
+        ColorDeconvolutionStains colorDeconvolutionStains = new ColorDeconvolutionStains(
+                "",
+                new StainVector("Stain 1", 1.0, 0.0, 0.0, false),
+                new StainVector("Stain 2", 0.0, 1.0, 0.0, false),
+                new StainVector("Stain 3", 0.0, 0.0, 1.0, false),
+                10.0,
+                11.0,
+                12.0
+        );
+        Map<String, List<Number>> expectedStains = new LinkedHashMap<>();       // LinkedHashMap to conserve order
+        expectedStains.put("Stain 1", List.of(1.0, 0.0, 0.0));
+        expectedStains.put("Stain 2", List.of(0.0, 1.0, 0.0));
+        expectedStains.put("Stain 3", List.of(0.0, 0.0, 1.0));
+        expectedStains.put("Background", List.of(10.0, 11.0, 12.0));
+
+        Map<String, List<Number>> stains = colorDeconvolutionStains.getColorDeconvolutionStainsAsMap();
+
+        Assertions.assertEquals(expectedStains, stains);
+    }
+
+    @Test
+    void Check_Color_Deconvolution_Stains_As_Map_With_Null_Stain() {
+        ColorDeconvolutionStains colorDeconvolutionStains = new ColorDeconvolutionStains(
+                "",
+                new StainVector("Stain 1", 1.0, 0.0, 0.0, false),
+                null,
+                new StainVector("Stain 3", 0.0, 0.0, 1.0, false),
+                10.0,
+                11.0,
+                12.0
+        );
+        Map<String, List<Number>> expectedStains = new LinkedHashMap<>();       // LinkedHashMap to conserve order
+        expectedStains.put("Stain 1", List.of(1.0, 0.0, 0.0));
+        expectedStains.put("Stain 3", List.of(0.0, 0.0, 1.0));
+        expectedStains.put("Background", List.of(10.0, 11.0, 12.0));
+
+        Map<String, List<Number>> stains = colorDeconvolutionStains.getColorDeconvolutionStainsAsMap();
+
+        Assertions.assertEquals(expectedStains, stains);
+    }
+}


### PR DESCRIPTION
Address https://github.com/qupath/qupath/pull/1887#issuecomment-2910305822, more specifically:

> We think about whether there is another syntax that would be more readable in a script than a huge string

This is done by:
* Adding two functions to `ColorDeconvolutionStains`: `parseColorDeconvolutionStains()` and `getColorDeconvolutionStainsAsMap`, which are used to convert `Map` <-> `ColorDeconvolutionStains`.
* Adding a `setColorDeconvolutionStains()` function to `QP` that uses `parseColorDeconvolutionStains()` described above to set the stains of the current image from a `Map`.
* Changing the worflow step that happens when stains are set, to use the functions described above.

Some unit tests were added to test the new functions. `equals()` and `hashCode()` were also added to `StainVector` to help for the tests.

About:

> We consider a separate PR to write a custom JSON serializer/deserializer for ColorDeconvolutionStains so that we can serialise and deserialise with Gson, with a view to removing the custom string stuff entirely

Is that needed? Serializing / deserializing `ColorDeconvolutionStains` seems to work without any custom code. Consider this:

```groovy
import qupath.lib.color.*

def stains = getCurrentImageData().getColorDeconvolutionStains()

def json = GsonTools.getInstance(false).toJson(stains)

println stains == GsonTools.getInstance(true).fromJson(json, ColorDeconvolutionStains.class)
// this prints True
```