### PR TITLE
Add toolbar button and accelerator to toggle detection display mode

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
@@ -150,7 +150,6 @@ class ToolBarComponent {
 		nodes.add(createToggleButton(overlayActions.FILL_DETECTIONS));
 		// TODO: Consider removing 'Show connections' button until it becomes more useful
 		nodes.add(createToggleButton(overlayActions.SHOW_CONNECTIONS));
-		nodes.add(createToggleButton(overlayActions.TOGGLE_DETECTION_DISPLAY));
 		nodes.add(createToggleButton(overlayActions.SHOW_PIXEL_CLASSIFICATION));
 
 		final Slider sliderOpacity = new Slider(0, 1, 1);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
@@ -150,6 +150,7 @@ class ToolBarComponent {
 		nodes.add(createToggleButton(overlayActions.FILL_DETECTIONS));
 		// TODO: Consider removing 'Show connections' button until it becomes more useful
 		nodes.add(createToggleButton(overlayActions.SHOW_CONNECTIONS));
+		nodes.add(createToggleButton(overlayActions.TOGGLE_DETECTION_DISPLAY));
 		nodes.add(createToggleButton(overlayActions.SHOW_PIXEL_CLASSIFICATION));
 
 		final Slider sliderOpacity = new Slider(0, 1, 1);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/OverlayActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/OverlayActions.java
@@ -113,7 +113,7 @@ public class OverlayActions {
 	@ActionConfig("OverlayActions.toggleDetectionDisplay")
 	@ActionIcon(PathIcons.CELL_NUCLEI_BOTH)
 	@ActionAccelerator("shift+n")
-	public final Action TOGGLE_DETECTION_DISPLAY;
+	public final Action NEXT_DETECTION_DISPLAY;
 
 	private OverlayOptions overlayOptions;
 	
@@ -142,7 +142,7 @@ public class OverlayActions {
 		
 		SHOW_CONNECTIONS = ActionTools.createSelectableAction(overlayOptions.showConnectionsProperty());
 
-		TOGGLE_DETECTION_DISPLAY = new Action(e -> {
+		NEXT_DETECTION_DISPLAY = new Action(e -> {
 			overlayOptions.detectionDisplayModeProperty().set(DetectionDisplayMode.next(overlayOptions.detectionDisplayModeProperty().get()));
 		});
 		ActionTools.getAnnotatedActions(this);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/OverlayActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/OverlayActions.java
@@ -109,7 +109,12 @@ public class OverlayActions {
 	@ActionIcon(PathIcons.SHOW_CONNECTIONS)
 	@ActionConfig("OverlayActions.showConnections")
 	public final Action SHOW_CONNECTIONS;
-	
+
+	@ActionConfig("OverlayActions.toggleDetectionDisplay")
+	@ActionIcon(PathIcons.CELL_NUCLEI_BOTH)
+	@ActionAccelerator("shift+n")
+	public final Action TOGGLE_DETECTION_DISPLAY;
+
 	private OverlayOptions overlayOptions;
 	
 	public OverlayActions(OverlayOptions overlayOptions) {
@@ -136,7 +141,10 @@ public class OverlayActions {
 		SHOW_CELL_CENTROIDS = ActionTools.createSelectableCommandAction(new SelectableItem<>(overlayOptions.detectionDisplayModeProperty(), DetectionDisplayMode.CENTROIDS));
 		
 		SHOW_CONNECTIONS = ActionTools.createSelectableAction(overlayOptions.showConnectionsProperty());
-		
+
+		TOGGLE_DETECTION_DISPLAY = new Action(e -> {
+			overlayOptions.detectionDisplayModeProperty().set(DetectionDisplayMode.next(overlayOptions.detectionDisplayModeProperty().get()));
+		});
 		ActionTools.getAnnotatedActions(this);
 	}
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/menus/ViewMenuActions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/actions/menus/ViewMenuActions.java
@@ -228,9 +228,7 @@ public class ViewMenuActions implements MenuActions {
 		public final Action ATTACH_VIEWER = qupath.createViewerAction(viewer -> qupath.getViewerManager().attachViewerToGrid(viewer));
 
 	}
-	
-	
-	
+
 	public class ZoomActions {
 		
 		@ActionConfig("Action.View.Zoom.400")
@@ -288,6 +286,10 @@ public class ViewMenuActions implements MenuActions {
 		public final Action SHOW_CELL_BOUNDARIES_AND_NUCLEI = overlayActions.SHOW_CELL_BOUNDARIES_AND_NUCLEI;
 
 		public final Action SHOW_CELL_CENTROIDS = overlayActions.SHOW_CELL_CENTROIDS;
+
+		public final Action SEP_9 = ActionTools.createSeparator();
+
+		public final Action NEXT_DETECTION_DISPLAY = overlayActions.NEXT_DETECTION_DISPLAY;
 		
 	}
 	
@@ -308,7 +310,7 @@ public class ViewMenuActions implements MenuActions {
 			PathPrefs.useRotateGesturesProperty().set(false);
 		});
 		
-		public final Action SEP_9 = ActionTools.createSeparator();
+		public final Action SEP_10 = ActionTools.createSeparator();
 		
 		@ActionConfig("Action.View.Multitouch.scroll")
 		public final Action GESTURES_SCROLL = ActionTools.createSelectableCommandAction(PathPrefs.useScrollGesturesProperty());

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/OverlayOptions.java
@@ -88,8 +88,18 @@ public class OverlayOptions {
 		/**
 		 * Show only detection centroids, not boundaries.
 		 */
-		CENTROIDS
-		};
+		CENTROIDS;
+		public static DetectionDisplayMode next(DetectionDisplayMode value) {
+			boolean pick = false;
+			for (var v: values()) {
+				if (pick) {
+					return v;
+				}
+				pick = v == value;
+			}
+			return values()[0];
+		}
+	};
 	
 	private final ObjectProperty<MeasurementMapper> measurementMapper = new SimpleObjectProperty<>();
 	private final BooleanProperty showAnnotations = new SimpleBooleanProperty(null, "showAnnotations", true);

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -150,6 +150,8 @@ OverlayActions.showTMALabels = Show TMA grid labels
 OverlayActions.showTMALabels.description = Show/hide the tissue microarray core labels (where available)
 OverlayActions.showConnections = Show object connections
 OverlayActions.showConnections.description = Show connections between objects, if available.\nThis can be used alongside some spatial commands, such as to display a Delaunay triangulation as an overlay.
+OverlayActions.toggleDetectionDisplay = Toggle detection display mode
+OverlayActions.toggleDetectionDisplay.description = Switch between detection display modes: cell boundaries only, nuclei only, nuclei & cell boundaries, or cell centroids only.
 
 OverlayActions.showCellBoundaries = Cell boundaries only
 OverlayActions.showCellBoundaries.description = Display cells by drawing the cell boundary ROI only

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -363,6 +363,7 @@ Action.Analyze.Spatial.detectionCentroidDistances2D.description = Calculate dist
 Menu.View = View
 Menu.View.Multiview = Multi-view
 Menu.View.Zoom = Zoom
+Menu.View.Detection-display = Detection display options
 Menu.View.CellDisplay = Cell display
 Menu.View.Multitouch = Multi-touch gestures
 


### PR DESCRIPTION
Introduce a toolbar button to toggle the detection display mode.

Ideally, the icon would reflect the current display mode.

This is a "nice to have" for me, but I appreciate we are close to polluting the toolbar at this point...