### PR TITLE
Update startup message

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathApp.java
@@ -128,7 +128,7 @@ public class QuPathApp extends Application {
 		var hyperlink = new Hyperlink("Show licenses");
 		hyperlink.setOnAction(e -> qupath.getCommonActions().SHOW_LICENSE.handle(e));
 
-		var labelContent = new Label("This software is not intended for clinical use.");
+		var labelContent = new Label("This software is not intended for clinical, diagnostic or therapeutic purposes.");
 		labelContent.setTextAlignment(TextAlignment.CENTER);
 		labelContent.setStyle("-fx-font-weight: bold;");
 


### PR DESCRIPTION
Use `This software is not intended for clinical, diagnostic or therapeutic purposes.` for extra clarity.