### PR TITLE
Fix size of empty tile

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -384,7 +384,7 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 
 			// If we have an empty region, try to use an empty tile
 			if (isEmptyRegion) {
-				return getEmptyTile(request.getWidth(), request.getHeight());
+				return getEmptyTile(width, height);
 			}
 
 			if (raster == null)


### PR DESCRIPTION
In `readRegion` of `AbstractTileableImageServer`, if all sub-regions of a region correspond to empty images, then an empty image is returned.

The width (or similarly the height) of this returned image is `RegionRequest.getWidth()`. However, if I understood correctly, `RegionRequest.getWidth()` corresponds to the width of the returned image at level **0**, not at the level specified by `RegionRequest`. This mean the returned image is too big when the level of `RegionRequest` is greater than 0. This PR fixes that.

This was needed when exporting an image with the stitching extension. Without this PR, [`emptyTileMap`](https://github.com/qupath/qupath/blob/d2f4ae53cdd1904134e53fa96f35aa2c98374b79/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java#L65) was taking 12 GB of memory during the export (because it stored images of size like 16384x16384), causing an out of memory error.