### PR TITLE
Add setClassification(Object) method

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathObject.java
@@ -774,10 +774,10 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 	}
 
 	/**
-	 * Convenience method to et the classification of the object from a string representation.
+	 * Convenience method to set the classification of the object from a string representation.
 	 * If the string is null or empty, the classification is reset.
 	 * Otherwise, it is equivalent to calling {@code setPathClass(PathClass.fromString(classification))}
-	 * @param classification
+	 * @param classification string representation of the classification to use
 	 * @see #getClassification()
 	 * @see #setPathClass(PathClass)
 	 * @see #setClassifications(Collection)
@@ -788,6 +788,26 @@ public abstract class PathObject implements Externalizable, MinimalMetadataStore
 			resetPathClass();
 		else
 			setPathClass(PathClass.fromString(classification));
+	}
+
+	/**
+	 * Companion method for {@link #setClassification(String)} to reduce the risk of issues when using Groovy.
+	 * <p>
+	 * Without this, calling {@code setClassification(["First", "Second"])} would result in a string representation
+	 * of the list being used as the name for the class.
+	 * @param obj the classification to set
+	 * @since v0.6.0
+	 */
+	public void setClassification(Object obj) {
+        switch (obj) {
+            case null -> resetPathClass();
+            case String s -> setClassification(s);
+            case Collection<?> collection ->
+                    throw new IllegalArgumentException("setClassification(String) requires a string " +
+                            "- did you mean to call setClassifications(Collection)?");
+            default -> throw new IllegalArgumentException("setClassification(String) requires a string input - " +
+                    "cannot parse " + obj);
+        }
 	}
 
 	/**


### PR DESCRIPTION
Add `PathObject.setClassification(Object)` as some protection from Groovy's laxness.

Otherwise, one letter makes a *big* difference. Consider
```groovy
getSelectedObject().classification = ["First", "Second"]
getSelectedObject().classifications = ["First", "Second"]
```
The second is probably intended (setting a derived class to give `First: Second`), but the first would result in a class being set to the string `["First", "Second"]`. This is because Groovy 'helpfully' and silently casts the list to a string.

Adding `PathObject.setClassification(Object)` intercepts any attempts to set a classification with a non-string, so that a more informative exception can be thrown instead.