### PR TITLE
Add 'Recent files' to ImageJ script runner

### DIFF
--- a/qupath-extension-processing/src/main/resources/qupath/imagej/gui/scripts/ij-script-runner.fxml
+++ b/qupath-extension-processing/src/main/resources/qupath/imagej/gui/scripts/ij-script-runner.fxml
@@ -254,7 +254,9 @@
                         <KeyCodeCombination alt="UP" code="O" control="UP" meta="UP" shift="UP" shortcut="DOWN" />
                      </accelerator>
                   </MenuItem>
-                  <Menu fx:id="menuExamples" mnemonicParsing="false" text="%menu.file.openExamples">
+               <Menu fx:id="menuRecent" mnemonicParsing="false" text="%menu.file.openRecent" />
+               <SeparatorMenuItem mnemonicParsing="false" />
+               <Menu fx:id="menuExamples" mnemonicParsing="false" text="%menu.file.openExamples">
                     <items>
                       <MenuItem mnemonicParsing="false" text="Action 1" />
                     </items>

--- a/qupath-extension-processing/src/main/resources/qupath/imagej/gui/scripts/strings.properties
+++ b/qupath-extension-processing/src/main/resources/qupath/imagej/gui/scripts/strings.properties
@@ -92,6 +92,7 @@ chooser.validFiles = ImageJ macros and scripts
 menu.file = File
 menu.file.new = New
 menu.file.open = Open...
+menu.file.openRecent = Open recent
 menu.file.openExamples = Open example
 menu.file.save = Save
 menu.file.saveAs = Save As...

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -1264,7 +1264,7 @@ public class QuPathGUI {
 				Dialogs.showErrorMessage("Project error", "Cannot find project " + uri);
 				logger.error("Error loading project", e1);
 			}
-		}, Project::getNameFromURI);
+		});
 		
 		return menuRecent;
 	}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/DefaultScriptEditor.java
@@ -1376,10 +1376,9 @@ public class DefaultScriptEditor implements ScriptEditor {
 				}
 				// TODO: Allow multiple extensions to be used?
 				Collection<String> extensions = tab.getRequestedExtensions();
-				String ext = extensions.isEmpty() ? null : extensions.iterator().next();
 				File file = FileChoosers.promptToSaveFile(dialog, "Save script file",
 						tab.getName() == null ? null : new File(dir, tab.getName()),
-						FileChoosers.createExtensionFilter(currentLanguage.getValue().getName() + " file", ext));
+						FileChoosers.createExtensionFilter(currentLanguage.getValue().getName() + " file", extensions));
 				if (file == null)
 					return false;
 				tab.saveToFile(getCurrentText(), file);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/JsonLanguage.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/JsonLanguage.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2022, 2024 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2022, 2024 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -21,8 +21,7 @@
 
 package qupath.lib.gui.scripting.languages;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import qupath.lib.scripting.languages.ScriptLanguage;
 
 /**
@@ -37,7 +36,7 @@ public class JsonLanguage extends ScriptLanguage {
 	private static final JsonLanguage INSTANCE = new JsonLanguage();
 	
 	private JsonLanguage() {
-		super("JSON", Set.of(".json", ".geojson"));
+		super("JSON", ImmutableSet.of(".json", ".geojson"));
 	}
 
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/MarkdownLanguage.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/MarkdownLanguage.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2022, 2024 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2022, 2024 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -21,10 +21,9 @@
 
 package qupath.lib.gui.scripting.languages;
 
-import java.util.Set;
-
 import javax.script.ScriptException;
 
+import com.google.common.collect.ImmutableSet;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 
@@ -44,7 +43,7 @@ public class MarkdownLanguage extends ScriptLanguage implements qupath.lib.gui.s
 	private static final MarkdownLanguage INSTANCE = new MarkdownLanguage();
 
 	private MarkdownLanguage() {
-		super("Markdown", Set.of(".md", ".markdown"));
+		super("Markdown", ImmutableSet.of(".md", ".markdown"));
 	}
 
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/PlainLanguage.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/PlainLanguage.java
@@ -21,8 +21,7 @@
 
 package qupath.lib.gui.scripting.languages;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import qupath.lib.scripting.languages.ScriptLanguage;
 
 /**
@@ -37,7 +36,7 @@ public class PlainLanguage extends ScriptLanguage {
 	private static final PlainLanguage INSTANCE = new PlainLanguage();
 
 	private PlainLanguage() {
-		super("None", Set.of(".txt", ".tsv", ".csv"));
+		super("None", ImmutableSet.of(".txt", ".tsv", ".csv"));
 	}
 	
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/PropertiesLanguage.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/scripting/languages/PropertiesLanguage.java
@@ -21,8 +21,7 @@
 
 package qupath.lib.gui.scripting.languages;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import qupath.lib.scripting.languages.ScriptLanguage;
 
 /**
@@ -36,7 +35,7 @@ public class PropertiesLanguage extends ScriptLanguage {
 	private static final PropertiesLanguage INSTANCE = new PropertiesLanguage();
 
 	private PropertiesLanguage() {
-		super("Properties", Set.of(".properties", ".cfg"));
+		super("Properties", ImmutableSet.of(".properties", ".cfg"));
 	}
 	
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -1289,31 +1289,41 @@ public class GuiTools {
 	
 	
 	/**
-	 * Create a menu that displays recent items, stored in the form of URIs, using default text to show for the menu item.
+	 * Create a menu that displays recent items, stored in the form of URIs.
+	 * <p>
+	 * This menu updates its items based upon the list of recent tiles.
+	 * <p>
+	 * An important limitation is that this requires setting the menu validation listener for any parent of the
+	 * menu that is created, since this is used to populate the items.
 	 * 
-	 * @param menuTitle
-	 * @param recentItems
-	 * @param consumer
-	 * @return
+	 * @param menuTitle name for the new menu
+	 * @param recentItems list containing URIs for recent items
+	 * @param consumer consumer to process a URI when the corresponding menu item is selected
+	 * @return a menu that automatically populates based upon a list of URIs
+	 * @see #configureRecentItemsMenu(Menu, ObservableList, Consumer) 
 	 */
 	public static Menu createRecentItemsMenu(String menuTitle, ObservableList<URI> recentItems, Consumer<URI> consumer) {
-		return createRecentItemsMenu(menuTitle, recentItems, consumer, GuiTools::getNameFromURI);
-	}
-	
-	
-	/**
-	 * Create a menu that displays recent items, stored in the form of URIs, customizing the text displayed for the menu items.
-	 * 
-	 * @param menuTitle
-	 * @param recentItems
-	 * @param consumer
-	 * @param menuitemText 
-	 * @return
-	 */
-	public static Menu createRecentItemsMenu(String menuTitle, ObservableList<URI> recentItems, Consumer<URI> consumer, Function<URI, String> menuitemText) {
 		// Create a recent projects list in the File menu
 		Menu menuRecent = MenuTools.createMenu(menuTitle);
+		configureRecentItemsMenu(menuRecent, recentItems, consumer);
+		return menuRecent;
+	}
 
+	/**
+	 * Configure a menu to displays recent items, stored in the form of URIs.
+	 * <p>
+	 * The menu updates its items based upon the list of recent tiles.
+	 * <p>
+	 * An important limitation is that this requires setting the menu validation listener for any parent of the
+	 * menu that is created, since this is used to populate the items.
+	 *
+	 * @param menuRecent the menu to configure
+	 * @param recentItems list containing URIs for recent items
+	 * @param consumer consumer to process a URI when the corresponding menu item is selected
+	 * @since v0.6.0
+	 * @see #createRecentItemsMenu(String, ObservableList, Consumer) 
+	 */
+	public static void configureRecentItemsMenu(Menu menuRecent, ObservableList<URI> recentItems, Consumer<URI> consumer) {
 		EventHandler<Event> validationHandler = e -> {
 			List<MenuItem> items = new ArrayList<>();
 			for (URI uri : recentItems) {
@@ -1335,9 +1345,8 @@ public class GuiTools {
 			if (n != null)
 				n.setOnMenuValidation(validationHandler);
 		});
-
-		return menuRecent;
-
+		if (menuRecent.getParentMenu() != null)
+			menuRecent.getParentMenu().setOnMenuValidation(validationHandler);
 	}
 
 


### PR DESCRIPTION
This involved updating the 'Recent' code for QuPath projects and the regular script editor.... so these should be checked to try and ensure there haven't been any regressions.

Also made a small fix in terms of the ordering of default file extensions when saving scripts (so that JSON defaults to .json rather than .geojson). This meant using `ImmutableSet.of()` rather than `Set.of()`.