### PR TITLE
Add line break to fix estimate stain vector truncated text

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
@@ -159,11 +159,15 @@ class EstimateStainVectorsCommand {
 		// Check if the background values may need to be changed
 		if (rMax != stains.getMaxRed() || gMax != stains.getMaxGreen() || bMax != stains.getMaxBlue()) {
 			ButtonType response =
-					Dialogs.showYesNoCancelDialog(TITLE,
-							String.format("Modal RGB values %s, %s, %s do not match current background values - do you want to use the modal values?",
+					Dialogs.showYesNoCancelDialog(
+							TITLE,
+							String.format(
+									"Modal RGB values %s, %s, %s do not match current background values.\nDo you want to use the modal values?",
 									GeneralTools.formatNumber(rMax, 2),
 									GeneralTools.formatNumber(gMax, 2),
-									GeneralTools.formatNumber(bMax, 2)));
+									GeneralTools.formatNumber(bMax, 2)
+							)
+					);
 			if (response == ButtonType.CANCEL)
 				return;
 			else if (response == ButtonType.YES) {


### PR DESCRIPTION
On MacOS, when clicking on `Analyze`, `Estimate stain vectors`, a modal window displays a truncated text and it is not possible to resize the window:

![image](https://github.com/user-attachments/assets/f1586b46-0d5c-4c02-b2cf-46b0403696a2)

This happens when QuPath is created from `./gradlew jpackage`, but not when QuPath is started from `./gradlew run`.

This is a very weird behaviour which may come from JavaFX. I didn't find any other solution than modifying the displayed text (by adding a line break).