### PR TITLE
Only log info, not warn, when using selected annotations for smoothed features

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
@@ -398,7 +398,7 @@ public class SmoothFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 					parents.add(pathObject);
 			}			
 			if (!parents.isEmpty())
-				logger.warn("Smoothing using annotations");
+				logger.info("Smoothing using annotations");
 		}
 		return parents;
 	}


### PR DESCRIPTION
It seems excessive to always warn when not smoothing by TMA cores