### PR TITLE
Fix docs versions

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/Urls.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/Urls.java
@@ -38,7 +38,7 @@ public final class Urls {
 	
 	private static final Logger logger = LoggerFactory.getLogger(Urls.class);
 	
-	private static final String DOCS_VERSION = "latest";
+	private static final String DOCS_VERSION = "0.6";
 	
 	static {
 		var version = QuPathGUI.getVersion();


### PR DESCRIPTION
Point to https://qupath.readthedocs.io/en/0.6/ and not https://qupath.readthedocs.io/en/latest