### PR TITLE
Improve dark mode icon contrast when focused

### DIFF
--- a/qupath-gui-fx/src/main/resources/css/main.css
+++ b/qupath-gui-fx/src/main/resources/css/main.css
@@ -76,6 +76,7 @@
   -fx-text-fill: -fx-text-base-color;
 }
 
+
 /* Used in command finder for help text */
 .popover * {
     -fx-background-color: -fx-base;
@@ -161,6 +162,10 @@
 /*.table-row-cell .button .text {*/
 /*  -fx-fill: -fx-text-base-color;*/
 /*}*/
+
+.list-cell:focused .qupath-icon {
+    -fx-text-fill: -fx-text-background-color;
+}
 
 .list-cell .extension-manager-list-icon {
   -fx-text-fill: -fx-text-background-color;


### PR DESCRIPTION
Before:

![Screenshot from 2025-06-26 11-15-10](https://github.com/user-attachments/assets/ed6556b0-58c9-4955-a89d-e248b30c576d)

With this change:

![Screenshot from 2025-06-26 11-15-31](https://github.com/user-attachments/assets/a2d4cbb5-598d-44c7-a74d-c0eb33d04277)

