### PR TITLE
Update opencv to 4.11.0-1.5.12

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ jdk             = "21"
 # For gradle-javacpp-platform (no 1.5.11 available)
 javacpp         = "1.5.10"
 
-opencv          = "4.10.0-1.5.11"
+opencv          = "4.11.0-1.5.12"
 
 # Warning! JavaFX 20.0.1 and later seem to break search links in Javadocs
 javafx          = "23.0.2"

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -1215,7 +1215,7 @@ public class ImageOps {
 					return Collections.singletonList(input);
 				var padding = getPadding();
 				var size = new Size(padding.getX1()*2+1, padding.getY1()*2+1);
-				OpenCVTools.applyToChannels(input, mat -> opencv_imgproc.GaussianBlur(mat, mat, size, sigmaX, sigmaY, opencv_core.BORDER_REFLECT));
+				OpenCVTools.applyToChannels(input, mat -> opencv_imgproc.GaussianBlur(mat, mat, size, sigmaX, sigmaY, opencv_core.BORDER_REFLECT, opencv_core.ALGO_HINT_DEFAULT));
 				return Collections.singletonList(input);
 			}
 

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
@@ -2322,7 +2322,7 @@ public class OpenCVTools {
 	public static void gaussianFilter(Mat mat, double sigma, int borderType) {
 		int s = (int)Math.ceil(sigma * 4) * 2 + 1;
 		try (var size = new Size(s, s)) {
-			opencv_imgproc.GaussianBlur(mat, mat, size, sigma, sigma, borderType);
+			opencv_imgproc.GaussianBlur(mat, mat, size, sigma, sigma, borderType, opencv_core.ALGO_HINT_DEFAULT);
 		}
 	}
 	


### PR DESCRIPTION
Update opencv to 4.11.0-1.5.1 to address https://github.com/qupath/qupath-extension-align/issues/15.

This required to add a parameter to `opencv_imgproc.GaussianBlur`. 