### PR TITLE
Ensure toolbar button heights are standardized

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/ToolBarComponent.java
@@ -30,10 +30,12 @@ import java.util.WeakHashMap;
 
 import javafx.geometry.HPos;
 import javafx.geometry.VPos;
+import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBase;
 import javafx.scene.control.Control;
 import javafx.scene.control.SeparatorMenuItem;
+import javafx.stage.Window;
 import org.controlsfx.control.action.Action;
 import org.controlsfx.control.decoration.Decorator;
 import org.controlsfx.control.decoration.GraphicDecoration;
@@ -201,12 +203,21 @@ class ToolBarComponent {
 		nodes.add(createButton(commonActions.SHOW_LOG));
 		nodes.add(createButton(commonActions.PREFERENCES));
 
-		toolbar.getItems().addListener(this::handleItemsChanged);
 		toolbar.getItems().setAll(nodes);
+		toolbar.getItems().addListener(this::handleItemsChanged);
+		// Ensure that buttons are sized whenever the toolbar is shown
+		toolbar.sceneProperty().flatMap(Scene::windowProperty).flatMap(Window::showingProperty).addListener((v, o, n) -> {
+			if (Boolean.TRUE.equals(n))
+				standardizeButtonHeight();
+		});
 	}
 
 	private void handleItemsChanged(Change<? extends Node> change) {
-		var buttons = change.getList().stream()
+		standardizeButtonHeight();
+	}
+
+	private void standardizeButtonHeight() {
+		var buttons = toolbar.getItems().stream()
 				.filter(p -> p instanceof ButtonBase)
 				.map(ButtonBase.class::cast)
 				.toList();


### PR DESCRIPTION
Without this change, the toolbar could end up looking squished if the processing extension wasn't installed:

<img width="1303" alt="qupath-squished" src="https://github.com/user-attachments/assets/43931a27-4083-4fdb-ab77-0e3952787a65" />

Installing the extension 'fixed' the issue, because it triggered an event that ultimately led to the button heights being updated. But the update should be called anyway whenever the toolbar is shown, so that it doesn't look strange if QuPath is installed *without* any extensions.