### PR TITLE
Recover if opencv native libs unavailable

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -263,8 +263,14 @@ public class QP {
 		var predicates = new PathObjectPredicates();
 		@SuppressWarnings("unused")
 		var colorModels = new ColorModels();
-		@SuppressWarnings("unused")
-		var dnnTools = new DnnTools();
+
+		try {
+			@SuppressWarnings("unused")
+			var dnnTools = new DnnTools();
+		} catch (LinkageError e) {
+			logger.warn("Unable to initialize DnnTools: {}", e.getMessage());
+			logger.debug(e.getMessage(), e);
+		}
 		
 	}
 

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ProcessingExtension.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ProcessingExtension.java
@@ -27,6 +27,7 @@ import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_dnn;
 import org.bytedeco.opencv.global.opencv_imgproc;
 import org.bytedeco.opencv.global.opencv_ml;
+import org.bytedeco.opencv.opencv_core.Mat;
 import org.controlsfx.control.action.Action;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -239,6 +240,14 @@ public class ProcessingExtension implements QuPathExtension {
 	
     @Override
     public void installExtension(QuPathGUI qupath) {
+
+		try (var mat = new Mat()) {
+			// Able to load Mat properly, so OpenCV should work
+		} catch (LinkageError e) {
+			logger.error("Unable to load OpenCV: {}", e.getMessage());
+			logger.debug(e.getMessage(), e);
+			return;
+		}
     	
     	logger.debug("Installing extension");
     	


### PR DESCRIPTION
The practical benefit is if we wish to make a stripped-down distribution that operates as a viewer but excludes OpenCV and other non-essential features.

We can't remove `qupath-core-processing`, which pulls in OpenCV, but these changes mean that the unavailability of the native libraries doesn't stop QuPath from launching.

This can be tested using
```
./gradlew run -PjavacppPlatform=-
```