### PR TITLE
Strip path in toURI() and toEncodedURI()

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -415,6 +415,8 @@ public final class GeneralTools {
 	 * ("http:", "https:" or ""file:") to see if it can construct the URI directly; 
 	 * if not, it assumes the path refers to a local file (as it generally did in 
 	 * QuPath 0.1.2 and earlier). This method does not encode special characters.
+	 * <p>
+	 * The provided path is also {@link String#strip() stripped} before the conversion.
 	 * 
 	 * @param path
 	 * @return
@@ -424,6 +426,7 @@ public final class GeneralTools {
 	public static URI toURI(String path) throws URISyntaxException {
 		if (path == null || path.isEmpty())
 			return new URI("");
+		path = path.strip();
 		if (path.startsWith("http:") || path.startsWith("https:") || path.startsWith("file:"))
 			return new URI(path);
 		return new File(path).toURI();

--- a/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
+++ b/qupath-core/src/main/java/qupath/lib/common/GeneralTools.java
@@ -441,6 +441,8 @@ public final class GeneralTools {
 	 * to a valid form. Finally, a reconstructed valid URI is returned. Note: this method will 
 	 * only encode the Query part of the URI (i.e. Fragments, if present, will be ignored ).
 	 * <p>
+	 * The provided path is also {@link String#strip() stripped} before the conversion.
+	 * <p>
 	 * E.g. "{@code https://host?query=first|second}" will return "{@code https://host?query%3Dfirst%7Csecond}".
 	 * 
 	 * @param path
@@ -452,6 +454,7 @@ public final class GeneralTools {
 	public static URI toEncodedURI(String path) throws URISyntaxException, UnsupportedEncodingException, MalformedURLException {
 		if (path == null || path.isEmpty())
 			return new URI("");
+		path = path.strip();
 		if (path.startsWith("http:") || path.startsWith("https:")) {
 			String urlQuery = new URL(path).getQuery();
 			if (urlQuery != null && !urlQuery.isEmpty()) {


### PR DESCRIPTION
Strip the provided path in the `toURI()` and `toEncodedURI()` functions.

This prevents errors from being triggered when the user inputs a path with leading or trailing white spaces (see the first error of https://forum.image.sc/t/qupath-0-6-0rc1-unable-to-read-remote-ome-zarr-by-url/101605/35)