### PR TITLE
avoid useless loadings of ImageServers

### DIFF
--- a/qupath-app/src/main/java/qupath/QuPath.java
+++ b/qupath-app/src/main/java/qupath/QuPath.java
@@ -397,7 +397,8 @@ class ScriptCommand implements Runnable {
 						if (imagePath != null && imagePath.equals(entry.getImageName()))
 							throw new RuntimeException(e);
 					} finally {
-						imageData.getServer().close();						
+						if (imageData.isLoaded())
+							imageData.getServer().close();
 					}
 				}
 				if (save) {

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ObjectClassifierCommand.java
@@ -1471,7 +1471,8 @@ public class ObjectClassifierCommand implements Runnable {
 			// Ensure we have closed any cached images
 			for (var data : trainingMap.values()) {
 				try {
-					data.getServer().close();
+					if (data.isLoaded())
+						data.getServer().close();
 				} catch (Exception e) {
 					logger.warn("Error closing server: " + e.getLocalizedMessage(), e);
 				}


### PR DESCRIPTION
QuPath 0.6.0 always loaded some `ImageServer` just to then close them right after.
This occurred when closing the object classifier's window and when executing a CLI script.

Actually, I expect these precautionary `getServer()` → `close()` to have slipped through in other parts. These two cases jumped to me because CLI scripting and object classifiers are tools that I regularly use.

Related to #1489 and #1579