### PR TITLE
Fixing tests where n might potentially be NULL

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastChannelPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastChannelPane.java
@@ -146,7 +146,7 @@ public class BrightnessContrastChannelPane extends BorderPane {
         filteredChannels.predicateProperty().bind(filter.predicateProperty());
         table.setItems(filteredChannels);
         table.sceneProperty().flatMap(Scene::windowProperty).flatMap(Window::showingProperty).addListener((v, o, n) -> {
-            if (n) updateShowTableColumnHeader();
+            if (n != null && n) updateShowTableColumnHeader();
         });
         initializeShowAllCheckbox();
         initializeColorPicker();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastSettingsPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/display/BrightnessContrastSettingsPane.java
@@ -176,7 +176,7 @@ public class BrightnessContrastSettingsPane extends GridPane {
      */
     private void tryToKeepSearchText() {
         comboSettings.sceneProperty().flatMap(Scene::windowProperty).flatMap(Window::showingProperty).addListener((v, o, n) -> {
-            if (n && defaultName == null)
+            if (n != null && n && defaultName == null)
                 handleComboShowing();
         });
     }


### PR DESCRIPTION
Hello,

This is to solve a very unlikely edge case where the variable `n` is NULL in two tests (as far as I can tell) in the Brightness & Contrast dialog, `n` being the number of channels. This can happen because the dialog can be opened even if no image is available in the current viewer.

Apparently a classic *autounboxing null problem* (?) in Java:  When `n` is null, this causes a NullPointerException because Java tries to invoke `n.booleanValue()` on a null reference.

I only noticed this because my [autodock script](https://forum.image.sc/t/script-for-docking-any-floating-window-to-the-analysis-pane-results-may-vary/103808/2) crashed with
```
[JavaFX Application Thread]	ERROR	qupath.lib.gui.QuPathUncaughtExceptionHandler	Cannot invoke "java.lang.Boolean.booleanValue()" because "n" is null	java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because "n" is null
	at qupath.lib.gui.commands.display.BrightnessContrastChannelPane.lambda$new$0(BrightnessContrastChannelPane.java:149)
	at com.sun.javafx.binding.ExpressionHelper$SingleChange.fireValueChangedEvent(ExpressionHelper.java:192)
	at com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:91)
	at javafx.beans.binding.ObjectBinding.invalidate(ObjectBinding.java:192)
```
Cheers,
Egor