### PR TITLE
Sync mini/channel viewers with a main viewer in multiple ways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Version in progress...
 
+### Enhancements
+* Sync mini/channel viewers with a main viewer in multiple ways
+  * Sync to the cursor, sync to the selected object or sync to the viewer center
+
 ### Bug fixes
 * Ensure toolbar button heights are standardized (https://github.com/qupath/qupath/pull/1950)
 * Avoid empty tooltips in grid view (https://github.com/qupath/qupath/pull/1952)


### PR DESCRIPTION
Add to the mini/channel viewer context menu to give different ways of syncing.

This means the mini viewer no longer has to follow the cursor: instead, it could update based on a selected object or the main viewer's central pixel.

![channel-viewer](https://github.com/user-attachments/assets/7007d093-67bb-4c4d-abcb-ea8f94980a1a)
