### PR TITLE
Improve toggling between point and multipoint tools

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingDialogCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingDialogCommand.java
@@ -226,20 +226,25 @@ public class CountingDialogCommand implements Runnable, ChangeListener<ImageData
 		labelDelete.setContentDisplay(ContentDisplay.CENTER);
 		labelDelete.setStyle("-fx-font-style: italic; -fx-opacity: 0.8;");
 		labelDelete.setTextAlignment(TextAlignment.CENTER);
-		
+
+		var actionMultipoint = ActionTools.createSelectableAction(PathPrefs.multipointToolProperty(), "Create multipoint annotations");
+		actionMultipoint.setLongText("Add points to the same annotation, instead of creating a new annotation for every new point.");
+
 		var actionConvexPoints = ActionTools.createSelectableAction(PathPrefs.showPointHullsProperty(), "Show point convex hull");
 		var actionSelectedColor = ActionTools.createSelectableAction(PathPrefs.useSelectedColorProperty(), "Highlight selected objects by color");
 		var actionDetectionsToPoints = qupath.createImageDataAction(imageData -> Commands.convertDetectionsToPoints(imageData, true));
 		actionDetectionsToPoints.setText("Convert detections to points");
-		
+
 		var btnConvert = ActionTools.createButton(actionDetectionsToPoints);
 		var convertPane = new Pane(btnConvert);
 		btnConvert.prefWidthProperty().bind(convertPane.widthProperty());
-		
+
+		var cbMultipoint = ActionTools.createCheckBox(actionMultipoint);
 		var cbConvex = ActionTools.createCheckBox(actionConvexPoints);
 		var cbSelected = ActionTools.createCheckBox(actionSelectedColor);
 //		panel.setSpacing(5);
 		panel.getChildren().addAll(
+				cbMultipoint,
 				cbConvex,
 				cbSelected,
 				sliderPane,

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingDialogCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingDialogCommand.java
@@ -179,9 +179,6 @@ public class CountingDialogCommand implements Runnable, ChangeListener<ImageData
 				var selection = listView.getSelectionModel().getSelectedItems();
 				List<PathObject> pointsList = countingPane.getPathObjects();
 				if (!selection.isEmpty()) {
-					ArrayList<String> choiceList = new ArrayList<>();
-					choiceList.addAll(Arrays.asList("All point annotations", "Selected objects"));
-					
 					var choice = Dialogs.showChoiceDialog("Save points", "Choose point annotations to save", Arrays.asList("All points", "Selected points"), savingOption);
 					if (choice == null)
 						return;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/CountingPane.java
@@ -281,9 +281,10 @@ class CountingPane implements PathObjectSelectionListener, PathObjectHierarchyLi
 		btnDelete.setDisabled(!hasPoints);
 		if (pathObjectSelected == listCounts.getSelectionModel().getSelectedItem())
 			return;
-		if (pathObjectSelected != null && PathObjectTools.hasPointROI(pathObjectSelected))
+		if (pathObjectSelected != null && PathObjectTools.hasPointROI(pathObjectSelected)) {
 			listCounts.getSelectionModel().select(pathObjectSelected);
-		else
+			listCounts.scrollTo(pathObjectSelected);
+		} else
 			listCounts.getSelectionModel().clearSelection();
 	}
 
@@ -304,11 +305,12 @@ class CountingPane implements PathObjectSelectionListener, PathObjectHierarchyLi
 
 	@Override
 	public void hierarchyChanged(PathObjectHierarchyEvent event) {
+		if (!Platform.isFxApplicationThread()) {
+			Platform.runLater(() -> hierarchyChanged(event));
+			return;
+		}
 		if (hierarchy == null) {
 			listCounts.getItems().clear();
-			return;
-		} else if (!Platform.isFxApplicationThread()) {
-			Platform.runLater(() -> hierarchyChanged(event));
 			return;
 		}
 		
@@ -326,7 +328,9 @@ class CountingPane implements PathObjectSelectionListener, PathObjectHierarchyLi
 		}
 		
 		// We want to retain selection status
-		selectedPathObjectChanged(hierarchy.getSelectionModel().getSelectedObject(), null, hierarchy.getSelectionModel().getSelectedObjects());
+		var selected = hierarchy.getSelectionModel().getSelectedObject();
+		var allSelected = hierarchy.getSelectionModel().getSelectedObjects();
+		selectedPathObjectChanged(selected, null, allSelected);
 	}	
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -1239,7 +1239,7 @@ public class PathPrefs {
 	}
 		
 	
-	private static BooleanProperty multipointTool = MANAGER.createTransientBooleanProperty("multipointTool", true);
+	private static final BooleanProperty multipointTool = MANAGER.createPersistentBooleanProperty("multipointTool", true);
 	
 	/**
 	 * Create multiple points within the same annotation when using the counting tool.

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -868,25 +868,25 @@ public class PathObjectPainter {
 		RectangularShape ellipse;
 
 		//		double radius = pathPointsROI == null ? PointsROI.defaultPointRadiusProperty().get() : pathPointsROI.getPointRadius();
-		// Ensure that points are drawn with at least a radius of one, after any transforms have been applied
+		// Ensure that points are drawn with at least a radius of 1, after any transforms have been applied
 		double scale = Math.max(1, downsample);
-		radius = (Math.max(1 / scale, radius));
+		double radius2 = (Math.max(1.0 / scale, radius));
 
 		// Get clip bounds
 		Rectangle2D bounds = g2d.getClipBounds();
 		if (bounds != null) {
-			bounds.setRect(bounds.getX()-radius, bounds.getY()-radius, bounds.getWidth()+radius*2, bounds.getHeight()+radius*2);
+			bounds.setRect(bounds.getX()-radius2, bounds.getY()-radius2, bounds.getWidth()+radius2*2, bounds.getHeight()+radius2*2);
 		}
 		// Don't fill if we have a small radius, and use a rectangle instead of an ellipse (as this repaints much faster)
 		Graphics2D g = g2d;
-		if (radius / downsample < 0.5) {
+		if (radius2 / downsample < 0.5) {
 			if (colorStroke == null)
 				colorStroke = colorFill;
 			colorFill = null;
 			ellipse = new Rectangle2D.Double();
 			// Use opacity to avoid obscuring points completely
 			int rule = AlphaComposite.SRC_OVER;
-			float alpha = (float)(radius / downsample);
+			float alpha = (float)(radius2 / downsample);
 			var composite = g.getComposite();
 			if (composite instanceof AlphaComposite) {
 				var temp = (AlphaComposite)composite;
@@ -906,7 +906,7 @@ public class PathObjectPainter {
 		for (Point2 p : pathPoints.getAllPoints()) {
 			if (bounds != null && !bounds.contains(p.getX(), p.getY()))
 				continue;
-			ellipse.setFrame(p.getX()-radius, p.getY()-radius, radius*2, radius*2);
+			ellipse.setFrame(p.getX()-radius2, p.getY()-radius2, radius2*2, radius2*2);
 			if (colorFill != null) {
 				g.setColor(colorFill);
 				g.fill(ellipse);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -777,9 +777,10 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 
 		setOverlayOptions(overlayOptions);
 		
-		// We need a simple repaint for color changes & simple (thick) line changes
+		// We need a simple repaint for color changes and simple (thick) line changes
 		manager.attachListener(PathPrefs.annotationStrokeThicknessProperty(), repainter);
 		manager.attachListener(PathPrefs.newDetectionRenderingProperty(), repainter);
+		manager.attachListener(PathPrefs.pointRadiusProperty(), repainter);
 
 		gammaProperty.set(PathPrefs.viewerGammaProperty().get());
 		gammaProperty.bind(PathPrefs.viewerGammaProperty());

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/PathTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/PathTools.java
@@ -139,7 +139,7 @@ public class PathTools {
 			createIcon(PathIcons.POINTS_TOOL));
 	
 	
-	private static List<PathTool> ALL_TOOLS = Arrays.asList(
+	private static final List<PathTool> ALL_TOOLS = Arrays.asList(
 			MOVE, RECTANGLE, ELLIPSE, LINE, POLYGON, POLYLINE, BRUSH, POINTS
 			);
 	


### PR DESCRIPTION
QuPath's counting tool can either draw single points as new annotations, or multiple points as part of the same annotation.

Previously, this was a transient setting in the preferences - and the default was the multipoint tool. If you wanted to consistently draw single points, you needed to set this every time QuPath was relaunched.

This PR makes that preference persistent, and also available in the counting tool dialog.
it also slightly changes the icon. While it still uses 3 circles to represent the points tool, 2 of these are translucent if 'single-point' mode is turned on.

Relatedly, the icons used to render points annotations are also slightly adjusted: if there are fewer than 3 points, then the remaining points will also be translucent.

<img width="1187" height="793" alt="points-4" src="https://github.com/user-attachments/assets/0aecf3a6-b437-4175-932c-2d1ed31661d9" />
