### PR TITLE
Update to DJL 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version in progress...
 * Sync mini/channel viewers with a main viewer in multiple ways (https://github.com/qupath/qupath/pull/1970)
   * Sync to the cursor, sync to the selected object or sync to the viewer center
 * Improve toggling between point and multipoint tools (https://github.com/qupath/qupath/pull/1972)
+* Update to Deep Java Library 0.34.0 (supports PyTorch 2.7.1)
 
 ### Bug fixes
 * Ensure toolbar button heights are standardized (https://github.com/qupath/qupath/pull/1950)
@@ -17,6 +18,7 @@ Version in progress...
 ### Dependency updates
 * Bio-Formats 8.3.0
 * CommonMark 0.25.1
+* Deep Java Library 0.34.0
 * Groovy 4.0.28
 
 ## Version 0.6.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ commonsMath3    = "3.6.1"
 commonsText     = "1.10.0"
 controlsFX      = "11.2.2"
 
-deepJavaLibrary = "0.33.0"
+deepJavaLibrary = "0.34.0"
 
 groovy          = "4.0.28"
 gson            = "2.13.1"


### PR DESCRIPTION
Addresses https://github.com/qupath/qupath/issues/1974

---

Not ready to be merged yet: I find it does enable the use of PyTorch 2.7.1 (good!) but breaks the InstanSeg extension (bad!).

Reason seems... surprising.

We [make calls to `baseManager.debugDump(2)`](https://github.com/qupath/qupath-extension-instanseg/blob/c4195caecb3e491c5aed934803fc14cc1e5cc898/src/main/java/qupath/ext/instanseg/core/InstanSeg.java#L239). This attempts to [create a substring of a UUID](https://github.com/deepjavalibrary/djl/blob/0392f119fafa8a5b18c40f0272601504988b7281/api/src/main/java/ai/djl/ndarray/BaseNDManager.java#L426), which would be ok except that [UUIDs aren't used any more](https://github.com/deepjavalibrary/djl/pull/3719).

The result is
```
java.lang.StringIndexOutOfBoundsException: Range [24, 21) out of bounds for length 21
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:55)
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:52)
	at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213)
	at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210)
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Preconditions.java:112)
	at java.base/jdk.internal.util.Preconditions.checkFromToIndex(Preconditions.java:349)
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4865)
	at java.base/java.lang.String.substring(String.java:2834)
	at java.base/java.lang.String.substring(String.java:2807)
	at ai.djl.ndarray.BaseNDManager.debugDump(BaseNDManager.java:426)
	at qupath.ext.instanseg.core.InstanSeg.runInstanSeg(InstanSeg.java:239)
```

We should be able to work around it by avoiding any use of `debugDump` - I've checked that removing this line means that InstanSeg can run. But I suspect this must affect others.