### PR TITLE
Log import objects error

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/InteractiveObjectImporter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/InteractiveObjectImporter.java
@@ -188,6 +188,7 @@ public final class InteractiveObjectImporter {
 				pathObjects.removeAll(tmaCores);
 			}
 		} catch (IOException | IllegalArgumentException ex) {
+			logger.error("Error importing objects", ex);
 			Dialogs.showErrorNotification("Error importing objects", ex.getLocalizedMessage());
 			return false;
 		}


### PR DESCRIPTION
Log import objects error. Before this PR, only `exception.getLocalizedMessage()` was shown.