### PR TITLE
Improve display histogram level choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Version in progress...
 * Channel viewer does not split channels in RGB fluorescence image by default (https://github.com/qupath/qupath/issues/1948)
 * "Split annotations by lines" with line thickness 0 px doesn’t work with multiple lines (https://github.com/qupath/qupath/issues/1978)
 * `TransformedServerBuilder.subtractOffset()` can thrown an `IllegalArgumentException` when being serialized (https://github.com/qupath/qupath/issues/1976)
+* Using the lowest resolution image for brightness/contrast settings can be problematic (https://github.com/qupath/qupath/issues/1958)
 
 ### Dependency updates
 * Bio-Formats 8.3.0


### PR DESCRIPTION
Avoid using extremely small pyramid levels when calculating histograms for the image display.

The simple heuristic is that we choose the highest resolution that gives us an image with no more than 1024x1024 pixels - or the lowest resolution level, if no level satisfies this rule.
Previously we *always* chose the lowest-resolution in QuPath v0.6.0.

This addresses https://github.com/qupath/qupath/issues/1958
With the PR, the image from https://zenodo.org/records/16569043 displays sensibly.

But it also makes a different for common OpenSlide test images OS-2.ndpi and similar.
It seems their lowest resolution level has a downsample of 4096, and dimensions of 31x18 pixels.
So histograms generated from these were *terrible*.
Therefore this PR helps the Brightness/Contrast dialog behave more sensibly with these images too, selecting from resolution level 8 of 13 (rather than 13).

Examples for the hematoxylin image, extracted from OS-2.ndpi using default stain vectors:

**In v0.6.0**
<img width="303" height="272" alt="Screenshot 2025-08-22 at 16 53 51" src="https://github.com/user-attachments/assets/971e6bb0-1360-4b71-bc98-77df8a19ff16" />


**With this PR**
<img width="303" height="272" alt="Screenshot 2025-08-22 at 16 54 05" src="https://github.com/user-attachments/assets/e83d6e57-cc81-4178-8c94-3da96ecfd7c4" />
