### PR TITLE
Update to Groovy v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Version in progress...
 * Bio-Formats 8.3.0
 * CommonMark 0.25.1
 * Deep Java Library 0.34.0
-* Groovy 4.0.28
+* Groovy 5.0.0
+* RichTextFX 0.11.6
 * SciJava POM 42.0.0 (for Fiji builds)
 
 ## Version 0.6.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ controlsFX      = "11.2.2"
 
 deepJavaLibrary = "0.34.0"
 
-groovy          = "4.0.28"
+groovy          = "5.0.0"
 gson            = "2.13.1"
 guava           = "33.4.8-jre"
 
@@ -50,7 +50,7 @@ qupath-fxtras   = "0.2.0"
 qupath-training = "0.1.0"
 qupath-djl      = "0.4.0"
 
-richtextfx      = "0.11.5"
+richtextfx      = "0.11.6"
 
 slf4j           = "2.0.16"
 snakeyaml       = "2.3"


### PR DESCRIPTION
Groovy 5 has just been released, and adds lots of features that may become useful to us.

More details at https://groovy-lang.org/releasenotes/groovy-5.0.html

Here's an extremely minor change that can be used to check you've using Groovy 5 and not 4:

```groovy
var file = new File("Hello.png")
println file.baseName
println file.extension
```

(Also snuck in very minor RichTextFX version bump)