### PR TITLE
Consider zarr images when trying to import images

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/DragDropImportListener.java
@@ -545,7 +545,12 @@ public class DragDropImportListener implements EventHandler<DragEvent> {
 			return;
 		} else if (qupath.getProject() != null) {
 			// Try importing multiple images to a project
-			String[] potentialFiles = list.stream().filter(File::isFile).map(File::getAbsolutePath).toArray(String[]::new);
+			String[] potentialFiles = list.stream()
+					.filter(potentialFile -> potentialFile.isFile() ||
+							(potentialFile.isDirectory() && potentialFile.getName().toLowerCase().endsWith(".zarr"))
+					)
+					.map(File::getAbsolutePath)
+					.toArray(String[]::new);
 			if (potentialFiles.length > 0) {
 				ProjectCommands.promptToImportImages(qupath, potentialFiles);
 				return;


### PR DESCRIPTION
Currently, it is not easily possible to import multiple zarr images at the same time, it has to be done one image at a time.

This PR fixes that by making it possible to drag and drop several zarr images at the same time (when a project is open).