### PR TITLE
Allow zarr images to be imported in project import images window

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ProjectImportImagesCommand.java
@@ -260,8 +260,8 @@ class ProjectImportImagesCommand {
 				try {
 					var paths = dragboard.getFiles()
 							.stream()
-							.filter(f -> f.isFile() && !f.isHidden())
-							.map(f -> f.getAbsolutePath())
+							.filter(f -> (f.isFile() || f.isDirectory() && f.getName().toLowerCase().endsWith(".zarr")) && !f.isHidden())
+							.map(File::getAbsolutePath)
 							.collect(Collectors.toCollection(ArrayList::new));
 					paths.removeAll(listView.getItems());
 					if (!paths.isEmpty())


### PR DESCRIPTION
Currently, the `Import images to project` window (accessible with `File` -> `Project` -> `Add images...`) doesn't allow zarr directories to be dropped to the list of images.

This PR fixes that.