### PR TITLE
Update macOS runners

### DIFF
--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -30,9 +30,9 @@ jobs:
         include:
           - platform: ubuntu-latest
             name: Linux
-          - platform: macos-13 # x64
+          - platform: macos-15-intel # x64
             name: Mac-x64
-          - platform: macos-14 # aarch64
+          - platform: macos-latest # aarch64
             name: Mac-arm64
           - platform: windows-latest
             name: Windows


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

It looks like Intel builds will not be possible from Fall 2027.