### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version in progress...
   * Sync to the cursor, sync to the selected object or sync to the viewer center
 * Improve toggling between point and multipoint tools (https://github.com/qupath/qupath/pull/1972)
 * Update to Deep Java Library 0.34.0 (supports PyTorch 2.7.1)
+* *Downgrade* of OpenCV to 4.9.0
+  * This is needed for https://github.com/qupath/qupath-extension-align to work
 
 ### Bug fixes
 * Ensure toolbar button heights are standardized (https://github.com/qupath/qupath/pull/1950)
@@ -20,9 +22,13 @@ Version in progress...
 
 ### Dependency updates
 * Bio-Formats 8.3.0
-* CommonMark 0.25.1
+* CommonMark 0.26.0
 * Deep Java Library 0.34.0
-* Groovy 5.0.0
+* Groovy 5.0.1
+* Gson 2.13.2
+* Guava 33.5.0-jre
+* JavaCPP 1.5.10
+* OpenCV 4.9.0
 * RichTextFX 0.11.6
 * SciJava POM 42.0.0 (for Fiji builds)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,16 +5,16 @@ bioimageIoSpec  = "0.2.0"
 omeZarrReader   = "0.6.0"
 blosc           = "1.21.6+01"
 
-commonmark      = "0.25.1"
+commonmark      = "0.26.0"
 commonsMath3    = "3.6.1"
 commonsText     = "1.10.0"
 controlsFX      = "11.2.2"
 
 deepJavaLibrary = "0.34.0"
 
-groovy          = "5.0.0"
-gson            = "2.13.1"
-guava           = "33.4.8-jre"
+groovy          = "5.0.1"
+gson            = "2.13.2"
+guava           = "33.5.0-jre"
 
 ikonli          = "12.3.1"
 imagej          = "1.54k"
@@ -25,7 +25,7 @@ jdk             = "21"
 # For gradle-javacpp-platform (no 1.5.11 available)
 javacpp         = "1.5.10"
 
-opencv          = "4.10.0-1.5.11"
+opencv          = "4.9.0-1.5.10"
 
 # Warning! JavaFX 20.0.1 and later seem to break search links in Javadocs
 javafx          = "23.0.2"
@@ -52,8 +52,8 @@ qupath-djl      = "0.4.0"
 
 richtextfx      = "0.11.6"
 
-slf4j           = "2.0.16"
-snakeyaml       = "2.3"
+slf4j           = "2.0.17"
+snakeyaml       = "2.5"
 
 
 [libraries]


### PR DESCRIPTION
This also attempts to resolve https://github.com/qupath/qupath/issues/1973

Note that, for Gradle 9.x, we can only use `jpackage` if the build is *not* using `org.gradle.parallel=true` - because of an issue with the license report, see https://github.com/jk1/Gradle-License-Report/issues/337

If parallel builds are already set in `gradle.properties`, the command line workaround is to use `gradlew jpackage --no-parallel`