### PR TITLE
Create thresholder window height issue

### DIFF
--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SimpleThresholdCommand.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/SimpleThresholdCommand.java
@@ -336,9 +336,7 @@ public class SimpleThresholdCommand implements Runnable {
 		stage.show();
 
 		stage.setMinHeight(320);
-		stage.setMaxHeight(420);
 		stage.setMinWidth(320);
-		stage.setMaxWidth(420);
 		stage.sizeToScene();
 		stage.setResizable(true);
 		


### PR DESCRIPTION
As described in issue #2000, the windows height was restricted and prevented access to key buttons. 
This PR removes the max height and width for this window to match the behaviour used by other similar windows throughout QuPath. 