### PR TITLE
Tentative move to Java 25

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        kotlin("jvm") version "2.0.21"
+        kotlin("jvm") version "2.2.20"
     }
 }
 

--- a/buildSrc/src/main/kotlin/qupath.application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.application-conventions.gradle.kts
@@ -21,6 +21,15 @@ application {
     applicationDefaultJvmArgs += "--add-opens"
     applicationDefaultJvmArgs += "javafx.graphics/com.sun.javafx.css=ALL-UNNAMED"
 
+    // Necessary when using JavaFX 24+
+    // See https://gluonhq.com/products/javafx/openjfx-24-release-notes/
+    applicationDefaultJvmArgs += "--enable-native-access"
+    applicationDefaultJvmArgs += "javafx.graphics,javafx.media,javafx.web"
+
+    // Necessary when using JavaCPP (for now anyway)
+    applicationDefaultJvmArgs += "--enable-native-access"
+    applicationDefaultJvmArgs += "ALL-UNNAMED"
+
     // Necessary when using ./gradlew run to support project metadata autocomplete
     // See https://github.com/controlsfx/controlsfx/issues/1505
     applicationDefaultJvmArgs += "--add-opens"

--- a/buildSrc/src/main/kotlin/qupath.jpackage-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.jpackage-conventions.gradle.kts
@@ -42,8 +42,9 @@ runtime {
         "--no-header-files",
         "--no-man-pages",
         "--strip-native-commands",
-        "--compress", "zip-6", // jlink option; can be zip-0 (no compression) to zip-9; default is zip-6
-        "--bind-services"
+        "--compress", "zip-6" // jlink option; can be zip-0 (no compression) to zip-9; default is zip-6
+//        "--bind-services"   // Fails on Temurin JDK 25 Temurin with
+                              // Error: This JDK does not contain packaged modules and cannot be used to create another image with the jdk.jlink module
     ))
     modules.addAll(listOf(
         "java.desktop",
@@ -57,8 +58,7 @@ runtime {
 
         "java.net.http",        // Add HttpClient support (might be used by scripts)
         "java.management",      // Useful to check memory usage
-        "jdk.management.agent", // Enables VisualVM to connect and sample CPU use
-        "jdk.jsobject",         // Needed to interact with WebView through JSObject
+        "jdk.management.agent"  // Enables VisualVM to connect and sample CPU use
     ))
 
     val params = JPackageParams(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ ikonli          = "12.3.1"
 imagej          = "1.54k"
 
 # Compatibility with Java 21 with QuPath v0.6.x
-jdk             = "21"
+jdk             = "25"
 
 # For gradle-javacpp-platform (no 1.5.11 available)
 javacpp         = "1.5.10"
@@ -28,7 +28,7 @@ javacpp         = "1.5.10"
 opencv          = "4.9.0-1.5.10"
 
 # Warning! JavaFX 20.0.1 and later seem to break search links in Javadocs
-javafx          = "23.0.2"
+javafx          = "25"
 jna             = "5.16.0"
 jfreeSvg        = "5.0.6"
 jfxtras         = "17-r1"
@@ -133,7 +133,7 @@ javacpp        = { id = "org.bytedeco.gradle-javacpp-platform",     version.ref 
 # If javafx plugin causes trouble, see https://github.com/openjfx/javafx-gradle-plugin#migrating-from-0014-to-010
 javafx         = { id = "org.openjfx.javafxplugin",                 version = "0.1.0" }
 # For jpackage
-jpackage       = { id = "org.beryx.runtime",                        version = "1.13.1" } # Non-modular
+jpackage       = { id = "org.beryx.runtime",                        version = "2.0.0-rc.1" } # Non-modular
 # For license report (including 3rd party licenses)
 license-report = { id = "com.github.jk1.dependency-license-report", version = "2.9" }
 # For checksums when creating builds

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,11 +2,11 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 pluginManagement {
     plugins {
-        kotlin("jvm") version "2.0.21"
+        kotlin("jvm") version "2.2.20"
     }
 }
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0" // to download JDK if needed
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0" // to download JDK if needed
 }
 
 // Define project name


### PR DESCRIPTION
This 'works', but is likely to require 1 big change and 2 small ones.

The big change is that removing '--bind-services' is probably stripping back the JRE too much, and we'll need to add in more modules or switch to a JDK other than Temurin so that we --bind-services can be reinstated.

The small changes:
- Use Kotlin 2.3 when available
- Use 2.0.0 for org.beryx.runtime when available

The license plugin should also be updated whenever possible, since it currently means we can only use jpackage if the build isn't parallelized.