### PR TITLE
Remove bioformats2raw.layout in zarr attributes

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrAttributesCreator.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/zarr/OMEZarrAttributesCreator.java
@@ -56,8 +56,7 @@ class OMEZarrAttributesCreator {
                                 "defaultZ", 0,
                                 "model", "color"
                         )
-                ),
-                "bioformats2raw.layout" , 3
+                )
         );
     }
 


### PR DESCRIPTION
Zarr created with the Zarr writer didn't pass the [ngff validator](https://ome.github.io/ome-ngff-validator). This PR fixes that by removing the `bioformats2raw.layout` attribute.

See https://forum.image.sc/t/qupath-zarr-export-using-bioformats2raw-layout-issue/116808 for more details.