### PR TITLE
More relaxed javadocs

### DIFF
--- a/buildSrc/src/main/kotlin/qupath.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.java-conventions.gradle.kts
@@ -87,6 +87,8 @@ tasks.withType<Javadoc> {
         if (strictJavadoc.getOrElse("false") != "true") {
             // This should be made more strict in the future
             addStringOption("Xdoclint:none", "-quiet")
+            // Failures can occur e.g. because javadoc.io is inaccessible
+            isFailOnError = false
         }
 
         tags(


### PR DESCRIPTION
See https://github.com/qupath/qupath/issues/2010

We're having too many failures due to javadoc.io not being reachable, and broken links shouldn't really be all that bad.