### PR TITLE
Standardize `createId()`, use last modified time

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/imagej/images/servers/ImageJServer.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/images/servers/ImageJServer.java
@@ -23,6 +23,38 @@
 
 package qupath.imagej.images.servers;
 
+import ij.CompositeImage;
+import ij.IJ;
+import ij.ImagePlus;
+import ij.ImageStack;
+import ij.gui.Roi;
+import ij.io.Opener;
+import ij.measure.Calibration;
+import ij.plugin.Duplicator;
+import ij.plugin.ImageInfo;
+import ij.process.ByteProcessor;
+import ij.process.ColorProcessor;
+import ij.process.FloatProcessor;
+import ij.process.ImageProcessor;
+import ij.process.LUT;
+import ij.process.ShortProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.imagej.tools.IJTools;
+import qupath.lib.color.ColorModelFactory;
+import qupath.lib.common.GeneralTools;
+import qupath.lib.images.servers.AbstractTileableImageServer;
+import qupath.lib.images.servers.ImageChannel;
+import qupath.lib.images.servers.ImageServerBuilder;
+import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
+import qupath.lib.images.servers.ImageServerMetadata;
+import qupath.lib.images.servers.PixelType;
+import qupath.lib.images.servers.ServerTools;
+import qupath.lib.images.servers.TileRequest;
+import qupath.lib.objects.PathObject;
+import qupath.lib.objects.PathObjectReader;
+import qupath.lib.objects.PathObjects;
+
 import java.awt.Rectangle;
 import java.awt.image.BandedSampleModel;
 import java.awt.image.BufferedImage;
@@ -42,38 +74,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import ij.CompositeImage;
-import ij.IJ;
-import ij.ImagePlus;
-import ij.ImageStack;
-import ij.gui.Roi;
-import ij.io.Opener;
-import ij.measure.Calibration;
-import ij.plugin.Duplicator;
-import ij.plugin.ImageInfo;
-import ij.process.ByteProcessor;
-import ij.process.ColorProcessor;
-import ij.process.FloatProcessor;
-import ij.process.ImageProcessor;
-import ij.process.LUT;
-import ij.process.ShortProcessor;
-import qupath.imagej.tools.IJTools;
-import qupath.lib.color.ColorModelFactory;
-import qupath.lib.common.GeneralTools;
-import qupath.lib.images.servers.AbstractTileableImageServer;
-import qupath.lib.images.servers.ImageChannel;
-import qupath.lib.images.servers.ImageServerBuilder;
-import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
-import qupath.lib.images.servers.ImageServerMetadata;
-import qupath.lib.images.servers.PixelType;
-import qupath.lib.images.servers.TileRequest;
-import qupath.lib.objects.PathObject;
-import qupath.lib.objects.PathObjectReader;
-import qupath.lib.objects.PathObjects;
 
 /**
  * ImageServer that uses ImageJ's image-reading capabilities.
@@ -347,7 +347,7 @@ public class ImageJServer extends AbstractTileableImageServer implements PathObj
 
 	@Override
 	protected String createID() {
-		return getClass().getName() + ": " + uri.toString();
+		return ServerTools.createDefaultID(getClass(), uri, args);
 	}
 	
 	@Override

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -61,6 +61,7 @@ import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
 import qupath.lib.images.servers.ImageServerMetadata;
 import qupath.lib.images.servers.ImageServerMetadata.ImageResolutionLevel;
 import qupath.lib.images.servers.PixelType;
+import qupath.lib.images.servers.ServerTools;
 import qupath.lib.images.servers.TileRequest;
 import qupath.lib.objects.PathObject;
 import qupath.lib.objects.PathObjectReader;
@@ -890,11 +891,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer implement
 	
 	@Override
 	public String createID() {
-		String id = getClass().getSimpleName() + ": " + uri.toString();
-		if (args.length > 0) {
-			id += "[" + String.join(", ", args) + "]";
-		}
-		return id;
+		return ServerTools.createDefaultID(getClass(), uri, args);
 	}
 
 	@Override

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
@@ -23,6 +23,22 @@
 
 package qupath.lib.images.servers.openslide;
 
+import com.google.gson.GsonBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.lib.common.GeneralTools;
+import qupath.lib.images.servers.AbstractTileableImageServer;
+import qupath.lib.images.servers.ImageChannel;
+import qupath.lib.images.servers.ImageServerBuilder.DefaultImageServerBuilder;
+import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
+import qupath.lib.images.servers.ImageServerMetadata;
+import qupath.lib.images.servers.ImageServerMetadata.ImageResolutionLevel;
+import qupath.lib.images.servers.PixelType;
+import qupath.lib.images.servers.ServerTools;
+import qupath.lib.images.servers.TileRequest;
+import qupath.lib.images.servers.openslide.jna.OpenSlide;
+import qupath.lib.images.servers.openslide.jna.OpenSlideLoader;
+
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
@@ -37,23 +53,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.gson.GsonBuilder;
-
-import qupath.lib.common.GeneralTools;
-import qupath.lib.images.servers.AbstractTileableImageServer;
-import qupath.lib.images.servers.ImageChannel;
-import qupath.lib.images.servers.ImageServerMetadata;
-import qupath.lib.images.servers.ImageServerMetadata.ImageResolutionLevel;
-import qupath.lib.images.servers.PixelType;
-import qupath.lib.images.servers.TileRequest;
-import qupath.lib.images.servers.ImageServerBuilder.DefaultImageServerBuilder;
-import qupath.lib.images.servers.ImageServerBuilder.ServerBuilder;
-import qupath.lib.images.servers.openslide.jna.OpenSlide;
-import qupath.lib.images.servers.openslide.jna.OpenSlideLoader;
 
 /**
  * ImageServer implementation using OpenSlide.
@@ -284,7 +283,7 @@ public class OpenslideImageServer extends AbstractTileableImageServer {
 	
 	@Override
 	protected String createID() {
-		return getClass().getName() + ": " + uri.toString();
+		return ServerTools.createDefaultID(getClass(), uri, args);
 	}
 	
 	@Override


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/2012

Opening an image in QuPath after it has been modified should no longer result in tiles being returned from the cache - at least for OpenSide, ImageJ and Bio-Formats - because the ID used for caching now includes the last modified time of the original file.

Other ImageServer implementations are responsible for creating their own ID that encodes this information, or using the new `ServerTools.createDefaultID` method.