### PR TITLE
Error if running brightfield cell detection on non-brightfield image

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/detect/cells/WatershedCellDetection.java
@@ -253,16 +253,6 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 						channelsCell.put(stain.getName() + " OD", fps[i]);
 					}
 				}
-//				channels.put("Hematoxylin OD",  fps[0]);
-//				if (stains.isH_DAB()) {
-//					channels.put("DAB OD", fps[1]);
-//					channelsCell.put("DAB OD", fps[1]);
-//				}
-//				else if (stains.isH_E()) {
-//					channels.put("Eosin OD", fps[1]);
-//					channelsCell.put("Eosin OD", fps[1]);
-//				}
-				
 
 				if (!params.getParameters().get("detectionImageBrightfield").isHidden()) {
 					String stainChoice = (String)params.getChoiceParameterValue("detectionImageBrightfield");
@@ -297,13 +287,8 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 						}
 					}
 				}
-				
-				// Temporary test of the usefulness of RGB measurements...
-//				channels.put("Red", ((ColorProcessor)ip).toFloat(0, null));
-//				channels.put("Green", ((ColorProcessor)ip).toFloat(1, null));
-//				channels.put("Blue", ((ColorProcessor)ip).toFloat(2, null));
-				
-			} //else {
+
+			}
 			if (fpDetection == null) {
 				List<ImageChannel> imageChannels = imageData.getServerMetadata().getChannels();
 				if (ip instanceof ColorProcessor) {
@@ -319,25 +304,23 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 							logger.warn("Channel with duplicate name '{}' - will be skipped", name);
 						else
 							channels.put(name, imp.getStack().getProcessor(imp.getStackIndex(c, 0, 0)).convertToFloatProcessor());
-//						channels.put("Channel " + c, imp.getStack().getProcessor(imp.getStackIndex(c, 0, 0)).convertToFloatProcessor());
 					}
 				}
-				// For fluorescence, measure everything
+
+                // For fluorescence, measure everything
 				channelsCell.putAll(channels);
-				
-				// Try to get detection channel for fluorescence
+
+
+                // Try to get detection channel for fluorescence
 				String detectionChannelName;
 				if (!isBrightfield) {
+                    if (params.containsKey("detectionImageBrightfield")) {
+                        throw new IllegalStateException("Non-brightfield image has brightfield detection image...");
+                    }
 					detectionChannelName = (String)params.getChoiceParameterValue("detectionImage");
 					fpDetection = channels.get(detectionChannelName);
-//					detectionChannel = params.getIntParameterValue("detectionImageFluorescence");
 				}
 				else throw new IllegalArgumentException("No valid detection channel is selected!");
-//				if (detectionChannelName == null) {
-//					detectionChannelName = imageChannels.get(detectionChannel-1).getName();
-//					logger.warn("Unable to find specified Channel {} - will default to Channel 1", detectionChannel);
-//				}
-//				fpDetection = channels.get(detectionChannelName);
 			}
 			WatershedCellDetector detector2 = new WatershedCellDetector(fpDetection, channels, channelsCell, roi, pathImage);
 			

--- a/qupath-core/src/main/java/qupath/lib/plugins/parameters/ParameterList.java
+++ b/qupath-core/src/main/java/qupath/lib/plugins/parameters/ParameterList.java
@@ -61,9 +61,7 @@ public class ParameterList implements Serializable {
 	private static final Logger logger = LoggerFactory.getLogger(ParameterList.class);
 	
 	private Map<String, Parameter<?>> params = new LinkedHashMap<>();
-	
-//	public ParameterList() {};
-	
+
 	private static ParameterList copyParameters(ParameterList params) {
 		ParameterList paramsCopy = new ParameterList();
 		for (Entry<String, Parameter<?>> entry : params.params.entrySet()) {
@@ -71,20 +69,6 @@ public class ParameterList implements Serializable {
 		}
 		return paramsCopy;
 	}
-	
-	
-//	/**
-//	 * Add all the parameters from a second ParameterList to this one.
-//	 * <p>
-//	 * Note that the parameters are added directly (not copied), therefore changes
-//	 * in one list will be reflected in the other.  If this is not desired, then
-//	 * a copy should be made first.
-//	 * @param params2
-//	 */
-//	public void addParameters(ParameterList params2) {
-//		params.putAll(params2.params);
-//	}
-	
 	
 	/**
 	 * Set the 'hidden' flag for parameters with the specified keys.
@@ -339,48 +323,7 @@ public class ParameterList implements Serializable {
 	public boolean containsKey(final Object key) {
 		return params.containsKey(key);
 	}
-	
-	
-	
-//	public Parameter<?> getParameter(String key) {
-//		return params.get(key);
-//	}
-//	
-//	public BooleanParameter getBooleanParameter(String key) {
-//		Parameter<?> p = params.get(key);
-//		if (p instanceof BooleanParameter)
-//			return (BooleanParameter)p;
-//		return null;
-//	}
-//	
-//	public DoubleParameter getDoubleParameter(String key) {
-//		Parameter<?> p = params.get(key);
-//		if (p instanceof DoubleParameter)
-//			return (DoubleParameter)p;
-//		return null;
-//	}
-//	
-//	public IntParameter getIntParameter(String key) {
-//		Parameter<?> p = params.get(key);
-//		if (p instanceof IntParameter)
-//			return (IntParameter)p;
-//		return null;
-//	}
-//	
-//	public StringParameter getStringParameter(String key) {
-//		Parameter<?> p = params.get(key);
-//		if (p instanceof StringParameter)
-//			return (StringParameter)p;
-//		return null;
-//	}
-//	
-//	public ChoiceParameter<?> getChoiceParameter(String key) {
-//		Parameter<?> p = params.get(key);
-//		if (p instanceof ChoiceParameter<?>)
-//			return (ChoiceParameter<?>)p;
-//		return null;
-//	}
-	
+
 	
 	Boolean getBooleanParameterValue(String key, Boolean defaultValue) {
 		Parameter<?> p = params.get(key);
@@ -507,15 +450,6 @@ public class ParameterList implements Serializable {
 			String key = entry.getKey();
 			Parameter<?> parameter = mapParams.get(key);
 			if (parameter == null || !parameter.setStringLastValue(locale, entry.getValue())) {
-//				if (parameter != null && parameter.isHidden())
-//					logger.info("Skipping hidden parameter " + key + " with value " + entry.getValue());
-//				else
-				
-//				if (key.equals(InteractivePluginTools.KEY_REGIONS))
-//					params.addChoiceParameter(InteractivePluginTools.KEY_REGIONS, "Regions", entry.getValue(), new String[]{entry.getValue()});
-//				else if (key.equals(InteractivePluginTools.KEY_SKIP_NON_EMPTY))
-//					params.addBooleanParameter(InteractivePluginTools.KEY_SKIP_NON_EMPTY, "Skip non-empty", Boolean.parseBoolean(entry.getValue()));
-//				else
 					logger.warn("Unable to set parameter {} with value {}", key, entry.getValue());
 			} else
 				parameter.setStringLastValue(locale, entry.getValue());
@@ -612,7 +546,6 @@ public class ParameterList implements Serializable {
 			else if (value instanceof Boolean)
 				sb.append(value.toString());
 			else if (value instanceof Number) {
-//				sb.append(NumberFormat.getInstance().format(value));
 				sb.append(value.toString());
 			} else
 				sb.append("\"").append(value).append("\"");
@@ -662,18 +595,5 @@ public class ParameterList implements Serializable {
 		var json = convertToJson(map);
 		return json;
 	}
-	
-	
-//	/**
-//	 * Put a parameter into the list, possibly replacing a previous parameter.
-//	 * 
-//	 * @param key
-//	 * @param parameter
-//	 * @return
-//	 */
-//	public Parameter<? extends Object> putParameter(String key, Parameter<?> parameter) {
-//		return params.put(key, parameter);
-//	}
-	
 
 }


### PR DESCRIPTION
Throw an error if trying to run an instance of brightfield cell detection on a non-brightfield image.

To reproduce:

1. open a brightfield image
2. run cell detection, or open a workflow of a previous cell detection on this image
3. without closing cell detection, open a non-brightfield image
4. run cell detection using either of the two detection images and observe that the results look suspiciously normal (at least, when DAPI is the first channel).

Draft PR pending further testing.