### PR TITLE
Update Gradle license plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -137,6 +137,6 @@ javafx         = { id = "org.openjfx.javafxplugin",                 version = "0
 # For jpackage
 jpackage       = { id = "org.beryx.runtime",                        version = "2.0.0" } # Non-modular
 # For license report (including 3rd party licenses)
-license-report = { id = "com.github.jk1.dependency-license-report", version = "2.9" }
+license-report = { id = "com.github.jk1.dependency-license-report", version = "3.0.1" }
 # For checksums when creating builds
 checksum       = { id = "org.gradle.crypto.checksum",               version = "1.4.0" }


### PR DESCRIPTION
Update https://github.com/jk1/Gradle-License-Report to 3.0.1.

It's still necessary to run with `--no-parallel` (the default in Gradle, so it should only affect people who are explicitly making their builds parallel).