### PR TITLE
Log an exception in ImageServerProvider for debugging

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
@@ -225,7 +225,7 @@ public class ImageServerProvider {
 			try (var server = support.getBuilders().get(0).build()) {
 				return support;
 			} catch (Exception e) {
-				logger.warn("Unable to open {}", support);
+				logger.warn("Unable to open {}", support, e);
 			}
 		}
 		return supports.isEmpty() ? null : supports.get(0);


### PR DESCRIPTION
I found this change useful when debugging the CZI extension.

Either the log message should be at a lower level (eg, debug) to signal that it's not unusual behaviour, or we should be propagate the full exception into the log.