### PR TITLE
Log at warn only if all supports failed

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java
@@ -227,7 +227,7 @@ public class ImageServerProvider {
 			try (var server = support.getBuilders().get(0).build()) {
 				return support;
 			} catch (Exception e) {
-				logger.debug("Unable to open {}", support);
+				logger.debug("Unable to open {}", support, e);
 				exceptions.put(support, e);
 			}
 		}


### PR DESCRIPTION
From discussion in #2035. This improves the logging for image server providers, only warning if no supported servers can open and then warn logging all exceptions encountered, and debug logging exceptions in the normal case, where advanced users/developers may want to view the exceptions but in normal use they are irrelevant.