### PR TITLE
Reduce navigation speed using arrow keys in viewer

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -23,6 +23,31 @@
 
 package qupath.lib.gui.prefs;
 
+import javafx.beans.binding.BooleanBinding;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.LongProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.StringProperty;
+import javafx.beans.value.ObservableBooleanValue;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener.Change;
+import javafx.collections.ObservableList;
+import javafx.scene.text.FontWeight;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.fx.prefs.PreferenceManager;
+import qupath.lib.common.ColorTools;
+import qupath.lib.common.GeneralTools;
+import qupath.lib.common.ThreadTools;
+import qupath.lib.common.Version;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.gui.localization.QuPathResources;
+import qupath.lib.objects.classes.PathClass;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -44,26 +69,6 @@ import java.util.prefs.BackingStoreException;
 import java.util.prefs.InvalidPreferencesFormatException;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
-
-import javafx.beans.binding.BooleanBinding;
-import javafx.beans.property.*;
-import javafx.beans.value.ObservableBooleanValue;
-import javafx.beans.value.ObservableValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javafx.collections.FXCollections;
-import javafx.collections.ListChangeListener.Change;
-import javafx.collections.ObservableList;
-import javafx.scene.text.FontWeight;
-import qupath.fx.prefs.PreferenceManager;
-import qupath.lib.common.ColorTools;
-import qupath.lib.common.GeneralTools;
-import qupath.lib.common.ThreadTools;
-import qupath.lib.common.Version;
-import qupath.lib.gui.QuPathGUI;
-import qupath.lib.gui.localization.QuPathResources;
-import qupath.lib.objects.classes.PathClass;
 
 /**
  * Central storage of QuPath preferences.
@@ -620,7 +625,7 @@ public class PathPrefs {
 	}
 	
 	
-	private static IntegerProperty navigationSpeedProperty = createPersistentPreference("Navigation speed %", 100);
+	private static IntegerProperty navigationSpeedProperty = createPersistentPreference("Navigation speed %", 10);
 	
 	/**
 	 * Percentage to scale navigation speed.


### PR DESCRIPTION
This makes panning easier using the arrow keys by decreasing the effect of a single keypress - which previously could pan too far.

I found the old behavior *deeply* annoying when trying to pan to a precise location, but it turns out it can already be adjusted with a couple of preferences. So this PR just changes one of them.

Pressing and holding an arrow still makes it possible to gradually accelerate when wanting to move further (at least on macOS) - although there's a preference for this too..

You don't need to build this PR to check it - in QuPath v0.6.0, just reduce the preference value from `100` to `10`:

<img width="553" height="286" alt="Screenshot 2025-11-12 at 11 12 34" src="https://github.com/user-attachments/assets/9907a310-f196-4a8e-9773-f2b34cb6af66" />

The navigation code is horribly complicated and should probably be revisited, but to me this change is the simplest way to get more intuitive default behavior.