### PR TITLE
Change DEBUG to WARN log level when no primary selected object

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/scripting/QP.java
@@ -1068,7 +1068,7 @@ public class QP {
 			return null;
 		var selected = hierarchy.getSelectionModel().getSelectedObject();
 		if (selected == null && !hierarchy.getSelectionModel().noSelection())
-			logger.debug("getSelectedObject() is null because there is no primary selected object, "
+			logger.warn("getSelectedObject() is null because there is no primary selected object, "
 					+ "you might want getSelectedObjects() instead");
 		return selected;
 	}


### PR DESCRIPTION
This script doesn't work:

```java
selectObjectsByClassification("Tumour")
var roi = getSelectedROI()    // roi is null, even if a "Tumour" annotation exists
```

This is because there is a concept of "primary" selected object in the hierarchy:
* `selectObjectsByClassification("Tumour")` select all objects with the `Tumour` pathclass, but doesn't set the primary selected object.
* `def roi = getSelectedROI()` try to get the primary selected object. It doesn't exist, so roi is null.

This is not fundamentally a QuPath problem, because functions like `selectObjectsBy...()` should be followed by `getSelectedObjects()`, not `getSelectedROI()` or `getSelectedObject()`. However, this behaviour could be more explicit. Currently, `getSelectedROI()` is able to detect this specific situation and logs a message, but only with the `DEBUG` level. This PR converts it to a `WARN` message.