### PR TITLE
Optionally use ICC profiles with OpenSlide images

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/imagej/images/servers/ImageJServerBuilder.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/images/servers/ImageJServerBuilder.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -23,24 +23,21 @@
 
 package qupath.imagej.images.servers;
 
-import java.awt.image.BufferedImage;
-import java.io.IOException;
-import java.net.URI;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import ij.IJ;
 import ij.io.Opener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import qupath.lib.common.GeneralTools;
 import qupath.lib.images.servers.FileFormatInfo;
+import qupath.lib.images.servers.FileFormatInfo.ImageCheckType;
 import qupath.lib.images.servers.ImageServer;
 import qupath.lib.images.servers.ImageServerBuilder;
-import qupath.lib.images.servers.FileFormatInfo.ImageCheckType;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Builder for ImageServers that use ImageJ to read images.
@@ -96,11 +93,10 @@ public class ImageJServerBuilder implements ImageServerBuilder<BufferedImage> {
 			return 0;
 		else {
 			// We can't use ImageJ to read ROIs, tables, etc.
+            // We also can't use it to read .mrxs files, although they can masquerade as jpegs
 			String format = Opener.getFileFormat(path.toAbsolutePath().toString());
-			var unsupportedFormats = IntStream.of(
-					Opener.UNKNOWN, Opener.JAVA_OR_TEXT, Opener.ROI, Opener.TABLE, Opener.TEXT
-			).mapToObj(i -> Opener.types[i]).collect(Collectors.toSet());
-			if (unsupportedFormats.contains(format))
+			if (UNSUPPORTED_FORMATS.contains(format) ||
+                    ("jpg".equals(format) && path.toString().toLowerCase().endsWith(".mrxs")))
 				return 0f;
 			else
 				return 1f;

--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2021 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2021, 2024 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -20,6 +20,13 @@
  */
 
 package qupath.lib.images.servers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.lib.awt.common.BufferedImageTools;
+import qupath.lib.color.ColorModelFactory;
+import qupath.lib.images.servers.ImageServerMetadata.ChannelType;
+import qupath.lib.regions.RegionRequest;
 
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
@@ -39,14 +46,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import qupath.lib.awt.common.BufferedImageTools;
-import qupath.lib.color.ColorModelFactory;
-import qupath.lib.images.servers.ImageServerMetadata.ChannelType;
-import qupath.lib.regions.RegionRequest;
-
 /**
  * Abstract {@link ImageServer} for BufferedImages that internally breaks up requests into constituent tiles.
  * <p>
@@ -62,14 +61,14 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 	private static final Logger logger = LoggerFactory.getLogger(AbstractTileableImageServer.class);
 	
 	private ColorModel colorModel;
-	private Map<String, BufferedImage> emptyTileMap = new HashMap<>();
+	private final Map<String, BufferedImage> emptyTileMap = new HashMap<>();
 	
-	private transient Set<TileRequest> emptyTiles = new HashSet<>();
+	private final transient Set<TileRequest> emptyTiles = new HashSet<>();
 	
-	private static final Long ZERO = Long.valueOf(0L);
+	private static final Long ZERO = 0L;
 	
 	// Maintain a record of tiles that could not be cached, so we warn for each only once
-	private transient Set<RegionRequest> failedCacheTiles = new HashSet<>();
+	private final transient Set<RegionRequest> failedCacheTiles = new HashSet<>();
 		
 	protected AbstractTileableImageServer() {
 		super(BufferedImage.class);
@@ -77,9 +76,6 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 	
 	protected BufferedImage getEmptyTile(int width, int height) throws IOException {
 		return getEmptyTile(width, height, true);
-//		return getEmptyTile(width, height,
-//				width == getMetadata().getPreferredTileWidth() &&
-//				height == getMetadata().getPreferredTileHeight());
 	}
 	
 	/**

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerBuilder.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerBuilder.java
@@ -4,250 +4,249 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * QuPath is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License 
+ *
+ * You should have received a copy of the GNU General Public License
  * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
  * #L%
  */
 
 package qupath.lib.images.servers.bioformats;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.lib.images.servers.FileFormatInfo;
+import qupath.lib.images.servers.FileFormatInfo.ImageCheckType;
+import qupath.lib.images.servers.ImageServer;
+import qupath.lib.images.servers.ImageServerBuilder;
+import qupath.lib.images.servers.bioformats.BioFormatsServerOptions.UseBioformats;
+
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.Map;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import qupath.lib.images.servers.ImageServer;
-import qupath.lib.images.servers.ImageServerBuilder;
-import qupath.lib.images.servers.FileFormatInfo;
-import qupath.lib.images.servers.FileFormatInfo.ImageCheckType;
-import qupath.lib.images.servers.bioformats.BioFormatsServerOptions.UseBioformats;
+import java.util.Map;
 
 /**
  * Builder for ImageServers that make use of the Bio-Formats library.
- * 
+ *
  * @author Pete Bankhead
  *
  */
 public class BioFormatsServerBuilder implements ImageServerBuilder<BufferedImage> {
-	
-	private static final Logger logger = LoggerFactory.getLogger(BioFormatsServerBuilder.class);
-	
-	@Override
-	public ImageServer<BufferedImage> buildServer(URI uri, String...args) {
-		try {
-			BioFormatsImageServer server = new BioFormatsImageServer(uri, args);
-			return server;
-		} catch (Exception e) {
-			logger.error("Unable to open {}: {}", uri, e.getMessage(), e);
-		}
-		return null;
-	}
 
-	@Override
-	public UriImageSupport<BufferedImage> checkImageSupport(URI uri, String...args) throws IOException {
-		float supportLevel = supportLevel(uri, args);
-		if (supportLevel > 0) {
-			try (BioFormatsImageServer server = BioFormatsImageServer.checkSupport(uri, BioFormatsServerOptions.getInstance(), args)) {
-				// If we requested a specified series, just allow one builder
-				Map<String, ServerBuilder<BufferedImage>> builders;
-				// --name is a legacy option, used in v0.1.2 - see https://github.com/qupath/qupath/issues/515
-				if (args.length > 0 && (Arrays.asList(args).contains("--series") || Arrays.asList(args).contains("--name")))
-					builders = Collections.singletonMap(server.getMetadata().getName(), server.getBuilder());
-				else
-					// If we didn't specify a series, return all of them
-					builders = server.getImageBuilders();
-				if ("OME-TIFF".equals(server.getFormat()))
-					supportLevel = 5f;
-				// If the image is large but not pyramidal, decrease support - maybe another server can find a pyramid
-				if (server.nResolutions() == 1) {
-					long nPixels = (long)server.getWidth() * (long)server.getHeight();
-					long nBytes = nPixels * server.nChannels() * server.getMetadata().getPixelType().getBytesPerPixel();
-					if (nPixels >= Integer.MAX_VALUE || nBytes > Runtime.getRuntime().maxMemory()/2)
-						supportLevel = 1;
-				}
-				return UriImageSupport.createInstance(this.getClass(), supportLevel, builders.values());
-			} catch (Exception e) {
-				// Special case where the issue is that Bio-Formats isn't supported on Apple Silicon -
-				// we want to make more noise so that the user knows what's going on
-				if (e instanceof IOException ioe) {
-					String msg = ioe.getLocalizedMessage();
-					if (msg != null && msg.toLowerCase().contains("apple silicon"))
-						throw ioe;
-				}
-				logger.debug("Unable to create server using Bio-Formats", e);
-			}
-		}
-		return null;
-	}
-	
-	private static float supportLevel(URI uri, String... args) {
-		
-		// We also can't do anything if Bio-Formats isn't installed
-		if (getBioFormatsVersion() == null)
-			return 0;
-		
-		ImageCheckType type = FileFormatInfo.checkType(uri);
-		String path = uri.getPath();
-		if (path == null)
-			return 0;
-								
-		// Check the options to see whether we really really do or don't want to read this
-		BioFormatsServerOptions options = BioFormatsServerOptions.getInstance();
-		
-		if (type.isURL() && options.getFilesOnly()) {
-			logger.debug("Cannot open URL with Bio-Formats - 'Bio-Formats files only' preference is turned on");
-			return 0;
-		}
-		
-		switch (checkPath(options, path)) {
-			case YES:
-				return 5;
-			case NO:
-				return 0;
-			default:
-				break;
-		}
-		
-		path = path.toLowerCase();
-		
-		// We don't want to handle zip files (which are very slow), and only try URL as last resort
-		float support = type.isURL() ? 1f : 3f;
-				
-		String description = type.getDescription();
-		if (path.endsWith(".zip"))
-			support = 1f;
-		else if (type.isTiff()) {
-			// Some nasty files seem to be larger than they think they are - which can be troublesome
-			if (!type.isBigTiff() && type.getFile().length() >= 1024L * 1024L * 1024L * 4L) {
-				support = 2f;
-			}
-			if (description != null) {
-				if (description.contains("<OME "))
-					support = 5f;
-				if (description.contains("imagej"))
-					support = 3.5f;
-				if (path.endsWith(".qptiff"))
-					support = 3.5f;
-			}
-			// Handle ome.tif extensions... necessary because micromanager can include an ImageJ ImageDescription
-			// despite also containing OME metadata
-			if (path.endsWith(".ome.tif") || path.endsWith(".ome.tiff"))
-				support = 5f;
-		} else {
-			// Check if we know the file type
-			File file = type.getFile();
-			path = file != null ? file.getAbsolutePath() : path;
-			if (path != null) {
-				String supportedReader = null;
-				try {
-					supportedReader = BioFormatsImageServer.getSupportedReaderClass(path);
-				} catch (Exception e) {
-					logger.warn("Error checking file " + path, e);
-				}
-				if (supportedReader == null) {
-					// If we have a file, still provide support level of 1 because we might still be able to 
-					// read the image with a more thorough check - but return 0 for a URL, because a thorough 
-					// check might be extremely slow.
-					logger.debug("No supported reader found for {}", path);
-					return file == null ? 0 : 1f;
-				} 
-				logger.debug("Potential Bio-Formats reader: {}", supportedReader);
-			}
-		}
-		return support;
-	}
+    private static final Logger logger = LoggerFactory.getLogger(BioFormatsServerBuilder.class);
 
-	@Override
-	public String getName() {
-		return "Bio-Formats builder";
-	}
+    @Override
+    public ImageServer<BufferedImage> buildServer(URI uri, String...args) {
+        try {
+            return new BioFormatsImageServer(uri, args);
+        } catch (Exception e) {
+            logger.error("Unable to open {}: {}", uri, e.getMessage(), e);
+        }
+        return null;
+    }
 
-	@Override
-	public String getDescription() {
-		String bfVersion = getBioFormatsVersion();
-		if (bfVersion == null)
-			return "Image server using the Bio-Formats library - but it won't work because 'bioformats_package.jar' is missing.";
-		else
-			return "Image server using the Bio-Formats library (" + bfVersion + ")";
-	}
-	
-	@Override
-	public Class<BufferedImage> getImageType() {
-		return BufferedImage.class;
-	}
-	
-	@Override
-	public boolean matchClassName(String... classNames) {
-		for (var className : classNames) {
-			if (this.getClass().getName().equals(className) ||
-					this.getClass().getSimpleName().equals(className) ||
-					BioFormatsImageServer.class.getName().equals(className) ||
-					BioFormatsImageServer.class.getSimpleName().equals(className) ||
-					"bioformats".equalsIgnoreCase(className))
-				return true;			
-		}
-		return false;
-	}
-	
-	
-	/**
-	 * Request the Bio-Formats version number from {@code loci.formats.FormatTools.VERSION}.
-	 * <p>
-	 * This uses reflection, returning {@code null} if Bio-Formats cannot be found.
-	 * 
-	 * @return
-	 */
-	static String getBioFormatsVersion() {
-		try {
-			Class<?> cls = Class.forName("loci.formats.FormatTools");
-			return (String)cls.getField("VERSION").get(null);	
-		} catch (Exception e) {
-			logger.error("Error requesting version from Bio-Formats", e);
-			return null;
-		}
-	}
-	
-	/**
-	 * Check whether Bio-Formats definitely should/shouldn't be used to try opening an image, 
-	 * based upon its path and the supplied BioFormatsServerOptions.
-	 * 
-	 * @param options
-	 * @param path
-	 * @return
-	 */
-	static UseBioformats checkPath(final BioFormatsServerOptions options, final String path) {
-		if (!options.bioformatsEnabled())
-			return UseBioformats.NO;
-		// Check if the file extension is one that we've been explicitly told to skip
-		String pathLower = path.toLowerCase();
-		for (String ext : options.getSkipAlwaysExtensions()) {
-			if (pathLower.endsWith(ext.toLowerCase()))
-				return UseBioformats.NO;
-		}
-		// Check if the file extension is one that we've been explicitly told to include
-		for (String ext : options.getUseAlwaysExtensions()) {
-			if (pathLower.endsWith(ext.toLowerCase()))
-				return UseBioformats.YES;
-		}
-		// If we get here, it could go either way... need to check support for format
-		return UseBioformats.MAYBE;
-	}
-	
+    @Override
+    public UriImageSupport<BufferedImage> checkImageSupport(URI uri, String...args) throws IOException {
+        float supportLevel = supportLevel(uri, args);
+        if (supportLevel > 0) {
+            try (BioFormatsImageServer server = BioFormatsImageServer.checkSupport(uri, BioFormatsServerOptions.getInstance(), args)) {
+                // If we requested a specified series, just allow one builder
+                Map<String, ServerBuilder<BufferedImage>> builders;
+                // --name is a legacy option, used in v0.1.2 - see https://github.com/qupath/qupath/issues/515
+                if (args.length > 0 && (Arrays.asList(args).contains("--series") || Arrays.asList(args).contains("--name")))
+                    builders = Collections.singletonMap(server.getMetadata().getName(), server.getBuilder());
+                else
+                    // If we didn't specify a series, return all of them
+                    builders = server.getImageBuilders();
+                if ("OME-TIFF".equals(server.getFormat()))
+                    supportLevel = 5f;
+                // If the image is large but not pyramidal, decrease support - maybe another server can find a pyramid
+                if (server.nResolutions() == 1) {
+                    long nPixels = (long)server.getWidth() * (long)server.getHeight();
+                    long nBytes = nPixels * server.nChannels() * server.getMetadata().getPixelType().getBytesPerPixel();
+                    if (nPixels >= Integer.MAX_VALUE || nBytes > Runtime.getRuntime().maxMemory()/2)
+                        supportLevel = 1;
+                }
+                return UriImageSupport.createInstance(this.getClass(), supportLevel, builders.values());
+            } catch (Exception e) {
+                // Special case where the issue is that Bio-Formats isn't supported on Apple Silicon -
+                // we want to make more noise so that the user knows what's going on
+                if (e instanceof IOException ioe) {
+                    String msg = ioe.getLocalizedMessage();
+                    if (msg != null && msg.toLowerCase().contains("apple silicon"))
+                        throw ioe;
+                }
+                logger.debug("Unable to create server using Bio-Formats", e);
+            }
+        }
+        return null;
+    }
+
+    private static float supportLevel(URI uri, String... args) {
+
+        // We also can't do anything if Bio-Formats isn't installed
+        if (getBioFormatsVersion() == null)
+            return 0;
+
+        ImageCheckType type = FileFormatInfo.checkType(uri);
+        String path = uri.getPath();
+        if (path == null)
+            return 0;
+
+        // Check the options to see whether we really really do or don't want to read this
+        BioFormatsServerOptions options = BioFormatsServerOptions.getInstance();
+
+        if (type.isURL() && options.getFilesOnly()) {
+            logger.debug("Cannot open URL with Bio-Formats - 'Bio-Formats files only' preference is turned on");
+            return 0;
+        }
+
+        switch (checkPath(options, path)) {
+            case YES:
+                return 5;
+            case NO:
+                return 0;
+            default:
+                break;
+        }
+
+        path = path.toLowerCase();
+
+        // We don't want to handle zip files (which are very slow), and only try URL as last resort
+        float support = type.isURL() ? 1f : 3f;
+
+        String description = type.getDescription();
+        if (path.endsWith(".zip"))
+            support = 1f;
+        else if (type.isTiff()) {
+            // Some nasty files seem to be larger than they think they are - which can be troublesome
+            if (!type.isBigTiff() && type.getFile().length() >= 1024L * 1024L * 1024L * 4L) {
+                support = 2f;
+            }
+            if (description != null) {
+                if (description.contains("<OME "))
+                    support = 5f;
+                if (description.contains("imagej"))
+                    support = 3.5f;
+                if (path.endsWith(".qptiff"))
+                    support = 3.5f;
+            }
+            // Handle ome.tif extensions... necessary because micromanager can include an ImageJ ImageDescription
+            // despite also containing OME metadata
+            if (path.endsWith(".ome.tif") || path.endsWith(".ome.tiff"))
+                support = 5f;
+        } else {
+            // Check if we know the file type
+            File file = type.getFile();
+            path = file != null ? file.getAbsolutePath() : path;
+            String supportedReader = null;
+            try {
+                supportedReader = BioFormatsImageServer.getSupportedReaderClass(path);
+            } catch (Exception e) {
+                logger.warn("Error checking file {}", path, e);
+            }
+            if (supportedReader == null) {
+                // If we have a file, still provide support level of 1 because we might still be able to
+                // read the image with a more thorough check - but return 0 for a URL, because a thorough
+                // check might be extremely slow.
+                // Also return 0 if the path ends with .mrxs, because it's a common issue for the JPEG reader
+                // to kick in and produce a (useless) low-resolution version of the image.
+                logger.debug("No supported reader found for {}", path);
+                return file == null || path.endsWith(".mrxs") ? 0 : 1f;
+            }
+            logger.debug("Potential Bio-Formats reader: {}", supportedReader);
+        }
+        return support;
+    }
+
+    @Override
+    public String getName() {
+        return "Bio-Formats builder";
+    }
+
+    @Override
+    public String getDescription() {
+        String bfVersion = getBioFormatsVersion();
+        if (bfVersion == null)
+            return "Image server using the Bio-Formats library - but it won't work because 'bioformats_package.jar' is missing.";
+        else
+            return "Image server using the Bio-Formats library (" + bfVersion + ")";
+    }
+
+    @Override
+    public Class<BufferedImage> getImageType() {
+        return BufferedImage.class;
+    }
+
+    @Override
+    public boolean matchClassName(String... classNames) {
+        for (var className : classNames) {
+            if (this.getClass().getName().equals(className) ||
+                    this.getClass().getSimpleName().equals(className) ||
+                    BioFormatsImageServer.class.getName().equals(className) ||
+                    BioFormatsImageServer.class.getSimpleName().equals(className) ||
+                    "bioformats".equalsIgnoreCase(className))
+                return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Request the Bio-Formats version number from {@code loci.formats.FormatTools.VERSION}.
+     * <p>
+     * This uses reflection, returning {@code null} if Bio-Formats cannot be found.
+     *
+     * @return
+     */
+    static String getBioFormatsVersion() {
+        try {
+            Class<?> cls = Class.forName("loci.formats.FormatTools");
+            return (String)cls.getField("VERSION").get(null);
+        } catch (Exception e) {
+            logger.error("Error requesting version from Bio-Formats", e);
+            return null;
+        }
+    }
+
+    /**
+     * Check whether Bio-Formats definitely should/shouldn't be used to try opening an image,
+     * based upon its path and the supplied BioFormatsServerOptions.
+     *
+     * @param options
+     * @param path
+     * @return
+     */
+    static UseBioformats checkPath(final BioFormatsServerOptions options, final String path) {
+        if (!options.bioformatsEnabled())
+            return UseBioformats.NO;
+        // Check if the file extension is one that we've been explicitly told to skip
+        String pathLower = path.toLowerCase();
+        for (String ext : options.getSkipAlwaysExtensions()) {
+            if (pathLower.endsWith(ext.toLowerCase()))
+                return UseBioformats.NO;
+        }
+        // Check if the file extension is one that we've been explicitly told to include
+        for (String ext : options.getUseAlwaysExtensions()) {
+            if (pathLower.endsWith(ext.toLowerCase()))
+                return UseBioformats.YES;
+        }
+        // If we get here, it could go either way... need to check support for format
+        return UseBioformats.MAYBE;
+    }
+
 }

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenSlideOptions.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenSlideOptions.java
@@ -1,0 +1,63 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2025 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.images.servers.openslide;
+
+/**
+ * Helper class to store options related to how image servers using OpenSlide should be created.
+ * <p>
+ * Note that these options can result in different arguments being used when images are added to a project,
+ * but they should not modify images that are opened from previous projects.
+ */
+public class OpenSlideOptions {
+
+    private static final OpenSlideOptions instance = new OpenSlideOptions();
+
+    private boolean applyIccProfiles = false;
+
+    private OpenSlideOptions() {}
+
+    /**
+     * Optionally request that images read using OpenSlide are modified using embedded ICC profiles,
+     * where available.
+     * @param doApply true if the ICC profile should be applied, false otherwise
+     */
+    public void setApplyIccProfiles(boolean doApply) {
+        applyIccProfiles = doApply;
+    }
+
+    /**
+     * Query whether ICC profiles should be applied by default when new image servers are created.
+     * @return true if ICC profiles should be used, false otherwise
+     */
+    public boolean doApplyIccProfiles() {
+        return applyIccProfiles;
+    }
+
+    /**
+     * Get the main (singleton) instance of the options.
+     * @return
+     */
+    public static OpenSlideOptions getInstance() {
+        return instance;
+    }
+
+}

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenSlideOptions.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenSlideOptions.java
@@ -32,12 +32,13 @@ public class OpenSlideOptions {
     private static final OpenSlideOptions instance = new OpenSlideOptions();
 
     private boolean applyIccProfiles = false;
+    private boolean cropBoundingBox = true;
 
     private OpenSlideOptions() {}
 
     /**
      * Optionally request that images read using OpenSlide are modified using embedded ICC profiles,
-     * where available.
+     * where available. The default is false.
      * @param doApply true if the ICC profile should be applied, false otherwise
      */
     public void setApplyIccProfiles(boolean doApply) {
@@ -46,10 +47,32 @@ public class OpenSlideOptions {
 
     /**
      * Query whether ICC profiles should be applied by default when new image servers are created.
+     * The default is false.
      * @return true if ICC profiles should be used, false otherwise
      */
     public boolean doApplyIccProfiles() {
         return applyIccProfiles;
+    }
+
+    /**
+     * Control whether OpenSlide images are cropped to the stored bounding box.
+     * The default is true.
+     * <p>
+     * If false, some images (e.g. mrxs, svs) may have a large amount of empty padding,
+     * and have a size that does not match the size returned by other libraries (e.g. Bio-Formats).
+     * @param doCrop true if images should be cropped to their stored bounding box, false otherwise
+     */
+    public void setCropBoundingBox(boolean doCrop) {
+        cropBoundingBox = doCrop;
+    }
+
+    /**
+     * Query whether OpenSlide images should be cropped to the stored bounding box.
+     * The default is true.
+     * @return true if images should be cropped to their stored bounding box, false otherwise
+     */
+    public boolean doCropBoundingBox() {
+        return cropBoundingBox;
     }
 
     /**

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideIccImageServer.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideIccImageServer.java
@@ -1,0 +1,155 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2025 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License 
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package qupath.lib.images.servers.openslide;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.lib.images.servers.TileRequest;
+
+import java.awt.color.ICC_ColorSpace;
+import java.awt.color.ICC_Profile;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorConvertOp;
+import java.awt.image.WritableRaster;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+/**
+ * ImageServer implementation using OpenSlide, while also applying source and destination ICC profiles to transform
+ * pixels.
+ * <p>
+ * By default, the source ICC profile is read from the image itself, while the destination profile is the default for
+ * sRGB>
+ */
+public class OpenslideIccImageServer extends OpenslideImageServer {
+
+	private static final Logger logger = LoggerFactory.getLogger(OpenslideIccImageServer.class);
+
+    private volatile transient ColorConvertOp iccOp;
+
+    /**
+     * Create an ImageServer using OpenSlide for the specified file, applying ICC profiles to transform pixels.
+     *
+     * @param uri URI for the image
+     * @param args optional arguments; these will also be passed to {@link OpenslideImageServer}
+     * @throws IOException if the image and/or ICC profiles cannot be opened
+     */
+    public OpenslideIccImageServer(URI uri, String... args) throws IOException {
+        super(uri, args);
+    }
+
+    private ColorConvertOp getOp() throws IOException {
+        if (iccOp == null) {
+            synchronized (this) {
+                try {
+                    iccOp = createOp();
+                } catch (IllegalArgumentException e) {
+                    throw new IOException("Exception creating ICC profiles", e);
+                }
+            }
+        }
+        return iccOp;
+    }
+
+    private ColorConvertOp createOp() throws IOException, IllegalArgumentException {
+        var args = getArgs();
+        return new ColorConvertOp(
+                new ICC_Profile[] {
+                        getSourceProfile(args),
+                        getDestProfile(args)
+                }, null);
+    }
+
+    private ICC_Profile getSourceProfile(List<String> args) throws IOException {
+        var source = searchArgsForProfile(args, "--icc-profile-source");
+        if (source == null) {
+            return readEmbeddedIccProfile();
+        } else {
+            logger.debug("Requesting source ICC profile {}", source);
+            return ICC_Profile.getInstance(source);
+        }
+    }
+
+    private ICC_Profile readEmbeddedIccProfile() throws IOException {
+        var bytes = getIccProfileBytes();
+        if (bytes == null)
+            throw new IOException("Unable to read ICC profile from " + getURI());
+        logger.debug("Read embedded ICC profile ({} bytes)", bytes.length);
+        return ICC_Profile.getInstance(bytes);
+    }
+
+    private ICC_Profile getDestProfile(List<String> args) throws IOException {
+        var dest = searchArgsForProfile(args, "--icc-profile-dest");
+        if (dest == null) {
+            logger.debug("Using default destination ICC profile");
+            return getDefaultDestProfile();
+        } else {
+            logger.debug("Requesting destination ICC profile {}", dest);
+            return ICC_Profile.getInstance(dest);
+        }
+    }
+
+    private ICC_Profile getDefaultDestProfile() {
+        return ICC_Profile.getInstance(ICC_ColorSpace.CS_sRGB);
+    }
+
+    /**
+     * Search a list of arguments for the next value occurring after a specified key.
+     * @param args the arguments
+     * @param key the key to search for
+     * @return
+     */
+    private String searchArgsForProfile(List<String> args, String key) {
+        int ind = args.indexOf(key);
+        if (ind < 0)
+            return null;
+        else if (ind >= args.size()-1) {
+            logger.warn("Unmatched arg key will be ignored ({})", key);
+            return null;
+        } else {
+            return args.get(ind + 1);
+        }
+    }
+
+    @Override
+    public BufferedImage readTile(TileRequest tileRequest) throws IOException {
+        var img = super.readTile(tileRequest);
+        applyInPlace(getOp(), img.getRaster());
+        return img;
+    }
+
+    private static void applyInPlace(ColorConvertOp op, WritableRaster raster) {
+        op.filter(raster, raster);
+    }
+
+    @Override
+    public String getServerType() {
+        return "OpenSlide (ICC profile)";
+    }
+
+    @Override
+    protected String createID() {
+        return super.createID() + " (ICC profile)";
+    }
+
+}

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
@@ -88,8 +88,6 @@ public class OpenslideImageServer extends AbstractTileableImageServer {
 	private final OpenSlideState state;
 	private final Cleaner.Cleanable cleanable;
 
-	private static boolean useBoundingBoxes = true;
-
 	private final ImageServerMetadata originalMetadata;
 
 	private List<String> associatedImageList = null;
@@ -154,14 +152,9 @@ public class OpenslideImageServer extends AbstractTileableImageServer {
 		int height = (int)osr.getLevel0Height();
 
 		Map<String, String> properties = osr.getProperties();
-		
-		boolean applyBounds = useBoundingBoxes;
-		for (String arg : args) {
-            if ("--no-crop".equals(arg)) {
-                applyBounds = false;
-                break;
-            }
-		}
+
+        // Crop to the bounds (if available) unless clearly told otherwise
+		boolean applyBounds = Arrays.stream(args).noneMatch(OpenslideServerBuilder.ARG_NO_CROP::equals);
 
 		// Read bounds
 		boolean isCropped = false;

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
@@ -149,10 +149,16 @@ public class OpenslideServerBuilder implements ImageServerBuilder<BufferedImage>
 			String vendor = OpenSlideLoader.detectVendor(file.toString());
 			if (vendor == null)
 				return 0;
+            else if ("dicom".equals(vendor)) {
+                // (WSI) dicom support is good, particularly given ICC profile support
+                return 4;
+            }
 		} catch (Exception e) {
-			logger.debug("Unable to read with OpenSlide: {}", e.getLocalizedMessage());
+			logger.debug("Unable to read with OpenSlide: {}", e.getMessage());
+            return 0;
 		} catch (UnsatisfiedLinkError e) {
-			LogTools.warnOnce(logger, "OpenSlide is not available (" + e.getLocalizedMessage() + ")");
+			LogTools.warnOnce(logger, "OpenSlide is not available (" + e.getMessage() + ")");
+            return 0;
 		}
 		
 		// We can only handle RGB images with OpenSlide... so if we don't think it's RGB, use only as a last resort

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -34,8 +34,13 @@ import qupath.lib.images.servers.openslide.jna.OpenSlideLoader;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Builder for Openslide ImageServer.
@@ -52,6 +57,9 @@ public class OpenslideServerBuilder implements ImageServerBuilder<BufferedImage>
 	 */
 	private boolean failedToLoad = false;
 
+    private static final String ARG_ICC_PROFILE = "--icc-profile";
+
+
 	@Override
 	public ImageServer<BufferedImage> buildServer(URI uri, String...args) {
 		if (!OpenSlideLoader.isOpenSlideAvailable() && !OpenSlideLoader.tryToLoadQuietly()) {
@@ -59,7 +67,11 @@ public class OpenslideServerBuilder implements ImageServerBuilder<BufferedImage>
 			return null;
 		}
 		try {
-			return new OpenslideImageServer(uri, args);
+            if (Set.of(args).contains(ARG_ICC_PROFILE)) {
+                return new OpenslideIccImageServer(uri, args);
+            } else {
+                return new OpenslideImageServer(uri, args);
+            }
 		} catch (Exception e) {
 			logger.error("Unable to open {} with OpenSlide: {}", uri, e.getMessage(), e);
 		} catch (NoClassDefFoundError e) {
@@ -72,8 +84,51 @@ public class OpenslideServerBuilder implements ImageServerBuilder<BufferedImage>
 	@Override
 	public UriImageSupport<BufferedImage> checkImageSupport(URI uri, String...args) {
 		float supportLevel = supportLevel(uri, args);
-		return UriImageSupport.createInstance(this.getClass(), supportLevel, DefaultImageServerBuilder.createInstance(this.getClass(), uri, args));
+        if (supportLevel > 0) {
+            args = updateArgs(uri, args);
+        }
+		return UriImageSupport.createInstance(this.getClass(), supportLevel,
+                DefaultImageServerBuilder.createInstance(this.getClass(), uri, args));
 	}
+
+    /**
+     * Update the string arguments to reflect any preferences requested by the user,
+     * while also checking that these are consistent with the image itself.
+     * <p>
+     * This was introduced to help handle ICC profile requests, so that the args may contain
+     * {@code --icc-profile} only if
+     * <ol>
+     *     <li>the user expressed they want that (through args or preferences)</li>
+     *     <li>the image has a readable ICC profile embedded.</li>
+     * </ol>
+     * @param uri the image URI
+     * @param args the initial optional args
+     * @return a new array of args suitable for the image
+     */
+    private String[] updateArgs(URI uri, String[] args) {
+        Set<String> argsSet = Arrays.stream(args).collect(Collectors.toCollection(LinkedHashSet::new));
+        var options = OpenSlideOptions.getInstance();
+        if (options.doApplyIccProfiles() || argsSet.contains(ARG_ICC_PROFILE)) {
+            try (var server = new OpenslideIccImageServer(uri, args)) {
+                argsSet.add(ARG_ICC_PROFILE);
+            } catch (IOException e) {
+                logger.warn("ICC profile requested, but not available for {}", uri);
+                argsSet.remove(ARG_ICC_PROFILE);
+            }
+        }
+        // TODO: Handle crop bounds here
+        return argsSet.toArray(String[]::new);
+    }
+
+
+
+    private boolean useIccProfile(String[] args) {
+        for (String arg : args) {
+            if (arg.strip().equalsIgnoreCase("--icc-profile"))
+                return true;
+        }
+        return OpenSlideOptions.getInstance().doApplyIccProfiles();
+    }
 
 	private float supportLevel(URI uri, String...args) {
 		if (!OpenSlideLoader.isOpenSlideAvailable() && !failedToLoad && !OpenSlideLoader.tryToLoadQuietly()) {

--- a/qupath-extension-openslide/src/main/resources/qupath/ext/openslide/strings.properties
+++ b/qupath-extension-openslide/src/main/resources/qupath/ext/openslide/strings.properties
@@ -4,5 +4,10 @@ pref.openslide.path.description = Path to the OpenSlide installation that should
 
 pref.openslide.icc-profile = Apply OpenSlide ICC profiles
 pref.openslide.icc-profile.description = Apply ICC profiles to images read using OpenSlide, where available.\n\
-  Warning! This will change pixel values and impact analysis.\n\
+  Warning! This will change pixel values and impact analysis. \n\
   This is an experimental feature introduced in v0.7.0.
+
+pref.openslide.crop = Crop to OpenSlide bounds
+pref.openslide.crop.description = Crop images to the bounding box, as provided by OpenSlide.\n\
+  Default value is true. Setting it to false can result in a lot of empty padding, and differences in image size \
+  compared to Bio-Formats.

--- a/qupath-extension-openslide/src/main/resources/qupath/ext/openslide/strings.properties
+++ b/qupath-extension-openslide/src/main/resources/qupath/ext/openslide/strings.properties
@@ -1,3 +1,8 @@
 category.openslide = OpenSlide
 pref.openslide.path = Path to OpenSlide installation
 pref.openslide.path.description = Path to the OpenSlide installation that should be used
+
+pref.openslide.icc-profile = Apply OpenSlide ICC profiles
+pref.openslide.icc-profile.description = Apply ICC profiles to images read using OpenSlide, where available.\n\
+  Warning! This will change pixel values and impact analysis.\n\
+  This is an experimental feature introduced in v0.7.0.


### PR DESCRIPTION
Addresses https://github.com/qupath/qupath/issues/982, albeit in a limited way.

## Main changes
1. ICC profiles can optionally be used to transform pixel values *at the point they are read* (i.e., not limited to the viewer) when using OpenSlide
2. New persistent preference are added to turn ICC profiles on (off by default)
   * Bonus preference to request that OpenSlide images are cropped to their bounding box (on by default)
3. OpenSlide is now used ahead of Bio-Formats for compatible DICOM images

## Use
The expected use is by toggling the preference. Then the DICOM image from https://github.com/qupath/qupath/issues/982#issuecomment-3591741674 looks like this:

<img width="1528" height="781" alt="image" src="https://github.com/user-attachments/assets/a43fc4bb-f4f6-4234-984a-573c554e5643" />

Note that the 'server type' is used to indicate that it is not using the original pixels.

The source profile is that provided by OpenSlide, the destination is from Java via `ICC_Profile.getInstance(ICC_ColorSpace.CS_sRGB)`.

With the checkbox turned off, it looks as before.

<img width="1528" height="781" alt="image" src="https://github.com/user-attachments/assets/be405dd0-6486-4200-869b-a3b5a59aad68" />

It's also possible to specify that the profile should be used by passing the argument `--icc-profile` when importing an image to a project.

This gives some additional options to explore alternative source and destination profiles in a form compatible with [`ICC_Profile.getInstance(String)`](https://docs.oracle.com/en/java/javase/25/docs/api//java.desktop/java/awt/color/ICC_Profile.html#getInstance(java.lang.String)). For example `--icc-profile --icc-profile-dest LINEAR_RGB.pf` would use an alternative destination, and adding `--icc-profile-source file_name` would give a different source.

Based on the javadocs for `ICC_Profile`, setting a system property for `java.iccprofile.path` would *potentially* make it possible to access alternative profiles in a different location... but this is rather experimental and not to be recommended as it hasn't been tested at all. 

## Compatibility
Projects created using these transforms can be opened with older versions of QuPath *but they won't apply the ICC profiles*.

I'd prefer that the projects *wouldn't* open, but the approach taken here was to encode the information about the profiles into the string arguments the are already stored for each entry in a project - since this avoided making more drastic changes.

## Things I tried (and gave up on)

### Supporting Bio-Formats / anything other than OpenSlide
OpenSlide provides straightforward access to the ICC profile stored in an image, but Bio-Formats does not. I initially tried adding some support to pull out the ICC profiles from TIFF images, but this proved tricky (considering that there might be multiple images in a single file, and I struggled to access the required info through the Bio-Formats API).

### A generic wrapper for any image
I also experimented creating a new `ImageServer` implementation that would wrap up any image, and then have JSON-serializable way to store the necessary ICC profile information - both for embedded profiles, and profiles saved as external files.

In the end, this became too complex - mostly because of the need to
1. serialise things properly, without breaking compatibility
2. handle the fact that files move (and so paths need updated)
3. cope with the fact that QuPath `ImageServers` can be wrapped in other `ImageServers` lots of times, and these might perform spatial/intensity transforms
4. make the UI intuitive, and clearly show when a transform has been applied... rather than hope the user remembers.

### ICC profiles applied only in the viewer
This was tricky firstly because applying the required transform is slow enough to require caching, which meant that the most effective way to do it would be to write the generic wrapper in the last section.

Also, QuPath's viewer doesn't focus on showing RGB images - it supports multiplexed images, LUT changes, and extra tricks like live color deconvolution - and so it was hard to figure out where exactly the profiles should be applied.

## Outlook
Hopefully this helps address *most* of the need for ICC profile support in QuPath well enough, while also giving some flexibility to explore without changing the code (by passing in other args).

Within the next year or two, we want to write an entirely new viewer and also an entirely different way to access pixels. This will give a chance to consider how ICC profiles should be considered from the start, rather than needing to squeeze them in later.