### PR TITLE
Ensure pending tile requests are cleared

### DIFF
--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsImageServer.java
@@ -1488,7 +1488,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer implement
 					throw new IOException("Unable to request pixels for region with downsampled size " + tileWidth + " x " + tileHeight);
 				}
 		
-				synchronized(ipReader) {
+				synchronized (ipReader) {
 					ipReader.setSeries(series);
 
 					// Some files provide z scaling (the number of z stacks decreases when the resolution becomes
@@ -1524,7 +1524,7 @@ public class BioFormatsImageServer extends AbstractTileableImageServer implement
 							byte[] bytesSimple = ipReader.openBytes(ind, tileX, tileY, tileWidth, tileHeight);
 							return AWTImageTools.openImage(bytesSimple, ipReader, tileWidth, tileHeight);
 						} catch (Exception | UnsatisfiedLinkError e) {
-							logger.warn("Unable to open image " + ind + " for " + tileRequest.getRegionRequest());
+                            logger.warn("Unable to open image {} for {}", ind, tileRequest.getRegionRequest());
 							throw convertToIOException(e);
 						}
 					}
@@ -1542,6 +1542,9 @@ public class BioFormatsImageServer extends AbstractTileableImageServer implement
 					}
 				}
 			} finally {
+				if (Thread.interrupted()) {
+					logger.debug("Thread interrupted, flag will be reset: {}", Thread.currentThread());
+				}
 				queue.put(ipReader);
 			}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/PixelClassificationOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/PixelClassificationOverlay.java
@@ -21,6 +21,12 @@
 
 package qupath.lib.gui.viewer.overlays;
 
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ObservableBooleanValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import qupath.lib.awt.common.AwtTools;
 import qupath.lib.classifiers.pixel.PixelClassificationImageServer;
 import qupath.lib.classifiers.pixel.PixelClassifier;
@@ -35,8 +41,8 @@ import qupath.lib.gui.viewer.OverlayOptions;
 import qupath.lib.gui.viewer.RegionFilter;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
-import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.images.servers.ImageServerMetadata.ChannelType;
+import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.images.servers.ServerTools;
 import qupath.lib.images.servers.TileRequest;
 import qupath.lib.objects.PathObject;
@@ -63,18 +69,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Function;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javafx.application.Platform;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.value.ObservableBooleanValue;
 
 /**
  * {@link PathOverlay} that gives the results of pixel classification.
@@ -585,7 +582,13 @@ public class PixelClassificationOverlay extends AbstractImageOverlay  {
 		                }
                     }
                 } catch (Exception e) {
-                   logger.error("Error requesting tile classification", e);
+					if (pool.isShutdown())
+						logger.debug("Pool shutdown - error requesting tile classification: {}", tile, e);
+					else
+						logger.error("Error requesting tile classification: level={}, x={}, y={}, w={}, h={}, z={}, t={}",
+								tile.getLevel(),
+								tile.getTileX(), tile.getTileX(), tile.getTileWidth(), tile.getTileHeight(),
+								tile.getZ(), tile.getT(), e);
                 } finally {
                     currentRequests.remove(tile);
                     pendingRequests.remove(tile);


### PR DESCRIPTION
This was causing a problem whenever pixel classification overlays were stopped in the midst of live prediction: tiles might not be read, and then the exception was retained and returned on every later attempt to access the same tile.

This moves `pendingTiles.remove` to a `finally` block to ensure it is run.

It's possible this causes some issues if a tile really *is* invalid though, so we may need to retain exceptions in some cases - rather than repeatedly making the same (doomed) requests.

Still, this change is necessary to avoid failures in perfectly normal circumstances.