### PR TITLE
Warn when opacity is low

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/ContextHelpViewer.java
@@ -307,7 +307,7 @@ public class ContextHelpViewer {
 				createHiddenClassificationsEntry(),
 				createNoImageEntry(),
 				createNoProjectEntry(),
-				createOpacityZeroEntry(),
+				createOpacityLowEntry(),
 				createGammaNotDefault(),
 				createInvertedColors(),
 				createGreyscaleColors(),
@@ -635,11 +635,11 @@ public class ContextHelpViewer {
 		return entry;
 	}
 	
-	private HelpListEntry createOpacityZeroEntry() {
+	private HelpListEntry createOpacityLowEntry() {
 		var entry = HelpListEntry.createInfo(
 				"ContextHelp.warning.opacityZero");
 		entry.visibleProperty().bind(
-				qupath.getOverlayOptions().opacityProperty().lessThanOrEqualTo(0.0));
+				qupath.getOverlayOptions().opacityProperty().lessThanOrEqualTo(0.2));
 		return entry;
 	}
 	

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -29,7 +29,7 @@ ContextHelp.warning.classificationsHidden = Objects might be hidden based on the
                                         You can change this in the 'Classifications' list under the 'Annotations' tab.
 ContextHelp.warning.tmaCoresHidden = The TMA grid is hidden
 ContextHelp.warning.pixelOverlayHidden = Pixel classification overlay is hidden
-ContextHelp.warning.opacityZero = Opacity slider is zero (unselected objects won't be visible)
+ContextHelp.warning.opacityZero = Opacity slider is very low (unselected objects won't be visible)
 ContextHelp.warning.noImage = No image is open in the current viewer
 ContextHelp.warning.noProject = No project is open (QuPath works best using projects)
 ContextHelp.warning.gamma = Gamma value is not 1.0. This affects how the image is displayed.\n\


### PR DESCRIPTION
Previously, it would only warn when the opacity was zero.

(This one's for @alanocallaghan after he pointed it out during a workshop.)