### PR TITLE
Possibility to export user defined metadata entries when exporting measurements through the dialog

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementExportCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MeasurementExportCommand.java
@@ -75,6 +75,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 /**
  * Dialog box to export measurements
@@ -327,9 +328,23 @@ public class MeasurementExportCommand implements Runnable {
 						double progress = (double)counter / n;
 						Platform.runLater(() -> progressIndicator.setProgress(progress));
 						counter++;
+
+						// 1. Get standard measurement columns
 						ObservableMeasurementTableData model = new ObservableMeasurementTableData();
 						model.setImageData(imageData, imageData == null ? Collections.emptyList() : imageData.getHierarchy().getObjects(null, type));
 						allColumnsForCombo.addAll(model.getAllNames());
+
+						// 2. Get Project Entry Metadata keys
+						// Using entry.getMetadata().keySet() (v0.6 API)
+						var metadata = entry.getMetadata();
+						if (metadata != null) {
+							allColumnsForCombo.addAll(
+								metadata.keySet()
+									.stream()
+									.map(key -> key + " (metadata)")
+									.collect(Collectors.toList())
+							);
+						}
 					} catch (Exception ex) {
 						logger.warn("Error loading columns for entry {}: {}", entry.getImageName(), ex.getMessage());
 						logger.debug("{}", ex.getMessage(), ex);
@@ -346,7 +361,7 @@ public class MeasurementExportCommand implements Runnable {
 		// Reset the checks
 		includeCombo.getCheckModel().clearChecks();
 	}
-	
+
 	private void setType(String typeString){
 		if (typeString != null) {
 			switch (typeString) {


### PR DESCRIPTION
Hello,

The request for this feature was made on https://forum.image.sc/t/qupath-metadata/80733

This implementation enables the "Populate" button in the "Export Measurements" dialog to add user defined metadata entries to the "Columns to include (optional)" set and lets the user choose exactly which relevant metadata entries they want to add.

<img width="609" height="305" alt="image" src="https://github.com/user-attachments/assets/f9edd657-818f-4507-8ebc-ccceed235618" />

To avoid potential naming collisions and distinguish metadata entries from other QuPath columns, the suffix " (metadata)" is added to the displayed names and also columns in the exported file header.

In `MeasurementExporter.addRows()` , presence of " (metadata)" in a column name is used for triggering the addition of a metadata value instead of a measurement.

I haven't looked at implementing this in `QPEx.saveMeasurements()` yet and my implementation is not particularly clever...

Basically, just a first draft to (maybe) get the ball rolling.

Kind regards,
Egor
