### PR TITLE
Filter project entries by metadata like in the "Select project images" dialog

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -168,7 +168,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 	private BooleanProperty contextMenuShowing = new SimpleBooleanProperty();
 	
 	// Store the raw filter text
-    private StringProperty filterText = new SimpleStringProperty("");
+	private StringProperty filterText = new SimpleStringProperty("");
 
 	/**
 	 * Metadata keys that will always be present
@@ -948,7 +948,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 		}
 		return true;
 	}
-		
+
 	/**
 	 * Resize an image so that its dimensions fit inside thumbnailWidth x thumbnailHeight.
 	 * 
@@ -1146,6 +1146,7 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			}
 		});
 	}
+
 	private Action createSortByKeyAction(final String name, final String key) {
 		return new Action(name, e -> {
 			if (model == null)
@@ -1493,22 +1494,22 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 		}
 
 		@Override
-        public boolean isLeaf() {
-            if (computed)
-                return super.getChildren().isEmpty();
+		public boolean isLeaf() {
+			if (computed)
+				return super.getChildren().isEmpty();
 
-            // Prepare filter vars
-            String textRaw = filterText.get();
-            String text = textRaw == null ? "" : textRaw.trim().toLowerCase();
-            List<String> tokens;
-            if (text.contains("|")) {
-                 tokens = Arrays.stream(text.split("\\|"))
-                         .map(String::trim)
-                         .filter(s -> !s.isEmpty())
-                         .collect(Collectors.toList()); // [cite: 10]
-            } else {
-                 tokens = Collections.emptyList();
-            }
+			// Prepare filter vars
+			String textRaw = filterText.get();
+			String text = textRaw == null ? "" : textRaw.trim().toLowerCase();
+			List<String> tokens;
+			if (text.contains("|")) {
+				 tokens = Arrays.stream(text.split("\\|"))
+						 .map(String::trim)
+						 .filter(s -> !s.isEmpty())
+						 .collect(Collectors.toList()); // [cite: 10]
+			} else {
+				 tokens = Collections.emptyList();
+			}
 
             return switch (getValue().getType()) {
                 // Use custom matchesFilter instead of predicateProperty
@@ -1519,92 +1520,92 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
                 default ->
                         throw new IllegalArgumentException("Could not understand the type of the object: " + getValue().getType());
             };
-            
-        }
-        
-        @Override
-        public ObservableList<TreeItem<ProjectTreeRow>> getChildren() {
-            if (!isLeaf() && !computed) {
-                ObservableList<TreeItem<ProjectTreeRow>> children = FXCollections.observableArrayList();
-                
-                // Prepare filter variables once for this node
-                String textRaw = filterText.get();
-                String text = textRaw == null ? "" : textRaw.trim().toLowerCase();
-                List<String> tokens;
-                if (text.contains("|")) {
-                     tokens = Arrays.stream(text.split("\\|"))
-                             .map(String::trim)
-                             .filter(s -> !s.isEmpty())
-                             .collect(Collectors.toList());
-                } else {
-                     tokens = Collections.emptyList();
-                }
+			
+		}
+		
+		@Override
+		public ObservableList<TreeItem<ProjectTreeRow>> getChildren() {
+			if (!isLeaf() && !computed) {
+				ObservableList<TreeItem<ProjectTreeRow>> children = FXCollections.observableArrayList();
+				
+				// Prepare filter variables once for this node
+				String textRaw = filterText.get();
+				String text = textRaw == null ? "" : textRaw.trim().toLowerCase();
+				List<String> tokens;
+				if (text.contains("|")) {
+					 tokens = Arrays.stream(text.split("\\|"))
+							 .map(String::trim)
+							 .filter(s -> !s.isEmpty())
+							 .collect(Collectors.toList());
+				} else {
+					 tokens = Collections.emptyList();
+				}
 
-                var metadataKey = model.getMetadataKey();
-                switch (getValue().getType()) {
-                case ROOT:
-                    if (project == null)
-                        break;
-                    
-                    if (metadataKey == null) {
-                        for (var row: getAllImageRows()) {
-                            // Use custom filter logic
-                            if (!matchesFilter(ProjectTreeRow.getEntry(row), text, tokens))
-                                continue;
-                            children.add(new ProjectTreeRowItem(row));
-                        }
-                    } else {
-                        // ... existing metadata group creation ...
-                        // (Note: metadata grouping logic stays mostly the same, 
-                        // filtering happens inside the METADATA case below for children of groups)
-                        var values = new ArrayList<>(getAllMetadataValues(metadataKey));
-                        GeneralTools.smartStringSort(values);
-                        var potentialChildren = values.stream()
-                                .map(value -> new ProjectTreeRowItem(new MetadataRow(value)))
-                                .toList();
-                        
-                        if (metadataKey.equals(BaseMetadataKeys.IMAGE_NAME.getKey()))
-                            potentialChildren = potentialChildren.stream().flatMap(c -> {
-                                if (c.isLeaf())
-                                    return Stream.empty();
-                                else
-                                    return c.getChildren().stream();
-                            }).map(t -> (ProjectTreeRowItem)t).toList();
+				var metadataKey = model.getMetadataKey();
+				switch (getValue().getType()) {
+				case ROOT:
+					if (project == null)
+						break;
+					
+					if (metadataKey == null) {
+						for (var row: getAllImageRows()) {
+							// Use custom filter logic
+							if (!matchesFilter(ProjectTreeRow.getEntry(row), text, tokens))
+								continue;
+							children.add(new ProjectTreeRowItem(row));
+						}
+					} else {
+						// (Note: metadata grouping logic stays mostly the same, 
+						// filtering happens inside the METADATA case below for children of groups)
+						var values = new ArrayList<>(getAllMetadataValues(metadataKey));
+						GeneralTools.smartStringSort(values);
+						var potentialChildren = values.stream()
+								.map(value -> new ProjectTreeRowItem(new MetadataRow(value)))
+								.toList();
+						// When sorting by name, we don't want to show grouped by name - since it looks weird,
+						// with the name effectively being repeated twice
+						if (metadataKey.equals(BaseMetadataKeys.IMAGE_NAME.getKey()))
+							potentialChildren = potentialChildren.stream().flatMap(c -> {
+								if (c.isLeaf())
+									return Stream.empty();
+								else
+									return c.getChildren().stream();
+							}).map(t -> (ProjectTreeRowItem)t).toList();
+						// When sorting by entry ID, we want to expand everything - since there should only be one
+						// entry per ID
+						if (metadataKey.equals(BaseMetadataKeys.ENTRY_ID.getKey()))
+							potentialChildren.forEach(c -> c.setExpanded(true));
 
-                        if (metadataKey.equals(BaseMetadataKeys.ENTRY_ID.getKey()))
-                            potentialChildren.forEach(c -> c.setExpanded(true));
-
-                        children.addAll(potentialChildren);
-                    }
-                    break;
-                case METADATA:
-                    if (metadataKey == null || metadataKey.isEmpty())
-                        break;
-                    
-                    for (var row: getAllImageRows()) {
-                        // Apply filter to images within metadata groups
-                        if (!matchesFilter(ProjectTreeRow.getEntry(row), text, tokens))
-                            continue;
-                        try {
-                            var value = getDefaultValue(ProjectTreeRow.getEntry(row), metadataKey);
-                            if (value != null && value.equals(((MetadataRow)getValue()).getDisplayableString()))
-                                children.add(new ProjectTreeRowItem(row));
-                        } catch (IOException ex) {
-                            logger.warn("Could not get {} from {}", metadataKey, row.getDisplayableString(), ex);
-                        }
-                    }
-                case IMAGE:
-                    break;
-                default:
-                    throw new IllegalArgumentException("Could not understand the type of the object: " + getValue().getType());
-                }
-                computed = true;
-                super.getChildren().setAll(children);
-            }
-            return super.getChildren();
-        }
+						children.addAll(potentialChildren);
+					}
+					break;
+				case METADATA:
+					if (metadataKey == null || metadataKey.isEmpty())		// This should never happen
+						break;
+					
+					for (var row: getAllImageRows()) {
+						// Apply filter to images within metadata groups
+						if (!matchesFilter(ProjectTreeRow.getEntry(row), text, tokens))
+							continue;
+						try {
+							var value = getDefaultValue(ProjectTreeRow.getEntry(row), metadataKey);
+							if (value != null && value.equals(((MetadataRow)getValue()).getDisplayableString()))
+								children.add(new ProjectTreeRowItem(row));
+						} catch (IOException ex) {
+							logger.warn("Could not get {} from {}", metadataKey, row.getDisplayableString(), ex);
+						}
+					}
+				case IMAGE:
+					break;
+				default:
+					throw new IllegalArgumentException("Could not understand the type of the object: " + getValue().getType());
+				}
+				computed = true;
+				super.getChildren().setAll(children);
+			}
+			return super.getChildren();
+		}
 	}
-	
 
 	enum ProjectThumbnailSize {
 		HIDDEN, SMALL, MEDIUM, LARGE;


### PR DESCRIPTION
Hello,

This PR adds to the "Search entry in project" search box the metadata filtering capability previously added in https://github.com/qupath/qupath/pull/1143,  and explained in [this forum post](https://forum.image.sc/t/qupath-metadata/80733/2).

It can be combined with the existing "Sort by" capability to narrow down the displayed entries to a useful set.

An example project and test image set (2MB zip with images cropped from the https://bbbc.broadinstitute.org/BBBC017/ dataset) is provided here: https://github.com/zindy/qupath-extension-fireparser/blob/main/sample_data/fireparser_test_data.zip

You could for example, sort by Treatment:

<img width="581" height="462" alt="image" src="https://github.com/user-attachments/assets/3b6dce75-fd90-4ddb-9473-96905a7034ff" />

And then use the following string in "Search entry in project": `.tif|well=a01|plate=001`. This will display the following project tree:

<img width="1179" height="507" alt="image" src="https://github.com/user-attachments/assets/83115886-bcce-4e79-9b20-e3f441b85d3e" />

One thing I wasn't expecting with https://github.com/qupath/qupath/pull/1143 is that the metadata keys and values must be input as *lowercase*.

Practicality: I fully understand [ProjectBrowser.java](https://github.com/qupath/qupath/blob/main/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java) is a huge file, and maybe adding random features to it may not be the best idea in the world. I'll let you be the judge!

Also for full disclosure, I used Gemini 3 to help fix some bugs along the way.

Kind regards,
Egor 