### PR TITLE
Change visibility of MiniViewers.MiniViewerManager.close() to public

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MiniViewers.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MiniViewers.java
@@ -484,7 +484,7 @@ public class MiniViewers {
 			requestFullUpdate();
 		}
 		
-		void close() {
+		public void close() {
 			mainViewer.zPositionProperty().removeListener(changeListener);
 			mainViewer.tPositionProperty().removeListener(changeListener);
 			mainViewer.repaintTimestamp().removeListener(fastChangeListener);


### PR DESCRIPTION
A `MiniViewers.MiniViewerManager` can be created from anywhere in the code with the `MiniViewers.createManager()` functions. However, it can only be closed within the `qupath.lib.gui.commands` package, because the `close()` function is package-private. This PR fixes that. 