### PR TITLE
Update preference node to 0.7

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -92,14 +92,14 @@ public class PathPrefs {
 	/**
 	 * Default name for preference node in this QuPath version
 	 */
-	private static final String DEFAULT_NODE_NAME = "io.github.qupath/0.6";
+	private static final String DEFAULT_NODE_NAME = "io.github.qupath/0.7";
 
 	/**
 	 * Previous preference node, in case these need to be restored.
 	 * For now, this isn't supported.
 	 */
 	@SuppressWarnings("unused")
-	private static final String PREVIOUS_NODE_NAME = "io.github.qupath/0.5";
+	private static final String PREVIOUS_NODE_NAME = "io.github.qupath/0.6";
 
 	/**
 	 * The preference manager used to store preferences.


### PR DESCRIPTION
This will stop the latest code sharing preferences (including a user directory) with v0.6.0.

Preferences may appear to be reset on first launch.