### PR TITLE
More project browser enhancements

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ProjectBrowser.java
@@ -1073,26 +1073,26 @@ public class ProjectBrowser implements ChangeListener<ImageData<BufferedImage>> 
 			
 			try {
 				var listOfChildren = tree.getRoot().getChildren();
-				for (int i = 0; i < listOfChildren.size(); i++) {
-					if (imageToSelect == null) {
-						if (!listOfChildren.get(i).getChildren().isEmpty()) {
-							listOfChildren.get(i).setExpanded(true);
-							tree.refresh();
-							break;
-						}							
-					} else {
-						for (var child: listOfChildren) {
-							if (child.getValue().getType() == Type.METADATA) {
-								for (var imageChild: child.getChildren()) {
-									if (imageChild.getValue().equals(imageToSelect)) {
-										child.setExpanded(true);
-										tree.getSelectionModel().select(imageChild);
-										break;
-									}
-								}
-							} else if (child.getValue().equals(imageToSelect))
-								tree.getSelectionModel().select(child);
+				// When filtering (imageToSelect is null), expand all matching group nodes
+				if (imageToSelect == null) {
+					for (var child : listOfChildren) {
+						if (!child.getChildren().isEmpty()) {
+							child.setExpanded(true);
 						}
+					}
+				} else {
+					// If a specific image is requested, expand only its parent group and select it
+					for (var child: listOfChildren) {
+						if (child.getValue().getType() == Type.METADATA) {
+							for (var imageChild: child.getChildren()) {
+								if (imageChild.getValue().equals(imageToSelect)) {
+									child.setExpanded(true);
+									tree.getSelectionModel().select(imageChild);
+									break;
+								}
+							}
+						} else if (child.getValue().equals(imageToSelect))
+							tree.getSelectionModel().select(child);
 					}
 				}
 			} catch (Exception ex) {


### PR DESCRIPTION
Two more changes based on feedback from @zindy and https://github.com/qupath/qupath/pull/2058

1. Reset the project filter text field when opening a new project (in case it looks broken, because no entries are shown)
2. When filtering after using metadata to group entries, expand all groups that contain images that pass the filter (rather than expanding only the first)