### PR TITLE
Avoid bundling fonts with javadocs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -191,7 +191,7 @@ tasks.register("shrinkJavadocs") {
         it.tasks.javadoc {
             options {
                 this as StandardJavadocDocletOptions
-//                addBooleanOption("-no-fonts", true)
+                addBooleanOption("-no-fonts", true)
             }
         }
     }


### PR DESCRIPTION
This add ~4 MB per jar... which adds up to 30-40 MB to the whole QuPath installation (~15%), which is really too much.

See https://bugs.openjdk.org/browse/JDK-8326683