### PR TITLE
Fix ICC profile bug

### DIFF
--- a/qupath-extension-openslide/src/main/java/qupath/ext/openslide/OpenSlideExtension.java
+++ b/qupath-extension-openslide/src/main/java/qupath/ext/openslide/OpenSlideExtension.java
@@ -75,7 +75,7 @@ public class OpenSlideExtension implements QuPathExtension {
         handleUseIccProfileChange(openslideUseIccProfile, null, openslideUseIccProfile.get());
 
         openslideCrop.addListener(cropListener);
-        handleUseIccProfileChange(openslideCrop, null, openslideCrop.get());
+        handleCropChange(openslideCrop, null, openslideCrop.get());
 
         if (!OpenSlideLoader.tryToLoadQuietly(openslidePathProperty.get())) {
             logger.warn("OpenSlide not found! Please specify the directory containing the OpenSlide library in the preferences.");


### PR DESCRIPTION
ICC profile was being applied too eagerly to OpenSlide images, since its status was wrongly connected to the 'crop' preference.