### PR TITLE
Set opacity of mini viewer tooltip to 0 if text empty

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MiniViewers.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/MiniViewers.java
@@ -581,6 +581,7 @@ public class MiniViewers {
 
 			Tooltip tooltip = new Tooltip();
 			tooltip.textProperty().bind(canvas.nameBinding);
+			tooltip.opacityProperty().bind(Bindings.when(canvas.nameBinding.isEmpty()).then(0).otherwise(1));
 			Tooltip.install(canvas, tooltip);
 			
 			return tempPane;


### PR DESCRIPTION
Fix #2081 