### PR TITLE
Update JavaFX and Groovy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,13 @@ Version in progress...
 * CommonMark 0.27.1
 * Commons Text 1.14.0
 * Deep Java Library 0.36.0
-* Groovy 5.0.3
+* Groovy 5.0.4
 * Gson 2.13.2
 * Guava 33.5.0-jre
 * Ikonli 12.4.0
 * ImageJ 1.54p
 * JavaCPP 1.5.12
-* JavaFX 25.0.1
+* JavaFX 25.0.2
 * Logback 1.5.23
 * OpenCV 4.11.0
 * QuPath FXtras 0.3.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ controlsFX      = "11.2.2"
 
 deepJavaLibrary = "0.36.0"
 
-groovy          = "5.0.3"
+groovy          = "5.0.4"
 gson            = "2.13.2"
 guava           = "33.5.0-jre"
 
@@ -29,7 +29,7 @@ javacpp         = "1.5.10"
 opencv          = "4.11.0-1.5.12"
 
 # Warning! JavaFX 20.0.1 and later seem to break search links in Javadocs
-javafx          = "25.0.1"
+javafx          = "25.0.2"
 jna             = "5.16.0"
 jfreeSvg        = "5.0.6"
 jfxtras         = "17-r1"


### PR DESCRIPTION
JavaFX 25.0.2 contains some important fixes, at least for Mac users (especially the one with windows disappearing if moved to an external monitor).

See https://gluonhq.com/products/javafx/openjfx-25-release-notes/#25.0.2