### PR TITLE
Enter key should confirm values in annotation properties dialog

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -1061,7 +1061,7 @@ public class GuiTools {
 
 		var btnApply = dialog.getDialogPane().lookupButton(ButtonType.APPLY);
 		var enterPressed = new KeyCodeCombination(KeyCode.ENTER);
-		dialog.getDialogPane().addEventFilter(KeyEvent.KEY_PRESSED, e -> {
+		dialog.getDialogPane().addEventHandler(KeyEvent.KEY_PRESSED, e -> {
 			if (enterPressed.match(e)) {
 				btnApply.fireEvent(new ActionEvent());
 				e.consume();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tools/GuiTools.java
@@ -28,6 +28,7 @@ import javafx.collections.ObservableList;
 import javafx.css.StyleOrigin;
 import javafx.css.StyleableObjectProperty;
 import javafx.embed.swing.SwingFXUtils;
+import javafx.event.ActionEvent;
 import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
@@ -59,6 +60,9 @@ import javafx.scene.image.Image;
 import javafx.scene.image.WritableImage;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
@@ -1052,9 +1056,18 @@ public class GuiTools {
 			.buttons(ButtonType.APPLY, ButtonType.CANCEL)
 			.resizable()
 			.build();
-		
+
 //		dialog.getDialogPane().setMinSize(400, 400);
-			
+
+		var btnApply = dialog.getDialogPane().lookupButton(ButtonType.APPLY);
+		var enterPressed = new KeyCodeCombination(KeyCode.ENTER);
+		dialog.getDialogPane().addEventFilter(KeyEvent.KEY_PRESSED, e -> {
+			if (enterPressed.match(e)) {
+				btnApply.fireEvent(new ActionEvent());
+				e.consume();
+			}
+		});
+
 		var response = dialog.showAndWait();
 		
 		if (!Objects.equals(ButtonType.APPLY, response.orElse(ButtonType.CANCEL)))


### PR DESCRIPTION
Before this change, pressing enter in the annotation properties dialog did not confirm the values.

This is similar to the logic in ImageDetailsPane: https://github.com/qupath/qupath/blob/c42e0d09a1922b4645e013a4f9f26e4c98e58f25/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ImageDetailsPane.java#L634 

Before:

https://github.com/user-attachments/assets/471c5fe1-c06c-4d1a-9f62-0418996b7547


After:

https://github.com/user-attachments/assets/483f8416-7923-45db-95d1-72d0f8182891

