### PR TITLE
Improve drawing tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Version 0.8.0 (IN PROGRESS!)
 
 ### Enhancements
+* Improved brush and wand tools (https://github.com/qupath/qupath/pull/2125 https://github.com/qupath/qupath/pull/2126)
+  * View the size of the brush, and adjust it by scrolling with `Alt` key pressed
+  * Press `F` while drawing with the brush or wand to fill holes
+  * Avoid diagonal lines when using the wand, to make clearer when a pixel is 'inside' or 'outside'
+* Much faster `ObjectMeasurements`, especially for images with many channels (https://github.com/qupath/qupath/pull/2113)
 * Lots more strings externalized (https://github.com/qupath/qupath/pull/2104)
 
 ### Bug fixes
@@ -15,6 +20,7 @@
 * JavaCPP 1.5.13
 * JavaFX 26
 * OpenCV 4.13.0
+* SciJava POM 44.0.0
 
 
 ## Version 0.7.0

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/ProcessingExtension.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/ProcessingExtension.java
@@ -273,7 +273,7 @@ public class ProcessingExtension implements QuPathExtension {
 	    	loadCoreClasses();
 	    	
 			// Install the Wand tool
-			var wandTool = PathTools.createTool(new WandToolEventHandler(qupath), "Wand",
+			var wandTool = PathTools.createInputEventTool(new WandToolEventHandler(qupath), "Wand",
 					IconFactory.createNode(QuPathGUI.TOOLBAR_ICON_SIZE, QuPathGUI.TOOLBAR_ICON_SIZE, PathIcons.WAND_TOOL));
 			logger.debug("Installing wand tool");
 			Platform.runLater(() -> {

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/WandToolEventHandler.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/WandToolEventHandler.java
@@ -38,8 +38,6 @@ import org.bytedeco.opencv.opencv_core.Scalar;
 import org.bytedeco.opencv.opencv_core.Size;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.MultiPolygon;
-import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.util.AffineTransformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,7 +117,7 @@ public class WandToolEventHandler extends BrushToolEventHandler {
 	
 	private final Scalar threshold = Scalar.all(1.0);
 	private final Point seed = new Point(w/2, w/2);
-	private Mat strel = null;
+	private final Mat strel = opencv_imgproc.getStructuringElement(opencv_imgproc.MORPH_ELLIPSE, new Size(5, 5));;
 
 	private final Mat mean = new Mat();
 	private final Mat stddev = new Mat();
@@ -272,8 +270,6 @@ public class WandToolEventHandler extends BrushToolEventHandler {
 	@Override
 	protected Geometry createShape(MouseEvent e, double x, double y, boolean useTiles, Geometry addToShape) {
 		
-		GeometryFactory factory = getGeometryFactory();
-		
 		if (addToShape != null && pLast != null && pLast.distanceSq(x, y) < 2)
 			return null;
 		
@@ -303,6 +299,7 @@ public class WandToolEventHandler extends BrushToolEventHandler {
 		g2d.scale(1.0/downsample, 1.0/downsample);
 		g2d.translate(-xStart, -yStart);
 		regionStore.paintRegion(viewer.getServer(), g2d, bounds, viewer.getZPosition(), viewer.getTPosition(), downsample, null, null, viewer.getImageDisplay());
+
 		// Optionally include the overlay information when using the wand
 		float opacity = viewer.getOverlayOptions().getOpacity();
 		if (opacity > 0 && getWandUseOverlays()) {
@@ -346,7 +343,7 @@ public class WandToolEventHandler extends BrushToolEventHandler {
 			// Smooth a little
 			opencv_imgproc.GaussianBlur(mat, mat, blurSize, blurSigma);
 			
-			// Choose mat to threshold (may be adjusted)
+			// Choose mat to threshold (can be adjusted)
 			Mat matThreshold = mat;
 			
 			// Apply color transform if required
@@ -375,8 +372,6 @@ public class WandToolEventHandler extends BrushToolEventHandler {
 						}				
 					}
 				}
-				if (matThreshold == null)
-					matThreshold = new Mat();
 				opencv_core.extractChannel(matFloat, matThreshold, 0);
 				
 				// There are various ways we might choose a threshold now...
@@ -384,8 +379,6 @@ public class WandToolEventHandler extends BrushToolEventHandler {
 				// they are all >= 0
 				matThreshold.convertTo(matThreshold, opencv_core.CV_8U, 255.0/max, 0);
 				threshold.put(mean * getWandSensitivity());
-				
-				nChannels = 1;
 			} else {
 				// Base threshold on local standard deviation
 				meanStdDev(matThreshold, mean, stddev);
@@ -409,8 +402,6 @@ public class WandToolEventHandler extends BrushToolEventHandler {
 			opencv_imgproc.floodFill(matThreshold, matMask, seed, Scalar.ONE, null, threshold, threshold, 4 | (2 << 8) | opencv_imgproc.FLOODFILL_MASK_ONLY | opencv_imgproc.FLOODFILL_FIXED_RANGE);
 			subtractPut(matMask, Scalar.ONE);
 			
-			if (strel == null)
-				strel = opencv_imgproc.getStructuringElement(opencv_imgproc.MORPH_ELLIPSE, new Size(5, 5));
 			opencv_imgproc.morphologyEx(matMask, matMask, opencv_imgproc.MORPH_CLOSE, strel);
 	    }
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ScrollEventPanningFilter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ScrollEventPanningFilter.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2023 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -29,88 +29,92 @@ import javafx.scene.input.ScrollEvent;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.viewer.tools.PathTools;
 
+/**
+ * Specific handler for scroll events that are used for panning.
+ * The default behavior is usually to zoom, so this is dependent upon the user preferences and whether a touchscreen
+ * is being used.
+ */
 class ScrollEventPanningFilter implements EventHandler<ScrollEvent> {
 		
-		private QuPathViewer viewer;
-		private boolean lastTouchEvent = false;
-		private double deltaX = 0;
-		private double deltaY = 0;
-		private long lastTimestamp = 0L;
-		
-		ScrollEventPanningFilter(final QuPathViewer viewer) {
-			this.viewer = viewer;
-		}
+	private final QuPathViewer viewer;
+	private double deltaX = 0;
+	private double deltaY = 0;
+	private long lastTimestamp = 0L;
 
-		@Override
-		public void handle(ScrollEvent e) {
-			
-			// Check if we'd rather be using scroll to do something else (e.g. zoom, adjust opacity)
-			boolean wouldRatherDoSomethingElse = e.getTouchCount() == 0 && (!PathPrefs.useScrollGesturesProperty().get() || e.isShiftDown() || e.isShortcutDown());
-			if (wouldRatherDoSomethingElse) {
-				return;
-			}
-			
-			// Don't pan with inertia events (use the 'mover' instead)
-			if (e.isInertia()) {
-				e.consume();
-				return;
-			}
-			
-			// Return if we aren't using a touchscreen, and we don't want to handle scroll gestures - 
-			// but don't consume the event so that it can be handled elsewhere
-			lastTouchEvent = e.getTouchCount() != 0;
-			if (!lastTouchEvent && !PathPrefs.useScrollGesturesProperty().get() || e.isShiftDown() || e.isShortcutDown()) {
-				return;
-			}
-			// Swallow the event if we're using a touch screen without the move tool selected - we want to draw instead
-			if (lastTouchEvent && viewer.getActiveTool() != PathTools.MOVE) {
-				e.consume();
-				return;
-			}
-			
-			// If this is a SCROLL_FINISHED event, continue moving with the last starting velocity - but ignore inertia
-			if (!lastTouchEvent && e.getEventType() == ScrollEvent.SCROLL_FINISHED) {
-				if (System.currentTimeMillis() - lastTimestamp < 100L) {
-					viewer.requestStartMoving(deltaX, deltaY);
-					viewer.requestDecelerate();					
-				}
-				deltaX = 0;
-				deltaY = 0;
-				e.consume();
-				return;
-			}
-			
-			// Use downsample since shift will be defined in full-resolution pixel coordinates
-			double dx = e.getDeltaX() * viewer.getDownsampleFactor();
-			double dy = e.getDeltaY() * viewer.getDownsampleFactor();
-			
-			// Flip scrolling direction if necessary
-			if (PathPrefs.invertScrollingProperty().get()) {
-				dx = -dx;
-				dy = -dy;
-			}
-			
-			// Handle rotation
-			if (viewer.isRotated()) {
-				double cosTheta = Math.cos(-viewer.getRotation());
-				double sinTheta = Math.sin(-viewer.getRotation());
-				double dx2 = cosTheta*dx - sinTheta*dy;
-				double dy2 = sinTheta*dx + cosTheta*dy;
-				dx = dx2;
-				dy = dy2;
-			}
-
-			// Shift the viewer
-			viewer.setCenterPixelLocation(
-					viewer.getCenterPixelX() - dx,
-					viewer.getCenterPixelY() - dy);
-			
-			// Retain deltas in case we need to decelerate later
-			deltaX = dx;
-			deltaY = dy;
-			lastTimestamp = System.currentTimeMillis();
-			
-			e.consume();
-		}
-		
+	ScrollEventPanningFilter(final QuPathViewer viewer) {
+		this.viewer = viewer;
 	}
+
+	@Override
+	public void handle(ScrollEvent e) {
+
+		// Check if we'd rather be using scroll to do something else (e.g. zoom, adjust opacity)
+		boolean wouldRatherDoSomethingElse = e.getTouchCount() == 0 && (!PathPrefs.useScrollGesturesProperty().get() || e.isShiftDown() || e.isShortcutDown());
+		if (wouldRatherDoSomethingElse) {
+			return;
+		}
+
+		// Don't pan with inertia events (use the 'mover' instead)
+		if (e.isInertia()) {
+			e.consume();
+			return;
+		}
+
+		// Return if we aren't using a touchscreen, and we don't want to handle scroll gestures -
+		// but don't consume the event so that it can be handled elsewhere
+		boolean lastTouchEvent = e.getTouchCount() != 0;
+		if (!lastTouchEvent && !PathPrefs.useScrollGesturesProperty().get() || e.isShiftDown() || e.isShortcutDown()) {
+			return;
+		}
+		// Swallow the event if we're using a touch screen without the move tool selected - we want to draw instead
+		if (lastTouchEvent && viewer.getActiveTool() != PathTools.MOVE) {
+			e.consume();
+			return;
+		}
+
+		// If this is a SCROLL_FINISHED event, continue moving with the last starting velocity - but ignore inertia
+		if (!lastTouchEvent && e.getEventType() == ScrollEvent.SCROLL_FINISHED) {
+			if (System.currentTimeMillis() - lastTimestamp < 100L) {
+				viewer.requestStartMoving(deltaX, deltaY);
+				viewer.requestDecelerate();
+			}
+			deltaX = 0;
+			deltaY = 0;
+			e.consume();
+			return;
+		}
+
+		// Use downsample since shift will be defined in full-resolution pixel coordinates
+		double dx = e.getDeltaX() * viewer.getDownsampleFactor();
+		double dy = e.getDeltaY() * viewer.getDownsampleFactor();
+
+		// Flip scrolling direction if necessary
+		if (PathPrefs.invertScrollingProperty().get()) {
+			dx = -dx;
+			dy = -dy;
+		}
+
+		// Handle rotation
+		if (viewer.isRotated()) {
+			double cosTheta = Math.cos(-viewer.getRotation());
+			double sinTheta = Math.sin(-viewer.getRotation());
+			double dx2 = cosTheta*dx - sinTheta*dy;
+			double dy2 = sinTheta*dx + cosTheta*dy;
+			dx = dx2;
+			dy = dy2;
+		}
+
+		// Shift the viewer
+		viewer.setCenterPixelLocation(
+				viewer.getCenterPixelX() - dx,
+				viewer.getCenterPixelY() - dy);
+
+		// Retain deltas in case we need to decelerate later
+		deltaX = dx;
+		deltaY = dy;
+		lastTimestamp = System.currentTimeMillis();
+
+		e.consume();
+	}
+
+}

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ViewerManager.java
@@ -35,6 +35,8 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
+import javafx.event.Event;
+import javafx.event.EventHandler;
 import javafx.geometry.Orientation;
 import javafx.scene.Node;
 import javafx.scene.Scene;
@@ -795,9 +797,8 @@ public class ViewerManager implements QuPathViewerListener {
 
 
 		PathObject annotation = PathObjects.createAnnotationObject(roi, lastAnnotation.getPathClass());
-		//			hierarchy.addPathObject(annotation, false);
 
-		//			// Make sure any core parent is set
+		// Make sure any core parent is set
 		hierarchy.addObjectBelowParent(coreNewParent, annotation, true);
 
 		activeViewer.setSelectedObject(annotation);
@@ -835,68 +836,55 @@ public class ViewerManager implements QuPathViewerListener {
 				setActiveViewer(viewer);
 			}
 		});
-		
-		viewer.getView().addEventFilter(MouseEvent.MOUSE_PRESSED, e -> viewer.getView().requestFocus());
 
 		// Create popup menu
 		setViewerPopupMenu(viewer);
 		
-		
 		// Enable drag and drop
 		qupath.getDefaultDragDropListener().setupTarget(viewer.getView());
-		
-		
-		// Listen to the scroll wheel
-		viewer.getView().setOnScroll(e -> {
-			if (viewer == getActiveViewer() || !getSynchronizeViewers()) {
-				if (!viewer.hasServer())
-					return;
-				double scrollUnits = e.getDeltaY() * PathPrefs.getScaledScrollSpeed();
-				
-				// Use shift down to adjust opacity
-				if (e.isShortcutDown()) {
-					OverlayOptions options = viewer.getOverlayOptions();
-					options.setOpacity((float)(options.getOpacity() + scrollUnits * 0.001));
-					return;
-				}
-				
-				// Avoid zooming at the end of a gesture when using touchscreens
-				if (e.isInertia())
-					return;
-				
-				if (PathPrefs.invertScrollingProperty().get())
-					scrollUnits = -scrollUnits;
-				double newDownsampleFactor = viewer.getDownsampleFactor() * Math.pow(viewer.getDefaultZoomFactor(), scrollUnits);
-				newDownsampleFactor = Math.min(viewer.getMaxDownsample(), Math.max(newDownsampleFactor, viewer.getMinDownsample()));
-				viewer.setDownsampleFactor(newDownsampleFactor, e.getX(), e.getY());
-			}
-		});
-		
-		
-		viewer.getView().addEventFilter(RotateEvent.ANY, e -> {
-			if (!PathPrefs.useRotateGesturesProperty().get())
-				return;
-//			logger.debug("Rotating: " + e.getAngle());
-			viewer.setRotation(viewer.getRotation() + Math.toRadians(e.getAngle()));
-			e.consume();
-		});
 
-		viewer.getView().addEventFilter(ZoomEvent.ANY, e -> {
-			if (!PathPrefs.useZoomGesturesProperty().get())
-				return;
-			double zoomFactor = e.getZoomFactor();
-			if (Double.isNaN(zoomFactor))
-				return;
+		// Add a general event handler, rather than specific handlers for different event types.
+		// This is so that other (more specific) handlers have priority, and this becomes the fallback option.
+		viewer.getView().addEventHandler(Event.ANY, new ViewerEventHandler(viewer));
 
-            logger.debug("Zooming: {} ({})", e.getZoomFactor(), e.getTotalZoomFactor());
-			viewer.setDownsampleFactor(viewer.getDownsampleFactor() / zoomFactor, e.getX(), e.getY());
-			e.consume();
-		});
-		
+		// Grab focus when we can
+		viewer.getView().addEventFilter(MouseEvent.MOUSE_PRESSED, e -> viewer.getView().requestFocus());
+
+		// Handle special case of when scrolling should be used for panning
 		viewer.getView().addEventFilter(ScrollEvent.ANY, new ScrollEventPanningFilter(viewer));
-		
-		
-		viewer.getView().addEventHandler(KeyEvent.KEY_PRESSED, e -> {
+	}
+
+
+	private class ViewerEventHandler implements EventHandler<Event> {
+
+		private final QuPathViewer viewer;
+
+		private ViewerEventHandler(QuPathViewer viewer) {
+			this.viewer = viewer;
+		}
+
+		@Override
+		public void handle(Event event) {
+			if (event instanceof KeyEvent keyEvent) {
+				handleKeyEvent(keyEvent);
+			} else if (event instanceof ScrollEvent scrollEvent) {
+				handleScrollEvent(scrollEvent);
+			} else if (event instanceof RotateEvent rotateEvent) {
+				handleRotateEvent(rotateEvent);
+			} else if (event instanceof ZoomEvent zoomEvent) {
+				handleZoomEvent(zoomEvent);
+			}
+		}
+
+		private void handleKeyEvent(KeyEvent e) {
+			if (e.getEventType() == KeyEvent.KEY_PRESSED) {
+				handleKeyPressed(e);
+			} else if (e.getEventType() == KeyEvent.KEY_RELEASED) {
+				handleKeyReleased(e);
+			}
+		}
+
+		private void handleKeyPressed(KeyEvent e) {
 			if (e.isConsumed())
 				return;
 			PathObject pathObject = viewer.getSelectedObject();
@@ -919,18 +907,69 @@ public class ViewerManager implements QuPathViewerListener {
 				}
 			}
 			// For temporarily setting selection mode, we want to grab any S key presses eagerly
-			if (e.getCode() == KeyCode.S && e.getEventType() == KeyEvent.KEY_PRESSED) {
+			if (e.getCode() == KeyCode.S) {
 				PathPrefs.tempSelectionModeProperty().set(true);
-				// Don't consume the event! Doing so can break the 'Save' accelerators
+				// Don't consume the event! Doing so could break the 'Save' accelerators
 			}
-		});
-		viewer.getView().addEventHandler(KeyEvent.KEY_RELEASED, e -> {
+		}
+
+		private void handleKeyReleased(KeyEvent e) {
 			// For temporarily setting selection mode, we want to switch off the mode quickly for any key release events -
 			// to reduce the risk of accidentally leaving selection mode 'stuck' on if the S key release is missed
 			PathPrefs.tempSelectionModeProperty().set(false);
-		});
+		}
+
+		private void handleRotateEvent(RotateEvent e) {
+			if (!PathPrefs.useRotateGesturesProperty().get())
+				return;
+			viewer.setRotation(viewer.getRotation() + Math.toRadians(e.getAngle()));
+			e.consume();
+		}
+
+		private void handleZoomEvent(ZoomEvent e) {
+			if (!PathPrefs.useZoomGesturesProperty().get())
+				return;
+			double zoomFactor = e.getZoomFactor();
+			if (Double.isNaN(zoomFactor))
+				return;
+
+			logger.debug("Zooming: {} ({})", e.getZoomFactor(), e.getTotalZoomFactor());
+			viewer.setDownsampleFactor(viewer.getDownsampleFactor() / zoomFactor, e.getX(), e.getY());
+			e.consume();
+		}
+
+		private void handleScrollEvent(ScrollEvent e) {
+			// Listen to the scroll wheel
+			if (e.getEventType() != ScrollEvent.SCROLL
+					|| e.isConsumed()
+					|| !viewer.hasServer()
+					|| (viewer != getActiveViewer() && getSynchronizeViewers()))
+				return;
+
+			double scrollUnits = e.getDeltaY() * PathPrefs.getScaledScrollSpeed();
+
+			// Use shift down to adjust opacity
+			if (e.isShortcutDown()) {
+				OverlayOptions options = viewer.getOverlayOptions();
+				options.setOpacity((float)(options.getOpacity() + scrollUnits * 0.001));
+				return;
+			}
+
+			// Avoid zooming at the end of a gesture when using touchscreens
+			if (e.isInertia())
+				return;
+
+			if (PathPrefs.invertScrollingProperty().get())
+				scrollUnits = -scrollUnits;
+			double newDownsampleFactor = viewer.getDownsampleFactor() * Math.pow(viewer.getDefaultZoomFactor(), scrollUnits);
+			newDownsampleFactor = Math.min(viewer.getMaxDownsample(), Math.max(newDownsampleFactor, viewer.getMinDownsample()));
+			viewer.setDownsampleFactor(newDownsampleFactor, e.getX(), e.getY());
+			e.consume();
+		}
 
 	}
+
+
 
 	/**
 	 * Detach the currently active viewer from the viewer grid, if possible.
@@ -1251,7 +1290,7 @@ public class ViewerManager implements QuPathViewerListener {
 				});
 				stage.show();
 				refreshViewerList();
-				splitPaneRows.get(0).setDividerPositions(positions);
+				splitPaneRows.getFirst().setDividerPositions(positions);
 				return true;
 			} else {
 				logger.warn("Viewer is already detached!");

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/PathTools.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/PathTools.java
@@ -29,6 +29,7 @@ import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.event.EventType;
 import javafx.scene.Node;
+import javafx.scene.input.InputEvent;
 import javafx.scene.input.MouseEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,7 +128,7 @@ public class PathTools {
 	/**
 	 * Brush drawing tool
 	 */
-	public static final PathTool BRUSH = createTool(
+	public static final PathTool BRUSH = createInputEventTool(
 			PathToolEventHandlers.createBrushEventHandler(),
 			QuPathResources.getString("Tools.brush"),
 			createIcon(PathIcons.BRUSH_TOOL));
@@ -158,6 +159,18 @@ public class PathTools {
 	 */
 	public static PathTool createTool(EventHandler<MouseEvent> handler, String name, Node icon) {
 		return createTool(MouseEvent.ANY, handler, name, icon);
+	}
+
+	/**
+	 * Create a tool from the specified {@link InputEvent} handler.
+	 * When the tool is registered, the handler will be called for any mouse event.
+	 * @param handler the mouse event handler
+	 * @param name the name of the tool
+	 * @param icon the (toolbar) icon of the tool
+	 * @return a new {@link PathTool}
+	 */
+	public static PathTool createInputEventTool(EventHandler<InputEvent> handler, String name, Node icon) {
+		return createTool(InputEvent.ANY, handler, name, icon);
 	}
 	
 	

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathDraggingROIToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathDraggingROIToolEventHandler.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -23,6 +23,7 @@
 
 package qupath.lib.gui.viewer.tools.handlers;
 
+import javafx.scene.input.InputEvent;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import qupath.lib.objects.PathObject;
@@ -40,7 +41,7 @@ import java.util.Collections;
  * @author Pete Bankhead
  *
  */
-abstract class AbstractPathDraggingROIToolEventHandler extends AbstractPathROIToolEventHandler {
+abstract class AbstractPathDraggingROIToolEventHandler<T extends InputEvent> extends AbstractPathROIToolEventHandler<T> {
 
 	@Override
 	public void mouseDragged(MouseEvent e) {
@@ -51,7 +52,7 @@ abstract class AbstractPathDraggingROIToolEventHandler extends AbstractPathROITo
         }
 		
 		var viewer = getViewer();
-		ROI currentROI = viewer.getCurrentROI() instanceof ROI ? (ROI)viewer.getCurrentROI() : null;
+		ROI currentROI = viewer.getCurrentROI();
 		RoiEditor editor = viewer.getROIEditor();
 		
 		if (currentROI != null && editor.getROI() == currentROI && editor.hasActiveHandle()) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathROIToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathROIToolEventHandler.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -24,6 +24,7 @@
 package qupath.lib.gui.viewer.tools.handlers;
 
 import javafx.scene.Cursor;
+import javafx.scene.input.InputEvent;
 import javafx.scene.input.MouseEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +56,7 @@ import java.util.HashSet;
  * @author Pete Bankhead
  *
  */
-abstract class AbstractPathROIToolEventHandler extends AbstractPathToolEventHandler {
+abstract class AbstractPathROIToolEventHandler<T extends InputEvent> extends AbstractPathToolEventHandler<T> {
 	
 	private static final Logger logger = LoggerFactory.getLogger(AbstractPathROIToolEventHandler.class);
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPathToolEventHandler.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -27,7 +27,12 @@ import javafx.application.Platform;
 import javafx.event.EventHandler;
 import javafx.scene.Cursor;
 import javafx.scene.Node;
+import javafx.scene.input.GestureEvent;
+import javafx.scene.input.InputEvent;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
+import javafx.scene.input.ScrollEvent;
+import javafx.scene.input.TouchEvent;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.slf4j.Logger;
@@ -54,11 +59,11 @@ import java.util.Comparator;
  * @author Pete Bankhead
  *
  */
-abstract class AbstractPathToolEventHandler implements EventHandler<MouseEvent> {
+abstract class AbstractPathToolEventHandler<T extends InputEvent> implements EventHandler<T>, NotifiableEventHandler {
 	
 	private static final Logger logger = LoggerFactory.getLogger(AbstractPathToolEventHandler.class);
 
-	private ConstrainingObjects constrainingObjects = new ConstrainingObjects();
+	private final ConstrainingObjects constrainingObjects = new ConstrainingObjects();
 
 	/**
 	 * Ensure that the specified cursor is set in the current viewer.
@@ -222,23 +227,41 @@ abstract class AbstractPathToolEventHandler implements EventHandler<MouseEvent> 
 	}
 
 	@Override
-	public void handle(MouseEvent event) {
-		var type = event.getEventType();
-		if (type == MouseEvent.DRAG_DETECTED || type == MouseEvent.MOUSE_DRAGGED)
-			mouseDragged(event);
-		else if (type == MouseEvent.MOUSE_CLICKED)
-			mouseClicked(event);
-		else if (type == MouseEvent.MOUSE_MOVED)
-			mouseMoved(event);
-		else if (type == MouseEvent.MOUSE_PRESSED)
-			mousePressed(event);
-		else if (type == MouseEvent.MOUSE_RELEASED)
-			mouseReleased(event);
-		else if (type == MouseEvent.MOUSE_ENTERED)
-			mouseEntered(event);
-		else if (type == MouseEvent.MOUSE_EXITED)
-			mouseExited(event);
+	public void handle(T e) {
+		var type = e.getEventType();
+		if (e instanceof MouseEvent event) {
+			if (type == MouseEvent.DRAG_DETECTED || type == MouseEvent.MOUSE_DRAGGED)
+				mouseDragged(event);
+			else if (type == MouseEvent.MOUSE_CLICKED)
+				mouseClicked(event);
+			else if (type == MouseEvent.MOUSE_MOVED)
+				mouseMoved(event);
+			else if (type == MouseEvent.MOUSE_PRESSED)
+				mousePressed(event);
+			else if (type == MouseEvent.MOUSE_RELEASED)
+				mouseReleased(event);
+			else if (type == MouseEvent.MOUSE_ENTERED)
+				mouseEntered(event);
+			else if (type == MouseEvent.MOUSE_EXITED)
+				mouseExited(event);
+		} else if (e instanceof KeyEvent event) {
+			handleKeyEvent(event);
+		} else if (e instanceof ScrollEvent event) {
+			handleScrollEvent(event);
+		} if (e instanceof GestureEvent event) {
+			handleGestureEvent(event);
+		} else if (e instanceof TouchEvent event) {
+			handleTouchEvent(event);
+		}
 	}
+
+	protected void handleKeyEvent(KeyEvent e) {}
+
+	protected void handleScrollEvent(ScrollEvent e) {}
+
+	protected void handleGestureEvent(GestureEvent e) {}
+
+	protected void handleTouchEvent(TouchEvent e) {}
 
 
 	private static class ConstrainingObjects {
@@ -371,5 +394,10 @@ abstract class AbstractPathToolEventHandler implements EventHandler<MouseEvent> 
 
 	}
 
+	// Default, do-nothing implementation
+	public void handlerAdded(QuPathViewer viewer) {}
+
+	// Default, do-nothing implementation
+	public void handlerRemoved(QuPathViewer viewer) {}
 	
 }

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPolyROIToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/AbstractPolyROIToolEventHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -21,6 +21,7 @@
 
 package qupath.lib.gui.viewer.tools.handlers;
 
+import javafx.scene.input.InputEvent;
 import javafx.scene.input.MouseEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +37,7 @@ import java.awt.geom.Point2D;
 import java.util.Collections;
 import java.util.HashSet;
 
-abstract class AbstractPolyROIToolEventHandler extends AbstractPathROIToolEventHandler {
+abstract class AbstractPolyROIToolEventHandler<T extends InputEvent> extends AbstractPathROIToolEventHandler<T> {
 	
 	private static final Logger logger = LoggerFactory.getLogger(AbstractPolyROIToolEventHandler.class);
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/ArrowToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/ArrowToolEventHandler.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2023-2026 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
 package qupath.lib.gui.viewer.tools.handlers;
 
 import javafx.scene.input.MouseEvent;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushLimits.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushLimits.java
@@ -64,7 +64,8 @@ public class BrushLimits extends Group {
      * @param y the y-coordinate of the center
      */
     public void setCenter(double x, double y) {
-        var bounds = getParent().getBoundsInLocal();
+        var parent = getParent();
+        var bounds = parent == null ? null : getParent().getBoundsInLocal();
         if (bounds == null) {
             setVisible(false);
             setTranslateX(0);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
@@ -32,6 +32,7 @@ import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
+import javafx.scene.input.ScrollEvent;
 import javafx.scene.robot.Robot;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -41,6 +42,7 @@ import org.locationtech.jts.simplify.VWSimplifier;
 import org.locationtech.jts.util.GeometricShapeFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.prefs.PathPrefs;
 import qupath.lib.gui.viewer.QuPathViewer;
 import qupath.lib.gui.viewer.QuPathViewerListener;
@@ -91,6 +93,11 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler<Input
 	private final BrushLimits brushLimits = new BrushLimits();
 
 	private final ViewerListener listener = new ViewerListener();
+
+	public BrushToolEventHandler() {
+		super();
+		PathPrefs.brushDiameterProperty().subscribe(() -> updateLimitsAndCursor());
+	}
 
 	/**
 	 * Returns false.
@@ -230,9 +237,9 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler<Input
 	}
 
 	private void updateLimitsAndCursor() {
-		ensureCursorType(Cursor.CROSSHAIR);
 		var viewer = getViewer();
 		if (viewer != null) {
+			ensureCursorType(Cursor.CROSSHAIR);
 			double screenX = robot.getMouseX();
 			double screenY = robot.getMouseY();
 			var p = viewer.getView().screenToLocal(screenX, screenY);
@@ -392,7 +399,6 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler<Input
 				return currentObject;
 			}
 			
-//			shapeNew = new PathAreaROI(new Area(shapeNew.getShape()));
 			PathObject pathObjectNew = PathObjects.createAnnotationObject(roiNew, PathPrefs.autoSetAnnotationClassProperty().get());
 			if (currentObject != null) {
 				pathObjectNew.setName(currentObject.getName());
@@ -425,6 +431,19 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler<Input
 		this.currentObject = null;
 
 		resetConstrainingObjects();
+	}
+
+
+	@Override
+	protected void handleScrollEvent(ScrollEvent event) {
+		if (!event.isConsumed() && event.isAltDown()) {
+			PathPrefs.brushDiameterProperty().set(
+					GeneralTools.clipValue(
+							(int)Math.round(PathPrefs.brushDiameterProperty().get() + event.getDeltaY()), 10, 500
+					)
+			);
+			event.consume();
+		}
 	}
 
 	
@@ -553,18 +572,24 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler<Input
 			return;
 		}
 		if (e.getEventType() == KeyEvent.KEY_RELEASED && comboFill.match(e)) {
-			// Fill the existing object
-			var roi = currentObject.getROI();
-			var roiFilled = RoiTools.fillHoles(roi);
-			if (!roi.equals(roiFilled)) {
-				currentObject = PathObjectTools.createLike(currentObject, roiFilled);
-				var viewer = getViewer();
-				viewer.setSelectedObject(this.currentObject);
-				viewer.getROIEditor().setROI(null);
-			}
+			fillHolesInCurrentObject();
 		}
 		e.consume();
 	}
+
+	private void fillHolesInCurrentObject() {
+		if (currentObject == null)
+			return;
+		var roi = currentObject.getROI();
+		var roiFilled = RoiTools.fillHoles(roi);
+		if (!roi.equals(roiFilled)) {
+			currentObject = PathObjectTools.createLike(currentObject, roiFilled);
+			var viewer = getViewer();
+			viewer.setSelectedObject(this.currentObject);
+			viewer.getROIEditor().setROI(null);
+		}
+	}
+
 
 	private class ViewerListener implements QuPathViewerListener {
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
@@ -26,6 +26,11 @@ package qupath.lib.gui.viewer.tools.handlers;
 import java.awt.Shape;
 import java.awt.image.BufferedImage;
 import javafx.scene.Cursor;
+import javafx.scene.input.InputEvent;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.robot.Robot;
 import org.locationtech.jts.geom.Coordinate;
@@ -44,6 +49,7 @@ import qupath.lib.gui.viewer.tools.QuPathPenManager.PenInputManager;
 import qupath.lib.images.ImageData;
 import qupath.lib.objects.PathAnnotationObject;
 import qupath.lib.objects.PathObject;
+import qupath.lib.objects.PathObjectTools;
 import qupath.lib.objects.PathObjects;
 import qupath.lib.objects.PathTileObject;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
@@ -64,7 +70,7 @@ import java.util.List;
  * @author Pete Bankhead
  *
  */
-public class BrushToolEventHandler extends AbstractPathROIToolEventHandler implements NotifiableEventHandler {
+public class BrushToolEventHandler extends AbstractPathROIToolEventHandler<InputEvent> implements NotifiableEventHandler {
 	
 	private static final Logger logger = LoggerFactory.getLogger(BrushToolEventHandler.class);
 
@@ -202,24 +208,9 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler imple
 		// Can only modify annotations
 		if (!createNew && !(currentObject != null && currentObject.isAnnotation() && currentObject.isEditable() && RoiTools.isShapeROI(currentObject.getROI())))
 			return;
-						
-		// Get the parent, in case we need to constrain the shape
-//		PathObject parent = null;
-//		if (currentObject != null) {
-//			parent = currentObject.getParent();
-//		}
-//		var currentObject2 = currentObject;
-//		if (parent == null || parent.isDetection()) {
-//			parent = getSelectableObjectList(p.getX(), p.getY())
-//					.stream()
-//					.filter(o -> !o.isDetection() && o != currentObject2)
-//					.findFirst()
-//					.orElseGet(() -> null);
-//		}
-//		setConstrainedAreaParent(hierarchy, parent, currentObject);
+
 		updatingConstrainingObjects(viewer, xx, yy, Collections.singleton(currentObject));
 
-		
 		// Need to remove the object from the hierarchy while editing it
 		if (!createNew && currentObject != null) {
 			hierarchy.removeObjectWithoutUpdate(currentObject, true);
@@ -231,7 +222,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler imple
 			this.currentObject = createNewAnnotation(e, p.getX(), p.getY());
 			viewer.getROIEditor().setROI(null);
 		} else {
-			this.currentObject = getUpdatedObject(e, shapeROI, currentObject, -1);
+			this.currentObject = getUpdatedObject(e, shapeROI, currentObject);
 			viewer.setSelectedObject(this.currentObject);
 			viewer.getROIEditor().setROI(null); // Avoids handles appearing?
 		}		
@@ -296,7 +287,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler imple
 		if (currentROI == null)
 			return;
 
-        PathObject pathObjectUpdated = getUpdatedObject(e, currentROI, pathObject, -1);
+        PathObject pathObjectUpdated = getUpdatedObject(e, currentROI, pathObject);
 
 		if (pathObject != pathObjectUpdated) {
 			viewer.setSelectedObject(pathObjectUpdated, PathPrefs.selectionModeStatus().get());
@@ -314,7 +305,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler imple
 	}
 	
 	
-	private PathObject getUpdatedObject(MouseEvent e, ROI shapeROI, PathObject currentObject, double flatness) {
+	private PathObject getUpdatedObject(MouseEvent e, ROI shapeROI, PathObject currentObject) {
 		boolean pixelSnapping = requestPixelSnapping();
 		Point2D p = mouseLocationToImage(e, false, pixelSnapping);
 
@@ -550,6 +541,29 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler imple
 	 */
 	protected BrushLimits getBrushLimits() {
 		return brushLimits;
+	}
+
+	private static final KeyCombination comboFill = new KeyCodeCombination(KeyCode.F);
+
+	@Override
+	protected void handleKeyEvent(KeyEvent e) {
+		super.handleKeyEvent(e);
+		if (currentObject == null) {
+			// Don't consume events if we aren't drawing
+			return;
+		}
+		if (e.getEventType() == KeyEvent.KEY_RELEASED && comboFill.match(e)) {
+			// Fill the existing object
+			var roi = currentObject.getROI();
+			var roiFilled = RoiTools.fillHoles(roi);
+			if (!roi.equals(roiFilled)) {
+				currentObject = PathObjectTools.createLike(currentObject, roiFilled);
+				var viewer = getViewer();
+				viewer.setSelectedObject(this.currentObject);
+				viewer.getROIEditor().setROI(null);
+			}
+		}
+		e.consume();
 	}
 
 	private class ViewerListener implements QuPathViewerListener {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/EllipseToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/EllipseToolEventHandler.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -34,7 +34,7 @@ import qupath.lib.roi.interfaces.ROI;
  * @author Pete Bankhead
  *
  */
-class EllipseToolEventHandler extends AbstractPathDraggingROIToolEventHandler {
+class EllipseToolEventHandler extends AbstractPathDraggingROIToolEventHandler<MouseEvent> {
 
 	@Override
 	protected ROI createNewROI(MouseEvent e, double x, double y, ImagePlane plane) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/LineToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/LineToolEventHandler.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -37,9 +37,9 @@ import qupath.lib.roi.interfaces.ROI;
  * @author Pete Bankhead
  *
  */
-class LineToolEventHandler extends AbstractPathDraggingROIToolEventHandler {
+class LineToolEventHandler extends AbstractPathDraggingROIToolEventHandler<MouseEvent> {
 	
-	private StringProperty arrowhead = new SimpleStringProperty();
+	private final StringProperty arrowhead = new SimpleStringProperty();
 		
 	/**
 	 * Returns false (no pixel snapping for the line tool).

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/MoveToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/MoveToolEventHandler.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -56,7 +56,7 @@ import java.util.Collections;
  * @author Pete Bankhead
  *
  */
-public class MoveToolEventHandler extends AbstractPathToolEventHandler {
+public class MoveToolEventHandler extends AbstractPathToolEventHandler<MouseEvent> {
 	
 	private static final Logger logger = LoggerFactory.getLogger(MoveToolEventHandler.class);
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PathToolEventHandlers.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PathToolEventHandlers.java
@@ -1,6 +1,28 @@
+/*-
+ * #%L
+ * This file is part of QuPath.
+ * %%
+ * Copyright (C) 2023 - 2026 QuPath developers, The University of Edinburgh
+ * %%
+ * QuPath is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * QuPath is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QuPath.  If not, see <https://www.gnu.org/licenses/>.
+ * #L%
+ */
+
 package qupath.lib.gui.viewer.tools.handlers;
 
 import javafx.event.EventHandler;
+import javafx.scene.input.InputEvent;
 import javafx.scene.input.MouseEvent;
 
 public class PathToolEventHandlers {
@@ -33,19 +55,19 @@ public class PathToolEventHandlers {
 		return new PointsToolEventHandler();
 	}
 	
-	public static EventHandler<MouseEvent> createBrushEventHandler() {
+	public static EventHandler<InputEvent> createBrushEventHandler() {
 		return new BrushToolEventHandler();
 	}
 	
-	public static ArrowToolEventHandler createArrowStartEventHandler() {
+	public static EventHandler<MouseEvent> createArrowStartEventHandler() {
 		return new ArrowToolEventHandler("<");
 	}
 
-	public static ArrowToolEventHandler createArrowEndEventHandler() {
+	public static EventHandler<MouseEvent> createArrowEndEventHandler() {
 		return new ArrowToolEventHandler(">");
 	}
 
-	public static ArrowToolEventHandler createDoubleArrowEventHandler() {
+	public static EventHandler<MouseEvent> createDoubleArrowEventHandler() {
 		return new ArrowToolEventHandler("<>");
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PointsToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PointsToolEventHandler.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -51,7 +51,7 @@ import java.util.List;
  * @author Pete Bankhead
  *
  */
-class PointsToolEventHandler extends AbstractPathToolEventHandler {
+class PointsToolEventHandler extends AbstractPathToolEventHandler<MouseEvent> {
 
 	private PointsROI getCurrentPoints() {
 		var viewer = getViewer();
@@ -112,7 +112,6 @@ class PointsToolEventHandler extends AbstractPathToolEventHandler {
 		
 		// Find out the coordinates in the image domain & update the adjustment
 		Point2D pAdjusting = mouseLocationToImage(e, true, requestPixelSnapping());
-//		double radius = PointsROI.defaultPointRadiusProperty().get();
 		PointsROI points2 = (PointsROI)editor.setActiveHandlePosition(pAdjusting.getX(), pAdjusting.getY(), 0.25, e.isShiftDown());
 		if (points2 == points)
 			return;
@@ -120,18 +119,6 @@ class PointsToolEventHandler extends AbstractPathToolEventHandler {
 		PathROIObject currentObject = (PathROIObject)viewer.getSelectedObject();
 		currentObject.setROI(points2);
 		viewer.repaint();
-		
-//		viewer.getHierarchy().fireHierarchyChangedEvent(this, currentObject);
-
-//		//		points.updateAdjustment(pAdjusting.getX(), pAdjusting.getY(), e.isShiftDown());
-//		
-////		Point2 p = points.getNearest(pAdjusting.getX(), pAdjusting.getY(), radius);
-//		if (p == null) {
-//		} else {
-//			p.setLocation(pAdjusting.getX(), pAdjusting.getY());
-////			points.resetMeasurements();
-//			viewer.repaint();
-//		}
 	}
 	
 	
@@ -271,7 +258,6 @@ class PointsToolEventHandler extends AbstractPathToolEventHandler {
 			if (points2 != points) {
 				currentObject.setROI(points2);
 				viewer.getHierarchy().updateObject(currentObject, true);
-//				viewer.getHierarchy().fireHierarchyChangedEvent(this, currentObject);
 			}
 		}
 		viewer.repaint();

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PolygonToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PolygonToolEventHandler.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -34,7 +34,7 @@ import qupath.lib.roi.interfaces.ROI;
  * @author Pete Bankhead
  *
  */
-class PolygonToolEventHandler extends AbstractPolyROIToolEventHandler {
+class PolygonToolEventHandler extends AbstractPolyROIToolEventHandler<MouseEvent> {
 	
 	@Override
 	protected ROI createNewROI(MouseEvent e, double x, double y, ImagePlane plane) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PolylineToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PolylineToolEventHandler.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -34,7 +34,7 @@ import qupath.lib.roi.interfaces.ROI;
  * @author Pete Bankhead
  *
  */
-class PolylineToolEventHandler extends AbstractPolyROIToolEventHandler {
+class PolylineToolEventHandler extends AbstractPolyROIToolEventHandler<MouseEvent> {
 
 	/**
 	 * Returns false (no pixel snapping for the line tool).

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/RectangleToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/RectangleToolEventHandler.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -34,7 +34,7 @@ import qupath.lib.roi.interfaces.ROI;
  * @author Pete Bankhead
  *
  */
-class RectangleToolEventHandler extends AbstractPathDraggingROIToolEventHandler {
+class RectangleToolEventHandler extends AbstractPathDraggingROIToolEventHandler<MouseEvent> {
 
 	@Override
 	protected ROI createNewROI(MouseEvent e, double x, double y, ImagePlane plane) {


### PR DESCRIPTION
Two user-visible changes:
* Alt+scroll can dynamically change the size of the brush (which is now visible https://github.com/qupath/qupath/pull/2125 )
* Press `F` while using the brush or wand to fill all holes (alternative to https://github.com/qupath/qupath/pull/2120)

Two significant less visible changes were needed to make this possible:
* Drawing tools are now implemented using `InputEvent`, rather than being restricted only to `MouseEvent`. This means they can now handle key presses (or others).
* The previous collection have event handlers added to the viewer have been consolidated into a single handler for `Event.ANY`. The rationale is that more specific handlers are called first - and therefore these shouldn't take priority over the handlers added by custom tools.

Brief video showing the results below:

https://github.com/user-attachments/assets/4088602f-99ba-439e-b7a7-7da99b1b3493

