### PR TITLE
Update qupath-imglib2 to 0.1.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ picocli         = "4.7.7"
 qupath-fxtras   = "0.3.0"
 qupath-training = "0.1.0"
 qupath-djl      = "0.4.2"
-qupath-imglib2  = "0.1.1"
+qupath-imglib2  = "0.1.2"
 
 richtextfx      = "0.11.7"
 


### PR DESCRIPTION
Update qupath-imglib2 to [v0.1.2](https://github.com/qupath/qupath-imglib2/releases/tag/v0.1.2)