### PR TITLE
Improve painting opacity logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * 'Open image' dialog cannot be resized (https://github.com/qupath/qupath/issues/2099)
 * Drawing/moving annotations can cause jiggly class list scrolling behavior (https://github.com/qupath/qupath/issues/2101)
 * Removing child objects can give an unexpected exception in scripts (https://github.com/qupath/qupath/issues/2111)
+* Nested detections render poorly when filled (https://github.com/qupath/qupath/issues/2112)
 
 ### Dependency updates
 * Bio-Formats 8.5.0

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/PathObjectPainter.java
@@ -270,8 +270,20 @@ public class PathObjectPainter {
 			colorStroke = ColorToolsAwt.darkenColor(color);
 		Stroke stroke = colorStroke == null ? null : calculateStroke(pathObject, downsample, isSelected);
 
-		if (colorFill != null && pathObject.hasChildObjects())
-			colorFill = ColorToolsAwt.getColorWithOpacity(colorFill, 0.1);
+		// If the opacity isn't specified in the metadata, increase it if we have child objects so they are more visible
+		if (colorFill != null && pathObject.hasChildObjects() && getFillOpacityFromMetadataOrNull(pathObject) == null) {
+			// Decrease the opacity if the object only has direct children
+			double opacity = colorFill.getAlpha() / 255.0;
+			opacity *= 0.75;
+			// Decrease the opacity again if there are grandchildren
+			for (var child : pathObject.getChildObjects()) {
+				if (child.hasChildObjects()) {
+					opacity *= 0.75;
+					break;
+				}
+			}
+			colorFill = ColorToolsAwt.getColorWithOpacity(colorFill, opacity);
+		}
 
 		if (stroke != null)
 			g.setStroke(stroke);
@@ -406,10 +418,10 @@ public class PathObjectPainter {
 
 	private static Double tryToParseDouble(Object obj) {
 		try {
-			if (obj instanceof String) {
-				return Double.parseDouble((String)obj);
-			} else if (obj instanceof Number) {
-				return ((Number)obj).doubleValue();
+			if (obj instanceof String s) {
+				return Double.parseDouble(s);
+			} else if (obj instanceof Number n) {
+				return n.doubleValue();
 			}
 		} catch (Exception e) {
 			logger.warn("Unable to parse double from {}", obj);


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/2112

The opacity decreases more gradually when objects are nested, and it is possible to override the opacity for any object by using the metadata, e.g.,
```groovy
getSelectedObject().metadata['fillOpacity'] = '1.0'
```