### PR TITLE
Update gradle, fix geometry conversion tests (hopefully)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        fail-fast: false
+      fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
+        fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,13 +16,23 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
       with:
         java-version: 25
         distribution: temurin
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Execute build
       run: ./gradlew build
+
+    - name: Report if failed
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: reports
+        path: |
+          **/build/reports/
+          **/build/test-results/
+        retention-days: 7

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         path: qupath
 
@@ -70,7 +70,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Assemble javadocs
       run: |

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -10,13 +10,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: temurin
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
       - name: Publish package
         run: ./gradlew publish -P toolchain=25 -P release=true
         env:

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -10,13 +10,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: temurin
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
       - name: Publish package
         run: ./gradlew publish -P toolchain=25
         env:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
+++ b/qupath-core/src/main/java/qupath/lib/analysis/DelaunayTools.java
@@ -455,7 +455,11 @@ public class DelaunayTools {
 	 * @return
 	 */
 	private static Collection<Coordinate> prepareCoordinates(Collection<Coordinate> coords) {
-		return DelaunayTriangulationBuilder.unique(coords.toArray(Coordinate[]::new));
+		return coords.stream().distinct().sorted().toList();
+		// Changed in v0.8.0 because this method is no longer public in JTS
+		// It's expected that the above code should do the same, but this comment in preserved
+		// in case some unexpected case emerges
+//		return DelaunayTriangulationBuilder.unique(coords.toArray(Coordinate[]::new));
 	}
 	
 	/**

--- a/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
@@ -376,11 +376,12 @@ public class AreaROI extends AbstractPathROI implements Serializable {
 	
 	@Override
 	public Geometry getGeometry() {
+		// Previously this was synchronized, but it resulted in tests that failed (but rarely).
+		// See https://github.com/qupath/qupath/pull/2135
+		// The underlying bug may be in JTS and no reliable workaround has been found yet,
+		// but because AreaROI is a deprecated legacy class it isn't the highest priority.
 		if (geometry == null) {
-			synchronized(this) {
-				if (geometry == null)
-					geometry = super.getGeometry();
-			}
+			geometry = super.getGeometry();
 		}
 		return geometry;
 	}

--- a/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/AreaROI.java
@@ -376,12 +376,12 @@ public class AreaROI extends AbstractPathROI implements Serializable {
 	
 	@Override
 	public Geometry getGeometry() {
-		// Previously this was synchronized, but it resulted in tests that failed (but rarely).
-		// See https://github.com/qupath/qupath/pull/2135
-		// The underlying bug may be in JTS and no reliable workaround has been found yet,
-		// but because AreaROI is a deprecated legacy class it isn't the highest priority.
 		if (geometry == null) {
-			geometry = super.getGeometry();
+			synchronized (this) {
+				if (geometry == null) {
+					geometry = super.getGeometry();
+				}
+			}
 		}
 		return geometry;
 	}

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -1168,7 +1168,8 @@ public class GeometryTools {
 	     * being generated within some operations as described by https://github.com/locationtech/jts/issues/434
     	 * Consequently, there may be some loss of efficiency.
     	 * <p>
-    	 * See also https://github.com/locationtech/jts/issues/408
+    	 * See also https://github.com/locationtech/jts/issues/408 and
+		 * https://github.com/qupath/qupath/pull/2135
 	     * 
 	     * @param area
 	     * @param transform
@@ -1192,10 +1193,11 @@ public class GeometryTools {
 	    		LineString lineString = factory.createLineString(array);
 	    		geometries.add(lineString);
 	    	}
+			// Note that polygonizer is non-deterministic and appears to have a bug
+			// https://github.com/locationtech/jts/issues/1063
 			var geom = factory.buildGeometry(geometries).union();
 	    	polygonizer.add(geom);
 	    	return polygonizer.getGeometry();
-
 	    }
 
 	    /**

--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -21,6 +21,7 @@
 
 package qupath.lib.roi;
 
+import org.locationtech.jts.algorithm.Orientation;
 import org.locationtech.jts.algorithm.locate.SimplePointInAreaLocator;
 import org.locationtech.jts.awt.GeometryCollectionShape;
 import org.locationtech.jts.awt.PointTransformation;
@@ -36,6 +37,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Lineal;
 import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.MultiLineString;
 import org.locationtech.jts.geom.MultiPoint;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
@@ -1090,32 +1092,6 @@ public class GeometryTools {
 	    			return shapeFactory.createRectangle();
 	    		}
 	    	}
-            // TODO: Test if this is as reliable
-            // Update August 2024... it is not. Tests added to TestGeometryTools show it
-            // fails faster for complex (random) polygons than the old method, which
-            // converts via a java.awt.geom.Area.
-            //
-            // Exploratory code for v0.4.0, but rejected to reduce risk.
-            // Seems marginally faster, but not by a huge amount
-//	    	if (roi instanceof PolygonROI) {
-//		    	PrecisionModel precisionModel = factory.getPrecisionModel();
-//		    	Polygonizer polygonizer = new Polygonizer(true);
-//		    	List<Coordinate> coords = new ArrayList<>();
-//				Coordinate lastCoord = null;
-//		    	for (var p : roi.getAllPoints()) {
-//		    		var c = new Coordinate(p.getX(), p.getY());
-//		    		precisionModel.makePrecise(c);
-//					if (!Objects.equals(lastCoord, c))
-//			    		coords.add(c);
-//					lastCoord = c;
-//		    	}
-//		    	// Close if needed
-//		    	if (!coords.getFirst().equals(coords.getLast()))
-//		    		coords.add(coords.getFirst().copy());
-//	    		LineString lineString = factory.createLineString(coords.toArray(Coordinate[]::new));
-//		    	polygonizer.add(lineString.union());
-//		    	return polygonizer.getGeometry();
-//	    	}
 
 			if (roi.isEmpty()) {
 				var shape = RoiTools.getShape(roi);
@@ -1176,28 +1152,69 @@ public class GeometryTools {
 	     * @param flatness
 	     * @param factory
 	     * @return a geometry corresponding to the Area object
+		 * @throws IllegalArgumentException if the winding rule is not WIND_NON_ZERO
 	     */
-	    private static Geometry convertAreaToGeometry(final Area area, final AffineTransform transform, final double flatness, final GeometryFactory factory) {
+	    private static Geometry convertAreaToGeometry(final Area area, final AffineTransform transform, final double flatness, final GeometryFactory factory) throws IllegalArgumentException {
+
+			// This code become more complex, and limited to WIND_NON_ZERO, to cope with a change in behavior for Area
+			// introduces around April 2026 (Java 25.0.3).
+			// We make the association the orientation (CW, CCW) allows us to tell if a coordinate sequence is an
+			// outer ring or a hole.
+			// See https://github.com/qupath/qupath/pull/2135
 
 	    	PathIterator iter = area.getPathIterator(transform, flatness);
+			if (iter.getWindingRule() != PathIterator.WIND_NON_ZERO) {
+				throw new IllegalArgumentException("Winding rule is " + iter.getWindingRule() + " but must be " +
+						PathIterator.WIND_NON_ZERO + " (WIND_NON_ZERO)");
+			}
 
 	    	PrecisionModel precisionModel = factory.getPrecisionModel();
-	    	Polygonizer polygonizer = new Polygonizer(true);
 
-	    	List<Coordinate[]> coords = (List<Coordinate[]>)ShapeReader.toCoordinates(iter);
-	    	List<Geometry> geometries = new ArrayList<>();
-	    	for (Coordinate[] array : coords) {
-	    		for (var c : array)
-	    			precisionModel.makePrecise(c);
+			List<Coordinate[]> coords = (List<Coordinate[]>)ShapeReader.toCoordinates(iter);
+			List<Geometry> geometries = new ArrayList<>();
+			List<Geometry> holes = new ArrayList<>();
+			CoordinateList coordList = new CoordinateList();
+			boolean allowRepeated = false;
+			for (Coordinate[] array : coords) {
+				coordList.clear();
+				for (var c : array) {
+					precisionModel.makePrecise(c);
+					coordList.add(c, allowRepeated);
+				}
 
-	    		LineString lineString = factory.createLineString(array);
-	    		geometries.add(lineString);
-	    	}
-			// Note that polygonizer is non-deterministic and appears to have a bug
-			// https://github.com/locationtech/jts/issues/1063
-			var geom = factory.buildGeometry(geometries).union();
-	    	polygonizer.add(geom);
-	    	return polygonizer.getGeometry();
+				Coordinate[] lineStringCoords = coordList.toCoordinateArray();
+				Geometry lineString = factory.createLineString(lineStringCoords).union();
+				Polygonizer polygonizer = new Polygonizer(true);
+				polygonizer.add(lineString);
+
+				// If we have self-intersections, we want to estimate the orientation from the line with most coordinates
+				if (lineString instanceof MultiLineString multiLineString) {
+					lineStringCoords = multiLineString.getGeometryN(0).getCoordinates();
+					for (int i = 1; i < multiLineString.getNumGeometries(); i++) {
+						var temp = multiLineString.getGeometryN(i).getCoordinates();
+						if (temp.length > lineStringCoords.length)
+							lineStringCoords = temp;
+					}
+				}
+
+				// Use the orientation - should be trustworthy (we think...) because of winding rule
+				if (Orientation.isCCW(lineStringCoords)) {
+					holes.add(polygonizer.getGeometry());
+				} else {
+					geometries.add(polygonizer.getGeometry());
+				}
+			}
+
+			var mainGeometry = union(geometries);
+			var allHoles = union(holes);
+			if (allHoles.isEmpty())
+				return mainGeometry;
+
+			// If things have worked, the main geometry will be bigger than the holes
+			if (mainGeometry.getArea() >= allHoles.getArea())
+				return mainGeometry.difference(allHoles);
+			logger.warn("Switching main geometry and holes based on area - this is unexpected and might be a bug");
+			return allHoles.difference(mainGeometry);
 	    }
 
 	    /**

--- a/qupath-core/src/test/java/qupath/lib/roi/TestGeometryTools.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestGeometryTools.java
@@ -104,7 +104,7 @@ public class TestGeometryTools {
 		File fileHierarchy = new File("src/test/resources/data/test-objects.hierarchy");
 		try (InputStream stream = Files.newInputStream(fileHierarchy.toPath())) {
 			var hierarchy = (PathObjectHierarchy)new ObjectInputStream(stream).readObject();
-			var geometries = hierarchy.getFlattenedObjectList(null).stream().filter(p -> p.hasROI()).map(p -> p.getROI().getGeometry()).collect(Collectors.toCollection(() -> new ArrayList<>()));
+			var geometries = hierarchy.getFlattenedObjectList(null).stream().filter(p -> p.hasROI()).map(p -> p.getROI().getGeometry()).collect(Collectors.toCollection(ArrayList::new));
 			
 			// Include some extra geometries that we know can be troublesome
 			var rectangle = GeometryTools.createRectangle(0, 0, 100, 100);
@@ -117,14 +117,14 @@ public class TestGeometryTools {
 			
 			var filledNested = (Polygon)GeometryTools.fillHoles(nested);
 			assertNotEquals(nested.getArea(), filledNested.getArea());
-			assertNotEquals(nested.getNumGeometries(), 1);
-			assertEquals(filledNested.getNumInteriorRing(), 0);
+			assertNotEquals(1, nested.getNumGeometries());
+			assertEquals(0, filledNested.getNumInteriorRing());
 			assertEquals(filledNested.getArea(), GeometryTools.externalRingArea(filledNested));
 
 			var filledNested2 = (Polygon)GeometryTools.fillHoles(nested2);
 			assertNotEquals(nested2.getArea(), filledNested2.getArea());
-			assertNotEquals(nested2.getNumGeometries(), 1);
-			assertEquals(filledNested2.getNumInteriorRing(), 0);
+			assertNotEquals(1, nested2.getNumGeometries());
+			assertEquals(0, filledNested2.getNumInteriorRing());
 			assertEquals(filledNested2.getArea(), GeometryTools.externalRingArea(filledNested2));
 
 			for (var geom : geometries) {

--- a/qupath-core/src/test/java/qupath/lib/roi/TestGeometryTools.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestGeometryTools.java
@@ -35,6 +35,7 @@ import org.locationtech.jts.operation.valid.IsValidOp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.lib.geom.Point2;
+import qupath.lib.objects.PathObject;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.interfaces.ROI;
@@ -104,7 +105,7 @@ public class TestGeometryTools {
 		File fileHierarchy = new File("src/test/resources/data/test-objects.hierarchy");
 		try (InputStream stream = Files.newInputStream(fileHierarchy.toPath())) {
 			var hierarchy = (PathObjectHierarchy)new ObjectInputStream(stream).readObject();
-			var geometries = hierarchy.getFlattenedObjectList(null).stream().filter(p -> p.hasROI()).map(p -> p.getROI().getGeometry()).collect(Collectors.toCollection(ArrayList::new));
+			var geometries = hierarchy.getFlattenedObjectList(null).stream().filter(PathObject::hasROI).map(p -> p.getROI().getGeometry()).collect(Collectors.toCollection(ArrayList::new));
 			
 			// Include some extra geometries that we know can be troublesome
 			var rectangle = GeometryTools.createRectangle(0, 0, 100, 100);
@@ -128,8 +129,8 @@ public class TestGeometryTools {
 			assertEquals(filledNested2.getArea(), GeometryTools.externalRingArea(filledNested2));
 
 			for (var geom : geometries) {
-				
-				assertTrue(geom.isValid());
+
+				assertTrue(geom.isValid(), () -> "Invalid geometry: " + geom);
 				
 				var geom2 = GeometryTools.fillHoles(geom);
 				assertTrue(geom2.isValid());

--- a/qupath-core/src/test/java/qupath/lib/roi/TestROIs.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestROIs.java
@@ -107,7 +107,7 @@ public class TestROIs {
 			for (ROI roi : rois) {
 				Geometry geom = roi.getGeometry();
 				assertEquals(roi.isEmpty(), geom.isEmpty());
-				assertTrue(geom.isValid());
+				assertTrue(geom.isValid(), () -> "Invalid geometry " + geom);
 				if (roi.isArea()) {
 					assertEquals(roi.isEmpty(), geom.isEmpty());
 					if (roi instanceof EllipseROI) {

--- a/qupath-core/src/test/java/qupath/lib/roi/TestROIs.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestROIs.java
@@ -26,6 +26,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.lib.geom.Point2;
+import qupath.lib.objects.PathObject;
 import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.roi.RoiTools.CombineOp;
@@ -69,7 +70,7 @@ public class TestROIs {
 		
 		ROI rectangle = ROIs.createRectangleROI(0, 0, 1000, 1000, ImagePlane.getDefaultPlane());
 		double targetAreaRectangle = 1000.0 * 1000.0;
-		assertEquals(rectangle.getArea(), targetAreaRectangle, delta);
+		assertEquals(targetAreaRectangle, rectangle.getArea(), delta);
 		checkROIMeasurements(rectangle, 1, 1, delta);
 		checkROIMeasurements(rectangle, pixelWidth, pixelHeight, delta);
 		assertTrue(rectangle.getGeometry().isValid());
@@ -101,7 +102,7 @@ public class TestROIs {
 		File fileHierarchy = new File("src/test/resources/data/test-objects.hierarchy");
 		try (InputStream stream = Files.newInputStream(fileHierarchy.toPath())) {
 			PathObjectHierarchy hierarchy = (PathObjectHierarchy)new ObjectInputStream(stream).readObject();
-			List<ROI> rois = hierarchy.getFlattenedObjectList(null).stream().filter(p -> p.hasROI()).map(p -> p.getROI()).toList();
+			List<ROI> rois = hierarchy.getFlattenedObjectList(null).stream().filter(PathObject::hasROI).map(PathObject::getROI).toList();
 			assertNotEquals(0L, rois.size());
 			for (ROI roi : rois) {
 				Geometry geom = roi.getGeometry();


### PR DESCRIPTION
Attempts to investigate/fix problem that surfaced in https://github.com/qupath/qupath/pull/2134
This includes Gradle and workflow updates.

The source of the problem traces back to tests that fail (at least on macOS) using Temurin 25.0.3 (and 26.0.1) but did *not* fail on 25.0.2.

They relate to converting a `java.awt.geom.Area` to a `org.locationtech.jts.geom.Geometry`.

The failures are strange. The immediately relevant code is where `AreaROI` lazily creates a `Geometry`

```java
	@Override
	public Geometry getGeometry() {
		if (geometry == null) {
			synchronized(this) {
				if (geometry == null)
					geometry = super.getGeometry();
			}
		}
		return geometry;
	}
```

This fails by creating an invalid `Geometry` on 25.0.3, but works if I create the `Geometry` every time with
```java
	@Override
	public Geometry getGeometry() {
		return super.getGeometry();
	}
```

It also works if I remove the synchronisation
```java
	@Override
	public Geometry getGeometry() {
		if (geometry == null) {
			geometry = super.getGeometry();
		}
		return geometry;
	}
```

All the above calls ultimately lead back to [`GeometryTools.convertAreaToGeometry`](https://github.com/qupath/qupath/blob/31312a5708d1c396cba0a12db306358524c1e8c0/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java#L1179) and the use of `Polygonizer`.

Because of the non-deterministic behavior, my best guess is that the bug relates to https://github.com/locationtech/jts/issues/1063

Because `AreaROI` is really a legacy class to enable ROIs to be read from *very* old QuPath releases (possibly v0.2.0) and has been deprecated since v0.6.0, so one of the more hack-y workarounds above would address the failing tests... although `GeometryTools.convertAreaToGeometry` can still be used to convert manually-draw polygons, so we'd want it to be as reliable as possible.