### PR TITLE
Add raster brush preference

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -22,6 +22,7 @@
 package qupath.lib.roi;
 
 import org.locationtech.jts.algorithm.Orientation;
+import org.locationtech.jts.algorithm.locate.IndexedPointInAreaLocator;
 import org.locationtech.jts.algorithm.locate.SimplePointInAreaLocator;
 import org.locationtech.jts.awt.GeometryCollectionShape;
 import org.locationtech.jts.awt.PointTransformation;
@@ -37,6 +38,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Lineal;
 import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Location;
 import org.locationtech.jts.geom.MultiLineString;
 import org.locationtech.jts.geom.MultiPoint;
 import org.locationtech.jts.geom.Point;
@@ -56,6 +58,7 @@ import org.locationtech.jts.index.quadtree.Quadtree;
 import org.locationtech.jts.operation.overlay.snap.GeometrySnapper;
 import org.locationtech.jts.operation.overlayng.UnaryUnionNG;
 import org.locationtech.jts.operation.polygonize.Polygonizer;
+import org.locationtech.jts.operation.union.UnaryUnionOp;
 import org.locationtech.jts.operation.valid.IsValidOp;
 import org.locationtech.jts.operation.valid.TopologyValidationError;
 import org.locationtech.jts.precision.GeometryPrecisionReducer;
@@ -64,6 +67,7 @@ import org.locationtech.jts.util.GeometricShapeFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.lib.common.GeneralTools;
+import qupath.lib.common.LogTools;
 import qupath.lib.geom.Point2;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.regions.ImageRegion;
@@ -381,8 +385,69 @@ public class GeometryTools {
 		// Resort to expensive intersection calculation only if we need to
 		return a.intersection(b).getArea();
 	}
-	
-    
+
+	/**
+	 * Experimental method (use with caution!) that attempts to rasterize a geometry,
+	 * ensuring that it contains only horizontal and vertical lines at integer coordinates.
+	 * <p>
+	 * <b>Warning!</b> This uses a scanline approach that can be very slow for large and complex geometries.
+	 * The behavior of the method may change in a future release.
+	 *
+	 * @param geom the input geometry
+	 * @return a rasterized version of the geometry
+	 * @since v0.8.0
+	 */
+	public static Geometry rasterize(Geometry geom) {
+
+		// TODO: Find a way to short-circuit if the expensive calculations aren't needed!
+		LogTools.warnOnce(logger, "GeometryTools.rasterize(geom) is an experimental method that may change in a later version");
+
+		List<Polygon> rasterizedPolygons = new ArrayList<>();
+		var locator = new IndexedPointInAreaLocator(geom);
+		Coordinate coordinate = new Coordinate();
+		var envelope = geom.getEnvelopeInternal();
+		double minX = Math.floor(envelope.getMinX()) - 0.5;
+		double minY = Math.floor(envelope.getMinY()) - 0.5;
+		double maxX = Math.ceil(envelope.getMaxX()) + 1.5; // Go too far, so we'll definitely be outside
+		double maxY = Math.ceil(envelope.getMaxY()) + 1.5;
+		double scanlineStart = Double.NEGATIVE_INFINITY;
+		double scanlineEnd = Double.NEGATIVE_INFINITY;
+
+		// Create polygons (rectangles) for each scanline
+		for (double y = minY; y <= maxY; y++) {
+			coordinate.setY(y);
+			for (double x = minX; x <= maxX; x++) {
+				coordinate.setX(x);
+				int location = locator.locate(coordinate);
+				if (location == Location.EXTERIOR) {
+					if (Double.isFinite(scanlineEnd))
+						rasterizedPolygons.add(
+								GeometryTools.createRectangle(scanlineStart-0.5, y-0.5, scanlineEnd-scanlineStart+1, 1.0)
+						);
+					scanlineStart = Double.NEGATIVE_INFINITY;
+					scanlineEnd = Double.NEGATIVE_INFINITY;
+					continue;
+				}
+				// Keep if point is interior or at a left edge
+				// TODO: Ideally we'd know if point is at a top edge as well...
+				if (location == Location.INTERIOR || !Double.isFinite(scanlineStart)) {
+					if (!Double.isFinite(scanlineStart))
+						scanlineStart = x;
+					scanlineEnd = x;
+				}
+			}
+		}
+		// Merge the polygons
+		var geomNew = UnaryUnionOp.union(rasterizedPolygons);
+
+		// Remove unnecessary vertices on vertical lines
+		if (geomNew == null || geomNew.isEmpty())
+			return geom.getFactory().createPolygon();
+		else
+			return DouglasPeuckerSimplifier.simplify(geomNew, 0);
+	}
+
+
     /**
      * Create a rectangular Geometry for the specified bounding box.
      * @param x x ordinate for the top left of the rectangle bounding box

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PreferencePane.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -445,8 +445,11 @@ public class PreferencePane {
 		public final BooleanProperty clipROIsForHierarchy = PathPrefs.clipROIsForHierarchyProperty();
 
 		@IntegerPref("Prefs.Drawing.brushDiameter")
-		public final IntegerProperty brushDiameter = PathPrefs.brushDiameterProperty();		
-		
+		public final IntegerProperty brushDiameter = PathPrefs.brushDiameterProperty();
+
+		@BooleanPref("Prefs.Drawing.rasterBrush")
+		public final BooleanProperty rasterBrush = PathPrefs.useRasterBrushProperty();
+
 		@BooleanPref("Prefs.Drawing.tileBrush")
 		public final BooleanProperty tileBrush = PathPrefs.useTileBrushProperty();
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/prefs/PathPrefs.java
@@ -715,6 +715,17 @@ public class PathPrefs {
 		return useTileBrush;
 	}
 
+	private static final BooleanProperty useRasterBrush = createPersistentPreference("useRasterBrush", false);
+
+	/**
+	 * Request that the brush tool created 'rasterized' shapes.
+	 * These contain only integer coordinates, connected by horizontal or vertical lines.
+	 * @return
+	 */
+	public static BooleanProperty useRasterBrushProperty() {
+		return useRasterBrush;
+	}
+
 	private static BooleanProperty selectionMode = MANAGER.createTransientBooleanProperty("selectionMode", false);
 
 	/**

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
@@ -25,6 +25,7 @@ package qupath.lib.gui.viewer.tools.handlers;
 
 import java.awt.Shape;
 import java.awt.image.BufferedImage;
+import java.util.ArrayList;
 import javafx.scene.Cursor;
 import javafx.scene.input.InputEvent;
 import javafx.scene.input.KeyCode;
@@ -34,10 +35,14 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.ScrollEvent;
 import javafx.scene.robot.Robot;
+import org.locationtech.jts.algorithm.Distance;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.operation.overlayng.CoverageUnion;
+import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 import org.locationtech.jts.simplify.VWSimplifier;
 import org.locationtech.jts.util.GeometricShapeFactory;
 import org.slf4j.Logger;
@@ -489,25 +494,117 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler<Input
 		
 		// Compute a diameter scaled according to the pressure being applied
 		double diameter = Math.max(1, getBrushDiameter());
-		
+
+		boolean doRasterize = PathPrefs.useRasterBrushProperty().get();
+		if (doRasterize) {
+			double downsample = getViewer().getDownsampleFactor();
+			int resolution = (int)Math.max(1.0, Math.floor(downsample));
+			var c1 = new Coordinate(Math.floor(x), Math.floor(y));
+			var c2 = lastPoint == null ? c1 : new Coordinate(
+					Math.floor(lastPoint.getX()),
+					Math.floor(lastPoint.getY()));
+			double radius = getBrushDiameter() / 2.0;// / resolution;
+			var geom = rasterizedBufferedLine(c1, c2, radius, resolution);
+			if (geom.isEmpty()) {
+				return GeometryTools.createRectangle(Math.floor(x), Math.floor(y), 1, 1);
+			} else {
+				return geom;
+			}
+		}
+
 		Geometry geometry;
 		if (lastPoint == null) {
 			var shapeFactory = new GeometricShapeFactory(getGeometryFactory());
 			shapeFactory.setCentre(new Coordinate(x, y));
 			shapeFactory.setSize(diameter);
-//			shapeFactory.setCentre(new Coordinate(x-diameter/2, y-diameter/2));
 			geometry = shapeFactory.createEllipse();
 		} else {
 			if (lastPoint.distanceSq(x, y) == 0)
 				return null;
+			// For drawing a line, it's better to create the line and buffer
+			// (not add lots of separate circles)
 			var factory = getGeometryFactory();
 			geometry = factory.createLineString(new Coordinate[] {
 					new Coordinate(lastPoint.getX(), lastPoint.getY()),
-					new Coordinate(x, y)}).buffer(diameter/2.0);
+					new Coordinate(x, y)})
+					.buffer(diameter/2.0);
 		}
-		
+
 		return geometry;
 	}
+
+	/**
+	 * Create a geometry containing only integer coordinates and horizontal/vertical lines, derived from
+	 * a line or point that has been buffered with a specified radius.
+	 * @param c1 end point of the line, or center of the circle
+	 * @param c2 second end point of the line, or equal to c1 for a circle
+	 * @param radius buffer radius (or circle radius for a single point)
+	 * @param resolution the resolution of the output geometry; must be &geq; 1.
+	 *                   Use 1 to allow all integer coordinates,
+	 *                   or a higher number to improve performance (by creating less detailed geometries).
+	 * @return the rasterized geometry
+	 */
+	private static Geometry rasterizedBufferedLine(Coordinate c1, Coordinate c2, double radius, int resolution) {
+
+		if (resolution < 0)
+			throw new IllegalArgumentException("Resolution must be >= 1");
+
+		boolean isCircle = c2 == null || c1.equals2D(c2);
+
+		List<Polygon> rasterizedPolygons = new ArrayList<>();
+
+		// Compute the center of the central pixel
+		double centerX = Math.round((c1.getX() + c2.getX()) / 2.0) + 0.5;
+		double centerY = Math.round((c1.getY() + c2.getY()) / 2.0) + 0.5;
+
+		// Compute the number of horizontal grid pixels in the bounding box
+		int nHorizontal = (int)Math.max(1, Math.ceil(Math.abs(c1.getX() - c2.getX()) + radius * 2.0) / (double)resolution);
+		double minX = centerX - (nHorizontal / 2 + 2) * resolution;
+		double maxX = centerX + (nHorizontal / 2 + 2) * resolution;
+
+		// Compute the number of vertical grid pixels in the bounding box
+		int nVertical = (int)Math.max(2, Math.ceil(Math.abs(c1.getY() - c2.getY()) + radius * 2.0) / (double)resolution);
+		double minY = centerY - (nVertical / 2 + 2) * resolution;
+		double maxY = centerY + (nVertical / 2 + 2) * resolution;
+
+		Coordinate c = new Coordinate();
+		for (double y = minY; y <= maxY; y += resolution) {
+			c.setY(y);
+			double scanlineStart = Double.NEGATIVE_INFINITY;
+			double scanlineEnd = Double.NEGATIVE_INFINITY;
+			for (double x = minX; x <= maxX; x += resolution) {
+				c.setX(x);
+				double distance = isCircle ? c1.distance(c) : Distance.pointToSegment(c, c1, c2);
+				if (distance <= radius) {
+					if (!Double.isFinite(scanlineStart)) {
+						// Starting row
+						scanlineStart = x;
+					}
+					scanlineEnd = x;
+				} else {
+					// Finished row
+					if (Double.isFinite(scanlineEnd)) {
+						rasterizedPolygons.add(
+								GeometryTools.createRectangle(scanlineStart - 0.5, y - resolution / 2.0, scanlineEnd - scanlineStart + 1, resolution)
+						);
+						// Break, to avoid wasting time for pixels that are definitely outside
+						break;
+					}
+				}
+			}
+		}
+
+		// Merge the polygons
+		var factory = GeometryTools.getDefaultFactory();
+		var geomNew = CoverageUnion.union(factory.buildGeometry(rasterizedPolygons));
+
+		// Remove unnecessary vertices on vertical lines
+		if (geomNew == null || geomNew.isEmpty())
+			return factory.createPolygon();
+		else
+			return DouglasPeuckerSimplifier.simplify(geomNew, 0);
+	}
+
 	
 	private boolean creatingTiledROI = false;
 	

--- a/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
+++ b/qupath-gui-fx/src/main/resources/qupath/lib/gui/localization/qupath-gui-strings.properties
@@ -857,6 +857,9 @@ Prefs.Drawing.clipROIsForHierarchy = Clip ROIs to hierarchy
 Prefs.Drawing.clipROIsForHierarchy.description = Automatically clip ROIs so that they don't extend beyond a parent annotation, or encroach on a child annotation - this helps keep the hierarchy easier to interpret, without overlaps.\nThe setting can be overridden by pressing the 'shift' key.
 Prefs.Drawing.brushDiameter = Brush diameter
 Prefs.Drawing.brushDiameter.description = Set the default brush diameter.
+Prefs.Drawing.rasterBrush = Use raster brush
+Prefs.Drawing.rasterBrush.description = Request that the brush creates ROIs with integer coordinates, and horizontal and vertical line connections. \
+  This is not applied if the tile brush is active.
 Prefs.Drawing.tileBrush = Use tile brush
 Prefs.Drawing.tileBrush.description = Adapt brush tool to select tiles, where available.
 Prefs.Drawing.brushScaleByMag = Scale brush by magnification


### PR DESCRIPTION
This prevents the brush from creating ROIs that contain diagonal connections between coordinates. Because coordinates are constrained to be integers, this results an ROIs that rasterize more predictably.

## Example

The top nucleus is annotated with the new preference turned **on**, while the bottom nucleus is annotated with the preference turned **off** (the previous behavior).

<img width="1433" height="805" alt="image" src="https://github.com/user-attachments/assets/5e24aea4-12b0-4686-905e-40bfb428a80a" />

## Extra

A new 'experimental' method `GeometryTools.rasterize(Geometry)` has been added to enable any arbitrary polygonal geometry to be rasterised. *However* its performance is poor for large and complex geometries, and it requires further testing for small ones.

It exists for now as a 'better than nothing' option for use in scripts. In the end, the code for this was not used to implement the raster brush option.