### PR TITLE
fix: size filter on pixel-classifier object creation ignores holes

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ml/pixel/PixelClassifierTools.java
@@ -43,6 +43,7 @@ import qupath.lib.objects.hierarchy.PathObjectHierarchy;
 import qupath.lib.regions.ImagePlane;
 import qupath.lib.regions.RegionRequest;
 import qupath.lib.roi.GeometryTools;
+import qupath.lib.roi.RoiTools;
 import qupath.lib.roi.interfaces.ROI;
 import qupath.opencv.ml.pixel.PixelClassifiers.ClassifierFunction;
 
@@ -177,7 +178,7 @@ public class PixelClassifierTools {
 	 * 
 	 * @return true if the command ran successfully to completion, false otherwise.
 	 * @throws IOException 
-	 * @see GeometryTools#refineAreas(Geometry, double, double)
+	 * @see RoiTools#refineAreasByArea(Geometry, double, double)
 	 */
 	public static boolean createObjectsFromPredictions(
 			ImageServer<BufferedImage> server, PathObjectHierarchy hierarchy, Collection<PathObject> selectedObjects, 
@@ -440,7 +441,7 @@ public class PixelClassifierTools {
 	
 	private static List<PathObject> geometryToObjects(Geometry geometry, Function<ROI, ? extends PathObject> creator, PathClass pathClass, double minAreaPixels, double minHoleAreaPixels, boolean doSplit, ImagePlane plane) {
 		// Apply size filters
-		geometry = GeometryTools.refineAreas(geometry, minAreaPixels, minHoleAreaPixels);
+		geometry = RoiTools.refineAreasByArea(geometry, minAreaPixels, minHoleAreaPixels);
 		if (geometry == null || geometry.isEmpty())
 			return Collections.emptyList();
 		

--- a/qupath-core-processing/src/test/java/qupath/opencv/ml/pixel/TestPixelClassifierTools.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/ml/pixel/TestPixelClassifierTools.java
@@ -24,6 +24,7 @@ package qupath.opencv.ml.pixel;
 
 import ij.process.ByteProcessor;
 import ij.process.ImageStatistics;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.locationtech.jts.operation.valid.IsValidOp;
@@ -222,6 +223,69 @@ class TestPixelClassifierTools {
 			assertEquals(hist[label], totalArea);
 		}
 		
+	}
+
+	@Test
+	void testSplitObjectsFiltersHoledRegionsByNetArea() throws IOException {
+		var server = createHoledClassificationServer();
+		try {
+			var objects = PixelClassifierTools.createObjectsFromPixelClassifier(
+					server,
+					server.getMetadata().getClassificationLabels(),
+					null,
+					PathObjects::createAnnotationObject,
+					50, 0,
+					true);
+			assertTrue(objects.isEmpty());
+		} finally {
+			server.close();
+		}
+	}
+
+	@Test
+	void testSplitObjectsFillHolesBeforeAreaFiltering() throws IOException {
+		var server = createHoledClassificationServer();
+		try {
+			var objects = PixelClassifierTools.createObjectsFromPixelClassifier(
+					server,
+					server.getMetadata().getClassificationLabels(),
+					null,
+					PathObjects::createAnnotationObject,
+					50, 100,
+					true);
+			assertEquals(2, objects.size());
+			assertEquals(200.0, objects.stream().mapToDouble(p -> p.getROI().getArea()).sum(), 1e-6);
+		} finally {
+			server.close();
+		}
+	}
+
+	private static ImageServer<BufferedImage> createHoledClassificationServer() {
+		var img = new BufferedImage(26, 12, BufferedImage.TYPE_BYTE_GRAY);
+		paintRectangle(img, 1, 1, 10, 10, 1);
+		paintRectangle(img, 2, 2, 8, 8, 0);
+		paintRectangle(img, 14, 1, 10, 10, 1);
+		paintRectangle(img, 15, 2, 8, 8, 0);
+
+		ImageServer<BufferedImage> server = new WrappedBufferedImageServer(UUID.randomUUID().toString(), img);
+		var classificationLabels = new LinkedHashMap<Integer, PathClass>();
+		classificationLabels.put(1, PathClass.getInstance("Class 1"));
+		server.setMetadata(
+				new ImageServerMetadata.Builder(server.getOriginalMetadata())
+						.channelType(ChannelType.CLASSIFICATION)
+						.classificationLabels(classificationLabels)
+						.build()
+		);
+		return server;
+	}
+
+	private static void paintRectangle(BufferedImage img, int x, int y, int width, int height, int value) {
+		var raster = img.getRaster();
+		for (int yy = y; yy < y + height; yy++) {
+			for (int xx = x; xx < x + width; xx++) {
+				raster.setSample(xx, yy, 0, value);
+			}
+		}
 	}
 	
 

--- a/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RoiTools.java
@@ -24,9 +24,11 @@
 package qupath.lib.roi;
 
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.locationtech.jts.geom.util.AffineTransformation;
+import org.locationtech.jts.geom.util.PolygonExtracter;
 import org.locationtech.jts.shape.random.RandomPointsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -417,6 +419,83 @@ public class RoiTools {
 		if (geometry2 == null)
 			return ROIs.createEmptyROI(roi.getImagePlane());
 		return GeometryTools.geometryToROI(geometry2, roi.getImagePlane());
+	}
+
+	/**
+	 * Remove small fragments and fill small holes of an area ROI, using the full geometry area
+	 * of each fragment after any hole filling has been applied.
+	 * <p>
+	 * This differs from {@link #removeSmallPieces(ROI, double, double)}, which preserves the
+	 * historical behavior of applying the fragment threshold to each polygon's exterior ring.
+	 *
+	 * @param roi the ROI to refine
+	 * @param minAreaPixels the minimum geometry area of a fragment to retain
+	 * @param minHoleAreaPixels the minimum size of a hole to retain, or -1 if all holes should be retained
+	 * @return an updated ROI - which may be empty if the modifications caused the ROI to disappear
+	 */
+	public static ROI removeSmallPiecesByArea(ROI roi, double minAreaPixels, double minHoleAreaPixels) {
+		logger.trace("Removing small pieces from {} using geometry area (min = {}, max = {})", roi, minAreaPixels, minHoleAreaPixels);
+
+		// We can't have holes if we don't have an AreaROI
+		if (roi instanceof RectangleROI || roi instanceof EllipseROI || roi instanceof LineROI || roi instanceof PolylineROI) {
+			if (roi.getArea() < minAreaPixels)
+				return ROIs.createEmptyROI(roi.getImagePlane());
+			else
+				return roi;
+		}
+
+		var geometry = roi.getGeometry();
+		var geometry2 = refineAreasByArea(geometry, minAreaPixels, minHoleAreaPixels);
+		if (geometry == geometry2)
+			return roi;
+		if (geometry2 == null)
+			return ROIs.createEmptyROI(roi.getImagePlane());
+		return GeometryTools.geometryToROI(geometry2, roi.getImagePlane());
+	}
+
+	/**
+	 * Remove small fragments and fill small interior rings within a Geometry, using the full
+	 * geometry area of each fragment after any hole filling has been applied.
+	 * <p>
+	 * Note that any modifications to the geometry will result in points and lines being stripped away,
+	 * leaving only polygons.
+	 *
+	 * @param geometry input geometry to refine
+	 * @param minAreaPixels minimum geometry area of a fragment to keep
+	 * @param minHoleAreaPixels minimum size of an interior hole to keep
+	 * @return the refined geometry (possibly the original unchanged), or empty geometry if the changes resulted in the Geometry disappearing
+	 * @see GeometryTools#removeInteriorRings(Geometry, double)
+	 */
+	public static Geometry refineAreasByArea(Geometry geometry, double minAreaPixels, double minHoleAreaPixels) {
+		if (minAreaPixels <= 0 && minHoleAreaPixels <= 0)
+			return geometry;
+
+		var geometry2 = GeometryTools.ensurePolygonal(geometry);
+		geometry2 = GeometryTools.removeInteriorRings(geometry2, minHoleAreaPixels);
+		geometry2 = removeFragmentsByArea(geometry2, minAreaPixels);
+		return geometry2;
+	}
+
+	private static Geometry removeFragmentsByArea(Geometry geometry, double minAreaPixels) {
+		if (minAreaPixels <= 0)
+			return geometry;
+		if (geometry instanceof Polygon) {
+			if (geometry.getArea() >= minAreaPixels)
+				return geometry;
+			else
+				return geometry.getFactory().createPolygon();
+		}
+		@SuppressWarnings("unchecked")
+		var polygons = (List<Polygon>)PolygonExtracter.getPolygons(geometry);
+		if (polygons.isEmpty())
+			return geometry.getFactory().createPolygon();
+		var filtered = polygons
+				.stream()
+				.filter(g -> g.getArea() >= minAreaPixels)
+				.toList();
+		if (filtered.isEmpty())
+			return geometry.getFactory().createPolygon();
+		return geometry.getFactory().buildGeometry(filtered);
 	}
 
 	/**

--- a/qupath-core/src/test/java/qupath/lib/roi/TestRoiTools.java
+++ b/qupath-core/src/test/java/qupath/lib/roi/TestRoiTools.java
@@ -135,6 +135,29 @@ public class TestRoiTools {
 		assertTrue(RoiTools.removeSmallPieces(points, 50, 0).isEmpty());
 
 	}
+
+	@Test
+	public void testRemoveSmallRegionsByArea() {
+
+		var plane = ImagePlane.getDefaultPlane();
+		var outer = ROIs.createRectangleROI(0, 0, 10, 10, plane);
+		var inner = ROIs.createRectangleROI(0.5, 0.5, 9, 9, plane);
+		var holed = RoiTools.combineROIs(outer, inner, CombineOp.SUBTRACT);
+
+		assertEquals(19.0, holed.getArea(), 1e-6);
+		assertFalse(RoiTools.removeSmallPieces(holed, 20, 0).isEmpty());
+		assertTrue(RoiTools.removeSmallPiecesByArea(holed, 20, 0).isEmpty());
+		assertFalse(RoiTools.removeSmallPiecesByArea(holed, 19, 0).isEmpty());
+
+		var filledBeforeFiltering = RoiTools.removeSmallPiecesByArea(holed, 50, 100);
+		assertFalse(filledBeforeFiltering.isEmpty());
+		assertEquals(100.0, filledBeforeFiltering.getArea(), 1e-6);
+
+		var solid = ROIs.createRectangleROI(20, 0, 10, 5, plane);
+		assertEquals(solid, RoiTools.removeSmallPiecesByArea(solid, 50, 0));
+		assertTrue(RoiTools.removeSmallPiecesByArea(solid, 51, 0).isEmpty());
+
+	}
 	
 	
 	


### PR DESCRIPTION
## Summary

The minimum-object-size filter in pixel-classifier object creation now measures net geometry area (outer ring minus retained holes) and runs after hole handling, so objects whose net area is below the threshold are removed even when their outer ring exceeds it.

## Why this matters

In #2136 you diagnosed the cause: the area test is applied to the outer ring of each polygon and ignores holes, so with "split objects" enabled, a 5 um^2 minimum still lets through ring-shaped fragments whose outer ring passes but whose net area does not. You proposed exactly this reordering (handle holes first, then apply the area test to what remains). The shared filtering in `RoiTools` carries the corrected semantics so the behavior is consistent, while the change is limited to the pixel-classifier creation path since you flagged that "Remove fragments & holes" carries an intentional, changelog-documented behavior from years back.

## Testing

New cases in `TestPixelClassifierTools` cover ring-shaped objects below/above the net-area threshold with and without hole removal, and `TestRoiTools` covers the net-area computation. No JVM was available in the implementation environment, so CI is the verification run for the suites.

Fixes #2136
