### PR TITLE
Improve brush and wand

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/GeometryTools.java
@@ -326,8 +326,14 @@ public class GeometryTools {
 	 */
 	public static Geometry constrainToBounds(Geometry geometry, double x, double y, double width, double height) {
 		var env = geometry.getEnvelopeInternal();
+		boolean isPolygonal = geometry instanceof Polygonal;
 		if (env.getMinX() < x || env.getMinY() < y || env.getMaxX() >= x + width || env.getMaxY() >= y + height)
 			geometry = geometry.intersection(GeometryTools.createRectangle(x, y, width, height));
+		// Don't permit lines to be introduced in a geometry that was previously polygonal
+		// (This fixes an issue where the wand tool didn't work at image bounds)
+		if (isPolygonal && (!(geometry instanceof Polygonal))) {
+			geometry = homogenizeGeometryCollection(geometry);
+		}
 		return geometry;
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
@@ -618,7 +618,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler<Input
 		lastPoint = null;
 		Geometry geom = createShape(e, x, y, PathPrefs.useTileBrushProperty().get(), null);
 		if (geom == null || geom.isEmpty())
-			return ROIs.createEmptyROI();
+			return ROIs.createEmptyROI().updatePlane(plane);
 		var viewer = getViewer();
 		geom = GeometryTools.roundCoordinates(geom);
 		geom = GeometryTools.constrainToBounds(geom, 0, 0, viewer.getServerWidth(), viewer.getServerHeight());


### PR DESCRIPTION
Fix (hopefully) issue where the brush/wand could sometimes create a ROI on the default plane, rather than the current plane showing in the viewer. Also fix issue where ROIs could not be added at the image bounds.