### PR TITLE
Support `--background-color` for OpenSlide

### DIFF
--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2024 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -24,6 +24,7 @@
 package qupath.lib.images.servers.openslide;
 
 import com.google.gson.GsonBuilder;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.lib.common.GeneralTools;
@@ -248,18 +249,19 @@ public class OpenslideImageServer extends AbstractTileableImageServer {
 		associatedImageList = Collections.unmodifiableList(osr.getAssociatedImages());
 		
 		// Try to get a background color
+		backgroundColor = Color.WHITE;
 		try {
+			// Update from properties, if available
 			String bg = properties.get(OpenSlide.PROPERTY_NAME_BACKGROUND_COLOR);
 			if (bg != null) {
-				if (!bg.startsWith("#"))
-					bg = "#" + bg;
-				backgroundColor = Color.decode(bg);
+				backgroundColor = parseBackgroundColorFromString(bg).orElse(backgroundColor);
 			}
+			// Update from args, if available
+			backgroundColor = parseColorFromArgs(args).orElse(backgroundColor);
 		} catch (Exception e) {
-			backgroundColor = null;
-			logger.debug("Unable to find background color: {}", e.getLocalizedMessage());
+			logger.debug("Exception parsing background color: {}", e.getMessage(), e);
 		}
-		
+
 		// Try reading a thumbnail... the point being that if this is going to fail,
 		// we want it to fail quickly so that it may yet be possible to try another server
 		// This can occur with corrupt .svs (.tif) files that Bioformats is able to handle better
@@ -269,6 +271,45 @@ public class OpenslideImageServer extends AbstractTileableImageServer {
 			logger.error("Unable to read thumbnail using OpenSlide: {}", e.getLocalizedMessage());
 			throw(e);
 		}
+	}
+
+	private static Optional<Color> parseColorFromArgs(String[] args) {
+		for (int i = 0; i < args.length; i++) {
+			String[] split = args[i].split("=");
+			if (OpenslideServerBuilder.ARG_BACKGROUND_COLOR.equalsIgnoreCase(split[0].strip())) {
+				String value;
+				if (split.length > 1)
+					value = split[1];
+				else
+					value = i == args.length-1 ? null : args[i+1];
+				if (value == null || value.isBlank()) {
+					logger.warn("Background color requested, but no value given");
+					return Optional.empty();
+				}
+				return parseBackgroundColorFromString(value);
+			}
+		}
+		return Optional.empty();
+	}
+
+	static Optional<Color> parseBackgroundColorFromString(String value) {
+		if (value == null || value.isBlank())
+			return Optional.empty();
+		var val = value.strip();
+		if (val.equalsIgnoreCase("white"))
+			return Optional.of(Color.WHITE);
+		if (val.equalsIgnoreCase("black"))
+			return Optional.of(Color.BLACK);
+		if (val.equalsIgnoreCase("red"))
+			return Optional.of(Color.RED);
+		if (val.equalsIgnoreCase("green"))
+			return Optional.of(Color.GREEN);
+		if (val.equalsIgnoreCase("blue"))
+			return Optional.of(Color.BLUE);
+		// OpenSlide often uses hex representation
+		if (!val.startsWith("#"))
+			val = "#" + val;
+		return Optional.of(Color.decode(val));
 	}
 	
 	@Override

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideImageServer.java
@@ -85,6 +85,9 @@ public class OpenslideImageServer extends AbstractTileableImageServer {
 		}
 	}
 
+	// Default color to fill tiles when not overridden within the image properties or string args
+	private static final Color DEFAULT_BACKGROUND_COLOR = Color.WHITE;
+
 	private static final Cleaner cleaner = Cleaner.create();
 	private final OpenSlideState state;
 	private final Cleaner.Cleanable cleanable;
@@ -249,28 +252,39 @@ public class OpenslideImageServer extends AbstractTileableImageServer {
 		associatedImageList = Collections.unmodifiableList(osr.getAssociatedImages());
 		
 		// Try to get a background color
-		backgroundColor = Color.WHITE;
-		try {
-			// Update from properties, if available
-			String bg = properties.get(OpenSlide.PROPERTY_NAME_BACKGROUND_COLOR);
-			if (bg != null) {
-				backgroundColor = parseBackgroundColorFromString(bg).orElse(backgroundColor);
-			}
-			// Update from args, if available
-			backgroundColor = parseColorFromArgs(args).orElse(backgroundColor);
-		} catch (Exception e) {
-			logger.debug("Exception parsing background color: {}", e.getMessage(), e);
-		}
+		backgroundColor = findBackgroundColor(properties, args);
 
 		// Try reading a thumbnail... the point being that if this is going to fail,
 		// we want it to fail quickly so that it may yet be possible to try another server
 		// This can occur with corrupt .svs (.tif) files that Bioformats is able to handle better
 		try {
-			logger.debug("Test reading thumbnail with openslide: passed (" + getDefaultThumbnail(0, 0).toString() + ")");
+            logger.debug("Test reading thumbnail with openslide: passed ({})", getDefaultThumbnail(0, 0).toString());
 		} catch (IOException e) {
 			logger.error("Unable to read thumbnail using OpenSlide: {}", e.getLocalizedMessage());
 			throw(e);
 		}
+	}
+
+	private static Color findBackgroundColor(Map<String, String> properties, String[] args) {
+		// Try to get a background color
+		Color backgroundColor = null;
+		String bgProperty = properties.getOrDefault(OpenSlide.PROPERTY_NAME_BACKGROUND_COLOR, null);
+		if (bgProperty != null && !bgProperty.isBlank()) {
+			try {
+				// Update from properties, if available
+				backgroundColor = parseBackgroundColorFromString(bgProperty).orElse(backgroundColor);
+			} catch (Exception e) {
+				logger.warn("Exception parsing background color from property: {} ({})", bgProperty, e.getMessage(), e);
+			}
+		}
+
+		// Override background color using the args
+		try {
+			backgroundColor = parseColorFromArgs(args).orElse(backgroundColor);
+		} catch (Exception e) {
+			logger.warn("Exception parsing background color from args: {} ({})", Arrays.asList(args), e.getMessage(), e);
+		}
+		return backgroundColor == null ? DEFAULT_BACKGROUND_COLOR : backgroundColor;
 	}
 
 	private static Optional<Color> parseColorFromArgs(String[] args) {
@@ -292,7 +306,7 @@ public class OpenslideImageServer extends AbstractTileableImageServer {
 		return Optional.empty();
 	}
 
-	static Optional<Color> parseBackgroundColorFromString(String value) {
+	static Optional<Color> parseBackgroundColorFromString(String value) throws NumberFormatException {
 		if (value == null || value.isBlank())
 			return Optional.empty();
 		var val = value.strip();

--- a/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
+++ b/qupath-extension-openslide/src/main/java/qupath/lib/images/servers/openslide/OpenslideServerBuilder.java
@@ -4,7 +4,7 @@
  * %%
  * Copyright (C) 2014 - 2016 The Queen's University of Belfast, Northern Ireland
  * Contact: IP Management (ipmanagement@qub.ac.uk)
- * Copyright (C) 2018 - 2025 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -67,6 +67,11 @@ public class OpenslideServerBuilder implements ImageServerBuilder<BufferedImage>
      */
     private static final String ARG_ICC_PROFILE = "--icc-profile";
 
+	/**
+	 * Argument to use when specifying a background color (usually WHITE or BLACK).
+	 */
+	public static final String ARG_BACKGROUND_COLOR = "--background-color";
+
 
 	@Override
 	public ImageServer<BufferedImage> buildServer(URI uri, String...args) {
@@ -98,6 +103,7 @@ public class OpenslideServerBuilder implements ImageServerBuilder<BufferedImage>
 		return UriImageSupport.createInstance(this.getClass(), supportLevel,
                 DefaultImageServerBuilder.createInstance(this.getClass(), uri, args));
 	}
+
 
     /**
      * Update the string arguments to reflect any preferences requested by the user,


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/2151

Now the background value will be chosen using the following descending order of preference:

1. An optional string argument, in the format `--background-color=black` or `--background-color white` (i.e. with or without equals; valid values also include `red`, `green`, `blue` or a hex like `#ff2288`)
2. From `openslide.background-color` (a [recognized OpenSlide property](https://openslide.org/docs/properties/)
3. White (previously it default to black, on account of no background filling being performed)

This results in Argos sample images displaying properly with white backgrounds (the original problem), while mrxs OpenSlide samples appear to continue to display correctly. However, they can be coerced into displaying badly if you like, for example by passing `--background-color red` to see what it does

<img width="676" height="691" alt="image" src="https://github.com/user-attachments/assets/36077dca-c634-4d8e-af0b-102416cd4717" />
