### PR TITLE
Minor fixes

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/images/servers/LabeledImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/LabeledImageServer.java
@@ -218,7 +218,7 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 			}
 
 			if (params.grayscaleLut) {
-				if (maxLabel < 255)
+				if (maxLabel < 256)
 					colorModel = COLOR_MODEL_GRAY_UINT8;
 				else if (maxLabel < 65536){
 					colorModel = COLOR_MODEL_GRAY_UINT16;
@@ -335,10 +335,10 @@ public class LabeledImageServer extends AbstractTileableImageServer implements G
 		 * Previously, this was achieved with a UUID - although this looks strange if exporting classes.
 		 */
 //		private PathClass unannotatedClass = PathClassFactory.getPathClass("Unannotated " + UUID.randomUUID().toString());
-		private PathClass unannotatedClass = PathClass.getInstance("*Background*");
+		private PathClass unannotatedClass = PathClass.getInstance("*Background*", ColorTools.BLACK);
 
 		private Predicate<PathObject> objectFilter = PathObjectFilter.ANNOTATIONS;
-		private Function<PathObject, ROI> roiFunction = p -> p.getROI();
+		private Function<PathObject, ROI> roiFunction = PathObject::getROI;
 
 		private boolean createInstanceLabels = false;
 		private boolean shuffleInstanceLabels = true; // Only if using instance labels

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -3201,7 +3201,11 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 				var hierarchy = getHierarchy();
 				if (hierarchy != null) {
 					if (hierarchy.getSelectionModel().singleSelection()) {
-						GuiTools.promptToRemoveSelectedObject(hierarchy.getSelectionModel().getSelectedObject(), hierarchy);
+						// Handle case when there is no primary selected object
+						var selected = hierarchy.getSelectionModel().getSelectedObject();
+						if (selected == null)
+							selected = hierarchy.getSelectionModel().getSelectedObjects().stream().findFirst().orElse(null);
+						GuiTools.promptToRemoveSelectedObject(selected, hierarchy);
 					} else {
 						GuiTools.promptToClearAllSelectedObjects(getImageData());
 					}


### PR DESCRIPTION
Minor fixes for:
* Pressing `backspace` to delete a single selected object, whenever this wasn't flagged as the 'main' selected object
* Choosing a more sensible default color for the background class in `LabeledImageServer`