### PR TITLE
Improve point tool behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Removing child objects can give an unexpected exception in scripts (https://github.com/qupath/qupath/issues/2111)
 * Nested detections render poorly when filled (https://github.com/qupath/qupath/issues/2112)
 * 'Add shape features' wrongly gives 'Length µm' in pixels (https://github.com/qupath/qupath/issues/2158)
+* Adding single points can cause unhelpful 'empty' point annotations to remain (https://github.com/qupath/qupath/issues/2155)
 
 ### Dependency updates
 * Bio-Formats 8.5.0

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PointsToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PointsToolEventHandler.java
@@ -86,13 +86,16 @@ class PointsToolEventHandler extends AbstractPathToolEventHandler<MouseEvent> {
 		editor.resetActiveHandle();
 		
 		var currentObject = viewer.getSelectedObject();
-		viewer.getHierarchy().updateObject(currentObject, false);
-//		viewer.getHierarchy().fireHierarchyChangedEvent(this, vcurrentObject);
 
-//		// Find out the coordinates in the image domain & update the adjustment
-//		Point2D p = viewer.componentPointToImagePoint(e.getX(), e.getY(), null, false);
-//		points.finishAdjusting(p.getX(), p.getY(), e.isShiftDown());
-//		points.resetMeasurements();
+		// If in single-point mode and we've removed the only point, remove the object.
+		// Don't remove the object in multi-point mode, because in that case we may want to
+		// retain the object's properties (e.g., classification)
+		var hierarchy = viewer.getHierarchy();
+		if (points.isEmpty() && !PathPrefs.multipointToolProperty().get()) {
+			hierarchy.removeObject(currentObject, true);
+		} else {
+			viewer.getHierarchy().updateObject(currentObject, false);
+		}
 	}
 	
 	
@@ -150,9 +153,8 @@ class PointsToolEventHandler extends AbstractPathToolEventHandler<MouseEvent> {
 			if (points.getImagePlane().equals(viewerPlane)) {
 				ROI points2 = removeNearbyPoint(points, x, y, distance);
 				if (points != points2) {
-					((PathROIObject)currentObject).setROI(points2);
+					((PathROIObject) currentObject).setROI(points2);
 					hierarchy.updateObject(currentObject, false);
-	//				hierarchy.fireHierarchyChangedEvent(this, currentObject);
 					return true;
 				}
 			}
@@ -225,13 +227,14 @@ class PointsToolEventHandler extends AbstractPathToolEventHandler<MouseEvent> {
 		if (currentROI != null && currentROI.isPoint() && (currentROI.isEmpty() || currentROI.getImagePlane().equals(viewerPlane)))
 			points = currentROI;
 		
-		// If Alt is pressed, try to delete a point
 		if (e.isAltDown()) {
+			// If Alt is pressed, try to delete a point
 			handleAltClick(viewer, xx, yy, currentObject);
-		} 
-		// Create a new ROI if we've got Alt & Shift pressed - or we just don't have a point ROI
-		else if (points == null || !currentUnlocked || (!PathPrefs.multipointToolProperty().get() && !editor.grabHandle(xx, yy, radius, e.isShiftDown()))
+		} else if (points == null || !currentUnlocked
+				|| (!PathPrefs.multipointToolProperty().get() && !editor.grabHandle(xx, yy, radius, e.isShiftDown()) && points.getNumPoints() > 0)
 				|| (e.isShiftDown() && e.getClickCount() > 1)) {
+			// Create a new ROI if we've got Alt & Shift pressed - or we just don't have a point ROI
+
 			// PathPoints is effectively ready from the start - don't need to finalize
 			points = ROIs.createPointsROI(xx, yy, viewerPlane);
 			


### PR DESCRIPTION
Attempts to fix https://github.com/qupath/qupath/issues/2155

Integrates 2 changes that apply when using 'single point' annotation mode:
1. If the current selected annotation contains an empty `PointsROI` (i.e. it has 0 points), add a point to it instead of creating an entirely new annotation.
2. If the last point is removed with an alt-click, remove the entire annotation

Behavior when using 'multi-point' mode should be unchanged, because in that case we often *want* empty ROIs to remain. For example, when training a classifier based upon point annotations, it's helpful to initialize an empty points annotation with the appropriate class and then add to it. When doing this, we wouldn't want the annotation to disappear again because we changed our mind and deleted the first point we created.