### PR TITLE
Fix region request bug with the `path` is wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Version 0.8.0 (IN PROGRESS!)
 
 ### Enhancements
+* Much improved pixel classifier user interface (https://github.com/qupath/qupath/pull/2162)
+  * Calculate feature importance
+  * Calculate performance metrics using cross validation
+  * Support 3D feature calculations (for small-ish images!)
+  * Remember settings within a QuPath session
 * Improved brush and wand tools (https://github.com/qupath/qupath/pull/2125 https://github.com/qupath/qupath/pull/2126)
   * View the size of the brush, and adjust it by scrolling with `Alt` key pressed
   * Press `F` while drawing with the brush or wand to fill holes
@@ -18,6 +23,7 @@
 * Nested detections render poorly when filled (https://github.com/qupath/qupath/issues/2112)
 * 'Add shape features' wrongly gives 'Length µm' in pixels (https://github.com/qupath/qupath/issues/2158)
 * Adding single points can cause unhelpful 'empty' point annotations to remain (https://github.com/qupath/qupath/issues/2155)
+* Calling `ImageServer.readRegion(RegionRequest)` can return the wrong pixels if `RegionRequest.getPath()` is wrong (https://github.com/qupath/qupath/issues/2164) 
 
 ### Dependency updates
 * Bio-Formats 8.5.0

--- a/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
+++ b/qupath-core-processing/src/main/java/qupath/imagej/tools/IJTools.java
@@ -851,8 +851,11 @@ public class IJTools {
 	 * @throws IOException 
 	 */
 	public static PathImage<ImagePlus> convertToImagePlus(String title, ImageServer<BufferedImage> server, BufferedImage img, RegionRequest request) throws IOException {
-		if (img == null)
-			img = server.readRegion(request);
+		if (img == null) {
+			// Read region, updating the path in case the wrong one was provided
+			// (and we might inadvertently get inappropriate cached tiles)
+			img = server.readRegion(request.updatePath(server.getPath()));
+		}
 		ImagePlus imp = convertToUncalibratedImagePlus(title, img);
 		// Set dimensions - because RegionRequest is only 2D, every 'slice' is a channel
 		imp.setDimensions(imp.getStackSize(), 1, 1);
@@ -862,10 +865,11 @@ public class IJTools {
 			if (sampleModel.getNumBands() > 1) {
 				CompositeImage impComp = imp.isRGB() ? (CompositeImage) CompositeConverter.makeComposite(imp) : new CompositeImage(imp, CompositeImage.COMPOSITE);
 				for (int b = 0; b < sampleModel.getNumBands(); b++) {
+					var channel = server.getChannel(b);
 					impComp.setChannelLut(
 							LUT.createLutFromColor(
-									new Color(server.getChannel(b).getColor())), b + 1);
-					impComp.getStack().setSliceLabel(server.getChannel(b).getName(), b + 1);
+									new Color(channel.getColor())), b + 1);
+					impComp.getStack().setSliceLabel(channel.getName(), b + 1);
 				}
 				impComp.updateAllChannelsAndDraw();
 				impComp.resetDisplayRanges();

--- a/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
+++ b/qupath-core/src/main/java/qupath/lib/images/servers/AbstractTileableImageServer.java
@@ -262,7 +262,7 @@ public abstract class AbstractTileableImageServer extends AbstractImageServer<Bu
 		// Check if we already have a tile for precisely this occasion - with the right server path
 		// Make a defensive copy, since the cache is critical
 		var cache = getCache();
-		var currentPath = request.getPath();
+		var currentPath = getPath();
 		if (request.getPath().equals(currentPath) && cache != null) {
 			BufferedImage img = cache.getOrDefault(request, null);
 			if (img != null)


### PR DESCRIPTION
Fix https://github.com/qupath/qupath/issues/2164

This includes 2 fixes: one when requesting tiles via ImageJ, and one inside `AbstractTileableImageServer`.

Probably only the second fix is required, but I hadn't figured that out at the time of making the first fix.