### PR TITLE
Simplify use of include-extra

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 import org.apache.tools.ant.taskdefs.condition.Os
+import java.nio.file.Paths
 
 pluginManagement {
     plugins {
@@ -203,7 +204,19 @@ fun handleExtensionConfig(file: File) {
             "[includeFlat]" -> search = searchIncludeFlat
             "[dependencies]" -> search = searchDependencies
             else -> {
-                when (search) {
+                var localSearch = search
+                // If what we're searching for isn't specified, figure it out
+                // This can simplify the include-extras file layout
+                if (localSearch == searchNothing) {
+                    if (File(line).exists()) {
+                        localSearch = searchIncludeBuild
+                    } else if (File(rootDir, "../" + line).exists()) {
+                        localSearch = searchIncludeFlat
+                    } else if (line.contains(":", ignoreCase = false)) {
+                        localSearch = searchDependencies
+                    }
+                }
+                when (localSearch) {
                     searchIncludeBuild -> includeBuild(line)
                     searchIncludeFlat -> includeFlat(line)
                     searchDependencies -> dependenciesToAdd.add(line)


### PR DESCRIPTION
Support for an `include-extra` file made it easier to set up QuPath for extension development: https://github.com/qupath/qupath/pull/1710

The contents might look like this:
```
[includeBuild]
../qupath-extension-djl

[dependencies]
io.github.qupath:qupath-extension-djl
```

The `[includeBuild]` is needed to include the build (naturally), but this alone wouldn't get the extension picked up properly within QuPath. That's where `[dependencies]` was required.

The trouble is that the need for 2 lines added in 2 different sections is annoying if you have a long list of extensions.

This PR makes it possible to dispense with the sections, and instead use
```
../qupath-extension-djl
io.github.qupath:qupath-extension-djl
```

Basically, we try to figure out whether a line refers to something for `includeBuild`, `dependencies` or (rarely-used) `includeFlat`, by checking for the existing of a file/directory and (if not found) presence of a `:`.

The old strategy of using sections should still work (if you want to avoid the guesswork), but I think the new strategy is handy for me at least. I tend to have a long list of all my extensions inside `include-extras.properties`, then comment out the ones I don't currently need.. and doing this in 2 consecutive lines is much easier than finding the corresponding lines in 2 separate sections.