### PR TITLE
Use width and height for overview size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * 'Add shape features' wrongly gives 'Length µm' in pixels (https://github.com/qupath/qupath/issues/2158)
 * Adding single points can cause unhelpful 'empty' point annotations to remain (https://github.com/qupath/qupath/issues/2155)
 * Calling `ImageServer.readRegion(RegionRequest)` can return the wrong pixels if `RegionRequest.getPath()` is wrong (https://github.com/qupath/qupath/issues/2164) 
+* The image overview doesn't rescale for very 'tall' images (https://github.com/qupath/qupath/issues/2163)
 
 ### Dependency updates
 * Bio-Formats 8.5.0

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ImageOverview.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/ImageOverview.java
@@ -54,7 +54,7 @@ class ImageOverview implements QuPathViewerListener {
 
 	private QuPathViewer viewer;
 	
-	private Canvas canvas = new Canvas();
+	private final Canvas canvas = new Canvas();
 		
 	private boolean repaintRequested = false;
 
@@ -72,13 +72,13 @@ class ImageOverview implements QuPathViewerListener {
 	private BufferedImage imgLastThumbnail; // The last thumbnail the viewer gave us
 	private WritableImage imgPreview;       // The (probably downsampled) preview version
 
-	private int preferredWidth = 150; // Preferred component/image width - used for thumbnail scaling
+	private int maxLength = 150; // Maximum component width or height - used for thumbnail scaling
 
 	private Shape shapeVisible = null; // The visible shape (transformed already)
 	private AffineTransform transform;
 	
-	private static Color color = Color.rgb(200, 0, 0, .8);
-	private static Color colorBorder = Color.rgb(64, 64, 64);
+	private static final Color color = Color.rgb(200, 0, 0, .8);
+	private static final Color colorBorder = Color.rgb(64, 64, 64);
 
 	protected void mouseViewerToLocation(double x, double y) {
 		ImageServer<BufferedImage> server = viewer.getServer();
@@ -168,8 +168,6 @@ class ImageOverview implements QuPathViewerListener {
 					logger.debug("Unknown PathIterator type: {}", type);
 				iterator.next();
 			}
-			
-//			g2d.draw(shapeVisible);
 		}
 		
 		// Draw border
@@ -204,7 +202,9 @@ class ImageOverview implements QuPathViewerListener {
 		if (img == null) {
 			imgLastThumbnail = null;
 		} else {
-			int preferredHeight = (int)(img.getHeight() * (double)(preferredWidth / (double)img.getWidth()));
+			double scale = (double)maxLength / Math.max(img.getWidth(), img.getHeight());
+			int preferredWidth = (int)Math.round(img.getWidth() * scale);
+			int preferredHeight = (int)Math.round(img.getHeight() * scale);
 			
 			imgPreview = GuiTools.getScaledRGBInstance(img, preferredWidth, preferredHeight);
 


### PR DESCRIPTION
Fixes https://github.com/qupath/qupath/issues/2163

The behavior of *Edit → Copy to clipboard → Current viewer* was even worse than I had realised...

## Before the PR
<img width="795" height="899" alt="image" src="https://github.com/user-attachments/assets/724ae105-6e03-4aab-872f-7a304ecf3190" />

## After the PR
<img width="794" height="480" alt="image" src="https://github.com/user-attachments/assets/4adef06c-36c7-4e39-bfbd-60311fcbcabb" />
