### PR TITLE
Avoid implicit narrowing conversions

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/lib/analysis/features/LocalBinaryPatterns.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/analysis/features/LocalBinaryPatterns.java
@@ -233,7 +233,7 @@ public class LocalBinaryPatterns {
         double w4 =      tx  *      ty;
         // Compute the value
         // By checking weights first, this avoids requesting out-of-image pixels (assuming x & y were ok)
-        float value = 0;
+        double value = 0;
         if (w1 > 0)
         	value += w1*img.getValue(fx, fy);
         if (w2 > 0)
@@ -242,7 +242,7 @@ public class LocalBinaryPatterns {
         	value += w3*img.getValue(fx, cy);
         if (w4 > 0)
         	value += w4*img.getValue(cx, cy);
-        return value;
+        return (float)value;
 	}
 	
 	

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
@@ -318,7 +318,7 @@ public class SmoothFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 				// Update the class weights for both objects currently being tested
 				// Compute weight based on centroid distances
 //				double weight = Math.exp(-distSq/sigma2);
-				double weight = distanceWeights[(int)(Math.sqrt(distSq) + .5)];// * pathObjects.get(j).getClassProbability();
+				float weight = (float)distanceWeights[(int)(Math.sqrt(distSq) + .5)];// * pathObjects.get(j).getClassProbability();
 				float [] temp = measurementValues[j];
 				float [] tempWeighted = measurementsWeighted[j];
 				float [] tempDenominator = measurementDenominators[j];

--- a/qupath-core/src/test/java/qupath/lib/images/servers/TestColorTransforms.java
+++ b/qupath-core/src/test/java/qupath/lib/images/servers/TestColorTransforms.java
@@ -193,7 +193,7 @@ public class TestColorTransforms {
                             .toList()
                             .indexOf(entry.getKey());
 
-                    expectedPixels[y*image.getWidth() + x] += entry.getValue() * SampleImageServer.getPixel(x, y, channelIndex);
+                    expectedPixels[y*image.getWidth() + x] += (float)(entry.getValue() * SampleImageServer.getPixel(x, y, channelIndex));
                 }
             }
         }
@@ -264,7 +264,7 @@ public class TestColorTransforms {
         for (int y=0; y<image.getHeight(); y++) {
             for (int x=0; x<image.getWidth(); x++) {
                 for (int i=0; i<coefficients.size(); i++) {
-                    expectedPixels[y*image.getWidth() + x] += coefficients.get(i) * SampleImageServer.getPixel(x, y, i);
+                    expectedPixels[y*image.getWidth() + x] += (float)(coefficients.get(i) * SampleImageServer.getPixel(x, y, i));
                 }
             }
         }
@@ -331,7 +331,7 @@ public class TestColorTransforms {
         for (int y=0; y<image.getHeight(); y++) {
             for (int x=0; x<image.getWidth(); x++) {
                 for (int i=0; i<coefficients.length; i++) {
-                    expectedPixels[y*image.getWidth() + x] += coefficients[i] * SampleImageServer.getPixel(x, y, i);
+                    expectedPixels[y*image.getWidth() + x] += (float)(coefficients[i] * SampleImageServer.getPixel(x, y, i));
                 }
             }
         }
@@ -379,7 +379,7 @@ public class TestColorTransforms {
         for (int y=0; y<image.getHeight(); y++) {
             for (int x=0; x<image.getWidth(); x++) {
                 for (int c=0; c<sampleServer.nChannels(); c++) {
-                    expectedPixels[y*image.getWidth() + x] += SampleImageServer.getPixel(x, y, c);
+                    expectedPixels[y*image.getWidth() + x] += (float)SampleImageServer.getPixel(x, y, c);
                 }
                 expectedPixels[y*image.getWidth() + x] /= sampleServer.nChannels();
             }

--- a/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriter.java
+++ b/qupath-extension-bioformats/src/main/java/qupath/lib/images/writers/ome/OMEPyramidWriter.java
@@ -307,8 +307,8 @@ public class OMEPyramidWriter {
 				if (!bigTiff && !noBigTiff && Boolean.FALSE.equals(temp.bigTiff))
 					noBigTiff = true;
 				for (double d : temp.downsamples) {
-					nPixelBytes += ((long)Math.ceil(temp.width / d) * Math.ceil(temp.height / d) 
-							* temp.channels.length 
+					nPixelBytes += (long)(Math.ceil(temp.width / d) * Math.ceil(temp.height / d)
+							* temp.channels.length
 							* temp.getExportPixelType().getBytesPerPixel() 
 							* (temp.tEnd - temp.tStart)
 							* (temp.zEnd - temp.zStart));


### PR DESCRIPTION
When converting `double` to `float` or to `long`, make the conversions explicit.