### PR TITLE
Fix TMASummaryViewer predicate support

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/tma/TMASummaryViewer.java
@@ -2168,7 +2168,7 @@ public class TMASummaryViewer {
 			this.commandOriginal = predicate;
 			String quotedRegex = "\"([^\"]*)\"";
 			String test = predicate.replaceAll(quotedRegex, "");
-			isValid = test.replaceAll("[ ()+-<>=*/&|!]", "").trim().isEmpty(); // Check we don't have invalid characters
+			isValid = test.replaceAll("[() +0-9,:;<>=*/&|!\\-.]", "").trim().isEmpty(); // Check we don't have invalid characters
 			
 			if (isValid) {
 				this.command = predicate.replaceAll(quotedRegex, "entry.getMeasurementAsDouble(\"$1\")").trim();
@@ -2178,7 +2178,10 @@ public class TMASummaryViewer {
 			
 			
 			ScriptEngineManager manager = new ScriptEngineManager();
-	        engine = manager.getEngineByName("JavaScript");
+			// Switched from JavaScript, since is no longer bundled
+			engine = manager.getEngineByName("Groovy");
+			if (engine == null)
+				throw new RuntimeException("No Groovy engine found!");
 	        engine.setBindings(bindings, ScriptContext.GLOBAL_SCOPE);
 		}
 


### PR DESCRIPTION
It was broken ever since JavaScript support was dropped, so presumably this wasn't being widely used.

The screenshot below shows the way in which the predicate can be applied:

<img width="841" height="216" alt="Regex-debugging" src="https://github.com/user-attachments/assets/55001d4d-3a3d-436d-83de-df51a2090de0" />
