### PR TITLE
Update path class list with colors change, ensure ImageRenderer applied

### DIFF
--- a/qupath-core/src/main/java/qupath/lib/color/ColorModelFactory.java
+++ b/qupath-core/src/main/java/qupath/lib/color/ColorModelFactory.java
@@ -109,7 +109,7 @@ public final class ColorModelFactory {
      * @param includeAlpha if true, allow alpha values to be included in the colormap
      * @return
      */
-    public static ColorModel createIndexedColorModel(Map<Integer, Integer> labelColors, boolean includeAlpha) {
+    public static IndexColorModel createIndexedColorModel(Map<Integer, Integer> labelColors, boolean includeAlpha) {
     	var stats = labelColors.keySet().stream().mapToInt(c -> c).summaryStatistics();
     	if (stats.getMin() < 0)
     		throw new IllegalArgumentException("Minimum label must be >= 0");

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/PathClassPane.java
@@ -903,6 +903,10 @@ class PathClassPane {
 					pathClass.setColor(rgb);
 					var qupath = QuPathGUI.getInstance();
 					if (qupath != null) {
+						// Update the class list (even though entries are unchanged) - this notifies listeners
+						var available = List.copyOf(qupath.getAvailablePathClasses());
+						qupath.getAvailablePathClasses().setAll(available);
+
 						// TODO: Consider whether project class list needs to be updated
 						for (var viewer : qupath.getAllViewers()) {
 							// Technically we only need to repaint the viewers, but we need to ensure that

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/PixelClassificationOverlay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/overlays/PixelClassificationOverlay.java
@@ -501,10 +501,11 @@ public class PixelClassificationOverlay extends AbstractImageOverlay  {
 		 // but live measurements are not made (because the actual prediction tiles are no longer in the cache)
     	var img = server.getCachedTile(request);
         if (img != null) {
-            if (img.getType() == BufferedImage.TYPE_INT_ARGB ||
+            if (renderer.get() == null &&
+					(img.getType() == BufferedImage.TYPE_INT_ARGB ||
             		img.getType() == BufferedImage.TYPE_INT_RGB ||
             		img.getType() == BufferedImage.TYPE_BYTE_INDEXED ||
-            		img.getType() == BufferedImage.TYPE_BYTE_GRAY) {
+            		img.getType() == BufferedImage.TYPE_BYTE_GRAY)) {
 				// Return tile if it is already renderable
                 return img;
             } else {


### PR DESCRIPTION
Minor adjustments that make it possible to create pixel classification overlays that update immediately when class colors change.

(The default overlays when training a pixel classifier don't use this yet)