### PR TITLE
Fix overlay clip for curtain effect

### DIFF
--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -1939,6 +1939,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 		Graphics2D gOverlay = imgOverlay.createGraphics();
 		gOverlay.setBackground(new Color(0, true));
 		gOverlay.clearRect(0, 0, imgOverlay.getWidth(), imgOverlay.getHeight());
+		gOverlay.setClip(0, 0, imgOverlay.getWidth(), imgOverlay.getHeight());
 		gOverlay.transform(transform);
 
 		float opacity = overlayOptions.getOpacity();


### PR DESCRIPTION
Enough time has passed since I fixed this that I can't remember exactly *what* was wrong before, but I believe it was a regression associated with the curtain effect that turned up with some overlays.