### PR TITLE
Add rotated ridge filters to `ImageOps`

### DIFF
--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -1334,9 +1334,9 @@ public class ImageOps {
 						case MIN -> Scalar.all(Double.POSITIVE_INFINITY);
 						case MAX -> Scalar.all(Double.NEGATIVE_INFINITY);
 					};
-					output.add(
-							new Mat(input.rows(), input.cols(), outputType, fill)
-					);
+					var temp = new Mat(input.rows(), input.cols(), outputType, fill);
+					temp.retainReference();
+					output.add(temp);
 					fill.close();
 				}
 
@@ -1396,8 +1396,11 @@ public class ImageOps {
 						var temp = firstKernel.clone();
 						opencv_imgproc.warpAffine(firstKernel, temp, affine, firstKernel.size());
 						kernels.add(temp);
-//						OpenCVTools.matToImagePlus("Rot " + Math.toDegrees(theta), temp).show();
 					}
+				}
+				// Don't garbage collect too quickly
+				for (var k : kernels) {
+					k.retainReference();
 				}
 				return kernels;
 			}

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -1127,7 +1127,10 @@ public class ImageOps {
 		 * @return
 		 */
 		public static ImageOp rotatedRidge(double sigmaWidth, double sigmaLength, int nRotations, RidgeProjections... projections) {
-			return new RotatedFilterFeatureOp(sigmaWidth, sigmaLength, nRotations, projections);
+			return new RotatedFilterFeatureOp(
+					new RotatedFilterFeatureOp.GaussianDerivative(sigmaWidth, 2),
+					new RotatedFilterFeatureOp.GaussianDerivative(sigmaLength, 0),
+					nRotations, projections);
 		}
 		
 		/**
@@ -1304,23 +1307,31 @@ public class ImageOps {
 		@OpType("rotated-ridge")
 		static class RotatedFilterFeatureOp extends PaddedOp {
 
-			private double sigmaWidth;
-			private double sigmaLength;
+			private record GaussianDerivative(double sigma, int order) {}
+
+			private GaussianDerivative filterWidth;
+			private GaussianDerivative filterLength;
 			private int nRotations;
 			private List<RidgeProjections> projections;
 			private transient List<Mat> kernels;
 
-			RotatedFilterFeatureOp(double sigmaWidth, double sigmaLength, int nRotations, RidgeProjections... projections) {
-				if (sigmaWidth <= 0)
-					throw new IllegalArgumentException("sigmaWidth must be > 0");
-				if (sigmaLength <= 0)
-					throw new IllegalArgumentException("sigmaLength must be > 0");
+			RotatedFilterFeatureOp(GaussianDerivative filterWidth, GaussianDerivative filterLength, int nRotations, RidgeProjections... projections) {
+				this.filterWidth = validateFilter(filterWidth);
+				this.filterLength = validateFilter(filterLength);
 				if (nRotations < 1)
 					throw new IllegalArgumentException("nRotations must be > 1");
-				this.sigmaWidth = sigmaWidth;
-				this.sigmaLength = sigmaLength;
 				this.nRotations = nRotations;
 				this.projections = projections.length == 0 ? List.of(RidgeProjections.values()) : List.of(projections);
+			}
+
+			private static GaussianDerivative validateFilter(GaussianDerivative filter) {
+				if (filter == null)
+					throw new IllegalArgumentException("Filter must not be null");
+				if (filter.sigma() <= 0)
+					throw new IllegalArgumentException("Sigma must be > 0, not " + filter.sigma());
+				if (filter.order() < 0)
+					throw new IllegalArgumentException("Order must be >= 0, not " + filter.order());
+				return filter;
 			}
 
 			@Override
@@ -1385,7 +1396,6 @@ public class ImageOps {
 						transform.setToIdentity();
 						transform.rotate(theta, anchorX, anchorY);
 						try (FloatIndexer idx = affine.createIndexer()) {
-							// TODO: Check if this returns elements in the required order! If not, transpose
 							idx.put(0, 0, (float)transform.getScaleX());
 							idx.put(0, 1, (float)transform.getShearX());
 							idx.put(0, 2, (float)transform.getTranslateX());
@@ -1406,7 +1416,7 @@ public class ImageOps {
 			}
 
 			private double getMaxSigma() {
-				return Math.max(sigmaWidth, sigmaLength);
+				return Math.max(filterWidth.sigma(), filterLength.sigma());
 			}
 
 			private Mat createFirstKernel() {
@@ -1416,8 +1426,8 @@ public class ImageOps {
 				try (DoubleIndexer idx = mat.createIndexer()) {
 					// Use -1 to get positive values for 'bright' ridges, negative values for 'dark' ridges
 					idx.put(size/2, size/2, -1.0);
-					try (var kx = OpenCVTools.getGaussianDerivKernel(sigmaWidth, 2, false)) {
-						try (var ky = OpenCVTools.getGaussianDerivKernel(sigmaLength, 0, true)) {
+					try (var kx = OpenCVTools.getGaussianDerivKernel(filterWidth.sigma(), filterWidth.order(), false)) {
+						try (var ky = OpenCVTools.getGaussianDerivKernel(filterLength.sigma(), filterLength.order(), true)) {
 							opencv_imgproc.sepFilter2D(mat, mat, mat.depth(), kx, ky);
 						}
 					}
@@ -1432,12 +1442,12 @@ public class ImageOps {
 
 			public List<ImageChannel> getChannels(List<ImageChannel> channels) {
 				List<ImageChannel> output = new ArrayList<>();
-				String name = "%s (%s %d rotations, sigma=[%f,%f]";
+				String name = "%s (%s %d rotations, sigma=[%.2f,%.2f], order=[%d,%d]";
 				for (var proj : projections) {
 					for (var c : channels) {
 						output.add(ImageChannel.getInstance(
 								String.format(name, c.getName(), proj.toString().toLowerCase(),
-													nRotations, sigmaWidth, sigmaLength),
+													nRotations, filterWidth.sigma(), filterLength.sigma(), filterWidth.order(), filterLength.order()),
 								c.getColor()));
 					}
 				}

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -21,6 +21,7 @@
 
 package qupath.opencv.ops;
 
+import java.awt.geom.AffineTransform;
 import org.apache.commons.math3.util.FastMath;
 import org.bytedeco.javacpp.PointerScope;
 import org.bytedeco.javacpp.indexer.DoubleIndexer;
@@ -1259,6 +1260,123 @@ public class ImageOps {
 			}
 			
 			
+		}
+
+		@OpType("rotatedFilter")
+		static class RotatedFilterFeatureOp extends PaddedOp {
+
+			private double sigmaX;
+			private double sigmaY;
+			private int nRotations;
+			private transient List<Mat> kernels;
+
+			RotatedFilterFeatureOp(double sigmaX, double sigmaY, int nRotations) {
+				this.sigmaX = sigmaX;
+				this.sigmaY = sigmaY;
+				this.nRotations = nRotations;
+			}
+
+			@Override
+			public List<Mat> transformPadded(Mat input) {
+				var outputType = input.depth() == opencv_core.CV_64F ? input.type() : opencv_core.CV_32FC(OpenCVTools.typeToChannels(input.type()));
+				var min = new Mat(input.rows(), input.cols(), outputType, Scalar.all(Double.POSITIVE_INFINITY));
+				var max = new Mat(input.rows(), input.cols(), outputType, Scalar.all(Double.NEGATIVE_INFINITY));
+				try (var temp = new Mat()) {
+					for (var k : getKernels()) {
+						opencv_imgproc.filter2D(input, temp, outputType, k);
+						opencv_core.min(min, temp, min);
+						opencv_core.max(max, temp, max);
+					}
+				}
+				return List.of(min, max);
+			}
+
+			private List<Mat> getKernels() {
+				if (kernels == null || kernels.size() < nRotations || kernels.stream().anyMatch(m -> m.isNull())) {
+					synchronized (this) {
+						if (kernels == null) {
+							kernels = createKernels();
+						}
+					}
+				}
+				return kernels;
+			}
+
+			private List<Mat> createKernels() {
+				var firstKernel = createFirstKernel();
+				List<Mat> kernels = new ArrayList<>();
+				kernels.add(firstKernel);
+				var transform = new AffineTransform();
+				int anchorX = firstKernel.cols() / 2;
+				int anchorY = firstKernel.rows() / 2;
+				try (var affine = new Mat(2, 3, opencv_core.CV_32F)) {
+					for (int rot = 1; rot < nRotations; rot++) {
+						double theta = Math.PI / nRotations * rot;
+						transform.setToIdentity();
+						transform.rotate(theta, anchorX, anchorY);
+						try (FloatIndexer idx = affine.createIndexer()) {
+							// TODO: Check if this returns elements in the required order! If not, transpose
+							idx.put(0, 0, (float)transform.getScaleX());
+							idx.put(0, 1, (float)transform.getShearX());
+							idx.put(0, 2, (float)transform.getTranslateX());
+							idx.put(1, 0, (float)transform.getShearY());
+							idx.put(1, 1, (float)transform.getScaleY());
+							idx.put(1, 2, (float)transform.getTranslateY());
+						}
+						var temp = firstKernel.clone();
+						opencv_imgproc.warpAffine(firstKernel, temp, affine, firstKernel.size());
+						kernels.add(temp);
+//						OpenCVTools.matToImagePlus("Rot " + Math.toDegrees(theta), temp).show();
+					}
+				}
+				return kernels;
+			}
+
+			private Mat createFirstKernel() {
+				double maxSigma = Math.max(sigmaX, sigmaY);
+				int size = (int)Math.ceil(maxSigma * 4) * 2 + 1;
+				var mat = new Mat(size, size, opencv_core.CV_64FC1, Scalar.ZERO);
+				int orderX = sigmaX < sigmaY ? 2 : 0;
+				int orderY = orderX == 2 ? 0 : 2;
+				try (DoubleIndexer idx = mat.createIndexer()) {
+					idx.put(size/2, size/2, 1.0);
+					try (var kx = OpenCVTools.getGaussianDerivKernel(sigmaX, orderX, false)) {
+						try (var ky = OpenCVTools.getGaussianDerivKernel(sigmaY, orderY, true)) {
+							opencv_imgproc.sepFilter2D(mat, mat, mat.depth(), kx, ky);
+						}
+					}
+				}
+				return mat;
+			}
+
+			@Override
+			public PixelType getOutputType(PixelType pixelType) {
+				return pixelType.isFloatingPoint() ? pixelType : PixelType.FLOAT32;
+			}
+
+			public List<ImageChannel> getChannels(List<ImageChannel> channels) {
+				List<ImageChannel> output = new ArrayList<>();
+				String name = "%s (%s %d rotations, sigma=[%f,%f]";
+				for (var c : channels) {
+					output.add(ImageChannel.getInstance(
+							String.format(name, c.getName(), "min", nRotations, sigmaX, sigmaY),
+							c.getColor()));
+				}
+				for (var c : channels) {
+					output.add(ImageChannel.getInstance(
+							String.format(name, c.getName(), "max", nRotations, sigmaX, sigmaY),
+							c.getColor()));
+				}
+				return output;
+			}
+
+
+			@Override
+			protected Padding calculatePadding() {
+				double sigmaMax = Math.max(sigmaX, sigmaY);
+				return getDefaultGaussianPadding(sigmaMax, sigmaMax);
+			}
+
 		}
 		
 		

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -2,7 +2,7 @@
  * #%L
  * This file is part of QuPath.
  * %%
- * Copyright (C) 2018 - 2020 QuPath developers, The University of Edinburgh
+ * Copyright (C) 2018 - 2026 QuPath developers, The University of Edinburgh
  * %%
  * QuPath is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -1090,6 +1090,45 @@ public class ImageOps {
 		public static ImageOp features(Collection<MultiscaleFeature> features, double sigmaX, double sigmaY) {
 			return new MultiscaleFeatureOp(features, sigmaX, sigmaY);
 		}
+
+		/**
+		 * Enum giving ways to combine rotated ridge images.
+		 */
+		public enum RidgeProjections {
+			/**
+			 * Calculate the minimum pixel value across rotations.
+			 */
+			MIN,
+			/**
+			 * Calculate the maximum pixel value across rotations.
+			 */
+			MAX
+		}
+
+		/**
+		 * Apply a ridge-enhancing filter rotated at different orientations, projecting the result onto one or more outputs.
+		 * @param sigmaWidth sigma value for the estimated ridge width; a second order Gaussian derivative would be calculated
+		 * @param projections optional array of projections.
+		 *                    If not set, all projections will be used.
+		 * @return
+		 */
+		public static ImageOp rotatedRidge(double sigmaWidth, RidgeProjections... projections) {
+			return rotatedRidge(sigmaWidth, sigmaWidth * 4,12, projections);
+		}
+
+		/**
+		 * Apply a ridge-enhancing filter rotated at different orientations, projecting the result onto one or more outputs.
+		 * @param sigmaWidth sigma value for the estimated ridge width; a second order Gaussian derivative would be calculated
+		 * @param sigmaLength sigma value for the filter length; this is usually &gt; sigmaWidth and relates to the ridge tortuosity
+		 *                    (for ridges with infrequent changes in orientations, a higher value may be used)
+		 * @param nRotations number of rotations to calculate (typically 8-12)
+		 * @param projections optional array of projections.
+		 *                    If not set, all projections will be used.
+		 * @return
+		 */
+		public static ImageOp rotatedRidge(double sigmaWidth, double sigmaLength, int nRotations, RidgeProjections... projections) {
+			return new RotatedFilterFeatureOp(sigmaWidth, sigmaLength, nRotations, projections);
+		}
 		
 		/**
 		 * Apply a 2D maximum filter.
@@ -1262,33 +1301,64 @@ public class ImageOps {
 			
 		}
 
-		@OpType("rotatedFilter")
+		@OpType("rotated-ridge")
 		static class RotatedFilterFeatureOp extends PaddedOp {
 
-			private double sigmaX;
-			private double sigmaY;
+			private double sigmaWidth;
+			private double sigmaLength;
 			private int nRotations;
+			private List<RidgeProjections> projections;
 			private transient List<Mat> kernels;
 
-			RotatedFilterFeatureOp(double sigmaX, double sigmaY, int nRotations) {
-				this.sigmaX = sigmaX;
-				this.sigmaY = sigmaY;
+			RotatedFilterFeatureOp(double sigmaWidth, double sigmaLength, int nRotations, RidgeProjections... projections) {
+				if (sigmaWidth <= 0)
+					throw new IllegalArgumentException("sigmaWidth must be > 0");
+				if (sigmaLength <= 0)
+					throw new IllegalArgumentException("sigmaLength must be > 0");
+				if (nRotations < 1)
+					throw new IllegalArgumentException("nRotations must be > 1");
+				this.sigmaWidth = sigmaWidth;
+				this.sigmaLength = sigmaLength;
 				this.nRotations = nRotations;
+				this.projections = projections.length == 0 ? List.of(RidgeProjections.values()) : List.of(projections);
 			}
 
 			@Override
 			public List<Mat> transformPadded(Mat input) {
 				var outputType = input.depth() == opencv_core.CV_64F ? input.type() : opencv_core.CV_32FC(OpenCVTools.typeToChannels(input.type()));
-				var min = new Mat(input.rows(), input.cols(), outputType, Scalar.all(Double.POSITIVE_INFINITY));
-				var max = new Mat(input.rows(), input.cols(), outputType, Scalar.all(Double.NEGATIVE_INFINITY));
+
+				// Preallocate output
+				List<Mat> output = new ArrayList<>(projections.size());
+				for (var proj : projections) {
+					Scalar fill = switch(proj) {
+						case MIN -> Scalar.all(Double.POSITIVE_INFINITY);
+						case MAX -> Scalar.all(Double.NEGATIVE_INFINITY);
+					};
+					output.add(
+							new Mat(input.rows(), input.cols(), outputType, fill)
+					);
+					fill.close();
+				}
+
 				try (var temp = new Mat()) {
 					for (var k : getKernels()) {
 						opencv_imgproc.filter2D(input, temp, outputType, k);
-						opencv_core.min(min, temp, min);
-						opencv_core.max(max, temp, max);
+						int ind = 0;
+						for (var proj : projections) {
+							Mat tempOutput = output.get(ind);
+							switch (proj) {
+                                case MIN -> {
+									opencv_core.min(tempOutput, temp, tempOutput);
+								}
+								case MAX -> {
+									opencv_core.max(tempOutput, temp, tempOutput);
+								}
+							}
+							ind++;
+						}
 					}
 				}
-				return List.of(min, max);
+				return List.copyOf(output);
 			}
 
 			private List<Mat> getKernels() {
@@ -1332,16 +1402,19 @@ public class ImageOps {
 				return kernels;
 			}
 
+			private double getMaxSigma() {
+				return Math.max(sigmaWidth, sigmaLength);
+			}
+
 			private Mat createFirstKernel() {
-				double maxSigma = Math.max(sigmaX, sigmaY);
+				double maxSigma = getMaxSigma();
 				int size = (int)Math.ceil(maxSigma * 4) * 2 + 1;
 				var mat = new Mat(size, size, opencv_core.CV_64FC1, Scalar.ZERO);
-				int orderX = sigmaX < sigmaY ? 2 : 0;
-				int orderY = orderX == 2 ? 0 : 2;
 				try (DoubleIndexer idx = mat.createIndexer()) {
-					idx.put(size/2, size/2, 1.0);
-					try (var kx = OpenCVTools.getGaussianDerivKernel(sigmaX, orderX, false)) {
-						try (var ky = OpenCVTools.getGaussianDerivKernel(sigmaY, orderY, true)) {
+					// Use -1 to get positive values for 'bright' ridges, negative values for 'dark' ridges
+					idx.put(size/2, size/2, -1.0);
+					try (var kx = OpenCVTools.getGaussianDerivKernel(sigmaWidth, 2, false)) {
+						try (var ky = OpenCVTools.getGaussianDerivKernel(sigmaLength, 0, true)) {
 							opencv_imgproc.sepFilter2D(mat, mat, mat.depth(), kx, ky);
 						}
 					}
@@ -1357,15 +1430,13 @@ public class ImageOps {
 			public List<ImageChannel> getChannels(List<ImageChannel> channels) {
 				List<ImageChannel> output = new ArrayList<>();
 				String name = "%s (%s %d rotations, sigma=[%f,%f]";
-				for (var c : channels) {
-					output.add(ImageChannel.getInstance(
-							String.format(name, c.getName(), "min", nRotations, sigmaX, sigmaY),
-							c.getColor()));
-				}
-				for (var c : channels) {
-					output.add(ImageChannel.getInstance(
-							String.format(name, c.getName(), "max", nRotations, sigmaX, sigmaY),
-							c.getColor()));
+				for (var proj : projections) {
+					for (var c : channels) {
+						output.add(ImageChannel.getInstance(
+								String.format(name, c.getName(), proj.toString().toLowerCase(),
+													nRotations, sigmaWidth, sigmaLength),
+								c.getColor()));
+					}
 				}
 				return output;
 			}
@@ -1373,7 +1444,7 @@ public class ImageOps {
 
 			@Override
 			protected Padding calculatePadding() {
-				double sigmaMax = Math.max(sigmaX, sigmaY);
+				double sigmaMax = getMaxSigma();
 				return getDefaultGaussianPadding(sigmaMax, sigmaMax);
 			}
 

--- a/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/ops/ImageOps.java
@@ -1102,7 +1102,11 @@ public class ImageOps {
 			/**
 			 * Calculate the maximum pixel value across rotations.
 			 */
-			MAX
+			MAX,
+			/**
+			 * Take the pixel with the largest absolute value, retaining the original sign.
+			 */
+			MAX_ABS
 		}
 
 		/**
@@ -1344,6 +1348,7 @@ public class ImageOps {
 					Scalar fill = switch(proj) {
 						case MIN -> Scalar.all(Double.POSITIVE_INFINITY);
 						case MAX -> Scalar.all(Double.NEGATIVE_INFINITY);
+						case MAX_ABS -> Scalar.all(0.0);
 					};
 					var temp = new Mat(input.rows(), input.cols(), outputType, fill);
 					temp.retainReference();
@@ -1364,12 +1369,22 @@ public class ImageOps {
 								case MAX -> {
 									opencv_core.max(tempOutput, temp, tempOutput);
 								}
+								case MAX_ABS -> {
+									OpenCVTools.apply(tempOutput, temp, tempOutput, RotatedFilterFeatureOp::absMax);
+								}
 							}
 							ind++;
 						}
 					}
 				}
 				return List.copyOf(output);
+			}
+
+			private static double absMax(double a, double b) {
+				if (Math.abs(b) > Math.abs(a))
+					return b;
+				else
+					return a;
 			}
 
 			private List<Mat> getKernels() {

--- a/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/tools/OpenCVTools.java
@@ -30,6 +30,7 @@ import ij.process.ByteProcessor;
 import ij.process.FloatProcessor;
 import ij.process.ImageProcessor;
 import ij.process.ShortProcessor;
+import java.util.function.DoubleBinaryOperator;
 import org.apache.commons.math3.stat.descriptive.rank.Percentile;
 import org.apache.commons.math3.stat.descriptive.rank.Percentile.EstimationType;
 import org.apache.commons.math3.stat.ranking.NaNStrategy;
@@ -226,7 +227,7 @@ public class OpenCVTools {
 	
 	
 	/**
-	 * Apply an operation to the pixels of an image.
+	 * Apply an operation to the pixels of an image, in-place.
 	 * <p>
 	 * No type conversion is applied; it is recommended to use floating point images, or otherwise check 
 	 * that clipping, rounding and non-finite values are handled as expected.
@@ -235,21 +236,96 @@ public class OpenCVTools {
 	 * @param operator operator to apply to pixels of the image, in-place
 	 */
 	public static void apply(Mat mat, DoubleUnaryOperator operator) {
-		Indexer indexer = mat.createIndexer();
+		apply(mat, mat, operator);
+	}
+
+	/**
+	 * Apply an operation to the pixels of an image.
+	 * @param mat the input image
+	 * @param matOutput the output image; this may be the same as the input image, or null to create an output
+	 *                  of the same size and type as the input.
+	 * @param operator the operator to apply to each pixel of the input image
+	 * @return the output image
+	 * @since v0.8.0
+	 */
+	public static Mat apply(Mat mat, Mat matOutput, DoubleUnaryOperator operator) {
+		if (matOutput == null) {
+			matOutput = new Mat();
+		}
+		if (matOutput.isNull() || matOutput.total() == 0L) {
+			matOutput.create(mat.rows(), mat.cols(), opencv_core.CV_MAKETYPE(mat.depth(), mat.channels()));
+		} else {
+			checkSizeOrThrow(mat, matOutput);
+		}
+		try (var scope = new PointerScope()) {
+			var idx = createLinearIndex(mat.createIndexer());
+			var idxOutput = createLinearIndex(matOutput.createIndexer());
+			long total = idx.size(0);
+			long[] inds = new long[1];
+			for (long i = 0; i < total; i++) {
+				inds[0] = i;
+				double val = operator.applyAsDouble(idx.getDouble(inds));
+				idxOutput.putDouble(inds, val);
+			}
+		}
+		return matOutput;
+	}
+
+	/**
+	 * Check that two Mats have the same dimensions, or throw an exception.
+	 * @param matA
+	 * @param matB
+	 * @throws IllegalArgumentException
+	 */
+	private static void checkSizeOrThrow(Mat matA, Mat matB) throws IllegalArgumentException {
+		if (matA.rows() == matB.rows() && matA.cols() == matB.cols() && matA.channels() == matB.channels())
+			return;
+		throw new IllegalArgumentException("Mat shapes do not match: " + matA + ", " + matB);
+	}
+
+	private static <I extends Indexer> I createLinearIndex(I indexer) {
 		long[] sizes = indexer.sizes();
 		long total = 1;
 		for (long dim : sizes)
 			total *= dim;
-		var indexer2 = indexer.reindex(Index.create(total));
-		long[] inds = new long[1];
-		for (long i = 0; i < total; i++) {
-			inds[0] = i;
-			double val = indexer2.getDouble(inds);
-			val = operator.applyAsDouble(val);
-			indexer2.putDouble(inds, val);
+		return indexer.reindex(Index.create(total));
+	}
+
+	/**
+	 * Apply an operation to the corresponding pixels of two images, to obtain an output image.
+	 * @param matA the first input image
+	 * @param matB the second input image; this must have the same dimensions as matA
+	 * @param matOutput the output image; this may be the same as the first input image, or null to create an output
+	 *                  of the same size and type as the first input.
+	 * @param operator the operator to apply to each corresponding pixel of the input images
+	 * @return the output image
+	 * @since v0.8.0
+	 */
+	public static Mat apply(Mat matA, Mat matB, Mat matOutput, DoubleBinaryOperator operator) {
+		checkSizeOrThrow(matA, matB);
+		if (matOutput == null) {
+			matOutput = new Mat();
 		}
-		indexer2.close();
-		indexer.close();
+		if (matOutput.isNull() || matOutput.total() == 0L) {
+			matOutput.create(matA.rows(), matA.cols(), opencv_core.CV_MAKETYPE(matA.depth(), matA.channels()));
+		} else {
+			checkSizeOrThrow(matA, matOutput);
+		}
+		try (var scope = new PointerScope()) {
+			var idxA = createLinearIndex(matA.createIndexer());
+			var idxB = createLinearIndex(matB.createIndexer());
+			var idxOutput = createLinearIndex(matOutput.createIndexer());
+			long total = idxA.size(0);
+			long[] inds = new long[1];
+			for (long i = 0; i < total; i++) {
+				inds[0] = i;
+				double val = operator.applyAsDouble(
+						idxA.getDouble(inds), idxB.getDouble(inds)
+				);
+				idxOutput.putDouble(inds, val);
+			}
+		}
+		return matOutput;
 	}
 	
 	

--- a/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
+++ b/qupath-core-processing/src/test/java/qupath/opencv/tools/TestOpenCVTools.java
@@ -21,6 +21,7 @@
 
 package qupath.opencv.tools;
 
+import java.util.function.DoubleBinaryOperator;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.bytedeco.javacpp.PointerScope;
 import org.bytedeco.javacpp.indexer.FloatIndexer;
@@ -210,6 +211,20 @@ public class TestOpenCVTools {
 		double[] pixelsApply = OpenCVTools.extractDoubles(mat2);
 		assertEquals(total, pixelsCV.length);
 		assertArrayEquals(pixelsCV, pixelsApply, 1e-6);
+	}
+
+	@Test
+	public void testApplyBioperator() {
+		try (var scope = new PointerScope()) {
+			var matA = new Mat(1, 2, opencv_core.CV_32FC3, Scalar.ONE);
+			var matB = new Mat(1, 2, opencv_core.CV_32FC3, Scalar.ONEHALF);
+
+			var matOutput = OpenCVTools.apply(matA, matB, null, Double::sum);
+			assertArrayEquals(new double[]{1.5, 1.5, 1.5, 1.5, 1.5, 1.5}, OpenCVTools.extractDoubles(matOutput));
+
+			var matOutput2 = OpenCVTools.apply(matA, matB, null, (a, b) -> a * 2 - b * 3);
+			assertArrayEquals(new double[]{0.5, 0.5, 0.5, 0.5, 0.5, 0.5}, OpenCVTools.extractDoubles(matOutput2));
+		}
 	}
 	
 	@Test

--- a/qupath-core/src/main/java/qupath/lib/awt/common/AwtTools.java
+++ b/qupath-core/src/main/java/qupath/lib/awt/common/AwtTools.java
@@ -128,8 +128,11 @@ public final class AwtTools {
 	 * @return
 	 */
 	public static ImageRegion getImageRegion(final Shape shape, final int z, final int t) {
-		if (shape instanceof Rectangle)
-			return getImageRegion((Rectangle)shape, z, t);
+		if (shape instanceof Rectangle rect)
+			return getImageRegion(rect, z, t);
+		else if (shape == null) {
+			throw new IllegalArgumentException("Shape is null!");
+		}
 		return getImageRegion(shape.getBounds(), z, t);
 	}
 

--- a/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/TrainingImageManager.java
+++ b/qupath-extension-processing/src/main/java/qupath/process/gui/commands/ml/TrainingImageManager.java
@@ -68,13 +68,21 @@ class TrainingImageManager {
                         if (tempData != null)
                             tempData.close();
                     } else {
+                        // TODO: Create timestamp for entry changes, since otherwise we can't detect if data files
+                        //       were modified externally, and may wrongly return a cached value.
                         var tempData = trainingMap.get(entry);
                         if (tempData == null) {
                             tempData = entry.readImageData();
                             trainingMap.put(entry, tempData);
                         }
+                        // This is a stronger test than is required, because we could train a model across images
+                        // that have different channels as long as we only use shared channels...
+                        // however, managing this could become very complicated - so we are strict.
                         if (PixelClassifierUtils.compatibleChannels(imageData.getServer(), tempData.getServer()))
                             list.add(tempData);
+                        else
+                            logger.warn("Channels of {} are not compatible (expected {}, found {})", tempData.getServer(),
+                                    imageData.getServer().getMetadata().getChannels(), tempData.getServer().getMetadata().getChannels());
                     }
                 } catch (Exception e) {
                     logger.error(e.getLocalizedMessage(), e);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/QuPathViewer.java
@@ -1939,6 +1939,7 @@ public class QuPathViewer implements TileListener<BufferedImage>, PathObjectHier
 		Graphics2D gOverlay = imgOverlay.createGraphics();
 		gOverlay.setBackground(new Color(0, true));
 		gOverlay.clearRect(0, 0, imgOverlay.getWidth(), imgOverlay.getHeight());
+		gOverlay.setClip(0, 0, imgOverlay.getWidth(), imgOverlay.getHeight());
 		gOverlay.transform(transform);
 
 		float opacity = overlayOptions.getOpacity();


### PR DESCRIPTION
Add rotated ridge filters, in anticipation of their use in pixel classifiers.

This PR also includes:
* A fix for setting the `clip` of a `Graphics2D` before drawing overlays (the issue was introduced when implementing the curtain effect, and caused z-stack projections to break)
* More `OpenCV.apply` methods, which can be used to somewhat overcome the inability to use a boolean `Mat` as a mask to change specific pixel values (as one would do in numpy, e.g., `im[im < 0] = 0`
* Better logging when trying to train a pixel classifier on multiple images, where channels are incompatible

*Note that the ridge filters aren't yet available in a default pixel classifier feature extractor, so another PR will be needed to make these useful.*