### PR TITLE
Ignore brush/wand/point ctrl clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Support to close more windows with Ctrl/Cmd+W (https://github.com/qupath/qupath/issues/2107)
 * Lots more strings externalized (https://github.com/qupath/qupath/pull/2104)
 * Ask to remove projects that are not found (https://github.com/qupath/qupath/pull/2167)
+* Hold down `Ctrl` (`Cmd` on macOS) when clicking viewer to focus it without creating an annotation with the brush, wand or points tool (https://github.com/qupath/qupath/pull/2185)
 
 ### Bug fixes
 * StackOverflowError at ROITypeAdapters.writeCoordinates when exporting some geometries (https://github.com/qupath/qupath/issues/2115)

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/BrushToolEventHandler.java
@@ -136,7 +136,12 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler<Input
 	
 	@Override
 	public void mousePressed(MouseEvent e) {
-		if (!e.isPrimaryButtonDown() || e.isConsumed()) {
+		// v0.8.0 change to skip clicks if ctrl/cmd down,
+		// because this gives a way to bring the viewer into focus
+		// without accidentally creating a new annotation.
+		// We can't use spacebar, because we don't know if it was pressed with
+		// any other window in focus.
+		if (!e.isPrimaryButtonDown() || e.isConsumed() || e.isShortcutDown()) {
             return;
         }
 
@@ -146,7 +151,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler<Input
 		PathObjectHierarchy hierarchy = viewer.getHierarchy();
 		if (hierarchy == null)
 			return;
-		
+
 		PathObject currentObject = viewer.getSelectedObject();
 		
 		// Ignore the current object if it belongs to a different image plane
@@ -158,7 +163,7 @@ public class BrushToolEventHandler extends AbstractPathROIToolEventHandler<Input
 				currentObject.getROI().getT() != viewer.getTPosition()) {
 			currentObject = null;
 		}
-		
+
 		// Determine if we are creating a new object
 //		boolean createNew = currentObject == null || e.getClickCount() > 1;// || (!currentObject.getROI().contains(p.getX(), p.getY()) && !e.isAltDown());
 		Point2D p = mouseLocationToImage(e, false, false);

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PointsToolEventHandler.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/viewer/tools/handlers/PointsToolEventHandler.java
@@ -191,7 +191,8 @@ class PointsToolEventHandler extends AbstractPathToolEventHandler<MouseEvent> {
 	@Override
 	public void mousePressed(MouseEvent e) {
 		super.mousePressed(e);
-		if (!e.isPrimaryButtonDown() || e.isConsumed()) {
+		// v0.8.0 skip clicks with ctrl/cmd down, for consistency with brush/wand
+		if (!e.isPrimaryButtonDown() || e.isConsumed() || e.isShortcutDown()) {
             return;
         }
 		


### PR DESCRIPTION
Ignore viewer clicks with ctrl (or cmd) key pressed and the brush, wand or points tool active.

This makes it possible to bring a viewer into focus without inadvertently creating a new annotation.

It's especially important when a different window was focused and any of these tools were active.

The user often needs to bring a viewer into focus so they can interact with it (and even have keypresses recognized), and this needs to be possible without accidentally creating an annotation that then needs to be deleted.