### PR TITLE
Update scijava maven repo

### DIFF
--- a/buildSrc/src/main/kotlin/qupath.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.common-conventions.gradle.kts
@@ -30,7 +30,7 @@ repositories {
     // Required for scijava (including some QuPath jars)
     maven {
     	name = "SciJava"
-	    url = uri("https://maven.scijava.org/content/groups/public/")
+	    url = uri("https://maven.scijava.org/content/repositories/releases/")
 	}
 
     // May be required during development


### PR DESCRIPTION
Seems to resolve https://forum.image.sc/t/trouble-building-qupath-on-rhel-8-system-with-jdk-25-and-no-root/122342/2

Builds that worked were *presumably* thanks to some dependencies being cached; when I ran `jpackage` via GitHub actions, 3/4 builds succeeded, where the failure was on macOS Intel (i.e. the one we don't use routinely).

I could also replicate the failure on Apple Silicon using a computer that hadn't build QuPath for a long time.

There were sciJava maven issues recently, and [`public` is mentioned here](https://forum.image.sc/t/maven-scijava-org-unavailable/120874/10).

It seems that using `public` was somehow resulting in Gradle not checking the right repo for some Bio-Formats dependencies, resulting in

```
Execution failed for task ':qupath-extension-bioformats:compileJava' (registered by plugin class 'org.gradle.api.plugins.JavaBasePlugin').
> Could not resolve all files for configuration ':qupath-extension-bioformats:compileClasspath'.
   > Could not find formats-gpl-8.5.0.jar (ome:formats-gpl:8.5.0).
     Searched in the following locations:
         https://maven.scijava.org/content/groups/public/ome/formats-gpl/8.5.0/formats-gpl-8.5.0.jar
   > Could not find turbojpeg-8.5.0.jar (ome:turbojpeg:8.5.0).
     Searched in the following locations:
         https://maven.scijava.org/content/groups/public/ome/turbojpeg/8.5.0/turbojpeg-8.5.0.jar
```

In the event this doesn't work, an alternative (which seems to work) is to simply put sciJava further down the list in` qupath.commons-conventions.gradle.kts` so that others are searched first.