### PR TITLE
Chase away build warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -163,8 +163,9 @@ dependencies {
     // Include Groovy scripting
     runtimeOnly(libs.bundles.groovy)
 
-    includedProjects.forEach {
-        implementation(it)
+    includedProjects.forEach { p ->
+        // Direct inclusion of project object is deprecated
+        implementation(project(p.name))
     }
 
     with (gradle.extra["qupath.included.dependencies"] as List<*>) {

--- a/buildSrc/src/main/kotlin/qupath.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.common-conventions.gradle.kts
@@ -33,6 +33,11 @@ repositories {
 	    url = uri("https://maven.scijava.org/content/repositories/releases/")
 	}
 
+    maven {
+        name = "SciJava public"
+        url = uri("https://maven.scijava.org/content/groups/public/")
+    }
+
     // May be required during development
     maven {
         name = "SciJava snapshots"

--- a/buildSrc/src/main/kotlin/qupath.fiji-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.fiji-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.internal.extensions.core.extra
+
 /**
  * This performs some extra configuration when building QuPath
  * with Fiji's dependencies.
@@ -12,10 +14,10 @@ plugins {
  * Check if we should build with Fiji dependencies
  * Can use -Pfiji=true or even just -Pfiji
  */
-var buildWithFiji: Boolean by project.extra {
-    providers.gradleProperty("fiji")
-        .getOrElse("false").trim().lowercase() != "false"
-}
+val buildWithFiji: Boolean = providers.gradleProperty("fiji")
+    .getOrElse("false").trim().lowercase() != "false"
+project.extra.set("buildWithFiji", buildWithFiji)
+
 
 if (buildWithFiji) {
 

--- a/buildSrc/src/main/kotlin/qupath.fiji-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.fiji-conventions.gradle.kts
@@ -13,7 +13,8 @@ plugins {
  * Can use -Pfiji=true or even just -Pfiji
  */
 var buildWithFiji: Boolean by project.extra {
-    providers.gradleProperty("fiji").getOrElse("false").trim().lowercase() != "false"
+    providers.gradleProperty("fiji")
+        .getOrElse("false").trim().lowercase() != "false"
 }
 
 if (buildWithFiji) {
@@ -37,10 +38,8 @@ if (buildWithFiji) {
             "java.desktop/sun.awt.X11=ALL-UNNAMED",
             "java.desktop/com.apple.eawt=ALL-UNNAMED",
             // Scenery
-            "java.base/java.lang=ALL-UNNAMED",
             "java.base/java.lang.invoke=ALL-UNNAMED",
             "java.base/java.net=ALL-UNNAMED",
-            "java.base/java.nio=ALL-UNNAMED",
             "java.base/java.time=ALL-UNNAMED",
             "java.base/java.util.concurrent.atomic=ALL-UNNAMED",
             "java.base/sun.nio.ch=ALL-UNNAMED",

--- a/buildSrc/src/main/kotlin/qupath.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.java-conventions.gradle.kts
@@ -56,12 +56,12 @@ afterEvaluate {
                 "QuPath-build-time" to formatter.format(LocalDateTime.now())
             )
             // Set the module name where we can
-            val moduleName = properties.getOrDefault("moduleName", null)
+            val moduleName = ext.properties.getOrDefault("moduleName", null)
             if (moduleName != null) {
                 manifestAttributes["Automatic-Module-Name"] = "io.github.$moduleName"
             }
 
-            val gitCommit = properties.getOrDefault("git.commit", null)
+            val gitCommit = ext.properties.getOrDefault("git.commit", null)
             if (gitCommit is String) {
                 manifestAttributes["QuPath-latest-commit"] = gitCommit
             }

--- a/buildSrc/src/main/kotlin/qupath.jpackage-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/qupath.jpackage-conventions.gradle.kts
@@ -268,7 +268,8 @@ fun getDistOutputDir(): File {
  * Postprocessing of jpackage outputs; this is needed to fix the macOS version
  * and assemble the outputs for the checksums.
  */
-val jpackageFinalize by tasks.registering {
+val jpackageFinalize = tasks.register("jpackageFinalize") {
+    description = "Postprocess jpackage outputs"
     doLast {
         val outputDir = getDistOutputDir()
         // Loop for Mac things to do
@@ -294,7 +295,7 @@ val jpackageFinalize by tasks.registering {
                 delete(appFile)
             }
         }
-        // On windows, for the installer we should also zip up the image
+        // On Windows, for the installer we should also zip up the image
         if (Utils.currentPlatform().isWindows) {
             val imageDir = File(outputDir, qupathAppName)
             if (imageDir.isDirectory() && packageType == "installer") {

--- a/qupath-core-processing/src/main/java/qupath/opencv/io/OpenCVTypeAdapters.java
+++ b/qupath-core-processing/src/main/java/qupath/opencv/io/OpenCVTypeAdapters.java
@@ -71,7 +71,6 @@ public class OpenCVTypeAdapters {
 	 * Register a new JSON-serializable {@link PredictionModel} or {@link TrainableModel},
 	 * using the simple class name as "model-type".
 	 * @param cls the JSON-serializable class
-	 * @return
 	 */
 	public static void registerPredictionModel(Class<? extends PredictionModel> cls) {
 		registerPredictionModel(cls, cls.getSimpleName());
@@ -81,7 +80,6 @@ public class OpenCVTypeAdapters {
 	 * Register a new JSON-serializable {@link PredictionModel} or {@link TrainableModel}.
 	 * @param cls the JSON-serializable class
 	 * @param label the "model-type" label; note that this must be unique.
-	 * @return
 	 */
 	@SuppressWarnings("unchecked")
 	public static void registerPredictionModel(Class<? extends PredictionModel> cls, String label) {

--- a/qupath-extension-bioformats/build.gradle.kts
+++ b/qupath-extension-bioformats/build.gradle.kts
@@ -14,7 +14,7 @@ base {
 }
 
 var bioformatsVersion = libs.versions.bioformats.get()
-val versionOverride = project.properties["bioformats-version"]
+val versionOverride = ext.properties["bioformats-version"]
 if (versionOverride is String) {
 	println("Using specified Bio-Formats version $versionOverride")
 	bioformatsVersion = versionOverride


### PR DESCRIPTION
Removes most build warnings, especially those associated with Gradle.

Some remain, but I think most (perhaps all?) are linked to https://github.com/bytedeco/gradle-javacpp